### PR TITLE
Let `Kill` preempt actor work

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -190,11 +190,10 @@ class FileWriter(Actor):
 **When It Runs:**
 - Called automatically in both normal and error termination
 - *Not* called on fatal failures such as OOMs, panics, or fatal signals (e.g., `SIGSEGV`)
-- Cancelled if it exceeds `HYPERACTOR_CLEANUP_TIMEOUT`, which puts the actor in an error state
 
 **What Has Already Happened:**
-- Every mesh this actor owns has already been stopped recursively
-- Each owned actor's `__cleanup__` has already run
+- On graceful shutdown, owned actors normally finish first
+- On failure or forced teardown, residual descendants are transferred to proc supervision and sent `Kill`; their cleanup may not run
 - Owned actor meshes and proc meshes are no longer usable from this method
 - For shutdown work that needs an owned mesh, expose a dedicated endpoint and call it before `stop()`
 

--- a/docs/source/api/monarch.config.rst
+++ b/docs/source/api/monarch.config.rst
@@ -173,13 +173,6 @@ Timeouts
     - **Default**: ``"10s"``
     - **Environment**: ``HYPERACTOR_STOP_ACTOR_TIMEOUT``
 
-``cleanup_timeout``
-    Timeout for cleanup operations during shutdown.
-
-    - **Type**: ``str`` (duration format)
-    - **Default**: ``"3s"``
-    - **Environment**: ``HYPERACTOR_CLEANUP_TIMEOUT``
-
 ``actor_spawn_max_idle``
     Maximum idle time between updates while spawning actors in a proc mesh.
 

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -84,6 +84,16 @@ pub enum StopMode {
 }
 wirevalue::register_type!(StopMode);
 
+/// The runtime behavior requested by an actor after its stop hook returns.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StopProgress {
+    /// Finish with the original stop reason. The runtime forcefully tears down
+    /// any children that remain linked.
+    Complete,
+    /// Continue processing ordinary work and lifecycle events until the actor exits.
+    Continue,
+}
+
 /// An Actor is an independent, asynchronous thread of execution. Each
 /// actor instance has a mailbox, whose messages are delivered through
 /// the method [`Actor::handle`].
@@ -104,19 +114,26 @@ pub trait Actor: Sized + Send + 'static {
 
     /// Handle a stop request from the runtime.
     ///
-    /// The default implementation closes handler ingress and then
-    /// either exits immediately or queues an exit after already
-    /// accepted handler work drains. Actors that need to coordinate
-    /// asynchronous shutdown work can override this method and call
-    /// `Instance::exit()` / `Instance::exit_after_drain()` later,
-    /// once they are ready to terminate.
+    /// The default implementation closes handler ingress, propagates the stop
+    /// mode to direct children, and asks the runtime to finish after they stop.
+    /// Actors that need to coordinate asynchronous shutdown can return
+    /// [`StopProgress::Continue`] and call [`Instance::exit`] when finished.
+    /// [`Instance::kill`] cancels an in-progress stop hook.
+    ///
+    /// While this hook runs, the actor loop services signals but not ordinary
+    /// work, so awaiting anything delivered through handler dispatch blocks
+    /// until [`Instance::kill`]. Coordinate through ports, or return
+    /// [`StopProgress::Continue`] and finish the work in handlers.
+    ///
+    /// Once the hook has run, further `Stop` and `DrainAndStop` requests are
+    /// ignored; [`Instance::kill`] is the escalation path.
     async fn handle_stop(
         &mut self,
         this: &Instance<Self>,
         mode: StopMode,
         reason: &str,
-    ) -> Result<(), anyhow::Error> {
-        handle_stop(this, mode, reason)
+    ) -> Result<StopProgress, anyhow::Error> {
+        handle_stop(this, mode, reason).await
     }
 
     /// Cleanup things used by this actor before shutting down. Notably this function
@@ -302,18 +319,37 @@ pub fn handle_expired_delivery<A: Actor>(
 /// Default implementation of [`Actor::handle_stop`]. Defined as a free
 /// function so that `Actor` implementations that override
 /// [`Actor::handle_stop`] can fall back to this default.
-pub fn handle_stop<A: Actor>(
+///
+/// This closes handler ingress, forwards the original mode and reason to direct
+/// children in creation order, and waits for each to reach a terminal status.
+pub async fn handle_stop<A: Actor>(
     this: &Instance<A>,
     mode: StopMode,
     reason: &str,
-) -> Result<(), anyhow::Error> {
-    // After `close`, no more messages may be enqueued.
-    // exit_after_drain will drain any pending messages before exiting.
+) -> Result<StopProgress, anyhow::Error> {
     this.close();
-    match mode {
-        StopMode::Stop => this.exit(reason).map_err(anyhow::Error::from),
-        StopMode::DrainAndStop => this.exit_after_drain(reason).map_err(anyhow::Error::from),
+    let children = this.children();
+    for child in &children {
+        let result = match mode {
+            StopMode::Stop => child.stop(reason),
+            StopMode::DrainAndStop => child.drain_and_stop(reason),
+        };
+        if let Err(err) = result {
+            tracing::debug!(
+                actor_id = %this.self_addr(),
+                child_id = %child.actor_id(),
+                "child already stopped during parent shutdown: {}",
+                err,
+            );
+        }
     }
+    for child in &children {
+        // A child that never terminates holds this hook open until `Kill`;
+        // the caller owns that deadline.
+        let _ = child.status().wait_for(ActorStatus::is_terminal).await;
+    }
+
+    Ok(StopProgress::Complete)
 }
 
 /// An actor that does nothing. It is used to represent "client only" actors,
@@ -1065,6 +1101,11 @@ pub struct AnyActorHandle {
 }
 
 impl AnyActorHandle {
+    /// Create a lifecycle-only handle without changing supervision ownership.
+    pub(crate) fn new(cell: InstanceCell) -> Self {
+        Self { cell }
+    }
+
     /// The [`ActorAddr`] of the actor represented by this handle.
     pub fn actor_id(&self) -> &ActorAddr {
         self.cell.actor_addr()

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -145,9 +145,8 @@ pub trait Actor: Sized + Send + 'static {
     /// as an ActorError.
     /// This function is not called if there is a panic in the actor, as the
     /// actor may be in an indeterminate state. It is also not called if the
-    /// actor is stopped with [`Instance::kill`] or if the process is killed. If
-    /// [`Instance::kill`] is called while cleanup is running, the cleanup future
-    /// is cancelled.
+    /// actor is killed, aborted by the runtime, or its process terminates. A
+    /// `Kill` or Abort request that arrives during cleanup cancels its future.
     async fn cleanup(
         &mut self,
         _this: &Instance<Self>,
@@ -767,11 +766,6 @@ pub enum Signal {
 
     /// Exit the actor loop with the provided stop reason.
     ExitRequested(String),
-
-    /// Kill the actor. This will exit the actor loop with an error,
-    /// causing a supervision event to propagate up the supervision
-    /// hierarchy.
-    Kill(String),
 }
 
 impl fmt::Display for Signal {
@@ -780,7 +774,6 @@ impl fmt::Display for Signal {
             Signal::DrainAndStop(reason) => write!(f, "DrainAndStop({})", reason),
             Signal::Stop(reason) => write!(f, "Stop({})", reason),
             Signal::ExitRequested(reason) => write!(f, "ExitRequested({})", reason),
-            Signal::Kill(reason) => write!(f, "Kill({})", reason),
         }
     }
 }
@@ -992,7 +985,7 @@ impl<A: Actor> ActorHandle<A> {
     /// Signal the actor to terminate immediately.
     pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
         tracing::info!("actor handle kill called: {}", self.actor_addr());
-        self.cell.signal(Signal::Kill(reason.to_string()))
+        self.cell.kill(reason.to_string())
     }
 
     /// A watch that observes the lifecycle state of the actor.
@@ -1123,7 +1116,7 @@ impl AnyActorHandle {
 
     /// Signal the actor to terminate immediately.
     pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
-        self.cell.signal(Signal::Kill(reason.to_string()))
+        self.cell.kill(reason.to_string())
     }
 
     /// A watch that observes the lifecycle state of the actor.

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -128,7 +128,9 @@ pub trait Actor: Sized + Send + 'static {
     /// as an ActorError.
     /// This function is not called if there is a panic in the actor, as the
     /// actor may be in an indeterminate state. It is also not called if the
-    /// process is killed, there is no atexit handler or signal handler.
+    /// actor is stopped with [`Instance::kill`] or if the process is killed. If
+    /// [`Instance::kill`] is called while cleanup is running, the cleanup future
+    /// is cancelled.
     async fn cleanup(
         &mut self,
         _this: &Instance<Self>,

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -829,8 +829,8 @@ impl fmt::Display for HandlerInfo {
 pub enum ActorStoppingReason {
     /// The actor is stopping through the normal cooperative shutdown path.
     Requested,
-    /// The actor did not respond to hard kill, and teardown stopped waiting on
-    /// it normally.
+    /// The actor was detached from its parent during forced tree teardown and
+    /// has not yet published its terminal status.
     Zombie(String),
 }
 

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -730,9 +730,6 @@ pub enum Signal {
     /// Exit the actor loop with the provided stop reason.
     ExitRequested(String),
 
-    /// The direct child with the given uid was stopped.
-    ChildStopped(crate::id::Uid),
-
     /// Kill the actor. This will exit the actor loop with an error,
     /// causing a supervision event to propagate up the supervision
     /// hierarchy.
@@ -745,7 +742,6 @@ impl fmt::Display for Signal {
             Signal::DrainAndStop(reason) => write!(f, "DrainAndStop({})", reason),
             Signal::Stop(reason) => write!(f, "Stop({})", reason),
             Signal::ExitRequested(reason) => write!(f, "ExitRequested({})", reason),
-            Signal::ChildStopped(uid) => write!(f, "ChildStopped({})", uid),
             Signal::Kill(reason) => write!(f, "Kill({})", reason),
         }
     }

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -174,14 +174,6 @@ declare_attrs! {
     ))
     pub attr STOP_ACTOR_TIMEOUT: Duration = Duration::from_secs(10);
 
-    /// Timeout used by proc for running the cleanup callback on an actor.
-    /// Should be less than the timeout for STOP_ACTOR_TIMEOUT.
-    @meta(CONFIG = ConfigAttr::new(
-        Some("HYPERACTOR_CLEANUP_TIMEOUT".to_string()),
-        Some("cleanup_timeout".to_string()),
-    ))
-    pub attr CLEANUP_TIMEOUT: Duration = Duration::from_secs(3);
-
     /// How often to check for full MPSC channel on NetRx.
     @meta(CONFIG = ConfigAttr::new(
         Some("HYPERACTOR_CHANNEL_NET_RX_BUFFER_FULL_CHECK_INTERVAL".to_string()),
@@ -364,7 +356,6 @@ mod tests {
             export HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT=1m
             # export HYPERACTOR_CODEC_MAX_FRAME_LENGTH=10737418240
             export HYPERACTOR_CODEC_MAX_FRAME_LENGTH=1024
-            # export HYPERACTOR_CLEANUP_TIMEOUT=3s
             # export HYPERACTOR_SPLIT_MAX_BUFFER_AGE=50ms
             # export HYPERACTOR_DEFAULT_ENCODING=serde_multipart
             # export HYPERACTOR_HOST_SPAWN_READY_TIMEOUT=30s

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -109,15 +109,15 @@
 //!   is derived from root-cause actor identity; a parent that failed
 //!   due to a child's event must report `failure_is_propagated ==
 //!   true`.
-//! - **FI-9 (stored-terminal vs delivered-zombie):** For an actor
+//! - **FI-9 (detached-zombie completion suppression):** For an actor
 //!   marked `Zombie` during teardown that then reaches a terminal
 //!   status, `InstanceCell::supervision_event` records the true
-//!   terminal event (`Stopped`/`Failed`, for introspection) while
-//!   the supervision event delivered to the parent/proc remains the
-//!   non-error `Zombie` verdict (for supervision policy). The two
-//!   intentionally diverge; enforced in `proc.rs` `serve()`, where
-//!   the stored `event` and the delivered `event_to_deliver` are
-//!   computed separately.
+//!   terminal event (`Stopped`/`Failed`, for introspection), and the
+//!   terminal status replaces `Zombie`. Because detachment already
+//!   removed the actor from its parent's completion barrier and
+//!   transferred it to proc ownership, the terminal event does not
+//!   re-enter supervision. `try_handle_completion_event` makes this decision
+//!   while holding the supervision ownership lock.
 //!
 //! ## Attrs view invariants (AV-*)
 //!

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3263,30 +3263,68 @@ impl<A: Actor> Instance<A> {
                 }
             }
         }
+        let was_killed = result
+            .as_ref()
+            .is_err_and(|err| matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)));
         // Run the actor cleanup function before the actor stops to delete
         // resources. If it times out, continue with stopping the actor.
         // Don't call it if there was a panic, because the actor may
         // be in an invalid state and unable to access anything, for example
         // the GIL.
-        let cleanup_result = if !did_panic {
+        let cleanup_result = if !did_panic && !was_killed {
             let cleanup_timeout = hyperactor_config::global::get(config::CLEANUP_TIMEOUT);
-            match tokio::time::timeout(
+            let cleanup = tokio::time::timeout(
                 cleanup_timeout,
                 self.inner
                     .proc
                     .with_current(actor.cleanup(self, result.as_ref().err())),
-            )
-            .await
-            {
-                Ok(Ok(x)) => Ok(x),
-                Ok(Err(e)) => Err(ActorError::new(
-                    self.self_addr(),
-                    ActorErrorKind::cleanup(e),
-                )),
-                Err(e) => Err(ActorError::new(
-                    self.self_addr(),
-                    ActorErrorKind::cleanup(e.into()),
-                )),
+            );
+            tokio::pin!(cleanup);
+            let signal_receiver = &mut actor_loop_receivers.0;
+            let mut receive_signals = true;
+            loop {
+                tokio::select! {
+                    biased;
+                    signal = signal_receiver.recv(), if receive_signals => {
+                        match signal {
+                            Some(Signal::Kill(reason)) => {
+                                // Aborting discards `result`, so carry an
+                                // already-failed exit into the reason. It is
+                                // the root cause, and nothing downstream sees
+                                // `result` once we return.
+                                let reason = match result.as_ref() {
+                                    Err(err) => {
+                                        format!("{reason} (killed during cleanup after: {err})")
+                                    }
+                                    Ok(_) => reason,
+                                };
+                                return Err(ActorError::new(
+                                    self.self_addr(),
+                                    ActorErrorKind::Aborted(reason),
+                                ));
+                            }
+                            Some(
+                                Signal::Stop(_)
+                                | Signal::DrainAndStop(_)
+                                | Signal::ExitRequested(_),
+                            ) => {}
+                            None => receive_signals = false,
+                        }
+                    }
+                    cleanup_result = &mut cleanup => {
+                        break match cleanup_result {
+                            Ok(Ok(result)) => Ok(result),
+                            Ok(Err(err)) => Err(ActorError::new(
+                                self.self_addr(),
+                                ActorErrorKind::cleanup(err),
+                            )),
+                            Err(err) => Err(ActorError::new(
+                                self.self_addr(),
+                                ActorErrorKind::cleanup(err.into()),
+                            )),
+                        };
+                    }
+                }
             }
         } else {
             Ok(())
@@ -7093,6 +7131,154 @@ mod tests {
         parent.drain_and_stop("test").unwrap();
         assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
         assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[derive(Debug)]
+    struct CleanupReportingActor {
+        cleaned: Option<oneshot::Sender<()>>,
+    }
+
+    struct CleanupDropGuard(Option<oneshot::Sender<()>>);
+
+    impl Drop for CleanupDropGuard {
+        fn drop(&mut self) {
+            if let Some(dropped) = self.0.take() {
+                let _ = dropped.send(());
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct BlockingCleanupActor {
+        cleanup_started: Option<oneshot::Sender<()>>,
+        cleanup_dropped: Option<oneshot::Sender<()>>,
+    }
+
+    #[async_trait]
+    impl Actor for BlockingCleanupActor {
+        async fn cleanup(
+            &mut self,
+            _this: &Instance<Self>,
+            _err: Option<&ActorError>,
+        ) -> Result<(), anyhow::Error> {
+            let _drop_guard = CleanupDropGuard(self.cleanup_dropped.take());
+            self.cleanup_started.take().unwrap().send(()).unwrap();
+            std::future::pending().await
+        }
+    }
+
+    #[async_trait]
+    impl Actor for CleanupReportingActor {
+        async fn cleanup(
+            &mut self,
+            _this: &Instance<Self>,
+            _err: Option<&ActorError>,
+        ) -> Result<(), anyhow::Error> {
+            self.cleaned.take().unwrap().send(()).unwrap();
+            Ok(())
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_skips_actor_cleanup() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let (cleaned_tx, cleaned_rx) = oneshot::channel();
+        let actor = proc.spawn(CleanupReportingActor {
+            cleaned: Some(cleaned_tx),
+        });
+        actor
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_idle)
+            .await
+            .unwrap();
+
+        actor.kill("kill").unwrap();
+
+        assert_matches!(
+            actor.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: kill"
+        );
+        assert!(cleaned_rx.await.is_err(), "cleanup ran after kill");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_interrupts_actor_cleanup() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let (cleanup_started_tx, cleanup_started_rx) = oneshot::channel();
+        let (cleanup_dropped_tx, cleanup_dropped_rx) = oneshot::channel();
+        let actor = proc.spawn(BlockingCleanupActor {
+            cleanup_started: Some(cleanup_started_tx),
+            cleanup_dropped: Some(cleanup_dropped_tx),
+        });
+
+        actor.stop("stop").unwrap();
+        cleanup_started_rx.await.unwrap();
+        actor.kill("kill").unwrap();
+
+        assert_matches!(
+            tokio::time::timeout(Duration::from_secs(1), actor)
+                .await
+                .expect("kill should interrupt cleanup"),
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: kill"
+        );
+        cleanup_dropped_rx
+            .await
+            .expect("cleanup future should be cancelled");
+    }
+
+    #[derive(Debug)]
+    struct FailingBlockingCleanupActor {
+        cleanup_started: Option<oneshot::Sender<()>>,
+    }
+
+    #[async_trait]
+    impl Actor for FailingBlockingCleanupActor {
+        async fn handle_stop(
+            &mut self,
+            _this: &Instance<Self>,
+            _mode: StopMode,
+            _reason: &str,
+        ) -> Result<(), anyhow::Error> {
+            Err(anyhow::anyhow!("original failure"))
+        }
+
+        async fn cleanup(
+            &mut self,
+            _this: &Instance<Self>,
+            _err: Option<&ActorError>,
+        ) -> Result<(), anyhow::Error> {
+            self.cleanup_started.take().unwrap().send(()).unwrap();
+            std::future::pending().await
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_during_cleanup_preserves_failure_cause() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let (cleanup_started_tx, cleanup_started_rx) = oneshot::channel();
+        let actor = proc.spawn(FailingBlockingCleanupActor {
+            cleanup_started: Some(cleanup_started_tx),
+        });
+
+        // The actor has already failed by the time cleanup starts, so the kill
+        // that interrupts cleanup must not erase why it failed.
+        actor.stop("stop").unwrap();
+        cleanup_started_rx.await.unwrap();
+        actor.kill("kill").unwrap();
+
+        assert_matches!(
+            tokio::time::timeout(Duration::from_secs(1), actor)
+                .await
+                .expect("kill should interrupt cleanup"),
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("kill") && reason.contains("original failure")
+        );
     }
 
     #[derive(Debug)]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3281,18 +3281,14 @@ impl<A: Actor> Instance<A> {
             .as_ref()
             .is_err_and(|err| matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)));
         // Run the actor cleanup function before the actor stops to delete
-        // resources. If it times out, continue with stopping the actor.
-        // Don't call it if there was a panic, because the actor may
+        // resources. Don't call it if there was a panic, because the actor may
         // be in an invalid state and unable to access anything, for example
         // the GIL.
         let cleanup_result = if !did_panic && !was_killed {
-            let cleanup_timeout = hyperactor_config::global::get(config::CLEANUP_TIMEOUT);
-            let cleanup = tokio::time::timeout(
-                cleanup_timeout,
-                self.inner
-                    .proc
-                    .with_current(actor.cleanup(self, result.as_ref().err())),
-            );
+            let cleanup = self
+                .inner
+                .proc
+                .with_current(actor.cleanup(self, result.as_ref().err()));
             tokio::pin!(cleanup);
             let signal_receiver = &mut actor_loop_receivers.0;
             let mut receive_signals = true;
@@ -3326,17 +3322,9 @@ impl<A: Actor> Instance<A> {
                         }
                     }
                     cleanup_result = &mut cleanup => {
-                        break match cleanup_result {
-                            Ok(Ok(result)) => Ok(result),
-                            Ok(Err(err)) => Err(ActorError::new(
-                                self.self_addr(),
-                                ActorErrorKind::cleanup(err),
-                            )),
-                            Err(err) => Err(ActorError::new(
-                                self.self_addr(),
-                                ActorErrorKind::cleanup(err.into()),
-                            )),
-                        };
+                        break cleanup_result.map_err(|err| {
+                            ActorError::new(self.self_addr(), ActorErrorKind::cleanup(err))
+                        });
                     }
                 }
             }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -466,9 +466,6 @@ struct ProcState {
     /// All actor instances in this proc.
     instances: DashMap<ActorId, WeakInstanceCell>,
 
-    /// Root actor ids in this proc, tracked independently from uid shape.
-    root_actors: DashSet<ActorId>,
-
     /// Proc-level queue-pressure accounting (PD-6 through PD-9).
     /// Runtime-driven — updated from `account_enqueue` /
     /// `account_dequeue`, not from publish-time sampling.
@@ -813,7 +810,6 @@ impl Proc {
                 reserved_roots: DashSet::new(),
                 reserved_child_uids: DashSet::new(),
                 instances: DashMap::new(),
-                root_actors: DashSet::new(),
                 queue_stats: Arc::new(ProcQueueStats::new()),
                 terminated_snapshots: DashMap::new(),
                 actor_tombstones: DashMap::new(),
@@ -1308,15 +1304,14 @@ impl Proc {
         })
     }
 
-    /// Traverse all actor trees in this proc, starting from root actors.
+    /// Traverse all actor trees in this proc, starting from each
+    /// proc-supervised actor.
     pub fn traverse<F>(&self, f: &mut F)
     where
         F: FnMut(&InstanceCell, usize),
     {
-        for entry in self.state().root_actors.iter() {
-            if let Some(cell) = self.get_instance_by_id(entry.key()) {
-                cell.traverse(f);
-            }
+        for cell in self.proc_supervised_instances() {
+            cell.traverse(f);
         }
     }
 
@@ -1348,15 +1343,29 @@ impl Proc {
             .and_then(|cell| cell.upgrade())
     }
 
-    /// Returns the ActorAddrs of all root actors in this proc.
-    pub fn root_actor_ids(&self) -> Vec<ActorAddr> {
-        self.state()
-            .root_actors
+    /// Live instances supervised directly by this proc.
+    ///
+    /// Upgrades are collected before filtering: dropping a rejected cell inside
+    /// the iterator can run `InstanceCellState::drop`, which removes from
+    /// `instances` under the iteration guard.
+    fn proc_supervised_instances(&self) -> Vec<InstanceCell> {
+        let live: Vec<InstanceCell> = self
+            .state()
+            .instances
             .iter()
-            .filter_map(|entry| {
-                self.get_instance_by_id(entry.key())
-                    .map(|cell| cell.actor_addr().clone())
-            })
+            .filter_map(|entry| entry.value().upgrade())
+            .collect();
+        live.into_iter()
+            .filter(InstanceCell::is_proc_supervised)
+            .collect()
+    }
+
+    /// Returns the ActorAddrs of all actors supervised directly by this proc.
+    /// An actor whose parent link has expired is not a root.
+    pub fn root_actor_ids(&self) -> Vec<ActorAddr> {
+        self.proc_supervised_instances()
+            .into_iter()
+            .map(|cell| cell.actor_addr().clone())
             .collect()
     }
 
@@ -1567,10 +1576,8 @@ impl Proc {
         // (which must stay alive to receive stop events from the others).
         let mut statuses = HashMap::new();
         for actor_id in self
-            .state()
-            .root_actors
-            .iter()
-            .filter_map(|entry| self.get_instance_by_id(entry.key()))
+            .proc_supervised_instances()
+            .into_iter()
             .filter(|cell| !matches!(*cell.status().borrow(), ActorStatus::Client))
             .map(|cell| cell.actor_addr().clone())
             .collect::<Vec<_>>()
@@ -3770,7 +3777,7 @@ impl<A: Actor> Instance<A> {
 
     /// Return a handle to this instance's parent actor, if it has one.
     pub fn parent_handle<P: Actor>(&self) -> Option<ActorHandle<P>> {
-        let parent_cell = self.inner.cell.inner.parent.upgrade()?;
+        let parent_cell = self.inner.cell.parent()?;
         let ports = if let Ok(ports) = parent_cell.inner.ports.clone().downcast() {
             ports
         } else {
@@ -3988,8 +3995,8 @@ struct InstanceCellState {
     /// An observer that stores the current status of the actor.
     status: watch::Receiver<ActorStatus>,
 
-    /// A weak reference to this instance's parent.
-    parent: WeakInstanceCell,
+    /// The actor or proc that currently supervises this instance.
+    supervision_link: SupervisionLink,
 
     /// This instance's children by their uids.
     children: DashMap<crate::id::Uid, InstanceCell>,
@@ -4094,12 +4101,34 @@ struct InstanceCellState {
     actor_attrs_snapshot: RwLock<Option<Box<dyn Fn() -> hyperactor_config::Attrs + Send + Sync>>>,
 }
 
+/// Logical supervision ownership, independent of weak-reference liveness.
+///
+/// An expired `Actor` link is a broken topology edge, not proc supervision.
+#[derive(Debug)]
+enum SupervisionLink {
+    /// Supervised directly by the proc: a root.
+    Proc,
+    /// Supervised by an actor. The reference may expire; an expired link is a
+    /// broken edge, not proc ownership.
+    Actor(WeakInstanceCell),
+}
+
+impl SupervisionLink {
+    /// The supervising actor, if this link names one that is still live.
+    fn parent(&self) -> Option<InstanceCell> {
+        match self {
+            SupervisionLink::Actor(parent) => parent.upgrade(),
+            SupervisionLink::Proc => None,
+        }
+    }
+}
+
 impl InstanceCellState {
     /// Unlink this instance from its parent, if it has one. If it was unlinked,
     /// the parent is returned.
     fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
-        self.parent
-            .upgrade()
+        self.supervision_link
+            .parent()
             .filter(|parent| parent.inner.unlink(self))
     }
 
@@ -4207,7 +4236,6 @@ impl InstanceCell {
             Box<dyn Fn() -> crate::ordering::OrderingSnapshot + Send + Sync>,
         >,
     ) -> Self {
-        let is_root = parent.is_none();
         let _ais = actor_id.to_string();
         let cell = Self {
             inner: Arc::new(InstanceCellState {
@@ -4220,7 +4248,9 @@ impl InstanceCell {
                 actor_loop,
                 status_tx,
                 status,
-                parent: parent.map_or_else(WeakInstanceCell::new, |cell| cell.downgrade()),
+                supervision_link: parent.as_ref().map_or(SupervisionLink::Proc, |cell| {
+                    SupervisionLink::Actor(cell.downgrade())
+                }),
                 children: DashMap::new(),
                 actor_task_handle: OnceLock::new(),
                 exported_named_ports: DashMap::new(),
@@ -4245,9 +4275,6 @@ impl InstanceCell {
         proc.inner
             .instances
             .insert(actor_id.id().clone(), cell.downgrade());
-        if is_root {
-            proc.inner.root_actors.insert(actor_id.id().clone());
-        }
         cell
     }
 
@@ -4523,7 +4550,7 @@ impl InstanceCell {
 
     /// Link this instance to its parent, if it has one.
     fn maybe_link_parent(&self) {
-        if let Some(parent) = self.inner.parent.upgrade() {
+        if let Some(parent) = self.inner.supervision_link.parent() {
             parent.link(self.clone());
         }
     }
@@ -4662,7 +4689,13 @@ impl InstanceCell {
 
     /// Get parent instance cell, if it exists.
     pub fn parent(&self) -> Option<InstanceCell> {
-        self.inner.parent.upgrade()
+        self.inner.supervision_link.parent()
+    }
+
+    /// Whether the proc supervises this instance directly. Distinct from
+    /// `parent().is_none()`, which is also true of an expired actor link.
+    fn is_proc_supervised(&self) -> bool {
+        matches!(&self.inner.supervision_link, SupervisionLink::Proc)
     }
 
     /// The actor's type name.
@@ -4841,7 +4874,6 @@ impl Drop for InstanceCellState {
         {
             tracing::error!("instance {} was dropped but not in proc", self.actor_id);
         }
-        self.proc.inner.root_actors.remove(self.actor_id.id());
     }
 }
 
@@ -4852,18 +4884,7 @@ pub struct WeakInstanceCell {
     inner: Weak<InstanceCellState>,
 }
 
-impl Default for WeakInstanceCell {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl WeakInstanceCell {
-    /// Create a new weak instance cell that is never upgradeable.
-    pub fn new() -> Self {
-        Self { inner: Weak::new() }
-    }
-
     /// Upgrade this weak instance cell to a strong reference, if possible.
     pub fn upgrade(&self) -> Option<InstanceCell> {
         self.inner.upgrade().map(InstanceCell::wrap)
@@ -6420,10 +6441,7 @@ mod tests {
             child.actor_addr().proc_addr(),
             parent.actor_addr().proc_addr()
         );
-        assert_eq!(
-            child.inner.parent.upgrade().unwrap().actor_addr(),
-            parent.actor_addr()
-        );
+        assert_eq!(child.parent().unwrap().actor_addr(), parent.actor_addr());
         assert_matches!(
             parent.inner.children.get(child.uid()),
             Some(node) if node.actor_addr() == child.actor_addr()
@@ -6481,7 +6499,7 @@ mod tests {
         // Supervision tree is constructed correctly.
         validate_link(third.cell(), second.cell());
         validate_link(second.cell(), first.cell());
-        assert!(first.cell().inner.parent.upgrade().is_none());
+        assert!(first.cell().parent().is_none());
 
         // Supervision tree is torn down correctly.
         // Once each actor is stopped, it should have no linked children.
@@ -6489,6 +6507,11 @@ mod tests {
         third.drain_and_stop("test").unwrap();
         third.await;
         assert!(third_cell.inner.children.is_empty());
+        assert_eq!(
+            third_cell.parent().unwrap().actor_addr(),
+            second.actor_addr()
+        );
+        assert!(second.cell().get_child(third_cell.uid()).is_none());
         drop(third_cell);
         validate_link(second.cell(), first.cell());
 
@@ -6502,6 +6525,44 @@ mod tests {
         first.drain_and_stop("test").unwrap();
         first.await;
         assert!(first_cell.inner.children.is_empty());
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn expired_parent_link_is_not_a_root() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+
+        let parent = proc.spawn_with_label::<TestActor>("parent", TestActor);
+        let child = TestActor::spawn_child(&client, &parent).await;
+        let child_cell = child.cell().clone();
+        let child_addr = child_cell.actor_addr().clone();
+
+        assert!(parent.cell().is_proc_supervised());
+        assert!(!child_cell.is_proc_supervised());
+
+        parent.drain_and_stop("test").unwrap();
+        parent.await;
+        drop(child);
+
+        for i in 0..1000 {
+            if child_cell.parent().is_none() {
+                break;
+            }
+            if i < 50 {
+                tokio::task::yield_now().await;
+            } else {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+        assert!(
+            child_cell.parent().is_none(),
+            "parent cell should be released once the parent stops"
+        );
+
+        // The link stays `Actor`, so an expired parent never promotes the
+        // child to a proc root.
+        assert!(!child_cell.is_proc_supervised());
+        assert!(!proc.root_actor_ids().contains(&child_addr));
     }
 
     #[async_timed_test(timeout_secs = 30)]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -176,6 +176,7 @@ use crate::actor::Referable;
 use crate::actor::RemoteHandles;
 use crate::actor::Signal;
 use crate::actor::StopMode;
+use crate::actor::StopProgress;
 use crate::actor_local::ActorLocalStorage;
 use crate::channel;
 use crate::channel::ChannelAddr;
@@ -2083,16 +2084,41 @@ struct InstanceState<A: Actor> {
     instance_locals: ActorLocalStorage,
 }
 
-struct ActorStopped {
+/// A cooperative stop request that may be carried across a drain barrier.
+#[derive(Debug)]
+struct StopRequest {
+    /// Whether accepted ordinary work must drain before the stop hook runs.
+    mode: StopMode,
+    /// The caller-supplied reason that becomes the clean terminal reason.
     reason: String,
-    stop_mode: StopMode,
 }
 
-fn cooperative_child_signal(mode: StopMode) -> Signal {
-    match mode {
-        StopMode::DrainAndStop => Signal::DrainAndStop("parent draining".to_string()),
-        StopMode::Stop => Signal::Stop("parent stopping".to_string()),
+/// The internal actor-loop state that controls which inputs are polled.
+#[derive(Debug)]
+enum LoopState {
+    /// No cooperative stop request has been accepted.
+    Running,
+    /// Handler ingress is closed while previously accepted work reaches the drain barrier.
+    Draining(oneshot::Receiver<StopRequest>),
+    /// The stop hook returned control to the ordinary actor loop.
+    AwaitingExit,
+}
+
+impl LoopState {
+    async fn drain_request(&mut self) -> Result<StopRequest, oneshot::error::RecvError> {
+        match self {
+            Self::Draining(receiver) => receiver.await,
+            Self::Running | Self::AwaitingExit => std::future::pending().await,
+        }
     }
+}
+
+/// The successful outcome of an actor stop hook.
+enum StopOutcome {
+    /// The actor loop should exit cleanly with the supplied reason.
+    Exit(String),
+    /// Ordinary actor processing should resume.
+    Continue,
 }
 
 type DelayedPost<A> = Box<dyn FnOnce(&Instance<A>) + Send>;
@@ -2835,6 +2861,23 @@ impl<A: Actor> Instance<A> {
         self.inner.mailbox.drain();
     }
 
+    /// Return a point-in-time snapshot of direct children in creation order.
+    /// Actor IDs provide deterministic ordering for equal creation timestamps.
+    pub fn children(&self) -> Vec<AnyActorHandle> {
+        let mut children: Vec<_> = self
+            .inner
+            .cell
+            .child_iter()
+            .map(|child| child.value().clone())
+            .collect();
+        children.sort_by(|a, b| {
+            a.created_at()
+                .cmp(&b.created_at())
+                .then_with(|| a.actor_addr().id().cmp(b.actor_addr().id()))
+        });
+        children.into_iter().map(AnyActorHandle::new).collect()
+    }
+
     /// Subscribe to this actor's status changes.
     pub fn status(&self) -> watch::Receiver<ActorStatus> {
         self.inner.cell.status().clone()
@@ -2866,6 +2909,26 @@ impl<A: Actor> Instance<A> {
             Box::pin(async move {
                 this.exit(&reason).map_err(anyhow::Error::from)?;
                 Ok(())
+            })
+        });
+        self.enqueue_runtime_work(work)
+    }
+
+    /// Queue a barrier behind accepted ordinary work and return the stop request
+    /// to the actor loop when that barrier runs.
+    ///
+    /// Handler ingress must be closed first so no ordinary work can enter behind
+    /// the barrier.
+    fn handle_stop_after_drain(
+        &self,
+        request: StopRequest,
+        drain_stop_tx: oneshot::Sender<StopRequest>,
+    ) -> Result<(), ActorError> {
+        let work = WorkCell::new(move |_actor: &mut A, _instance: &Instance<A>| {
+            Box::pin(async move {
+                drain_stop_tx
+                    .send(request)
+                    .map_err(|_| anyhow::anyhow!("drain stop receiver closed"))
             })
         });
         self.enqueue_runtime_work(work)
@@ -3209,60 +3272,11 @@ impl<A: Actor> Instance<A> {
             tracing::error!("{}: actor failure: {}", self.self_addr(), err);
         }
 
-        if let Err(err) = &result {
-            let teardown_reason = format!("parent failed: {err}");
-            self.kill_residual_children(&teardown_reason);
-        } else if let Ok(stopped) = &result {
-            // After this point, we know we won't spawn any more children,
-            // so we can safely read the current child keys.
-            let mut to_unlink = Vec::new();
-            let child_signal = cooperative_child_signal(stopped.stop_mode);
-            for child in self.inner.cell.child_iter() {
-                if let Err(err) = child.value().signal(child_signal.clone()) {
-                    tracing::error!(
-                        "{}: failed to send stop signal to child pid {}: {:?}",
-                        self.self_addr(),
-                        child.key(),
-                        err
-                    );
-                    to_unlink.push(child.value().clone());
-                }
-            }
-            // Manually unlink children that have already been stopped.
-            for child in to_unlink {
-                self.inner.cell.unlink(&child);
-            }
-
-            let (_, mut supervision_event_receiver) = actor_loop_receivers;
-            while self.inner.cell.child_count() > 0 {
-                match tokio::time::timeout(
-                    Duration::from_millis(500),
-                    supervision_event_receiver.recv(),
-                )
-                .await
-                {
-                    Ok(Some(_)) => {}
-                    Ok(None) => {
-                        // The supervision channel closed, so no further child
-                        // completion events can arrive.
-                        // Drop remaining links and exit the drain loop, mirroring
-                        // the timeout branch below.
-                        self.inner.cell.unlink_all();
-                        break;
-                    }
-                    Err(_) => {
-                        tracing::warn!(
-                            "timeout waiting for child supervision event on actor: {}, ignoring",
-                            self.self_addr()
-                        );
-                        // No more waiting to receive messages. Unlink all remaining
-                        // children.
-                        self.inner.cell.unlink_all();
-                        break;
-                    }
-                }
-            }
-        }
+        let teardown_reason = match &result {
+            Ok(reason) => format!("parent exited: {reason}"),
+            Err(err) => format!("parent failed: {err}"),
+        };
+        self.kill_residual_children(&teardown_reason);
         let was_killed = result
             .as_ref()
             .is_err_and(|err| matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)));
@@ -3342,12 +3356,111 @@ impl<A: Actor> Instance<A> {
         }
         // If the original exit was not an error, let cleanup errors be
         // surfaced.
-        result.and_then(|stopped| cleanup_result.map(|_| stopped.reason))
+        result.and_then(|reason| cleanup_result.map(|_| reason))
+    }
+
+    /// Run the actor's stop hook while continuing to service terminal signals.
+    ///
+    /// `Kill` cancels the hook immediately. The first `ExitRequested` is retained
+    /// until the hook returns, and repeated cooperative stop requests coalesce.
+    async fn run_stop_handler(
+        &self,
+        actor: &mut A,
+        request: StopRequest,
+        signal_receiver: &mut mpsc::UnboundedReceiver<Signal>,
+        supervision_event_receiver: &mut mpsc::UnboundedReceiver<ActorSupervisionEvent>,
+    ) -> Result<StopOutcome, ActorError> {
+        let mut exit_reason = None;
+        let progress = {
+            let handler = self.inner.proc.with_current(actor.handle_stop(
+                self,
+                request.mode,
+                &request.reason,
+            ));
+            tokio::pin!(handler);
+            loop {
+                tokio::select! {
+                    result = &mut handler => {
+                        break result.map_err(|err| {
+                            ActorError::new(self.self_addr(), ActorErrorKind::processing(err))
+                        })?;
+                    }
+                    signal = signal_receiver.recv() => {
+                        let signal = signal.ok_or_else(|| {
+                            ActorError::new(self.self_addr(), ActorErrorKind::SignalChannelClosed)
+                        })?;
+                        self.apply_stop_signal(signal, &mut exit_reason)?;
+                    }
+                }
+            }
+        };
+
+        // The hook may have waited on children, so commit their verdicts before
+        // a clean exit can be taken.
+        self.process_queued_supervision_events(actor, supervision_event_receiver)
+            .await?;
+        self.process_queued_stop_signals(signal_receiver, &mut exit_reason)?;
+
+        if let Some(reason) = exit_reason {
+            return Ok(StopOutcome::Exit(reason));
+        }
+
+        Ok(match progress {
+            StopProgress::Complete => StopOutcome::Exit(request.reason),
+            StopProgress::Continue => StopOutcome::Continue,
+        })
+    }
+
+    /// Apply a lifecycle signal while cooperative shutdown is in progress.
+    ///
+    /// `Kill` wins over clean completion, the first explicit exit reason wins
+    /// over later exits, and additional cooperative stop requests are ignored.
+    fn apply_stop_signal(
+        &self,
+        signal: Signal,
+        exit_reason: &mut Option<String>,
+    ) -> Result<(), ActorError> {
+        match signal {
+            Signal::Kill(reason) => Err(ActorError::new(
+                self.self_addr(),
+                ActorErrorKind::Aborted(reason),
+            )),
+            Signal::ExitRequested(reason) => {
+                exit_reason.get_or_insert(reason);
+                Ok(())
+            }
+            Signal::Stop(_) | Signal::DrainAndStop(_) => Ok(()),
+        }
+    }
+
+    /// Process lifecycle signals queued when the stop hook completed.
+    fn process_queued_stop_signals(
+        &self,
+        signal_receiver: &mut mpsc::UnboundedReceiver<Signal>,
+        exit_reason: &mut Option<String>,
+    ) -> Result<(), ActorError> {
+        while let Ok(signal) = signal_receiver.try_recv() {
+            self.apply_stop_signal(signal, exit_reason)?;
+        }
+        Ok(())
+    }
+
+    /// Deliver all queued supervision events before committing a competing
+    /// terminal result.
+    async fn process_queued_supervision_events(
+        &self,
+        actor: &mut A,
+        supervision_event_receiver: &mut mpsc::UnboundedReceiver<ActorSupervisionEvent>,
+    ) -> Result<(), ActorError> {
+        while let Ok(supervision_event) = supervision_event_receiver.try_recv() {
+            self.handle_supervision_event(actor, supervision_event)
+                .await?;
+        }
+        Ok(())
     }
 
     /// Initialize and run the actor until it fails or is stopped. On success,
-    /// returns why the actor stopped and the mode that child actors inherit.
-    /// On failure, returns the error that caused the failure.
+    /// returns why the actor stopped. On failure, returns the error that caused the failure.
     async fn run(
         &mut self,
         actor: &mut A,
@@ -3356,9 +3469,8 @@ impl<A: Actor> Instance<A> {
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
         work_rx: &mut ActorWorkReceiver<A>,
-    ) -> Result<ActorStopped, ActorError> {
+    ) -> Result<String, ActorError> {
         let (signal_receiver, supervision_event_receiver) = actor_loop_receivers;
-        let mut stop_mode = StopMode::Stop;
 
         self.change_status(ActorStatus::Initializing);
         self.inner
@@ -3367,8 +3479,9 @@ impl<A: Actor> Instance<A> {
             .await
             .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::init(err)))?;
         let actor_id_str = self.self_addr().to_string();
+        let mut run_state = LoopState::Running;
         let stop_reason = 'messages: loop {
-            if !self.is_stopping() {
+            if matches!(&run_state, LoopState::Running) {
                 self.change_status(ActorStatus::Idle);
             }
             let next_delayed_deadline = self.inner.delayed_posts.next_deadline();
@@ -3382,30 +3495,61 @@ impl<A: Actor> Instance<A> {
                     tracing::debug!("received signal {signal:?}");
                     match signal {
                         Signal::Stop(reason) => {
-                            stop_mode = StopMode::Stop;
+                            if !matches!(&run_state, LoopState::Running) {
+                                continue 'messages;
+                            }
                             self.change_status(ActorStatus::stopping());
-                            self.inner
-                                .proc
-                                .with_current(actor.handle_stop(self, StopMode::Stop, &reason))
-                                .await
-                                .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::processing(err)))?;
+                            let request = StopRequest {
+                                mode: StopMode::Stop,
+                                reason,
+                            };
+                            run_state = match self
+                                .run_stop_handler(
+                                    actor,
+                                    request,
+                                    signal_receiver,
+                                    supervision_event_receiver,
+                                )
+                                .await?
+                            {
+                                StopOutcome::Exit(reason) => break 'messages reason,
+                                StopOutcome::Continue => LoopState::AwaitingExit,
+                            };
                         },
                         Signal::DrainAndStop(reason) => {
-                            stop_mode = StopMode::DrainAndStop;
+                            if !matches!(&run_state, LoopState::Running) {
+                                continue 'messages;
+                            }
                             self.change_status(ActorStatus::stopping());
-                            self.inner
-                                .proc
-                                .with_current(actor.handle_stop(self, StopMode::DrainAndStop, &reason))
-                                .await
-                                .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::processing(err)))?;
+                            self.close();
+                            let request = StopRequest {
+                                mode: StopMode::DrainAndStop,
+                                reason,
+                            };
+                            let (drain_stop_tx, rx) = oneshot::channel();
+                            self.handle_stop_after_drain(request, drain_stop_tx)?;
+                            run_state = LoopState::Draining(rx);
                         },
-                        Signal::ExitRequested(reason) => {
-                            break 'messages reason;
-                        }
+                        Signal::ExitRequested(reason) => break 'messages reason,
                         Signal::Kill(reason) => {
                             return Err(ActorError { actor_id: Box::new(self.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) });
                         }
                     }
+                }
+                request = run_state.drain_request() => {
+                    let request = request.expect("drain barrier sender should remain alive");
+                    run_state = match self
+                        .run_stop_handler(
+                            actor,
+                            request,
+                            signal_receiver,
+                            supervision_event_receiver,
+                        )
+                        .await?
+                    {
+                        StopOutcome::Exit(reason) => break 'messages reason,
+                        StopOutcome::Continue => LoopState::AwaitingExit,
+                    };
                 }
                 work = work_rx.recv() => {
                     ACTOR_MESSAGES_RECEIVED.add(1, metric_pairs);
@@ -3413,9 +3557,8 @@ impl<A: Actor> Instance<A> {
                     let _ = ACTOR_MESSAGE_HANDLER_DURATION.start(metric_pairs);
                     let work = work.expect("inconsistent work queue state");
                     if let Err(err) = work.handle(actor, self).await {
-                        while let Ok(supervision_event) = supervision_event_receiver.try_recv() {
-                            self.handle_supervision_event(actor, supervision_event).await?;
-                        }
+                        self.process_queued_supervision_events(actor, supervision_event_receiver)
+                            .await?;
                         let kind = ActorErrorKind::processing(err);
                         return Err(ActorError {
                             actor_id: Box::new(self.self_addr().clone()),
@@ -3453,10 +3596,7 @@ impl<A: Actor> Instance<A> {
             reason = stop_reason,
             "exited actor loop",
         );
-        Ok(ActorStopped {
-            reason: stop_reason,
-            stop_mode,
-        })
+        Ok(stop_reason)
     }
 
     /// Handle a supervision event using the provided actor.
@@ -4610,11 +4750,6 @@ impl InstanceCell {
     /// Unlink this instance from a child.
     fn unlink(&self, child: &InstanceCell) -> bool {
         self.inner.unlink(child.inner.as_ref())
-    }
-
-    /// Unlink this instance from all children.
-    fn unlink_all(&self) {
-        self.inner.children.clear();
     }
 
     /// Link this instance to its parent, if it has one.
@@ -6720,7 +6855,7 @@ mod tests {
 
         parent.drain_and_stop("test").unwrap();
         assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
-        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -6864,7 +6999,7 @@ mod tests {
                     .try_post(&client, TestActorMessage::Noop())
                     .is_err()
             );
-            assert_matches!(actor.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+            assert_matches!(actor.await, ActorStatus::Stopped(reason) if reason == "test");
         }
     }
 
@@ -6879,6 +7014,7 @@ mod tests {
     enum DrainCountingMessage {
         Block(oneshot::Sender<()>, oneshot::Receiver<()>),
         Count(),
+        Spawn(oneshot::Sender<ActorHandle<TestActor>>),
     }
 
     #[async_trait]
@@ -6897,6 +7033,15 @@ mod tests {
 
         async fn count(&mut self, _cx: &crate::Context<Self>) -> Result<(), anyhow::Error> {
             self.handled.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn spawn(
+            &mut self,
+            cx: &crate::Context<Self>,
+            child: oneshot::Sender<ActorHandle<TestActor>>,
+        ) -> Result<(), anyhow::Error> {
+            child.send(cx.spawn(TestActor)).unwrap();
             Ok(())
         }
     }
@@ -6934,8 +7079,112 @@ mod tests {
         release.send(()).unwrap();
 
         assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
-        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
         assert_eq!(handled.load(Ordering::SeqCst), 5);
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn drain_includes_children_spawned_by_accepted_work() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let parent = proc.spawn(DrainCountingActor {
+            handled: Arc::new(AtomicUsize::new(0)),
+        });
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        parent.post(&client, DrainCountingMessage::Block(entered_tx, release_rx));
+        entered_rx.await.unwrap();
+        let (child_tx, child_rx) = oneshot::channel();
+        parent.post(&client, DrainCountingMessage::Spawn(child_tx));
+
+        parent.drain_and_stop("test").unwrap();
+        release_tx.send(()).unwrap();
+        let child = child_rx.await.unwrap();
+
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn stopping_parent_waits_for_blocked_child() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        let release = block_and_queue_counts(&client, &child, 0).await;
+        let mut parent_status = parent.status();
+
+        parent.stop("test").unwrap();
+        parent_status
+            .wait_for(ActorStatus::is_stopping)
+            .await
+            .unwrap();
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(100),
+                parent_status.wait_for(ActorStatus::is_terminal),
+            )
+            .await
+            .is_err(),
+            "parent stopped before its child"
+        );
+
+        release.send(()).unwrap();
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_interrupts_parent_waiting_for_child() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let parent_cell = parent.cell().clone();
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        let child_cell = child.cell().clone();
+        let release = block_and_queue_counts(&client, &child, 0).await;
+
+        parent.stop("stop").unwrap();
+        parent
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_stopping)
+            .await
+            .unwrap();
+        parent.kill("kill").unwrap();
+
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: kill"
+        );
+        child_cell
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_zombie)
+            .await
+            .unwrap();
+        assert!(child_cell.parent().is_none());
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(proc.root_actor_ids().contains(child_cell.actor_addr()));
+
+        release.send(()).unwrap();
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -6957,9 +7206,41 @@ mod tests {
         release.send(()).unwrap();
 
         assert_matches!(grandparent.await, ActorStatus::Stopped(reason) if reason == "test");
-        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "parent draining");
-        assert_matches!(grandchild.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(grandchild.await, ActorStatus::Stopped(reason) if reason == "test");
         assert_eq!(handled.load(Ordering::SeqCst), 7);
+    }
+
+    #[derive(Debug)]
+    struct ExitThenKillActor;
+
+    #[async_trait]
+    impl Actor for ExitThenKillActor {
+        async fn handle_stop(
+            &mut self,
+            this: &Instance<Self>,
+            _mode: StopMode,
+            _reason: &str,
+        ) -> Result<StopProgress, anyhow::Error> {
+            this.exit("exit")?;
+            this.kill("kill")?;
+            Ok(StopProgress::Complete)
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn queued_kill_wins_over_exit() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let actor = proc.spawn(ExitThenKillActor);
+
+        actor.stop("stop").unwrap();
+
+        assert_matches!(
+            actor.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: kill"
+        );
     }
 
     #[derive(Debug)]
@@ -6972,8 +7253,31 @@ mod tests {
             _this: &Instance<Self>,
             _mode: StopMode,
             _reason: &str,
-        ) -> Result<(), anyhow::Error> {
+        ) -> Result<StopProgress, anyhow::Error> {
             Err(anyhow::anyhow!("stop failed"))
+        }
+    }
+
+    #[derive(Debug)]
+    struct BlockedStopParent {
+        release_stop: Option<oneshot::Receiver<()>>,
+    }
+
+    #[async_trait]
+    impl Actor for BlockedStopParent {
+        async fn handle_stop(
+            &mut self,
+            this: &Instance<Self>,
+            mode: StopMode,
+            reason: &str,
+        ) -> Result<StopProgress, anyhow::Error> {
+            let progress = crate::actor::handle_stop(this, mode, reason).await?;
+            self.release_stop
+                .take()
+                .expect("stop release should be present")
+                .await
+                .expect("stop release sender should remain alive");
+            Ok(progress)
         }
     }
 
@@ -6991,6 +7295,48 @@ mod tests {
             ActorStatus::Failed(ActorErrorKind::Generic(reason))
                 if reason.contains("parent failed")
         );
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(err) if err.to_string().contains("stop failed")
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn parent_observes_child_failure_during_stop() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let parent = proc.spawn(TestActor);
+        let child = proc.spawn_child(parent.cell().clone(), StopFailingActor);
+
+        parent.stop("test").unwrap();
+
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(err) if err.to_string().contains("stop failed")
+        );
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(err) if err.to_string().contains("stop failed")
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn queued_child_failure_is_observed_before_wait_completion() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let (release_stop_tx, release_stop_rx) = oneshot::channel();
+        let parent = proc.spawn(BlockedStopParent {
+            release_stop: Some(release_stop_rx),
+        });
+        let child = proc.spawn_child(parent.cell().clone(), StopFailingActor);
+
+        parent.stop("test").unwrap();
+
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(err) if err.to_string().contains("stop failed")
+        );
+        release_stop_tx.send(()).unwrap();
         assert_matches!(
             parent.await,
             ActorStatus::Failed(err) if err.to_string().contains("stop failed")
@@ -7243,7 +7589,7 @@ mod tests {
             _this: &Instance<Self>,
             _mode: StopMode,
             _reason: &str,
-        ) -> Result<(), anyhow::Error> {
+        ) -> Result<StopProgress, anyhow::Error> {
             Err(anyhow::anyhow!("original failure"))
         }
 
@@ -7294,7 +7640,7 @@ mod tests {
             this: &Instance<Self>,
             mode: StopMode,
             reason: &str,
-        ) -> Result<(), anyhow::Error> {
+        ) -> Result<StopProgress, anyhow::Error> {
             let this = this.clone_for_py();
             let release_stop = Arc::clone(&self.release_stop);
             let reason = reason.to_string();
@@ -7307,7 +7653,7 @@ mod tests {
                     StopMode::DrainAndStop => this.exit_after_drain(&reason).unwrap(),
                 }
             });
-            Ok(())
+            Ok(StopProgress::Continue)
         }
     }
 
@@ -7335,6 +7681,46 @@ mod tests {
 
         release_stop.notify_one();
         assert_matches!(handle.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[derive(Debug)]
+    struct MessageDrivenStopActor;
+
+    #[async_trait]
+    impl Actor for MessageDrivenStopActor {
+        async fn handle_stop(
+            &mut self,
+            _this: &Instance<Self>,
+            _mode: StopMode,
+            _reason: &str,
+        ) -> Result<StopProgress, anyhow::Error> {
+            Ok(StopProgress::Continue)
+        }
+    }
+
+    #[async_trait]
+    impl Handler<()> for MessageDrivenStopActor {
+        async fn handle(&mut self, cx: &crate::Context<Self>, _message: ()) -> anyhow::Result<()> {
+            cx.exit("shutdown message handled")?;
+            Ok(())
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn continuing_stop_processes_ordinary_work() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let actor = proc.spawn(MessageDrivenStopActor);
+        let mut status = actor.status();
+
+        actor.stop("test").unwrap();
+        status.wait_for(ActorStatus::is_stopping).await.unwrap();
+        actor.post(&client, ());
+
+        assert_matches!(
+            actor.await,
+            ActorStatus::Stopped(reason) if reason == "shutdown message handled"
+        );
     }
 
     #[async_timed_test(timeout_secs = 30)]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3150,33 +3150,14 @@ impl<A: Actor> Instance<A> {
         // Deliver the supervision event to the parent/proc BEFORE
         // change_status so that any observer waiting for this actor's
         // terminal state can only see it once the event has been
-        // enqueued at its destination.
-        if let Some(parent) = self.inner.cell.maybe_unlink_parent() {
-            if let Some(event) = event_to_deliver {
-                // Parent exists, failure should be propagated to the parent.
-                parent.send_supervision_event_or_crash(event);
-            }
-            // TODO: we should get rid of this signal, and use *only* supervision events for
-            // the purpose of conveying lifecycle changes
-            if let Err(err) = parent.signal(Signal::ChildStopped(self.inner.cell.uid().clone())) {
-                tracing::error!(
-                    "{}: failed to send stop message to parent uid {}: {:?}",
-                    self.self_addr(),
-                    parent.uid(),
-                    err
-                );
-            }
-        } else {
-            // Failure happened to the root actor or orphaned child actors.
-            // In either case, the failure should be propagated to proc.
-            //
-            // Note that orphaned actor is unexpected and would only happen if
-            // there is a bug.
-            if let Some(event) = event_to_deliver {
-                self.inner
-                    .proc
-                    .handle_unhandled_supervision_event(&self, event);
-            }
+        // enqueued at its destination. A returned event had no owning parent
+        // — the root actor, or an orphaned child, which would be a bug.
+        if let Some(event) = event_to_deliver
+            && let Some(event) = self.inner.cell.try_handle_completion_event(event)
+        {
+            self.inner
+                .proc
+                .handle_unhandled_supervision_event(&self, event);
         }
 
         self.stop_introspect(terminal_status.clone()).await;
@@ -3255,18 +3236,18 @@ impl<A: Actor> Instance<A> {
             self.inner.cell.unlink(&child);
         }
 
-        let (mut signal_receiver, _) = actor_loop_receivers;
+        let (_, mut supervision_event_receiver) = actor_loop_receivers;
         while self.inner.cell.child_count() > 0 {
-            match tokio::time::timeout(Duration::from_millis(500), signal_receiver.recv()).await {
-                Ok(Some(Signal::ChildStopped(uid))) => {
-                    assert!(self.inner.cell.get_child(&uid).is_none());
-                }
-                // Drain only tracks child termination; other signals are
-                // intentionally swallowed here.
+            match tokio::time::timeout(
+                Duration::from_millis(500),
+                supervision_event_receiver.recv(),
+            )
+            .await
+            {
                 Ok(Some(_)) => {}
                 Ok(None) => {
-                    // Signal channel closed: no further ChildStopped will
-                    // arrive, so we can no longer track child termination.
+                    // The supervision channel closed, so no further child
+                    // completion events can arrive.
                     // Drop remaining links and exit the drain loop, mirroring
                     // the timeout branch below.
                     self.inner.cell.unlink_all();
@@ -3274,7 +3255,7 @@ impl<A: Actor> Instance<A> {
                 }
                 Err(_) => {
                     tracing::warn!(
-                        "timeout waiting for ChildStopped signal from child on actor: {}, ignoring",
+                        "timeout waiting for child supervision event on actor: {}, ignoring",
                         self.self_addr()
                     );
                     // No more waiting to receive messages. Unlink all remaining
@@ -3381,9 +3362,6 @@ impl<A: Actor> Instance<A> {
                                 .with_current(actor.handle_stop(self, StopMode::DrainAndStop, &reason))
                                 .await
                                 .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::processing(err)))?;
-                        },
-                        Signal::ChildStopped(uid) => {
-                            assert!(self.inner.cell.get_child(&uid).is_none());
                         },
                         Signal::ExitRequested(reason) => {
                             break 'messages reason;
@@ -4124,6 +4102,28 @@ impl SupervisionLink {
 }
 
 impl InstanceCellState {
+    /// Deliver this instance's terminal event to its supervising actor, then
+    /// unlink. Returns the event if there is no owning parent to take it.
+    ///
+    /// The parent's completion barrier is `child_count()`, so unlinking first
+    /// would let the parent finish before the event is enqueued.
+    fn try_handle_completion_event(
+        &self,
+        event: ActorSupervisionEvent,
+    ) -> Option<ActorSupervisionEvent> {
+        let Some(parent) = self.supervision_link.parent() else {
+            return Some(event);
+        };
+        let Some(child_entry) = parent.inner.children.get(self.actor_id.uid()) else {
+            return Some(event);
+        };
+
+        parent.send_supervision_event_or_crash(event);
+        drop(child_entry);
+        parent.inner.unlink(self);
+        None
+    }
+
     /// Unlink this instance from its parent, if it has one. If it was unlinked,
     /// the parent is returned.
     fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
@@ -4555,10 +4555,11 @@ impl InstanceCell {
         }
     }
 
-    /// Unlink this instance from its parent, if it has one. If it was unlinked,
-    /// the parent is returned.
-    fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
-        self.inner.maybe_unlink_parent()
+    fn try_handle_completion_event(
+        &self,
+        event: ActorSupervisionEvent,
+    ) -> Option<ActorSupervisionEvent> {
+        self.inner.try_handle_completion_event(event)
     }
 
     /// Return an iterator over this instance's children. This may deadlock if the
@@ -4581,7 +4582,7 @@ impl InstanceCell {
             .collect()
     }
 
-    /// Get a child by its uid.
+    #[cfg(test)]
     fn get_child(&self, uid: &crate::id::Uid) -> Option<InstanceCell> {
         self.inner.children.get(uid).map(|child| child.clone())
     }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2088,26 +2088,10 @@ struct ActorStopped {
     stop_mode: StopMode,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ChildTeardown {
-    Cooperative(StopMode),
-    Kill,
-}
-
-impl ChildTeardown {
-    fn from_run_result(result: &Result<ActorStopped, ActorError>) -> Self {
-        match result {
-            Ok(stopped) => Self::Cooperative(stopped.stop_mode),
-            Err(err) if matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)) => Self::Kill,
-            Err(_) => Self::Cooperative(StopMode::Stop),
-        }
-    }
-
-    fn cooperative_signal(mode: StopMode) -> Signal {
-        match mode {
-            StopMode::DrainAndStop => Signal::DrainAndStop("parent draining".to_string()),
-            StopMode::Stop => Signal::Stop("parent stopping".to_string()),
-        }
+fn cooperative_child_signal(mode: StopMode) -> Signal {
+    match mode {
+        StopMode::DrainAndStop => Signal::DrainAndStop("parent draining".to_string()),
+        StopMode::Stop => Signal::Stop("parent stopping".to_string()),
     }
 }
 
@@ -3127,32 +3111,17 @@ impl<A: Actor> Instance<A> {
             },
         };
 
-        let current_status = self.inner.cell.status().borrow().clone();
-        // FI-9: supervisors observe the zombie lifecycle verdict, while the event
-        // stored below must describe the terminal status for introspection.
-        let event_to_deliver = if current_status.is_zombie() {
-            Some(ActorSupervisionEvent::new(
-                self.inner.cell.actor_addr().clone(),
-                actor.display_name(),
-                current_status,
-                None,
-            ))
-        } else {
-            event.clone()
-        };
-
         self.mailbox().close(terminal_status.clone());
         // FI-1: store supervision_event BEFORE change_status.
         if let Some(event) = &event {
             *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event.clone());
         }
 
-        // Deliver the supervision event to the parent/proc BEFORE
-        // change_status so that any observer waiting for this actor's
-        // terminal state can only see it once the event has been
-        // enqueued at its destination. A returned event had no owning parent
-        // — the root actor, or an orphaned child, which would be a bug.
-        if let Some(event) = event_to_deliver
+        // Resolve completion routing BEFORE change_status so that any observer
+        // waiting for this actor's terminal state cannot race the supervision
+        // decision. A returned event had no owning parent and must follow the
+        // proc's unhandled-supervision path.
+        if let Some(event) = event
             && let Some(event) = self.inner.cell.try_handle_completion_event(event)
         {
             self.inner
@@ -3164,9 +3133,40 @@ impl<A: Actor> Instance<A> {
         self.change_status(terminal_status);
     }
 
-    /// Runs the actor, and manages its supervision tree. When the function returns,
-    /// the whole tree rooted at this actor has stopped. On success, returns the reason
-    /// why the actor stopped. On failure, returns the error that caused the failure.
+    fn kill_residual_children(&self, reason: &str) {
+        // Detach the whole subtree, not just direct children: a child that
+        // never processes `Kill` would otherwise strand its own descendants
+        // under a zombie, where neither this parent nor the proc reaches them.
+        //
+        // Collecting first also keeps no child-map guard held while taking a
+        // child's supervision lock. Completion routing takes the supervision
+        // lock first.
+        let mut children = Vec::new();
+        self.inner.cell.traverse(&mut |cell: &InstanceCell, depth| {
+            if depth > 0 {
+                children.push(cell.clone());
+            }
+        });
+        for child in children {
+            if !child.detach_to_proc_as_zombie(format!(
+                "detached during forced parent teardown: {reason}"
+            )) {
+                continue;
+            }
+            if let Err(err) = child.signal(Signal::Kill(reason.to_string())) {
+                tracing::debug!(
+                    actor_id = %self.self_addr(),
+                    child_id = %child.actor_addr(),
+                    "detached child already stopped during forced teardown: {}",
+                    err,
+                );
+            }
+        }
+    }
+
+    /// Runs the actor and initiates teardown of its supervision tree. On success,
+    /// returns the reason why the actor stopped. On failure, returns the error that
+    /// caused the failure after transferring residual children to the proc.
     async fn run_actor_tree(
         &mut self,
         actor: &mut A,
@@ -3209,59 +3209,57 @@ impl<A: Actor> Instance<A> {
             tracing::error!("{}: actor failure: {}", self.self_addr(), err);
         }
 
-        // After this point, we know we won't spawn any more children,
-        // so we can safely read the current child keys.
-        let mut to_unlink = Vec::new();
-        let child_signal = match ChildTeardown::from_run_result(&result) {
-            ChildTeardown::Cooperative(mode) => ChildTeardown::cooperative_signal(mode),
-            ChildTeardown::Kill => {
-                // TODO: fan out kill once child teardown can detach
-                // unresponsive children without blocking this parent.
-                ChildTeardown::cooperative_signal(StopMode::Stop)
-            }
-        };
-        for child in self.inner.cell.child_iter() {
-            if let Err(err) = child.value().signal(child_signal.clone()) {
-                tracing::error!(
-                    "{}: failed to send stop signal to child pid {}: {:?}",
-                    self.self_addr(),
-                    child.key(),
-                    err
-                );
-                to_unlink.push(child.value().clone());
-            }
-        }
-        // Manually unlink children that have already been stopped.
-        for child in to_unlink {
-            self.inner.cell.unlink(&child);
-        }
-
-        let (_, mut supervision_event_receiver) = actor_loop_receivers;
-        while self.inner.cell.child_count() > 0 {
-            match tokio::time::timeout(
-                Duration::from_millis(500),
-                supervision_event_receiver.recv(),
-            )
-            .await
-            {
-                Ok(Some(_)) => {}
-                Ok(None) => {
-                    // The supervision channel closed, so no further child
-                    // completion events can arrive.
-                    // Drop remaining links and exit the drain loop, mirroring
-                    // the timeout branch below.
-                    self.inner.cell.unlink_all();
-                    break;
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        "timeout waiting for child supervision event on actor: {}, ignoring",
-                        self.self_addr()
+        if let Err(err) = &result {
+            let teardown_reason = format!("parent failed: {err}");
+            self.kill_residual_children(&teardown_reason);
+        } else if let Ok(stopped) = &result {
+            // After this point, we know we won't spawn any more children,
+            // so we can safely read the current child keys.
+            let mut to_unlink = Vec::new();
+            let child_signal = cooperative_child_signal(stopped.stop_mode);
+            for child in self.inner.cell.child_iter() {
+                if let Err(err) = child.value().signal(child_signal.clone()) {
+                    tracing::error!(
+                        "{}: failed to send stop signal to child pid {}: {:?}",
+                        self.self_addr(),
+                        child.key(),
+                        err
                     );
-                    // No more waiting to receive messages. Unlink all remaining
-                    // children.
-                    self.inner.cell.unlink_all();
-                    break;
+                    to_unlink.push(child.value().clone());
+                }
+            }
+            // Manually unlink children that have already been stopped.
+            for child in to_unlink {
+                self.inner.cell.unlink(&child);
+            }
+
+            let (_, mut supervision_event_receiver) = actor_loop_receivers;
+            while self.inner.cell.child_count() > 0 {
+                match tokio::time::timeout(
+                    Duration::from_millis(500),
+                    supervision_event_receiver.recv(),
+                )
+                .await
+                {
+                    Ok(Some(_)) => {}
+                    Ok(None) => {
+                        // The supervision channel closed, so no further child
+                        // completion events can arrive.
+                        // Drop remaining links and exit the drain loop, mirroring
+                        // the timeout branch below.
+                        self.inner.cell.unlink_all();
+                        break;
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            "timeout waiting for child supervision event on actor: {}, ignoring",
+                            self.self_addr()
+                        );
+                        // No more waiting to receive messages. Unlink all remaining
+                        // children.
+                        self.inner.cell.unlink_all();
+                        break;
+                    }
                 }
             }
         }
@@ -3974,7 +3972,7 @@ struct InstanceCellState {
     status: watch::Receiver<ActorStatus>,
 
     /// The actor or proc that currently supervises this instance.
-    supervision_link: SupervisionLink,
+    supervision_link: Mutex<SupervisionLink>,
 
     /// This instance's children by their uids.
     children: DashMap<crate::id::Uid, InstanceCell>,
@@ -4102,22 +4100,41 @@ impl SupervisionLink {
 }
 
 impl InstanceCellState {
-    /// Deliver this instance's terminal event to its supervising actor, then
-    /// unlink. Returns the event if there is no owning parent to take it.
-    ///
-    /// The parent's completion barrier is `child_count()`, so unlinking first
-    /// would let the parent finish before the event is enqueued.
+    /// Tries to consume a terminal event while holding supervision ownership
+    /// against forced detachment. It delivers the event to an owning parent or
+    /// suppresses it after zombie detachment, returning it only when proc
+    /// supervision must handle it.
     fn try_handle_completion_event(
         &self,
         event: ActorSupervisionEvent,
     ) -> Option<ActorSupervisionEvent> {
-        let Some(parent) = self.supervision_link.parent() else {
+        let link = self.supervision_link.lock().unwrap();
+        // FI-9: detachment already removed a zombie from its parent's completion
+        // barrier. Preserve its terminal event for introspection without
+        // re-entering supervision.
+        if self.status.borrow().is_zombie() {
+            assert!(
+                matches!(&*link, SupervisionLink::Proc),
+                "zombie actor {} is not proc-supervised",
+                self.actor_id
+            );
+            return None;
+        }
+
+        let SupervisionLink::Actor(parent) = &*link else {
+            return Some(event);
+        };
+        let Some(parent) = parent.upgrade() else {
             return Some(event);
         };
         let Some(child_entry) = parent.inner.children.get(self.actor_id.uid()) else {
             return Some(event);
         };
 
+        // Keep completion delivery and parent-map removal in one ownership
+        // critical section so forced teardown cannot retarget between them.
+        // Delivery precedes the unlink because the parent's completion barrier
+        // is `child_count()`.
         parent.send_supervision_event_or_crash(event);
         drop(child_entry);
         parent.inner.unlink(self);
@@ -4127,9 +4144,9 @@ impl InstanceCellState {
     /// Unlink this instance from its parent, if it has one. If it was unlinked,
     /// the parent is returned.
     fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
-        self.supervision_link
-            .parent()
-            .filter(|parent| parent.inner.unlink(self))
+        // Release the link before calling into the parent.
+        let parent = self.supervision_link.lock().unwrap().parent();
+        parent.filter(|parent| parent.inner.unlink(self))
     }
 
     /// Unlink this instance from a child.
@@ -4248,9 +4265,11 @@ impl InstanceCell {
                 actor_loop,
                 status_tx,
                 status,
-                supervision_link: parent.as_ref().map_or(SupervisionLink::Proc, |cell| {
-                    SupervisionLink::Actor(cell.downgrade())
-                }),
+                supervision_link: Mutex::new(
+                    parent.as_ref().map_or(SupervisionLink::Proc, |cell| {
+                        SupervisionLink::Actor(cell.downgrade())
+                    }),
+                ),
                 children: DashMap::new(),
                 actor_task_handle: OnceLock::new(),
                 exported_named_ports: DashMap::new(),
@@ -4317,13 +4336,26 @@ impl InstanceCell {
     /// the last status was active for.
     #[track_caller]
     fn change_status(&self, new: ActorStatus) {
+        let actor_linked = new.is_zombie()
+            && matches!(
+                &*self.inner.supervision_link.lock().unwrap(),
+                SupervisionLink::Actor(_)
+            );
+        self.change_status_inner(new, actor_linked);
+    }
+
+    /// `change_status`, with the supervision link already classified by the
+    /// caller. `supervision_link` is not reentrant, so a caller that holds it
+    /// must pass `actor_linked` instead of letting `change_status` re-lock.
+    #[track_caller]
+    fn change_status_inner(&self, new: ActorStatus, actor_linked: bool) {
         let mut old_status = None;
         let mut illegal_status = None;
         let actor_id = self.actor_addr().id().clone();
         let changed = self.inner.status_tx.send_if_modified(|status| {
             let old = status.clone();
             let mut status_change = classify_status_change(&old, &new);
-            if status_change == StatusChange::Apply && new.is_zombie() && self.parent().is_some() {
+            if status_change == StatusChange::Apply && new.is_zombie() && actor_linked {
                 status_change = StatusChange::Illegal(IllegalStatusChange::LinkedZombie);
             }
 
@@ -4538,9 +4570,8 @@ impl InstanceCell {
     }
 
     /// Unlink this instance from a child.
-    fn unlink(&self, child: &InstanceCell) {
-        assert_eq!(self.actor_addr().proc_id(), child.actor_addr().proc_id());
-        self.inner.children.remove(child.uid());
+    fn unlink(&self, child: &InstanceCell) -> bool {
+        self.inner.unlink(child.inner.as_ref())
     }
 
     /// Unlink this instance from all children.
@@ -4550,7 +4581,9 @@ impl InstanceCell {
 
     /// Link this instance to its parent, if it has one.
     fn maybe_link_parent(&self) {
-        if let Some(parent) = self.inner.supervision_link.parent() {
+        // Release the link before calling into the parent.
+        let parent = self.inner.supervision_link.lock().unwrap().parent();
+        if let Some(parent) = parent {
             parent.link(self.clone());
         }
     }
@@ -4560,6 +4593,30 @@ impl InstanceCell {
         event: ActorSupervisionEvent,
     ) -> Option<ActorSupervisionEvent> {
         self.inner.try_handle_completion_event(event)
+    }
+
+    /// Transfers a non-terminal child to proc supervision and publishes its
+    /// zombie status while holding the completion-routing lock.
+    ///
+    /// If detachment wins a completion race, the later terminal event remains
+    /// available to introspection but does not re-enter supervision.
+    fn detach_to_proc_as_zombie(&self, reason: String) -> bool {
+        let mut link = self.inner.supervision_link.lock().unwrap();
+        let SupervisionLink::Actor(parent) = &*link else {
+            return false;
+        };
+        if self.status().borrow().is_terminal() {
+            return false;
+        }
+        let parent = parent.clone();
+        if let Some(parent) = parent.upgrade()
+            && !parent.unlink(self)
+        {
+            return false;
+        }
+        *link = SupervisionLink::Proc;
+        self.change_status_inner(ActorStatus::zombie(reason), false);
+        true
     }
 
     /// Return an iterator over this instance's children. This may deadlock if the
@@ -4690,13 +4747,16 @@ impl InstanceCell {
 
     /// Get parent instance cell, if it exists.
     pub fn parent(&self) -> Option<InstanceCell> {
-        self.inner.supervision_link.parent()
+        self.inner.supervision_link.lock().unwrap().parent()
     }
 
     /// Whether the proc supervises this instance directly. Distinct from
     /// `parent().is_none()`, which is also true of an expired actor link.
     fn is_proc_supervised(&self) -> bool {
-        matches!(&self.inner.supervision_link, SupervisionLink::Proc)
+        matches!(
+            &*self.inner.supervision_link.lock().unwrap(),
+            SupervisionLink::Proc
+        )
     }
 
     /// The actor's type name.
@@ -6653,12 +6713,12 @@ mod tests {
         assert_matches!(handle.await, ActorStatus::Stopped(reason) if reason == "test");
     }
 
-    // FI-9: stored-terminal and delivered-zombie intentionally diverge.
+    // FI-9: a detached zombie stores its terminal event without propagating it.
     #[async_timed_test(timeout_secs = 60)]
-    async fn zombie_task_failure_stores_terminal_event_and_reports_zombie() {
+    async fn zombie_task_failure_stores_terminal_event_without_propagation() {
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let (mut reported_event, _coordinator) =
+        let (mut reported_event, coordinator) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
         let handle = proc.spawn_with_label::<TestActor>("alive", TestActor);
         let actor_id = handle.actor_addr().clone();
@@ -6692,17 +6752,16 @@ mod tests {
         );
         assert_eq!(event.actor_status, terminal_status);
 
-        let propagated = tokio::time::timeout(Duration::from_secs(1), reported_event.recv())
-            .await
-            .expect("zombie supervision event should arrive");
-        assert!(
-            propagated.actor_status.is_zombie(),
-            "zombie task failure should report its zombie lifecycle verdict"
+        // The marker is posted after the zombie reaches terminal status. Receiving
+        // it first proves that the earlier zombie completion was not propagated.
+        let marker = ActorSupervisionEvent::new(
+            coordinator.actor_addr().clone(),
+            None,
+            ActorStatus::Stopped("completion barrier".to_string()),
+            None,
         );
-        assert!(
-            !propagated.is_error(),
-            "zombie supervision event should remain non-error"
-        );
+        coordinator.post(&client, marker.clone());
+        assert_eq!(reported_event.recv().await, marker);
 
         let view = wait_for_terminated_actor_view(&proc, &actor_id).await;
         assert_eq!(
@@ -6881,7 +6940,7 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 30)]
-    async fn failed_drain_stop_stops_children_immediately() {
+    async fn failed_stop_hard_kills_children() {
         let proc = Proc::isolated();
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
         let parent = proc.spawn(StopFailingActor);
@@ -6889,11 +6948,151 @@ mod tests {
 
         parent.drain_and_stop("test").unwrap();
 
-        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent stopping");
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
         assert_matches!(
             parent.await,
             ActorStatus::Failed(err) if err.to_string().contains("stop failed")
         );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_detaches_blocked_child() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let parent_cell = parent.cell().clone();
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        let child_cell = child.cell().clone();
+        let release = block_and_queue_counts(&client, &child, 0).await;
+
+        parent.kill("kill").unwrap();
+
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: kill"
+        );
+        child_cell
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_zombie)
+            .await
+            .unwrap();
+        assert!(child_cell.parent().is_none());
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(proc.root_actor_ids().contains(child_cell.actor_addr()));
+
+        release.send(()).unwrap();
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_detaches_subtree_under_blocked_child() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        let child_cell = child.cell().clone();
+        let grandchild = proc.spawn_child(child_cell.clone(), TestActor);
+        let grandchild_cell = grandchild.cell().clone();
+        let release = block_and_queue_counts(&client, &child, 0).await;
+
+        parent.kill("kill").unwrap();
+
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: kill"
+        );
+
+        // The blocked child cannot process `Kill`, so it never tears down its
+        // own subtree. The grandchild must still reach the proc.
+        assert_eq!(child_cell.child_count(), 0);
+        assert!(grandchild_cell.parent().is_none());
+        assert!(proc.root_actor_ids().contains(grandchild_cell.actor_addr()));
+        assert_matches!(
+            grandchild.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+
+        release.send(()).unwrap();
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn completion_delivery_prevents_late_detach() {
+        let proc = Proc::isolated();
+        let parent = proc.spawn(TestActor);
+        let parent_cell = parent.cell().clone();
+        let child = proc.spawn_child(parent_cell.clone(), TestActor);
+        let child_cell = child.cell().clone();
+        let event = ActorSupervisionEvent::new(
+            child_cell.actor_addr().clone(),
+            None,
+            ActorStatus::Stopped("test completion".to_string()),
+            None,
+        );
+
+        assert!(child_cell.try_handle_completion_event(event).is_none());
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(!child_cell.detach_to_proc_as_zombie("forced teardown".to_string()));
+
+        child.drain_and_stop("test").unwrap();
+        parent.drain_and_stop("test").unwrap();
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn detach_suppresses_racing_completion() {
+        let proc = Proc::isolated();
+        let parent = proc.spawn(TestActor);
+        let parent_cell = parent.cell().clone();
+        let child = proc.spawn_child(parent_cell.clone(), TestActor);
+        let child_cell = child.cell().clone();
+
+        // Model completion creating its terminal event before forced teardown
+        // wins the ownership race.
+        let event = ActorSupervisionEvent::new(
+            child_cell.actor_addr().clone(),
+            None,
+            ActorStatus::Stopped("test completion".to_string()),
+            None,
+        );
+        assert!(child_cell.detach_to_proc_as_zombie("forced teardown".to_string()));
+        assert!(child_cell.try_handle_completion_event(event).is_none());
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(child_cell.parent().is_none());
+
+        child.drain_and_stop("test").unwrap();
+        parent.drain_and_stop("test").unwrap();
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
     }
 
     #[derive(Debug)]
@@ -6998,15 +7197,20 @@ mod tests {
             ActorStatus::Failed(err) if err.to_string() == "some random failure"
         );
 
-        // TODO: should we provide finer-grained stop reasons, e.g., to indicate it was
-        // stopped by a parent failure?
-        // Currently the parent fails with an error related to the child's failure.
         assert_matches!(
             root.await,
             ActorStatus::Failed(err) if err.to_string().contains("some random failure")
         );
-        assert_matches!(root_2_1.await, ActorStatus::Stopped(_));
-        assert_matches!(root_1.await, ActorStatus::Stopped(_));
+        assert_matches!(
+            root_2_1.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+        assert_matches!(
+            root_1.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -8522,35 +8726,6 @@ mod tests {
         // would panic in debug builds if running_total had wrapped to u64::MAX.
         account_enqueue(&depth, &stats, "a");
         assert_eq!(stats.running_total(), 1);
-    }
-
-    #[test]
-    fn child_teardown_distinguishes_kill_from_failure() {
-        let actor_addr = test_actor_id("proc", "actor");
-
-        let stopped = Ok(ActorStopped {
-            reason: "test".to_string(),
-            stop_mode: StopMode::DrainAndStop,
-        });
-        assert_eq!(
-            ChildTeardown::from_run_result(&stopped),
-            ChildTeardown::Cooperative(StopMode::DrainAndStop)
-        );
-
-        let killed = Err(ActorError::new(
-            &actor_addr,
-            ActorErrorKind::Aborted("test kill".to_string()),
-        ));
-        assert_eq!(ChildTeardown::from_run_result(&killed), ChildTeardown::Kill);
-
-        let failed = Err(ActorError::new(
-            &actor_addr,
-            ActorErrorKind::Generic("test failure".to_string()),
-        ));
-        assert_eq!(
-            ChildTeardown::from_run_result(&failed),
-            ChildTeardown::Cooperative(StopMode::Stop)
-        );
     }
 
     hyperactor_config::attrs::declare_attrs! {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1295,12 +1295,16 @@ impl Proc {
 
         instance.spawn_detached_introspect(receivers.introspect);
 
-        let (signal_rx, supervision_rx) = receivers.actor_loop.unwrap();
+        let ActorLoopReceivers {
+            signal,
+            supervision,
+            ..
+        } = receivers.actor_loop.unwrap();
         Ok(ActorInstance {
             instance,
             handle,
-            supervision: supervision_rx,
-            signal: signal_rx,
+            supervision,
+            signal,
             work: receivers.work,
         })
     }
@@ -1494,10 +1498,18 @@ impl Proc {
         self.spawn_inner(actor_id, actor, Some(parent), environment)
     }
 
-    /// Call `abort` on the `JoinHandle` associated with the given
-    /// root actor. If successful return `Some(root.clone())` else
-    /// `None`.
-    pub fn abort_root_actor(&self, root: &ActorId) -> Option<impl Future<Output = ActorAddr>> {
+    /// Abort a root actor while preserving runtime finalization.
+    ///
+    /// This cancels actor execution, including an in-progress handler or
+    /// cleanup future, but keeps the serving task alive to publish terminal
+    /// status, route supervision, and stop introspection. It does not call
+    /// [`JoinHandle::abort`], which would cancel those runtime responsibilities
+    /// together with actor execution.
+    pub(crate) fn abort_root_actor(
+        &self,
+        root: &ActorId,
+        reason: String,
+    ) -> Option<impl Future<Output = ActorAddr>> {
         self.state()
             .instances
             .get(root)
@@ -1505,20 +1517,23 @@ impl Proc {
             .flat_map(|entry| entry.value().upgrade())
             .map(|cell| {
                 let actor_addr = cell.actor_addr().clone();
-                let r1 = actor_addr.clone();
-                let r2 = actor_addr;
-                // `Instance::start()` is infallible and should
-                // complete quickly, so calling `wait()` on `actor_task_handle`
-                // should be safe (i.e., not hang forever).
+                let mut status = cell.status().clone();
+                let reason = reason.clone();
                 async move {
-                    tokio::task::spawn_blocking(move || {
-                        let h = cell.inner.actor_task_handle.wait();
-                        tracing::debug!("{}: aborting {:?}", r1, h);
-                        h.abort();
-                    })
-                    .await
-                    .unwrap();
-                    r2
+                    if !status.borrow().is_terminal() {
+                        if let Err(err) = cell.abort(reason) {
+                            tracing::debug!(
+                                actor_id = %actor_addr,
+                                "actor already stopped during Abort escalation: {}",
+                                err,
+                            );
+                        }
+                        status
+                            .wait_for(ActorStatus::is_terminal)
+                            .await
+                            .expect("aborted actor should publish terminal status");
+                    }
+                    actor_addr
                 }
             })
             .next()
@@ -1618,7 +1633,7 @@ impl Proc {
             .iter()
             .filter(|(actor_id, _)| !stopped_actors.contains(actor_id))
             .map(|(actor_id, _)| {
-                let f = self.abort_root_actor(actor_id.id());
+                let f = self.abort_root_actor(actor_id.id(), reason.to_string());
                 async move {
                     let _ = if let Some(f) = f { Some(f.await) } else { None };
                     // If `is_none(&_)` then the associated actor's
@@ -1646,7 +1661,7 @@ impl Proc {
             if stopped {
                 stopped_actors.push(coord_id.clone());
             } else {
-                if let Some(f) = self.abort_root_actor(coord_id.id()) {
+                if let Some(f) = self.abort_root_actor(coord_id.id(), reason.to_string()) {
                     f.await;
                 }
                 aborted_actors.push(coord_id.clone());
@@ -2121,6 +2136,11 @@ enum StopOutcome {
     Continue,
 }
 
+enum ActorExecutionOutcome {
+    Completed(Result<String, ActorError>),
+    Aborted(String),
+}
+
 type DelayedPost<A> = Box<dyn FnOnce(&Instance<A>) + Send>;
 
 trait PostAfterEndpoint<A: Actor, M: Message>: Send {
@@ -2450,14 +2470,23 @@ impl<A: Actor> Drop for InstanceState<A> {
 pub struct InstanceReceivers<A: Actor> {
     /// Signal and supervision receivers for the actor loop. `None`
     /// for detached/client instances that don't run an actor loop.
-    actor_loop: Option<(
-        mpsc::UnboundedReceiver<Signal>,
-        mpsc::UnboundedReceiver<ActorSupervisionEvent>,
-    )>,
+    actor_loop: Option<ActorLoopReceivers>,
     /// Work queue for dispatching messages to actor handlers.
     work: ActorWorkReceiver<A>,
     /// Introspect message receiver for the dedicated introspect task.
     introspect: PortReceiver<IntrospectMessage>,
+}
+
+struct ActorLoopSenders {
+    signal: mpsc::UnboundedSender<Signal>,
+    supervision: mpsc::UnboundedSender<ActorSupervisionEvent>,
+    abort: mpsc::UnboundedSender<String>,
+}
+
+struct ActorLoopReceivers {
+    signal: mpsc::UnboundedReceiver<Signal>,
+    supervision: mpsc::UnboundedReceiver<ActorSupervisionEvent>,
+    abort: mpsc::UnboundedReceiver<String>,
 }
 
 impl<A: Actor> Instance<A> {
@@ -2501,9 +2530,18 @@ impl<A: Actor> Instance<A> {
             let (signal_tx, signal_receiver) = mpsc::unbounded_channel::<Signal>();
             let (supervision_tx, supervision_receiver) =
                 mpsc::unbounded_channel::<ActorSupervisionEvent>();
+            let (abort_tx, abort_receiver) = mpsc::unbounded_channel::<String>();
             Some((
-                (signal_tx, supervision_tx),
-                (signal_receiver, supervision_receiver),
+                ActorLoopSenders {
+                    signal: signal_tx,
+                    supervision: supervision_tx,
+                    abort: abort_tx,
+                },
+                ActorLoopReceivers {
+                    signal: signal_receiver,
+                    supervision: supervision_receiver,
+                    abort: abort_receiver,
+                },
             ))
         };
 
@@ -3089,13 +3127,18 @@ impl<A: Actor> Instance<A> {
         // actor loop never sees IntrospectMessage.
         self.spawn_introspect(receivers.introspect);
 
-        let actor_loop_receivers = receivers
+        let ActorLoopReceivers {
+            signal,
+            supervision,
+            abort,
+        } = receivers
             .actor_loop
             .expect("non-detached instance must have actor loop receivers");
         let actor_task_handle = A::spawn_server_task(
             panic_handler::with_backtrace_tracking(self.serve(
                 actor,
-                actor_loop_receivers,
+                (signal, supervision),
+                abort,
                 receivers.work,
             ))
             .instrument(Span::current()),
@@ -3113,15 +3156,40 @@ impl<A: Actor> Instance<A> {
     async fn serve(
         mut self,
         mut actor: A,
-        actor_loop_receivers: (
+        mut actor_loop_receivers: (
             mpsc::UnboundedReceiver<Signal>,
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
+        mut abort_receiver: mpsc::UnboundedReceiver<String>,
         mut work_rx: ActorWorkReceiver<A>,
     ) {
-        let result = self
-            .run_actor_tree(&mut actor, actor_loop_receivers, &mut work_rx)
-            .await;
+        let outcome = {
+            let run_actor_tree =
+                self.run_actor_tree(&mut actor, &mut actor_loop_receivers, &mut work_rx);
+            tokio::pin!(run_actor_tree);
+            tokio::select! {
+                biased;
+                // An Abort accepted before actor execution completes owns the
+                // terminal outcome, even if both branches become ready together.
+                reason = abort_receiver.recv() => {
+                    ActorExecutionOutcome::Aborted(
+                        reason.expect("abort sender should outlive actor execution"),
+                    )
+                }
+                result = &mut run_actor_tree => ActorExecutionOutcome::Completed(result),
+            }
+        };
+        let result = match outcome {
+            ActorExecutionOutcome::Completed(result) => result,
+            ActorExecutionOutcome::Aborted(reason) => {
+                let result = Err(ActorError::new(
+                    self.self_addr(),
+                    ActorErrorKind::Aborted(reason),
+                ));
+                self.begin_actor_teardown(&result);
+                result
+            }
+        };
 
         assert!(self.is_stopping());
         // Compute the terminal status and supervision event, but defer
@@ -3160,8 +3228,11 @@ impl<A: Actor> Instance<A> {
                     .with_local_fence(local_fence);
                     (status, Some(event))
                 }
-                _ => {
-                    let error_kind = ActorErrorKind::Generic(err.kind.to_string());
+                error_kind => {
+                    let error_kind = match error_kind {
+                        error_kind @ ActorErrorKind::Aborted(_) => error_kind,
+                        error_kind => ActorErrorKind::Generic(error_kind.to_string()),
+                    };
                     let status = ActorStatus::Failed(error_kind);
                     let event = ActorSupervisionEvent::new(
                         self.inner.cell.actor_addr().clone(),
@@ -3227,13 +3298,31 @@ impl<A: Actor> Instance<A> {
         }
     }
 
+    fn begin_actor_teardown(&self, result: &Result<String, ActorError>) {
+        assert!(!self.is_terminal());
+        // `Zombie` is an out-of-band teardown verdict. Preserve it until the actor task
+        // publishes its true terminal status.
+        if !self.inner.cell.status().borrow().is_zombie() {
+            self.change_status(ActorStatus::stopping());
+        }
+        if let Err(err) = result {
+            tracing::error!("{}: actor failure: {}", self.self_addr(), err);
+        }
+
+        let teardown_reason = match result {
+            Ok(reason) => format!("parent exited: {reason}"),
+            Err(err) => format!("parent failed: {err}"),
+        };
+        self.kill_residual_children(&teardown_reason);
+    }
+
     /// Runs the actor and initiates teardown of its supervision tree. On success,
     /// returns the reason why the actor stopped. On failure, returns the error that
     /// caused the failure after transferring residual children to the proc.
     async fn run_actor_tree(
         &mut self,
         actor: &mut A,
-        mut actor_loop_receivers: (
+        actor_loop_receivers: &mut (
             mpsc::UnboundedReceiver<Signal>,
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
@@ -3245,7 +3334,7 @@ impl<A: Actor> Instance<A> {
         // What we do here is just to catch it early so we can handle it.
 
         let mut did_panic = false;
-        let result = match AssertUnwindSafe(self.run(actor, &mut actor_loop_receivers, work_rx))
+        let result = match AssertUnwindSafe(self.run(actor, actor_loop_receivers, work_rx))
             .catch_unwind()
             .await
         {
@@ -3262,21 +3351,7 @@ impl<A: Actor> Instance<A> {
             }
         };
 
-        assert!(!self.is_terminal());
-        // `Zombie` is an out-of-band teardown verdict. Preserve it until the actor task
-        // publishes its true terminal status.
-        if !self.inner.cell.status().borrow().is_zombie() {
-            self.change_status(ActorStatus::stopping());
-        }
-        if let Err(err) = &result {
-            tracing::error!("{}: actor failure: {}", self.self_addr(), err);
-        }
-
-        let teardown_reason = match &result {
-            Ok(reason) => format!("parent exited: {reason}"),
-            Err(err) => format!("parent failed: {err}"),
-        };
-        self.kill_residual_children(&teardown_reason);
+        self.begin_actor_teardown(&result);
         let was_killed = result
             .as_ref()
             .is_err_and(|err| matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)));
@@ -4126,10 +4201,7 @@ struct InstanceCellState {
     mailbox: Mailbox,
 
     /// Control plane message senders to the actor loop, if one is running.
-    actor_loop: Option<(
-        mpsc::UnboundedSender<Signal>,
-        mpsc::UnboundedSender<ActorSupervisionEvent>,
-    )>,
+    actor_loop: Option<ActorLoopSenders>,
 
     /// A watch for communicating the actor's state.
     status_tx: watch::Sender<ActorStatus>,
@@ -4406,10 +4478,7 @@ impl InstanceCell {
         actor_environment: ActorEnvironment,
         proc: Proc,
         mailbox: Mailbox,
-        actor_loop: Option<(
-            mpsc::UnboundedSender<Signal>,
-            mpsc::UnboundedSender<ActorSupervisionEvent>,
-        )>,
+        actor_loop: Option<ActorLoopSenders>,
         status_tx: watch::Sender<ActorStatus>,
         status: watch::Receiver<ActorStatus>,
         parent: Option<InstanceCell>,
@@ -4649,14 +4718,14 @@ impl InstanceCell {
         self.inner
             .actor_loop
             .as_ref()
-            .map(|(signal_tx, _)| signal_tx.clone())
+            .map(|actor_loop| actor_loop.signal.clone())
             .unwrap_or_else(|| panic!("{} has no runtime signal sender", self.actor_addr()))
     }
 
     /// Send a signal to the actor.
     pub fn signal(&self, signal: Signal) -> Result<(), ActorError> {
-        if let Some((signal_tx, _)) = &self.inner.actor_loop {
-            signal_tx.send(signal).map_err(|_| {
+        if let Some(actor_loop) = &self.inner.actor_loop {
+            actor_loop.signal.send(signal).map_err(|_| {
                 ActorError::new(self.actor_addr(), ActorErrorKind::SignalChannelClosed)
             })
         } else {
@@ -4669,6 +4738,23 @@ impl InstanceCell {
         }
     }
 
+    /// Cancel actor execution while preserving runtime-owned finalization.
+    ///
+    /// Unlike [`Signal::Kill`], this request is observed outside the ordinary
+    /// actor loop. Unlike [`JoinHandle::abort`], it leaves `Instance::serve`
+    /// running so terminal status, supervision, and introspection are finalized.
+    fn abort(&self, reason: String) -> Result<(), ActorError> {
+        let actor_loop = self
+            .inner
+            .actor_loop
+            .as_ref()
+            .unwrap_or_else(|| panic!("{} has no actor runtime", self.actor_addr()));
+        actor_loop
+            .abort
+            .send(reason)
+            .map_err(|_| ActorError::new(self.actor_addr(), ActorErrorKind::SignalChannelClosed))
+    }
+
     /// Used by this actor's children to send a supervision event to this actor.
     /// When it fails to send, we will crash the process. As part of the crash,
     /// all the procs and actors running on this process will be terminated
@@ -4679,8 +4765,8 @@ impl InstanceCell {
     /// detect and handle crashes.
     pub fn send_supervision_event_or_crash(&self, event: ActorSupervisionEvent) {
         match &self.inner.actor_loop {
-            Some((_, supervision_tx)) => {
-                if let Err(err) = supervision_tx.send(event.clone()) {
+            Some(actor_loop) => {
+                if let Err(err) = actor_loop.supervision.send(event.clone()) {
                     if !event.is_error() {
                         // Normal lifecycle events (e.g. clean stop) that fail to
                         // send are silently dropped. This happens when a child
@@ -7154,8 +7240,7 @@ mod tests {
 
         assert_matches!(
             parent.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason == "actor explicitly aborted due to: kill"
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "kill"
         );
         child_cell
             .status()
@@ -7170,8 +7255,7 @@ mod tests {
         release.send(()).unwrap();
         assert_matches!(
             child.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason.contains("parent failed")
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
     }
 
@@ -7226,8 +7310,7 @@ mod tests {
 
         assert_matches!(
             actor.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason == "actor explicitly aborted due to: kill"
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "kill"
         );
     }
 
@@ -7280,8 +7363,7 @@ mod tests {
 
         assert_matches!(
             child.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason.contains("parent failed")
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
         assert_matches!(
             parent.await,
@@ -7351,8 +7433,7 @@ mod tests {
 
         assert_matches!(
             parent.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason == "actor explicitly aborted due to: kill"
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "kill"
         );
         child_cell
             .status()
@@ -7367,8 +7448,7 @@ mod tests {
         release.send(()).unwrap();
         assert_matches!(
             child.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason.contains("parent failed")
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
     }
 
@@ -7393,8 +7473,7 @@ mod tests {
 
         assert_matches!(
             parent.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason == "actor explicitly aborted due to: kill"
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "kill"
         );
 
         // The blocked child cannot process `Kill`, so it never tears down its
@@ -7404,15 +7483,13 @@ mod tests {
         assert!(proc.root_actor_ids().contains(grandchild_cell.actor_addr()));
         assert_matches!(
             grandchild.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason.contains("parent failed")
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
 
         release.send(()).unwrap();
         assert_matches!(
             child.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason.contains("parent failed")
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
     }
 
@@ -7465,6 +7542,99 @@ mod tests {
         parent.drain_and_stop("test").unwrap();
         assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
         assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn abort_keeps_supervision_receiver_open_until_children_detach() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let parent = proc.spawn(TestActor);
+        let parent_cell = parent.cell().clone();
+        let child = proc.spawn_child(parent_cell.clone(), TestActor);
+        let child_cell = child.cell().clone();
+        let supervision_sender = parent_cell
+            .inner
+            .actor_loop
+            .as_ref()
+            .unwrap()
+            .supervision
+            .clone();
+
+        let locked_child = child_cell.clone();
+        let (locked_tx, locked_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let lock_task = tokio::task::spawn_blocking(move || {
+            let _link = locked_child.inner.supervision_link.lock().unwrap();
+            locked_tx.send(()).unwrap();
+            release_rx.blocking_recv().unwrap();
+        });
+        locked_rx.await.unwrap();
+
+        parent_cell.abort("test abort".to_string()).unwrap();
+        parent
+            .status()
+            .wait_for(ActorStatus::is_stopping)
+            .await
+            .unwrap();
+
+        let event = ActorSupervisionEvent::new(
+            child_cell.actor_addr().clone(),
+            None,
+            ActorStatus::generic_failure("test child failure"),
+            None,
+        );
+        assert!(
+            supervision_sender.send(event).is_ok(),
+            "supervision receiver closed before child detachment"
+        );
+
+        release_tx.send(()).unwrap();
+        lock_task.await.unwrap();
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "test abort"
+        );
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn abort_interrupts_blocked_handler_and_finalizes_actor() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let (mut reported_event, _coordinator) =
+            ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let actor = proc.spawn(TestActor);
+        let actor_addr = actor.actor_addr().clone();
+        let cell = actor.cell().clone();
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        actor.post(&client, TestActorMessage::Wait(entered_tx, release_rx));
+        entered_rx.await.unwrap();
+
+        let aborted = proc
+            .abort_root_actor(actor_addr.id(), "test abort".to_string())
+            .expect("live root actor should accept abort")
+            .await;
+
+        assert_eq!(aborted, actor_addr);
+        let terminal_status = actor.await;
+        assert_matches!(
+            &terminal_status,
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason))
+                if reason == "test abort"
+        );
+        assert!(
+            release_tx.send(()).is_err(),
+            "abort should cancel the ordinary handler future"
+        );
+        let event = cell
+            .supervision_event()
+            .expect("aborted actor should store a supervision event");
+        assert_eq!(event.actor_status, terminal_status);
+        assert_eq!(reported_event.recv().await, event);
     }
 
     #[derive(Debug)]
@@ -7532,8 +7702,7 @@ mod tests {
 
         assert_matches!(
             actor.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason == "actor explicitly aborted due to: kill"
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "kill"
         );
         assert!(cleaned_rx.await.is_err(), "cleanup ran after kill");
     }
@@ -7557,12 +7726,47 @@ mod tests {
             tokio::time::timeout(Duration::from_secs(1), actor)
                 .await
                 .expect("kill should interrupt cleanup"),
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason == "actor explicitly aborted due to: kill"
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "kill"
         );
         cleanup_dropped_rx
             .await
             .expect("cleanup future should be cancelled");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn abort_interrupts_actor_cleanup_and_finalizes_actor() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let (cleanup_started_tx, cleanup_started_rx) = oneshot::channel();
+        let (cleanup_dropped_tx, cleanup_dropped_rx) = oneshot::channel();
+        let actor = proc.spawn(BlockingCleanupActor {
+            cleanup_started: Some(cleanup_started_tx),
+            cleanup_dropped: Some(cleanup_dropped_tx),
+        });
+        let actor_addr = actor.actor_addr().clone();
+        let cell = actor.cell().clone();
+
+        actor.stop("stop").unwrap();
+        cleanup_started_rx.await.unwrap();
+        proc.abort_root_actor(actor_addr.id(), "test abort".to_string())
+            .expect("live root actor should accept abort")
+            .await;
+
+        cleanup_dropped_rx
+            .await
+            .expect("abort should cancel the cleanup future");
+        let terminal_status = actor.await;
+        assert_matches!(
+            &terminal_status,
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason))
+                if reason == "test abort"
+        );
+        assert_eq!(
+            cell.supervision_event()
+                .expect("aborted actor should store a supervision event")
+                .actor_status,
+            terminal_status
+        );
     }
 
     #[derive(Debug)]
@@ -7610,7 +7814,7 @@ mod tests {
             tokio::time::timeout(Duration::from_secs(1), actor)
                 .await
                 .expect("kill should interrupt cleanup"),
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason))
                 if reason.contains("kill") && reason.contains("original failure")
         );
     }
@@ -7763,13 +7967,11 @@ mod tests {
         );
         assert_matches!(
             root_2_1.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason.contains("parent failed")
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
         assert_matches!(
             root_1.await,
-            ActorStatus::Failed(ActorErrorKind::Generic(reason))
-                if reason.contains("parent failed")
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
     }
 

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -657,6 +657,8 @@ pub struct ActorInstance<A: Actor> {
     pub supervision: mpsc::UnboundedReceiver<ActorSupervisionEvent>,
     /// Control signals for the actor.
     pub signal: mpsc::UnboundedReceiver<Signal>,
+    /// Forced exits delivered to the actor.
+    pub forced_exit: mpsc::UnboundedReceiver<ForcedExit>,
     /// Primary work queue for handler dispatch.
     pub work: ActorWorkReceiver<A>,
 }
@@ -1298,13 +1300,14 @@ impl Proc {
         let ActorLoopReceivers {
             signal,
             supervision,
-            ..
+            forced_exit,
         } = receivers.actor_loop.unwrap();
         Ok(ActorInstance {
             instance,
             handle,
             supervision,
             signal,
+            forced_exit,
             work: receivers.work,
         })
     }
@@ -2136,9 +2139,19 @@ enum StopOutcome {
     Continue,
 }
 
+/// A request that cancels actor execution without cancelling runtime
+/// finalization.
+#[derive(Debug)]
+pub enum ForcedExit {
+    /// An external caller killed the actor.
+    Kill(String),
+    /// The runtime aborted the actor for an internal lifecycle reason.
+    Abort(String),
+}
+
 enum ActorExecutionOutcome {
     Completed(Result<String, ActorError>),
-    Aborted(String),
+    Forced(ForcedExit),
 }
 
 type DelayedPost<A> = Box<dyn FnOnce(&Instance<A>) + Send>;
@@ -2480,13 +2493,13 @@ pub struct InstanceReceivers<A: Actor> {
 struct ActorLoopSenders {
     signal: mpsc::UnboundedSender<Signal>,
     supervision: mpsc::UnboundedSender<ActorSupervisionEvent>,
-    abort: mpsc::UnboundedSender<String>,
+    forced_exit: mpsc::UnboundedSender<ForcedExit>,
 }
 
 struct ActorLoopReceivers {
     signal: mpsc::UnboundedReceiver<Signal>,
     supervision: mpsc::UnboundedReceiver<ActorSupervisionEvent>,
-    abort: mpsc::UnboundedReceiver<String>,
+    forced_exit: mpsc::UnboundedReceiver<ForcedExit>,
 }
 
 impl<A: Actor> Instance<A> {
@@ -2530,17 +2543,17 @@ impl<A: Actor> Instance<A> {
             let (signal_tx, signal_receiver) = mpsc::unbounded_channel::<Signal>();
             let (supervision_tx, supervision_receiver) =
                 mpsc::unbounded_channel::<ActorSupervisionEvent>();
-            let (abort_tx, abort_receiver) = mpsc::unbounded_channel::<String>();
+            let (forced_exit_tx, forced_exit_receiver) = mpsc::unbounded_channel::<ForcedExit>();
             Some((
                 ActorLoopSenders {
                     signal: signal_tx,
                     supervision: supervision_tx,
-                    abort: abort_tx,
+                    forced_exit: forced_exit_tx,
                 },
                 ActorLoopReceivers {
                     signal: signal_receiver,
                     supervision: supervision_receiver,
-                    abort: abort_receiver,
+                    forced_exit: forced_exit_receiver,
                 },
             ))
         };
@@ -2873,24 +2886,24 @@ impl<A: Actor> Instance<A> {
             .signal(Signal::DrainAndStop(reason.to_string()))
     }
 
-    /// Signal the actor to terminate immediately with a provided reason.
+    /// Kill the actor to terminate immediately with a provided reason.
     pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
         tracing::info!(
             actor_id = %self.inner.cell.actor_addr(),
             reason,
             "instance kill called",
         );
-        self.inner.cell.signal(Signal::Kill(reason.to_string()))
+        self.inner.cell.kill(reason.to_string())
     }
 
-    /// Backward-compatible alias for `kill()`.
+    /// Abort the actor to terminate immediately with a provided reason.
     pub fn abort(&self, reason: &str) -> Result<(), ActorError> {
         tracing::info!(
             actor_id = %self.inner.cell.actor_addr(),
             reason,
             "instance abort called",
         );
-        self.kill(reason)
+        self.inner.cell.abort(reason.to_string())
     }
 
     /// Close handler ingress for this actor.
@@ -2987,10 +3000,10 @@ impl<A: Actor> Instance<A> {
         self.inner.mailbox.open_once_port()
     }
 
-    /// Return this actor's runtime signal sender.
+    /// Return this actor's forced-exit sender.
     #[doc(hidden)]
-    pub fn signal_sender(&self) -> mpsc::UnboundedSender<Signal> {
-        self.inner.cell.signal_sender()
+    pub fn forced_exit_sender(&self) -> mpsc::UnboundedSender<ForcedExit> {
+        self.inner.cell.forced_exit_sender()
     }
 
     /// Get the per-instance local storage.
@@ -3130,7 +3143,7 @@ impl<A: Actor> Instance<A> {
         let ActorLoopReceivers {
             signal,
             supervision,
-            abort,
+            forced_exit,
         } = receivers
             .actor_loop
             .expect("non-detached instance must have actor loop receivers");
@@ -3138,7 +3151,7 @@ impl<A: Actor> Instance<A> {
             panic_handler::with_backtrace_tracking(self.serve(
                 actor,
                 (signal, supervision),
-                abort,
+                forced_exit,
                 receivers.work,
             ))
             .instrument(Span::current()),
@@ -3160,7 +3173,7 @@ impl<A: Actor> Instance<A> {
             mpsc::UnboundedReceiver<Signal>,
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
-        mut abort_receiver: mpsc::UnboundedReceiver<String>,
+        mut forced_exit_receiver: mpsc::UnboundedReceiver<ForcedExit>,
         mut work_rx: ActorWorkReceiver<A>,
     ) {
         let outcome = {
@@ -3169,23 +3182,33 @@ impl<A: Actor> Instance<A> {
             tokio::pin!(run_actor_tree);
             tokio::select! {
                 biased;
-                // An Abort accepted before actor execution completes owns the
+                // A forced exit accepted before actor execution completes owns the
                 // terminal outcome, even if both branches become ready together.
-                reason = abort_receiver.recv() => {
-                    ActorExecutionOutcome::Aborted(
-                        reason.expect("abort sender should outlive actor execution"),
+                forced_exit = forced_exit_receiver.recv() => {
+                    ActorExecutionOutcome::Forced(
+                        forced_exit.expect("forced-exit sender should outlive actor execution"),
                     )
                 }
-                result = &mut run_actor_tree => ActorExecutionOutcome::Completed(result),
+                result = &mut run_actor_tree => {
+                    // Establish actor completion as the point after which a forced
+                    // exit is rejected. Closing retains any exit queued during the
+                    // final poll of actor execution, so it still wins here.
+                    forced_exit_receiver.close();
+                    match forced_exit_receiver.recv().await {
+                        Some(forced_exit) => ActorExecutionOutcome::Forced(forced_exit),
+                        None => ActorExecutionOutcome::Completed(result),
+                    }
+                }
             }
         };
         let result = match outcome {
             ActorExecutionOutcome::Completed(result) => result,
-            ActorExecutionOutcome::Aborted(reason) => {
-                let result = Err(ActorError::new(
-                    self.self_addr(),
-                    ActorErrorKind::Aborted(reason),
-                ));
+            ActorExecutionOutcome::Forced(forced_exit) => {
+                let reason = match forced_exit {
+                    ForcedExit::Kill(reason) | ForcedExit::Abort(reason) => reason,
+                };
+                let error_kind = ActorErrorKind::Aborted(reason);
+                let result = Err(ActorError::new(self.self_addr(), error_kind));
                 self.begin_actor_teardown(&result);
                 result
             }
@@ -3287,7 +3310,7 @@ impl<A: Actor> Instance<A> {
             )) {
                 continue;
             }
-            if let Err(err) = child.signal(Signal::Kill(reason.to_string())) {
+            if let Err(err) = child.abort(reason.to_string()) {
                 tracing::debug!(
                     actor_id = %self.self_addr(),
                     child_id = %child.actor_addr(),
@@ -3352,57 +3375,16 @@ impl<A: Actor> Instance<A> {
         };
 
         self.begin_actor_teardown(&result);
-        let was_killed = result
-            .as_ref()
-            .is_err_and(|err| matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)));
         // Run the actor cleanup function before the actor stops to delete
         // resources. Don't call it if there was a panic, because the actor may
         // be in an invalid state and unable to access anything, for example
         // the GIL.
-        let cleanup_result = if !did_panic && !was_killed {
-            let cleanup = self
-                .inner
+        let cleanup_result = if !did_panic {
+            self.inner
                 .proc
-                .with_current(actor.cleanup(self, result.as_ref().err()));
-            tokio::pin!(cleanup);
-            let signal_receiver = &mut actor_loop_receivers.0;
-            let mut receive_signals = true;
-            loop {
-                tokio::select! {
-                    biased;
-                    signal = signal_receiver.recv(), if receive_signals => {
-                        match signal {
-                            Some(Signal::Kill(reason)) => {
-                                // Aborting discards `result`, so carry an
-                                // already-failed exit into the reason. It is
-                                // the root cause, and nothing downstream sees
-                                // `result` once we return.
-                                let reason = match result.as_ref() {
-                                    Err(err) => {
-                                        format!("{reason} (killed during cleanup after: {err})")
-                                    }
-                                    Ok(_) => reason,
-                                };
-                                return Err(ActorError::new(
-                                    self.self_addr(),
-                                    ActorErrorKind::Aborted(reason),
-                                ));
-                            }
-                            Some(
-                                Signal::Stop(_)
-                                | Signal::DrainAndStop(_)
-                                | Signal::ExitRequested(_),
-                            ) => {}
-                            None => receive_signals = false,
-                        }
-                    }
-                    cleanup_result = &mut cleanup => {
-                        break cleanup_result.map_err(|err| {
-                            ActorError::new(self.self_addr(), ActorErrorKind::cleanup(err))
-                        });
-                    }
-                }
-            }
+                .with_current(actor.cleanup(self, result.as_ref().err()))
+                .await
+                .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::cleanup(err)))
         } else {
             Ok(())
         };
@@ -3422,10 +3404,10 @@ impl<A: Actor> Instance<A> {
         result.and_then(|reason| cleanup_result.map(|_| reason))
     }
 
-    /// Run the actor's stop hook while continuing to service terminal signals.
+    /// Run the actor's stop hook while continuing to service cooperative signals.
     ///
-    /// `Kill` cancels the hook immediately. The first `ExitRequested` is retained
-    /// until the hook returns, and repeated cooperative stop requests coalesce.
+    /// The first `ExitRequested` is retained until the hook returns, and repeated
+    /// cooperative stop requests coalesce.
     async fn run_stop_handler(
         &self,
         actor: &mut A,
@@ -3476,18 +3458,14 @@ impl<A: Actor> Instance<A> {
 
     /// Apply a lifecycle signal while cooperative shutdown is in progress.
     ///
-    /// `Kill` wins over clean completion, the first explicit exit reason wins
-    /// over later exits, and additional cooperative stop requests are ignored.
+    /// The first explicit exit reason wins over later exits, and additional
+    /// cooperative stop requests are ignored.
     fn apply_stop_signal(
         &self,
         signal: Signal,
         exit_reason: &mut Option<String>,
     ) -> Result<(), ActorError> {
         match signal {
-            Signal::Kill(reason) => Err(ActorError::new(
-                self.self_addr(),
-                ActorErrorKind::Aborted(reason),
-            )),
             Signal::ExitRequested(reason) => {
                 exit_reason.get_or_insert(reason);
                 Ok(())
@@ -3594,9 +3572,6 @@ impl<A: Actor> Instance<A> {
                             run_state = LoopState::Draining(rx);
                         },
                         Signal::ExitRequested(reason) => break 'messages reason,
-                        Signal::Kill(reason) => {
-                            return Err(ActorError { actor_id: Box::new(self.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) });
-                        }
                     }
                 }
                 request = run_state.drain_request() => {
@@ -4714,12 +4689,12 @@ impl InstanceCell {
         self.inner.supervision_event.lock().unwrap().clone()
     }
 
-    fn signal_sender(&self) -> mpsc::UnboundedSender<Signal> {
+    fn forced_exit_sender(&self) -> mpsc::UnboundedSender<ForcedExit> {
         self.inner
             .actor_loop
             .as_ref()
-            .map(|actor_loop| actor_loop.signal.clone())
-            .unwrap_or_else(|| panic!("{} has no runtime signal sender", self.actor_addr()))
+            .map(|actor_loop| actor_loop.forced_exit.clone())
+            .unwrap_or_else(|| panic!("{} has no forced-exit sender", self.actor_addr()))
     }
 
     /// Send a signal to the actor.
@@ -4738,21 +4713,18 @@ impl InstanceCell {
         }
     }
 
-    /// Cancel actor execution while preserving runtime-owned finalization.
-    ///
-    /// Unlike [`Signal::Kill`], this request is observed outside the ordinary
-    /// actor loop. Unlike [`JoinHandle::abort`], it leaves `Instance::serve`
-    /// running so terminal status, supervision, and introspection are finalized.
-    fn abort(&self, reason: String) -> Result<(), ActorError> {
-        let actor_loop = self
-            .inner
-            .actor_loop
-            .as_ref()
-            .unwrap_or_else(|| panic!("{} has no actor runtime", self.actor_addr()));
-        actor_loop
-            .abort
-            .send(reason)
+    fn forced_exit(&self, forced_exit: ForcedExit) -> Result<(), ActorError> {
+        self.forced_exit_sender()
+            .send(forced_exit)
             .map_err(|_| ActorError::new(self.actor_addr(), ActorErrorKind::SignalChannelClosed))
+    }
+
+    pub(crate) fn kill(&self, reason: String) -> Result<(), ActorError> {
+        self.forced_exit(ForcedExit::Kill(reason))
+    }
+
+    fn abort(&self, reason: String) -> Result<(), ActorError> {
+        self.forced_exit(ForcedExit::Abort(reason))
     }
 
     /// Used by this actor's children to send a supervision event to this actor.
@@ -7242,21 +7214,15 @@ mod tests {
             parent.await,
             ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "kill"
         );
-        child_cell
-            .status()
-            .clone()
-            .wait_for(ActorStatus::is_zombie)
-            .await
-            .unwrap();
         assert!(child_cell.parent().is_none());
         assert_eq!(parent_cell.child_count(), 0);
         assert!(proc.root_actor_ids().contains(child_cell.actor_addr()));
 
-        release.send(()).unwrap();
         assert_matches!(
             child.await,
             ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
+        assert!(release.send(()).is_err(), "child handler should be aborted");
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -7435,21 +7401,15 @@ mod tests {
             parent.await,
             ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "kill"
         );
-        child_cell
-            .status()
-            .clone()
-            .wait_for(ActorStatus::is_zombie)
-            .await
-            .unwrap();
         assert!(child_cell.parent().is_none());
         assert_eq!(parent_cell.child_count(), 0);
         assert!(proc.root_actor_ids().contains(child_cell.actor_addr()));
 
-        release.send(()).unwrap();
         assert_matches!(
             child.await,
             ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
+        assert!(release.send(()).is_err(), "child handler should be aborted");
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -7476,8 +7436,8 @@ mod tests {
             ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "kill"
         );
 
-        // The blocked child cannot process `Kill`, so it never tears down its
-        // own subtree. The grandchild must still reach the proc.
+        // Forced teardown reaches the whole subtree without relying on the
+        // blocked child to propagate termination.
         assert_eq!(child_cell.child_count(), 0);
         assert!(grandchild_cell.parent().is_none());
         assert!(proc.root_actor_ids().contains(grandchild_cell.actor_addr()));
@@ -7486,11 +7446,11 @@ mod tests {
             ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
 
-        release.send(()).unwrap();
         assert_matches!(
             child.await,
             ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
+        assert!(release.send(()).is_err(), "child handler should be aborted");
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -7598,6 +7558,37 @@ mod tests {
             child.await,
             ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason.contains("parent failed")
         );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_interrupts_blocked_handler_and_finalizes_actor() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let (mut reported_event, _coordinator) =
+            ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let actor = proc.spawn(TestActor);
+        let cell = actor.cell().clone();
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        actor.post(&client, TestActorMessage::Wait(entered_tx, release_rx));
+        entered_rx.await.unwrap();
+
+        actor.kill("test kill").unwrap();
+
+        let terminal_status = actor.await;
+        assert_matches!(
+            &terminal_status,
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "test kill"
+        );
+        assert!(
+            release_tx.send(()).is_err(),
+            "kill should cancel the ordinary handler future"
+        );
+        let event = cell
+            .supervision_event()
+            .expect("killed actor should store a supervision event");
+        assert_eq!(event.actor_status, terminal_status);
+        assert_eq!(reported_event.recv().await, event);
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -7796,7 +7787,7 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 30)]
-    async fn kill_during_cleanup_preserves_failure_cause() {
+    async fn kill_during_cleanup_reports_kill() {
         let proc = Proc::isolated();
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
         let (cleanup_started_tx, cleanup_started_rx) = oneshot::channel();
@@ -7804,8 +7795,6 @@ mod tests {
             cleanup_started: Some(cleanup_started_tx),
         });
 
-        // The actor has already failed by the time cleanup starts, so the kill
-        // that interrupts cleanup must not erase why it failed.
         actor.stop("stop").unwrap();
         cleanup_started_rx.await.unwrap();
         actor.kill("kill").unwrap();
@@ -7814,8 +7803,7 @@ mod tests {
             tokio::time::timeout(Duration::from_secs(1), actor)
                 .await
                 .expect("kill should interrupt cleanup"),
-            ActorStatus::Failed(ActorErrorKind::Aborted(reason))
-                if reason.contains("kill") && reason.contains("original failure")
+            ActorStatus::Failed(ActorErrorKind::Aborted(reason)) if reason == "kill"
         );
     }
 

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -505,6 +505,7 @@ async fn bootstrap_host() -> GlobalState {
         handle,
         supervision,
         signal,
+        forced_exit: _,
         work,
     } = actor_instance;
 

--- a/hyperactor_remote/example/remote_spawner.rs
+++ b/hyperactor_remote/example/remote_spawner.rs
@@ -35,6 +35,7 @@ use hyperactor::RemoteSpawn;
 use hyperactor::Uid;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::StopMode;
+use hyperactor::actor::StopProgress;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::supervision::ActorSupervisionEvent;
@@ -118,16 +119,12 @@ impl Actor for Calculator {
     async fn handle_stop(
         &mut self,
         this: &Instance<Self>,
-        mode: StopMode,
+        _mode: StopMode,
         reason: &str,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<StopProgress> {
         println!("calculator stopping before driver exits: {reason}");
         this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
-        Ok(())
+        Ok(StopProgress::Complete)
     }
 }
 
@@ -205,26 +202,6 @@ impl Actor for SpawnerBootstrap {
         write_text(&self.token_file, &token.to_string()).await?;
         println!("proc spawner token {}", token);
         self.proc_spawner = Some(proc_spawner);
-        Ok(())
-    }
-
-    async fn handle_stop(
-        &mut self,
-        this: &Instance<Self>,
-        mode: StopMode,
-        reason: &str,
-    ) -> anyhow::Result<()> {
-        if let Some(proc_spawner) = &self.proc_spawner {
-            let _ = match mode {
-                StopMode::Stop => proc_spawner.stop(reason),
-                StopMode::DrainAndStop => proc_spawner.drain_and_stop(reason),
-            };
-        }
-        this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
         Ok(())
     }
 }
@@ -352,7 +329,7 @@ impl Handler<CalculationResult> for Driver {
             result.lhs, result.rhs, result.sum
         );
         println!("driver exiting through this.exit(); calculator should stop first");
-        cx.exit("demo complete")?;
+        cx.drain_and_stop("demo complete")?;
         Ok(())
     }
 }

--- a/hyperactor_remote/example/token_supervision.rs
+++ b/hyperactor_remote/example/token_supervision.rs
@@ -28,6 +28,7 @@ use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::Proc;
 use hyperactor::actor::StopMode;
+use hyperactor::actor::StopProgress;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::channel::TcpMode;
@@ -163,19 +164,15 @@ impl Actor for DemoChild {
     async fn handle_stop(
         &mut self,
         this: &Instance<Self>,
-        mode: StopMode,
+        _mode: StopMode,
         reason: &str,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<StopProgress> {
         println!("child stopping: {reason}");
         if let Some(path) = &self.stopped_file {
             write_text(path, reason).await?;
         }
         this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
-        Ok(())
+        Ok(StopProgress::Complete)
     }
 }
 

--- a/hyperactor_remote/src/keepalive.rs
+++ b/hyperactor_remote/src/keepalive.rs
@@ -509,8 +509,8 @@ mod tests {
 
         assert!(matches!(
             event.actor_status,
-            ActorStatus::Failed(ActorErrorKind::Generic(ref reason))
-                if reason == "actor explicitly aborted due to: keepalive missed for generation 0"
+            ActorStatus::Failed(ActorErrorKind::Aborted(ref reason))
+                if reason == "keepalive missed for generation 0"
         ));
         assert!(!event.actor_id.is_root());
 
@@ -571,8 +571,8 @@ mod tests {
         assert_eq!(event.actor_id.uid(), &uid);
         assert!(matches!(
             event.actor_status,
-            ActorStatus::Failed(ActorErrorKind::Generic(ref reason))
-                if reason == "actor explicitly aborted due to: keepalive acknowledgment missed"
+            ActorStatus::Failed(ActorErrorKind::Aborted(ref reason))
+                if reason == "keepalive acknowledgment missed"
         ));
 
         parent.stop("test").unwrap();

--- a/hyperactor_remote/src/link.rs
+++ b/hyperactor_remote/src/link.rs
@@ -198,8 +198,7 @@ mod tests {
         assert_eq!(event.actor_id.uid(), &uid);
         assert!(matches!(
             event.actor_status,
-            ActorStatus::Failed(ActorErrorKind::Generic(ref reason))
-                if reason == "actor explicitly aborted due to: link failed"
+            ActorStatus::Failed(ActorErrorKind::Aborted(ref reason)) if reason == "link failed"
         ));
         assert!(!event.actor_id.is_root());
 

--- a/hyperactor_remote/src/proc_spawner/unix.rs
+++ b/hyperactor_remote/src/proc_spawner/unix.rs
@@ -77,6 +77,8 @@ use hyperactor::ProcAddr;
 use hyperactor::Uid;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::StopMode;
+use hyperactor::actor::StopProgress;
+use hyperactor::actor::handle_stop as default_handle_stop;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::context;
@@ -310,29 +312,6 @@ impl Actor for UnixProcSpawner {
             self.procs.remove(&uid);
         }
         Ok(!event.is_error())
-    }
-
-    async fn handle_stop(
-        &mut self,
-        this: &Instance<Self>,
-        mode: StopMode,
-        reason: &str,
-    ) -> anyhow::Result<()> {
-        // The caller-side supervision tree owns each spawned actor-spawn endpoint.
-        // `UnixProcSpawner` also owns the OS child processes, so spawner shutdown must
-        // stop every worker even if no individual caller has requested it.
-        for worker in self.procs.values() {
-            let _ = match mode {
-                StopMode::Stop => worker.stop(reason),
-                StopMode::DrainAndStop => worker.drain_and_stop(reason),
-            };
-        }
-        this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
-        Ok(())
     }
 }
 
@@ -856,7 +835,7 @@ impl Actor for UnixProcWorker {
         this: &Instance<Self>,
         mode: StopMode,
         reason: &str,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<StopProgress> {
         self.stop_reason = Some(reason.to_string());
         let _ = self.unlink_session(reason);
         // Ask the proc to drain gracefully over the control channel and wait for
@@ -881,12 +860,7 @@ impl Actor for UnixProcWorker {
             // the OS process directly.
             self.signal_child(Signal::SIGTERM, reason);
         }
-        this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
-        Ok(())
+        default_handle_stop(this, mode, reason).await
     }
 }
 

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -1245,10 +1245,10 @@ mod tests {
     //         └── supervisor: Supervisor
     //             └── supervisor-side liveness actor: KeepaliveSupervisor
     //
-    // Killing Parent still tears down its local supervision subtree. Grandparent
+    // Killing Parent hard-kills its local supervision subtree. Grandparent
     // handles the parent failure so the test process does not treat it as an
-    // unhandled root failure. Parent stops Supervisor, Supervisor forwards the
-    // stop to Worker, and Worker stops TestChild.
+    // unhandled root failure. Since Supervisor does not run its graceful stop
+    // handler, Worker stops TestChild through the liveness orphan policy.
     #[tokio::test]
     async fn test_parent_kill_stops_remote_child() {
         let proc = Proc::isolated();
@@ -1282,7 +1282,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(reason, "parent stopping");
+        assert_eq!(reason, "supervision liveness failed");
 
         let event = tokio::time::timeout(Duration::from_secs(5), event_rx.recv())
             .await

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -34,6 +34,7 @@ use hyperactor::Uid;
 use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::StopMode;
+use hyperactor::actor::StopProgress;
 use hyperactor::context;
 use hyperactor::context::Actor as _;
 use hyperactor::mailbox::MessageEnvelope;
@@ -52,10 +53,26 @@ use crate::SupervisorEvent;
 use crate::WorkerCommand;
 use crate::WorkerLike;
 
-#[derive(Debug)]
-struct PendingStop {
+#[derive(Clone, Debug)]
+struct RemoteStopRequest {
     mode: StopMode,
     reason: String,
+}
+
+#[derive(Debug)]
+enum Shutdown {
+    PendingRemoteStop(RemoteStopRequest),
+    AwaitingRemoteCompletion { reason: String },
+    StoppingLiveness { reason: String },
+}
+
+impl Shutdown {
+    fn into_reason(self) -> String {
+        match self {
+            Self::PendingRemoteStop(request) => request.reason,
+            Self::AwaitingRemoteCompletion { reason } | Self::StoppingLiveness { reason } => reason,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -143,7 +160,7 @@ pub struct Supervisor {
     session_id: Uid,
     liveness_handle: Option<ActorHandle<KeepaliveSupervisor>>,
     session: Option<SupervisorSession>,
-    pending_stop: Option<PendingStop>,
+    shutdown: Option<Shutdown>,
     /// Optional one-shot notification posted after the worker links the child.
     ready: Option<OncePortHandle<()>>,
 }
@@ -227,7 +244,7 @@ impl Supervisor {
             session_id,
             liveness_handle: None,
             session: None,
-            pending_stop: None,
+            shutdown: None,
             ready,
         }
     }
@@ -260,17 +277,19 @@ impl Actor for Supervisor {
         this: &Instance<Self>,
         mode: StopMode,
         reason: &str,
-    ) -> anyhow::Result<()> {
-        self.pending_stop = Some(PendingStop {
+    ) -> anyhow::Result<StopProgress> {
+        let request = RemoteStopRequest {
             mode,
             reason: reason.to_string(),
-        });
-        self.send_pending_worker_stop(this)
+        };
+        self.shutdown = Some(Shutdown::PendingRemoteStop(request));
+        self.forward_remote_stop(this)?;
+        Ok(StopProgress::Continue)
     }
 
     async fn handle_supervision_event(
         &mut self,
-        _this: &Instance<Self>,
+        this: &Instance<Self>,
         event: &ActorSupervisionEvent,
     ) -> anyhow::Result<bool> {
         if self
@@ -278,8 +297,13 @@ impl Actor for Supervisor {
             .as_ref()
             .is_some_and(|handle| handle.actor_addr() == &event.actor_id)
         {
-            let event = self.synthesize_unreachable_event("supervision liveness failed");
-            return self.propagate_event(event);
+            self.liveness_handle = None;
+            let Some(shutdown) = self.shutdown.take() else {
+                let event = self.synthesize_unreachable_event("supervision liveness failed");
+                return self.propagate_event(event);
+            };
+            this.exit(&shutdown.into_reason())?;
+            return Ok(true);
         }
         Ok(!event.is_error())
     }
@@ -296,6 +320,10 @@ impl Handler<SupervisorEvent> for Supervisor {
                 display_name,
             } => {
                 self.ensure_session(&session_id)?;
+                anyhow::ensure!(
+                    self.session.is_none(),
+                    "remote supervision session already linked"
+                );
                 if let Some(ready) = self.ready.take() {
                     ready.post(cx, ());
                 }
@@ -304,7 +332,7 @@ impl Handler<SupervisorEvent> for Supervisor {
                     child,
                     display_name,
                 });
-                self.send_pending_worker_stop(cx)?;
+                self.forward_remote_stop(cx)?;
                 Ok(())
             }
             SupervisorEvent::SuperviseRejected { session_id, reason } => {
@@ -314,21 +342,55 @@ impl Handler<SupervisorEvent> for Supervisor {
             SupervisorEvent::SupervisionEvent {
                 session_id,
                 event,
-                disposition: _,
+                disposition,
             } => {
                 self.ensure_session(&session_id)?;
+                if matches!(disposition, RemoteActorDisposition::Terminal) {
+                    self.shutdown = None;
+                }
                 self.propagate_event(event)
             }
             SupervisorEvent::Unlinked { session_id, reason } => {
                 self.ensure_session(&session_id)?;
-                cx.exit(&reason)?;
-                Ok(())
+                let reason = match self.shutdown.take() {
+                    // A duplicate unlink is a peer protocol violation, not a
+                    // local invariant, so restore the phase and reject it.
+                    Some(shutdown @ Shutdown::StoppingLiveness { .. }) => {
+                        self.shutdown = Some(shutdown);
+                        anyhow::bail!("remote supervision session unlinked more than once")
+                    }
+                    Some(shutdown) => shutdown.into_reason(),
+                    None => reason,
+                };
+                self.shutdown = Some(Shutdown::StoppingLiveness { reason });
+                self.stop_liveness_for_shutdown(cx)
             }
         }
     }
 }
 
 impl Supervisor {
+    fn stop_liveness_for_shutdown(&mut self, cx: &Instance<Self>) -> anyhow::Result<()> {
+        let Some(Shutdown::StoppingLiveness { .. }) = self.shutdown.as_ref() else {
+            panic!("liveness stop requires a completed remote shutdown");
+        };
+        cx.close();
+
+        if let Some(liveness) = &self.liveness_handle {
+            let _ = liveness.stop("remote supervision ended");
+            return Ok(());
+        }
+
+        let shutdown = self
+            .shutdown
+            .take()
+            .expect("shutdown should remain present until completion");
+        let Shutdown::StoppingLiveness { reason } = shutdown else {
+            panic!("remote completion should be known after liveness stops");
+        };
+        cx.exit(&reason).map_err(Into::into)
+    }
+
     fn ensure_session(&self, session_id: &hyperactor::Uid) -> anyhow::Result<()> {
         if session_id != &self.session_id {
             anyhow::bail!("remote supervision session id mismatch");
@@ -336,33 +398,38 @@ impl Supervisor {
         Ok(())
     }
 
-    fn send_pending_worker_stop(&mut self, cx: &Instance<Self>) -> anyhow::Result<()> {
-        let Some(stop) = self.pending_stop.take() else {
+    fn forward_remote_stop(&mut self, cx: &Instance<Self>) -> anyhow::Result<()> {
+        let Some(Shutdown::PendingRemoteStop(request)) = self.shutdown.as_ref() else {
             return Ok(());
         };
-        let Some(session) = &self.session else {
+        if let Some(session) = &self.session {
+            (&session.worker).post(
+                cx,
+                WorkerCommand::Stop {
+                    session_id: self.session_id.clone(),
+                    mode: request.mode,
+                    reason: request.reason.clone(),
+                },
+            );
+        } else {
             let Some(worker) = self.bootstrap.worker_endpoint() else {
-                self.pending_stop = Some(stop);
                 return Ok(());
             };
             worker.post(
                 cx,
                 WorkerCommand::Stop {
                     session_id: self.session_id.clone(),
-                    mode: stop.mode,
-                    reason: stop.reason,
+                    mode: request.mode,
+                    reason: request.reason.clone(),
                 },
             );
-            return Ok(());
+        }
+        let Some(Shutdown::PendingRemoteStop(request)) = self.shutdown.take() else {
+            panic!("worker stop requires a pending remote shutdown");
         };
-        (&session.worker).post(
-            cx,
-            WorkerCommand::Stop {
-                session_id: self.session_id.clone(),
-                mode: stop.mode,
-                reason: stop.reason,
-            },
-        );
+        self.shutdown = Some(Shutdown::AwaitingRemoteCompletion {
+            reason: request.reason,
+        });
         Ok(())
     }
 
@@ -848,16 +915,12 @@ mod tests {
         async fn handle_stop(
             &mut self,
             this: &Instance<Self>,
-            mode: StopMode,
+            _mode: StopMode,
             reason: &str,
-        ) -> anyhow::Result<()> {
+        ) -> anyhow::Result<StopProgress> {
             self.stopped.post(this, reason.to_string());
             this.close();
-            match mode {
-                StopMode::Stop => this.exit(reason)?,
-                StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-            }
-            Ok(())
+            Ok(StopProgress::Complete)
         }
     }
 
@@ -1111,7 +1174,7 @@ mod tests {
     // ├── client instance
     // │   ├── ready port: receives the child address
     // │   ├── stopped port: receives the child stop reason
-    // │   └── events port: present but not expected to receive an event
+    // │   └── events port: receives the remote child's terminal event
     // ├── worker: Worker
     // │   ├── child: TestChild
     // │   └── worker-side liveness actor: KeepaliveWorker
@@ -1128,7 +1191,7 @@ mod tests {
         let client = proc.client("client");
         let session_id = Uid::anonymous();
 
-        let (_child_addr, worker, parent, mut stopped_rx, _event_rx) = spawn_supervised_pair(
+        let (child_addr, worker, parent, mut stopped_rx, mut event_rx) = spawn_supervised_pair(
             &proc,
             &client,
             session_id.clone(),
@@ -1144,7 +1207,14 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(reason, "parent stopping");
+        assert_eq!(reason, "test parent stopping");
+
+        let event = tokio::time::timeout(Duration::from_secs(5), event_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.actor_id, child_addr);
+        assert!(matches!(event.actor_status, ActorStatus::Stopped(_)));
 
         tokio::time::timeout(Duration::from_secs(5), parent)
             .await
@@ -1743,7 +1813,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(stop_reason, "parent stopping");
+        assert_eq!(stop_reason, "test stop");
 
         tokio::time::timeout(Duration::from_secs(5), parent)
             .await

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -419,9 +419,9 @@ async fn test_token_join_parent_exit_drain_and_stops_child_first() -> anyhow::Re
 
 // Same topology as `test_token_join_parent_exit_stops_child_first`.
 //
-// Killing the parent actor is the in-process hard-stop path. The parent still
-// owns a local supervision tree, so the runtime stops Supervisor while cleaning
-// up that tree, and Supervisor forwards the stop to Worker.
+// Killing the parent actor is the in-process hard-stop path. The runtime kills
+// the local Supervisor instead of running its graceful stop handler, so the
+// worker-side orphan policy stops the child when the liveness link fails.
 #[tokio::test]
 async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
     let mut harness = Harness::new().await?;
@@ -431,7 +431,7 @@ async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
         .post(&harness.observer, ParentControl::Kill);
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
-    assert_eq!(reason, "parent stopping");
+    assert_eq!(reason, "supervision liveness failed");
     harness.stop().await?;
     Ok(())
 }

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -20,6 +20,7 @@ use hyperactor::PortHandle;
 use hyperactor::Proc;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::StopMode;
+use hyperactor::actor::StopProgress;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::mailbox::PortReceiver;
@@ -187,16 +188,12 @@ impl Actor for SupervisedChild {
     async fn handle_stop(
         &mut self,
         this: &Instance<Self>,
-        mode: StopMode,
+        _mode: StopMode,
         reason: &str,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<StopProgress> {
         self.stopped.post(this, reason.to_string());
         this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
-        Ok(())
+        Ok(StopProgress::Complete)
     }
 }
 
@@ -397,7 +394,7 @@ async fn test_token_join_parent_exit_stops_child_first() -> anyhow::Result<()> {
         .post(&harness.observer, ParentControl::Exit(StopMode::Stop));
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
-    assert_eq!(reason, "parent stopping");
+    assert_eq!(reason, "parent requested stop");
     harness.stop().await?;
     Ok(())
 }
@@ -412,7 +409,7 @@ async fn test_token_join_parent_exit_drain_and_stops_child_first() -> anyhow::Re
     );
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
-    assert_eq!(reason, "parent draining");
+    assert_eq!(reason, "parent requested drain and stop");
     harness.stop().await?;
     Ok(())
 }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -40,6 +40,7 @@ use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::mailbox::UndeliverableMessageError;
 use hyperactor::mailbox::UndeliverableReason;
+use hyperactor::proc::ForcedExit;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::ProcMeshRef;
@@ -1223,6 +1224,7 @@ impl PythonActor {
 
         let handle = ai.handle;
         let signal_rx = ai.signal;
+        let forced_exit_rx = ai.forced_exit;
         let supervision_rx = ai.supervision;
         let work_rx = ai.work;
 
@@ -1245,6 +1247,7 @@ impl PythonActor {
             actor.init(instance).await.unwrap();
 
             let mut signal_rx = signal_rx;
+            let mut forced_exit_rx = forced_exit_rx;
             let mut supervision_rx = supervision_rx;
             let mut work_rx = work_rx;
             let mut need_drain = false;
@@ -1306,9 +1309,6 @@ impl PythonActor {
                                 break None;
                             },
                             Some(Signal::ExitRequested(_)) => break None,
-                            Some(Signal::Kill(reason)) => {
-                                break Some(ActorError { actor_id: Box::new(instance.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) })
-                            },
                             None => {
                                 break Some(ActorError {
                                     actor_id: Box::new(instance.self_addr().clone()),
@@ -1316,6 +1316,17 @@ impl PythonActor {
                                 })
                             },
                         }
+                    }
+                    forced_exit = forced_exit_rx.recv() => {
+                        let kind = match forced_exit.expect("forced-exit sender should outlive actor execution") {
+                            ForcedExit::Kill(reason) | ForcedExit::Abort(reason) => {
+                                ActorErrorKind::Aborted(reason)
+                            }
+                        };
+                        break Some(ActorError {
+                            actor_id: Box::new(instance.self_addr().clone()),
+                            kind: Box::new(kind),
+                        });
                     }
                     Some(supervision_event) = supervision_rx.recv() => {
                         if let Err(err) = instance.handle_supervision_event(&mut actor, supervision_event).await {
@@ -1838,7 +1849,7 @@ impl PythonActor {
 
         // Spawn a child actor to await the Python handler method.
         tokio::spawn(handle_async_endpoint_panic(
-            cx.signal_sender(),
+            cx.forced_exit_sender(),
             PythonTask::new(future)?,
             receiver,
             cx.self_addr().to_string(),
@@ -2051,7 +2062,7 @@ impl Handler<MeshFailure> for PythonActor {
 }
 
 async fn handle_async_endpoint_panic(
-    panic_sender: mpsc::UnboundedSender<Signal>,
+    panic_sender: mpsc::UnboundedSender<ForcedExit>,
     task: PythonTask,
     side_channel: oneshot::Receiver<Py<PyAny>>,
     actor_id: String,
@@ -2114,7 +2125,10 @@ async fn handle_async_endpoint_panic(
     if let Some(panic) = panic {
         // Record error and panic metrics
         ENDPOINT_ACTOR_ERROR.add(1, attributes);
-        if panic_sender.send(Signal::Kill(panic.to_string())).is_err() {
+        if panic_sender
+            .send(ForcedExit::Abort(panic.to_string()))
+            .is_err()
+        {
             tracing::warn!("dropped panic signal: actor already stopped: {panic}");
         }
     }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1306,7 +1306,6 @@ impl PythonActor {
                                 break None;
                             },
                             Some(Signal::ExitRequested(_)) => break None,
-                            Some(Signal::ChildStopped(_)) => {},
                             Some(Signal::Kill(reason)) => {
                                 break Some(ActorError { actor_id: Box::new(instance.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) })
                             },

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -55,7 +55,6 @@ def configure(
     split_max_buffer_size: int = ...,
     split_max_buffer_age: str = ...,
     stop_actor_timeout: str = ...,
-    cleanup_timeout: str = ...,
     default_encoding: Encoding = ...,
     channel_net_rx_buffer_full_check_interval: str = ...,
     message_latency_sampling_rate: float = ...,
@@ -127,7 +126,6 @@ def configure(
         split_max_buffer_age: Maximum age for split message buffers
             (humantime)
         stop_actor_timeout: Timeout for stopping actors (humantime)
-        cleanup_timeout: Timeout for cleanup operations (humantime)
         default_encoding: Default message encoding (Encoding.Bincode,
             Encoding.Json, or Encoding.Multipart)
         channel_net_rx_buffer_full_check_interval: Network receive buffer

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1712,14 +1712,14 @@ class Actor(MeshTrait):
         because of an error. The same ``__cleanup__`` runs in both cases;
         ``exc`` is ``None`` on a normal stop and carries the exception on an
         error stop. It is *not* called on fatal failures such as OOMs, panics,
-        or signals like ``SIGSEGV``. If it exceeds ``HYPERACTOR_CLEANUP_TIMEOUT``,
-        it is cancelled and the actor is placed in an error state.
+        or signals like ``SIGSEGV``.
 
-        By the time this runs, every mesh this actor owns has already been
-        stopped recursively, and each owned actor's ``__cleanup__`` has already
-        run. Owned actor meshes and proc meshes are no longer usable from this
-        method. For shutdown work that needs an owned mesh, expose a dedicated
-        endpoint and call it before ``stop()``.
+        On graceful shutdown, owned actors normally finish first. On failure or
+        forced teardown, residual descendants are transferred to proc
+        supervision and sent ``Kill``, so their cleanup may not run. Owned actor
+        meshes and proc meshes are no longer usable from this method. For
+        shutdown work that needs an owned mesh, expose a dedicated endpoint and
+        call it before ``stop()``.
 
         Use ``__cleanup__`` to release resources the actor owns directly: open
         files, network connections, background threads, asyncio tasks, and the

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -288,10 +288,10 @@ class Instance(abc.ABC):
         lifecycle pattern (map-reduce shards, batch processing,
         worker pools, etc.; see ``sleep_actors.py`` for an example).
 
-        This is observable in the mesh: on exit the actor emits
-        ``Signal::ChildStopped`` to its parent (always), so
-        ProcAgent *does* see the stop, and terminated snapshots
-        preserve post‑mortem state for introspection.
+        This is observable in the mesh: on exit the runtime emits an
+        ``ActorSupervisionEvent`` to the actor's supervisor, so ProcAgent
+        *does* see the stop, and terminated snapshots preserve post‑mortem
+        state for introspection.
 
         Use ``ActorMesh.stop()`` when you need coordinated, mesh-wide
         shutdown.

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -58,7 +58,6 @@ if TYPE_CHECKING:
             split_max_buffer_size: NotRequired[int]
             split_max_buffer_age: NotRequired[str]
             stop_actor_timeout: NotRequired[str]
-            cleanup_timeout: NotRequired[str]
             default_encoding: NotRequired[Encoding]
             channel_net_rx_buffer_full_check_interval: NotRequired[str]
             message_latency_sampling_rate: NotRequired[float]
@@ -130,7 +129,6 @@ def configure(**kwargs: "ConfigureKwargsType") -> None:
             split_max_buffer_size: Maximum buffer size for message splitting (bytes).
             split_max_buffer_age: Maximum age for split message buffers (humantime).
             stop_actor_timeout: Timeout for stopping actors (humantime).
-            cleanup_timeout: Timeout for cleanup operations (humantime).
             default_encoding: Default message encoding (Encoding.Bincode, Encoding.Json, or Encoding.Multipart).
             channel_net_rx_buffer_full_check_interval: Network receive buffer check interval (humantime).
             message_latency_sampling_rate: Sampling rate for message latency tracking (0.0 to 1.0).

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -258,7 +258,6 @@ def test_duration_config_multiple() -> None:
         ("message_ack_time_interval", "2s", "2s", "500ms"),
         ("split_max_buffer_age", "100ms", "100ms", "50ms"),
         ("stop_actor_timeout", "15s", "15s", "10s"),
-        ("cleanup_timeout", "25s", "25s", "3s"),
         ("channel_net_rx_buffer_full_check_interval", "200ms", "200ms", "5s"),
         # Mesh bootstrap config
         ("mesh_terminate_timeout", "20s", "20s", "10s"),
@@ -413,7 +412,6 @@ def test_all_params_together():
         split_max_buffer_size=2048,
         split_max_buffer_age="100ms",
         stop_actor_timeout="15s",
-        cleanup_timeout="25s",
         default_encoding=Encoding.Json,
         channel_net_rx_buffer_full_check_interval="200ms",
         message_latency_sampling_rate=0.5,
@@ -452,7 +450,6 @@ def test_all_params_together():
         assert config["split_max_buffer_size"] == 2048
         assert config["split_max_buffer_age"] == "100ms"
         assert config["stop_actor_timeout"] == "15s"
-        assert config["cleanup_timeout"] == "25s"
         assert config["default_encoding"] == Encoding.Json
         assert config["channel_net_rx_buffer_full_check_interval"] == "200ms"
         assert config["message_latency_sampling_rate"] == pytest.approx(0.5, rel=1e-5)
@@ -483,7 +480,6 @@ def test_all_params_together():
     assert config["split_max_buffer_size"] == 5
     assert config["split_max_buffer_age"] == "50ms"
     assert config["stop_actor_timeout"] == "10s"
-    assert config["cleanup_timeout"] == "3s"
     assert config["default_encoding"] == Encoding.Multipart
     assert config["channel_net_rx_buffer_full_check_interval"] == "5s"
     assert config["message_latency_sampling_rate"] == pytest.approx(0.01, rel=1e-5)


### PR DESCRIPTION
Summary: Route `Kill` outside the ordinary signal loop so it can cancel active handlers at their next yield while runtime finalization remains active. Keep `Stop` cooperative. The Python root client uses an inverted loop, so migrate its existing kill and endpoint-panic paths to `ForcedExit` after removing `Signal::Kill`; this preserves its behavior.

Differential Revision: D115847483
