### PR TITLE
Unify forced actor termination as Abort (#4664)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -719,9 +719,6 @@ pub enum Signal {
     /// Exit the actor loop with the provided stop reason.
     ExitRequested(String),
 
-    /// The direct child with the given uid was stopped.
-    ChildStopped(crate::id::Uid),
-
     /// Kill the actor. This will exit the actor loop with an error,
     /// causing a supervision event to propagate up the supervision
     /// hierarchy.
@@ -734,7 +731,6 @@ impl fmt::Display for Signal {
             Signal::DrainAndStop(reason) => write!(f, "DrainAndStop({})", reason),
             Signal::Stop(reason) => write!(f, "Stop({})", reason),
             Signal::ExitRequested(reason) => write!(f, "ExitRequested({})", reason),
-            Signal::ChildStopped(uid) => write!(f, "ChildStopped({})", uid),
             Signal::Kill(reason) => write!(f, "Kill({})", reason),
         }
     }

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -719,10 +719,10 @@ pub enum Signal {
     /// Exit the actor loop with the provided stop reason.
     ExitRequested(String),
 
-    /// Kill the actor. This will exit the actor loop with an error,
+    /// Abort the actor. This will exit the actor loop with an error,
     /// causing a supervision event to propagate up the supervision
     /// hierarchy.
-    Kill(String),
+    Abort(String),
 }
 
 impl fmt::Display for Signal {
@@ -731,7 +731,7 @@ impl fmt::Display for Signal {
             Signal::DrainAndStop(reason) => write!(f, "DrainAndStop({})", reason),
             Signal::Stop(reason) => write!(f, "Stop({})", reason),
             Signal::ExitRequested(reason) => write!(f, "ExitRequested({})", reason),
-            Signal::Kill(reason) => write!(f, "Kill({})", reason),
+            Signal::Abort(reason) => write!(f, "Abort({})", reason),
         }
     }
 }
@@ -780,7 +780,7 @@ impl fmt::Display for HandlerInfo {
 pub enum ActorStoppingReason {
     /// The actor is stopping through the normal cooperative shutdown path.
     Requested,
-    /// The actor did not respond to hard kill, and teardown stopped waiting on
+    /// The actor did not respond to abort, and teardown stopped waiting on
     /// it normally.
     Zombie(String),
 }
@@ -940,10 +940,9 @@ impl<A: Actor> ActorHandle<A> {
         self.cell.signal(Signal::Stop(reason.to_string()))
     }
 
-    /// Signal the actor to terminate immediately.
-    pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
-        tracing::info!("actor handle kill called: {}", self.actor_addr());
-        self.cell.signal(Signal::Kill(reason.to_string()))
+    /// Signal the actor to abort immediately.
+    pub fn abort(&self, reason: &str) -> Result<(), ActorError> {
+        self.cell.signal(Signal::Abort(reason.to_string()))
     }
 
     /// A watch that observes the lifecycle state of the actor.
@@ -1067,9 +1066,9 @@ impl AnyActorHandle {
         self.cell.signal(Signal::Stop(reason.to_string()))
     }
 
-    /// Signal the actor to terminate immediately.
-    pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
-        self.cell.signal(Signal::Kill(reason.to_string()))
+    /// Signal the actor to abort immediately.
+    pub fn abort(&self, reason: &str) -> Result<(), ActorError> {
+        self.cell.signal(Signal::Abort(reason.to_string()))
     }
 
     /// A watch that observes the lifecycle state of the actor.

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2055,14 +2055,14 @@ struct ActorStopped {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ChildTeardown {
     Cooperative(StopMode),
-    Kill,
+    Abort,
 }
 
 impl ChildTeardown {
     fn from_run_result(result: &Result<ActorStopped, ActorError>) -> Self {
         match result {
             Ok(stopped) => Self::Cooperative(stopped.stop_mode),
-            Err(err) if matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)) => Self::Kill,
+            Err(err) if matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)) => Self::Abort,
             Err(_) => Self::Cooperative(StopMode::Stop),
         }
     }
@@ -2789,24 +2789,9 @@ impl<A: Actor> Instance<A> {
             .signal(Signal::DrainAndStop(reason.to_string()))
     }
 
-    /// Signal the actor to terminate immediately with a provided reason.
-    pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
-        tracing::info!(
-            actor_id = %self.inner.cell.actor_addr(),
-            reason,
-            "instance kill called",
-        );
-        self.inner.cell.signal(Signal::Kill(reason.to_string()))
-    }
-
-    /// Backward-compatible alias for `kill()`.
+    /// Signal the actor to abort immediately with a provided reason.
     pub fn abort(&self, reason: &str) -> Result<(), ActorError> {
-        tracing::info!(
-            actor_id = %self.inner.cell.actor_addr(),
-            reason,
-            "instance abort called",
-        );
-        self.kill(reason)
+        self.inner.cell.signal(Signal::Abort(reason.to_string()))
     }
 
     /// Close handler ingress for this actor.
@@ -3178,8 +3163,8 @@ impl<A: Actor> Instance<A> {
         let mut to_unlink = Vec::new();
         let child_signal = match ChildTeardown::from_run_result(&result) {
             ChildTeardown::Cooperative(mode) => ChildTeardown::cooperative_signal(mode),
-            ChildTeardown::Kill => {
-                // TODO: fan out kill once child teardown can detach
+            ChildTeardown::Abort => {
+                // TODO: fan out abort once child teardown can detach
                 // unresponsive children without blocking this parent.
                 ChildTeardown::cooperative_signal(StopMode::Stop)
             }
@@ -3334,7 +3319,7 @@ impl<A: Actor> Instance<A> {
                         Signal::ExitRequested(reason) => {
                             break 'messages reason;
                         }
-                        Signal::Kill(reason) => {
+                        Signal::Abort(reason) => {
                             return Err(ActorError { actor_id: Box::new(self.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) });
                         }
                     }
@@ -8517,7 +8502,7 @@ mod tests {
     }
 
     #[test]
-    fn child_teardown_distinguishes_kill_from_failure() {
+    fn child_teardown_distinguishes_abort_from_failure() {
         let actor_addr = test_actor_id("proc", "actor");
 
         let stopped = Ok(ActorStopped {
@@ -8529,11 +8514,14 @@ mod tests {
             ChildTeardown::Cooperative(StopMode::DrainAndStop)
         );
 
-        let killed = Err(ActorError::new(
+        let aborted = Err(ActorError::new(
             &actor_addr,
-            ActorErrorKind::Aborted("test kill".to_string()),
+            ActorErrorKind::Aborted("test abort".to_string()),
         ));
-        assert_eq!(ChildTeardown::from_run_result(&killed), ChildTeardown::Kill);
+        assert_eq!(
+            ChildTeardown::from_run_result(&aborted),
+            ChildTeardown::Abort
+        );
 
         let failed = Err(ActorError::new(
             &actor_addr,

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3055,14 +3055,14 @@ impl<A: Actor> Instance<A> {
                     status.clone(),
                     None,
                 );
-                (status, Some(event))
+                (status, event)
             }
             Err(err) => match *err.kind {
                 ActorErrorKind::UnhandledSupervisionEvent(box event) => {
                     // We use the event's actor_status as this actor's terminal status.
                     assert!(event.actor_status.is_terminal());
                     let status = event.actor_status.clone();
-                    (status, Some(event))
+                    (status, event)
                 }
                 ActorErrorKind::SyntheticSupervision(synthetic) => {
                     let local_fence = synthetic.local_fence.clone();
@@ -3075,7 +3075,7 @@ impl<A: Actor> Instance<A> {
                         None,
                     )
                     .with_local_fence(local_fence);
-                    (status, Some(event))
+                    (status, event)
                 }
                 _ => {
                     let error_kind = ActorErrorKind::Generic(err.kind.to_string());
@@ -3086,7 +3086,7 @@ impl<A: Actor> Instance<A> {
                         status.clone(),
                         None,
                     );
-                    (status, Some(event))
+                    (status, event)
                 }
             },
         };
@@ -3095,52 +3095,33 @@ impl<A: Actor> Instance<A> {
         // FI-9: supervisors observe the zombie lifecycle verdict, while the event
         // stored below must describe the terminal status for introspection.
         let event_to_deliver = if current_status.is_zombie() {
-            Some(ActorSupervisionEvent::new(
+            ActorSupervisionEvent::new(
                 self.inner.cell.actor_addr().clone(),
                 actor.display_name(),
                 current_status,
                 None,
-            ))
+            )
         } else {
             event.clone()
         };
 
         self.mailbox().close(terminal_status.clone());
         // FI-1: store supervision_event BEFORE change_status.
-        if let Some(event) = &event {
-            *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event.clone());
-        }
+        *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event);
 
         // Deliver the supervision event to the parent/proc BEFORE
         // change_status so that any observer waiting for this actor's
         // terminal state can only see it once the event has been
-        // enqueued at its destination.
-        if let Some(parent) = self.inner.cell.maybe_unlink_parent() {
-            if let Some(event) = event_to_deliver {
-                // Parent exists, failure should be propagated to the parent.
-                parent.send_supervision_event_or_crash(event);
-            }
-            // TODO: we should get rid of this signal, and use *only* supervision events for
-            // the purpose of conveying lifecycle changes
-            if let Err(err) = parent.signal(Signal::ChildStopped(self.inner.cell.uid().clone())) {
-                tracing::error!(
-                    "{}: failed to send stop message to parent uid {}: {:?}",
-                    self.self_addr(),
-                    parent.uid(),
-                    err
-                );
-            }
-        } else {
-            // Failure happened to the root actor or orphaned child actors.
-            // In either case, the failure should be propagated to proc.
-            //
-            // Note that orphaned actor is unexpected and would only happen if
-            // there is a bug.
-            if let Some(event) = event_to_deliver {
-                self.inner
-                    .proc
-                    .handle_unhandled_supervision_event(&self, event);
-            }
+        // enqueued at its destination. A returned event had no owning parent
+        // — the root actor, or an orphaned child, which would be a bug.
+        if let Some(event) = self
+            .inner
+            .cell
+            .try_send_completion_event_to_parent(event_to_deliver)
+        {
+            self.inner
+                .proc
+                .handle_unhandled_supervision_event(&self, event);
         }
 
         self.stop_introspect(terminal_status.clone()).await;
@@ -3219,18 +3200,22 @@ impl<A: Actor> Instance<A> {
             self.inner.cell.unlink(&child);
         }
 
-        let (mut signal_receiver, _) = actor_loop_receivers;
+        let (_, mut supervision_event_receiver) = actor_loop_receivers;
         while self.inner.cell.child_count() > 0 {
-            match tokio::time::timeout(Duration::from_millis(500), signal_receiver.recv()).await {
-                Ok(Some(Signal::ChildStopped(uid))) => {
-                    assert!(self.inner.cell.get_child(&uid).is_none());
+            match tokio::time::timeout(
+                Duration::from_millis(500),
+                supervision_event_receiver.recv(),
+            )
+            .await
+            {
+                Ok(Some(event)) => {
+                    if let Some(child_id) = &event.child_to_unlink {
+                        self.inner.cell.inner.unlink_child_by_id(child_id);
+                    }
                 }
-                // Drain only tracks child termination; other signals are
-                // intentionally swallowed here.
-                Ok(Some(_)) => {}
                 Ok(None) => {
-                    // Signal channel closed: no further ChildStopped will
-                    // arrive, so we can no longer track child termination.
+                    // The supervision channel closed, so no further child
+                    // completion events can arrive.
                     // Drop remaining links and exit the drain loop, mirroring
                     // the timeout branch below.
                     self.inner.cell.unlink_all();
@@ -3238,7 +3223,7 @@ impl<A: Actor> Instance<A> {
                 }
                 Err(_) => {
                     tracing::warn!(
-                        "timeout waiting for ChildStopped signal from child on actor: {}, ignoring",
+                        "timeout waiting for child supervision event on actor: {}, ignoring",
                         self.self_addr()
                     );
                     // No more waiting to receive messages. Unlink all remaining
@@ -3346,9 +3331,6 @@ impl<A: Actor> Instance<A> {
                                 .await
                                 .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::processing(err)))?;
                         },
-                        Signal::ChildStopped(uid) => {
-                            assert!(self.inner.cell.get_child(&uid).is_none());
-                        },
                         Signal::ExitRequested(reason) => {
                             break 'messages reason;
                         }
@@ -3415,6 +3397,12 @@ impl<A: Actor> Instance<A> {
         actor: &mut A,
         supervision_event: ActorSupervisionEvent,
     ) -> Result<(), ActorError> {
+        // `actor_id` may identify a propagated descendant. `child_to_unlink`
+        // identifies the local ownership edge for this delivery.
+        if let Some(child_id) = &supervision_event.child_to_unlink {
+            self.inner.cell.inner.unlink_child_by_id(child_id);
+        }
+
         if supervision_event.is_locally_cancelled() {
             return Ok(());
         }
@@ -4063,6 +4051,30 @@ struct InstanceCellState {
 }
 
 impl InstanceCellState {
+    /// Route this instance's terminal event according to current supervision
+    /// ownership.
+    ///
+    /// If the parent still owns this child, enqueue the event while retaining
+    /// that ownership. The parent removes the child when it consumes the event,
+    /// so a queued terminal event remains visible to its shutdown policy.
+    /// Returns the event when no parent owns the child so the caller can route
+    /// it through proc supervision.
+    fn try_send_completion_event_to_parent(
+        &self,
+        event: ActorSupervisionEvent,
+    ) -> Option<ActorSupervisionEvent> {
+        let Some(parent) = self.parent.upgrade() else {
+            return Some(event);
+        };
+        let Some(child_entry) = parent.inner.children.get(self.actor_id.uid()) else {
+            return Some(event);
+        };
+
+        parent.send_supervision_event_or_crash(event.with_child_to_unlink(self.actor_id.clone()));
+        drop(child_entry);
+        None
+    }
+
     /// Unlink this instance from its parent, if it has one. If it was unlinked,
     /// the parent is returned.
     fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
@@ -4075,6 +4087,20 @@ impl InstanceCellState {
     fn unlink(&self, child: &InstanceCellState) -> bool {
         assert_eq!(self.actor_id.proc_id(), child.actor_id.proc_id());
         self.children.remove(child.actor_id.uid()).is_some()
+    }
+
+    /// Unlink a child when its terminal event is consumed by this actor.
+    fn unlink_child_by_id(&self, child_id: &ActorAddr) -> bool {
+        if self.actor_id.proc_id() != child_id.proc_id() {
+            return false;
+        }
+        match self.children.entry(child_id.uid().clone()) {
+            Entry::Occupied(entry) if entry.get().actor_addr() == child_id => {
+                entry.remove();
+                true
+            }
+            _ => false,
+        }
     }
 }
 
@@ -4498,10 +4524,11 @@ impl InstanceCell {
         }
     }
 
-    /// Unlink this instance from its parent, if it has one. If it was unlinked,
-    /// the parent is returned.
-    fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
-        self.inner.maybe_unlink_parent()
+    fn try_send_completion_event_to_parent(
+        &self,
+        event: ActorSupervisionEvent,
+    ) -> Option<ActorSupervisionEvent> {
+        self.inner.try_send_completion_event_to_parent(event)
     }
 
     /// Return an iterator over this instance's children. This may deadlock if the
@@ -4524,7 +4551,7 @@ impl InstanceCell {
             .collect()
     }
 
-    /// Get a child by its uid.
+    #[cfg(test)]
     fn get_child(&self, uid: &crate::id::Uid) -> Option<InstanceCell> {
         self.inner.children.get(uid).map(|child| child.clone())
     }
@@ -6435,7 +6462,13 @@ mod tests {
             third_cell.parent().unwrap().actor_addr(),
             second.actor_addr()
         );
-        assert!(second.cell().get_child(third_cell.uid()).is_none());
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while second.cell().get_child(third_cell.uid()).is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("parent must consume the terminal event and unlink the child");
         drop(third_cell);
         validate_link(second.cell(), first.cell());
 
@@ -7205,6 +7238,40 @@ mod tests {
         assert!(!root_1_1_1_state.load(Ordering::SeqCst));
         assert!(!root_2_state.load(Ordering::SeqCst));
         assert!(!root_2_1_state.load(Ordering::SeqCst));
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn terminal_event_unlinks_child_when_consumed() {
+        let proc = Proc::isolated();
+        let mut parent = proc.actor_instance::<TestActor>("parent").unwrap();
+        let parent_cell = parent.handle.cell().clone();
+        let child = parent.instance.spawn(TestActor);
+        let child_addr = child.actor_addr().clone();
+
+        child.drain_and_stop("test").unwrap();
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_eq!(
+            parent_cell.child_count(),
+            1,
+            "child must remain linked until its terminal event is consumed"
+        );
+
+        let event = parent
+            .supervision
+            .recv()
+            .await
+            .expect("child must publish a terminal supervision event");
+        assert_eq!(event.child_to_unlink.as_ref(), Some(&child_addr));
+        parent
+            .instance
+            .handle_supervision_event(&mut TestActor, event)
+            .await
+            .expect("clean child completion should be handled");
+        assert_eq!(
+            parent_cell.child_count(),
+            0,
+            "consuming the terminal event must unlink the child"
+        );
     }
 
     #[async_timed_test(timeout_secs = 30)]

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -71,6 +71,11 @@ pub struct ActorSupervisionEvent {
     #[serde(skip, default = "local_fence")]
     #[derivative(PartialEq = "ignore")]
     pub(crate) local_fence: Arc<AtomicBool>,
+    /// Direct child whose ownership edge the receiver must remove. This is
+    /// hop-local bookkeeping and is not part of the propagated event.
+    #[serde(skip)]
+    #[derivative(PartialEq = "ignore")]
+    pub(crate) child_to_unlink: Option<ActorAddr>,
 }
 wirevalue::register_type!(ActorSupervisionEvent);
 
@@ -93,11 +98,17 @@ impl ActorSupervisionEvent {
             actor_status,
             message_headers,
             local_fence: local_fence(),
+            child_to_unlink: None,
         }
     }
 
     pub(crate) fn with_local_fence(mut self, local_fence: Arc<AtomicBool>) -> Self {
         self.local_fence = local_fence;
+        self
+    }
+
+    pub(crate) fn with_child_to_unlink(mut self, child_to_unlink: ActorAddr) -> Self {
+        self.child_to_unlink = Some(child_to_unlink);
         self
     }
 

--- a/hyperactor_remote/src/keepalive.rs
+++ b/hyperactor_remote/src/keepalive.rs
@@ -315,7 +315,7 @@ impl Handler<KeepaliveAck> for KeepaliveWorker {
 impl Handler<AckDeadline> for KeepaliveWorker {
     async fn handle(&mut self, cx: &Context<Self>, message: AckDeadline) -> anyhow::Result<()> {
         if self.acked_generation < message.generation {
-            cx.kill("keepalive acknowledgment missed")?;
+            cx.abort("keepalive acknowledgment missed")?;
         }
         Ok(())
     }
@@ -382,7 +382,7 @@ impl Handler<Deadline> for KeepaliveSupervisor {
         // cannot be produced by this actor before it observes that generation.
         if message.generation == self.generation {
             let reason = format!("keepalive missed for generation {}", message.generation);
-            cx.kill(&reason)?;
+            cx.abort(&reason)?;
         }
         Ok(())
     }

--- a/hyperactor_remote/src/link.rs
+++ b/hyperactor_remote/src/link.rs
@@ -144,7 +144,7 @@ mod tests {
         async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
             let link = self.link.take().unwrap();
             let handle = link.spawn_worker(this).await?;
-            handle.kill("link failed")?;
+            handle.abort("link failed")?;
             Ok(())
         }
 

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -804,8 +804,8 @@ mod tests {
     wirevalue::register_type!(TestChildCommand);
 
     #[derive(Clone, Debug, Serialize, Deserialize, Named)]
-    struct KillParent;
-    wirevalue::register_type!(KillParent);
+    struct AbortParent;
+    wirevalue::register_type!(AbortParent);
 
     #[derive(Debug)]
     enum TestChildAction {
@@ -869,7 +869,7 @@ mod tests {
             message: TestChildCommand,
         ) -> anyhow::Result<()> {
             match message {
-                TestChildCommand::Fail => cx.kill("test child failed")?,
+                TestChildCommand::Fail => cx.abort("test child failed")?,
                 TestChildCommand::Drain(tag) => {
                     if let Some(ref port) = self.drain_observer {
                         port.post(cx, tag);
@@ -908,7 +908,7 @@ mod tests {
     }
 
     #[derive(Debug)]
-    #[hyperactor::export(KillParent)]
+    #[hyperactor::export(AbortParent)]
     struct Grandparent {
         parent: Option<Parent>,
         parent_addr: PortHandle<ActorAddr>,
@@ -940,16 +940,16 @@ mod tests {
     }
 
     #[async_trait]
-    impl Handler<KillParent> for Grandparent {
+    impl Handler<AbortParent> for Grandparent {
         async fn handle(
             &mut self,
             _cx: &Context<Self>,
-            _message: KillParent,
+            _message: AbortParent,
         ) -> anyhow::Result<()> {
             self.parent_handle
                 .as_ref()
-                .expect("parent must be spawned before kill")
-                .kill("test parent killed")?;
+                .expect("parent must be spawned before abort")
+                .abort("test parent aborted")?;
             Ok(())
         }
     }
@@ -1245,12 +1245,12 @@ mod tests {
     //         └── supervisor: Supervisor
     //             └── supervisor-side liveness actor: KeepaliveSupervisor
     //
-    // Killing Parent still tears down its local supervision subtree. Grandparent
+    // Aborting Parent still tears down its local supervision subtree. Grandparent
     // handles the parent failure so the test process does not treat it as an
     // unhandled root failure. Parent stops Supervisor, Supervisor forwards the
     // stop to Worker, and Worker stops TestChild.
     #[tokio::test]
-    async fn test_parent_kill_stops_remote_child() {
+    async fn test_parent_abort_stops_remote_child() {
         let proc = Proc::isolated();
         let client = proc.client("client");
         let (ready, mut ready_rx) = client.open_port::<ActorAddr>();
@@ -1276,7 +1276,7 @@ mod tests {
         let parent_addr = parent_addr_rx.recv().await.unwrap();
 
         tokio::time::sleep(Duration::from_millis(100)).await;
-        grandparent.post(&client, KillParent);
+        grandparent.post(&client, AbortParent);
 
         let reason = tokio::time::timeout(Duration::from_secs(5), stopped_rx.recv())
             .await

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -47,7 +47,7 @@ wirevalue::register_type!(ParentExit);
 #[derive(Clone, Debug, Serialize, Deserialize, Named)]
 enum ParentControl {
     Exit(StopMode),
-    Kill,
+    Abort,
 }
 wirevalue::register_type!(ParentControl);
 
@@ -161,7 +161,7 @@ impl Handler<ParentControl> for ParentRoot {
             .expect("parent must be spawned before control message");
         match message {
             ParentControl::Exit(stop_mode) => parent.post(cx, ParentExit(stop_mode)),
-            ParentControl::Kill => parent.kill("test parent killed")?,
+            ParentControl::Abort => parent.abort("test parent aborted")?,
         }
         Ok(())
     }
@@ -251,7 +251,7 @@ impl Handler<WorkerControl> for WorkerRoot {
         self.worker
             .as_ref()
             .expect("worker must be spawned before control message")
-            .kill("test worker killed")?;
+            .abort("test worker aborted")?;
         Ok(())
     }
 }
@@ -419,16 +419,16 @@ async fn test_token_join_parent_exit_drain_and_stops_child_first() -> anyhow::Re
 
 // Same topology as `test_token_join_parent_exit_stops_child_first`.
 //
-// Killing the parent actor is the in-process hard-stop path. The parent still
+// Aborting the parent actor is the in-process hard-stop path. The parent still
 // owns a local supervision tree, so the runtime stops Supervisor while cleaning
 // up that tree, and Supervisor forwards the stop to Worker.
 #[tokio::test]
-async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
+async fn test_token_join_parent_abort_stops_child() -> anyhow::Result<()> {
     let mut harness = Harness::new().await?;
 
     harness
         .parent_root
-        .post(&harness.observer, ParentControl::Kill);
+        .post(&harness.observer, ParentControl::Abort);
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
     assert_eq!(reason, "parent stopping");
@@ -438,12 +438,12 @@ async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
 
 // Same topology as `test_token_join_parent_exit_stops_child_first`.
 //
-// Killing the worker actor is the in-process equivalent of the child-side
+// Aborting the worker actor is the in-process equivalent of the child-side
 // process disappearing. The worker can no longer report the child lifecycle
 // directly, so the parent side observes a synthesized supervision event through
 // the keepalive link.
 #[tokio::test]
-async fn test_token_join_worker_kill_notifies_parent() -> anyhow::Result<()> {
+async fn test_token_join_worker_abort_notifies_parent() -> anyhow::Result<()> {
     let mut harness = Harness::new().await?;
 
     harness.worker_root.post(&harness.observer, WorkerControl);

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1276,7 +1276,6 @@ impl PythonActor {
                                 break None;
                             },
                             Some(Signal::ExitRequested(_)) => break None,
-                            Some(Signal::ChildStopped(_)) => {},
                             Some(Signal::Kill(reason)) => {
                                 break Some(ActorError { actor_id: Box::new(instance.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) })
                             },

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1276,7 +1276,7 @@ impl PythonActor {
                                 break None;
                             },
                             Some(Signal::ExitRequested(_)) => break None,
-                            Some(Signal::Kill(reason)) => {
+                            Some(Signal::Abort(reason)) => {
                                 break Some(ActorError { actor_id: Box::new(instance.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) })
                             },
                             None => {

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -100,12 +100,6 @@ impl PyInstance {
     }
 
     #[pyo3(signature = (reason = None))]
-    fn kill(&self, reason: Option<&str>) -> PyResult<()> {
-        let reason = reason.unwrap_or("(no reason provided)");
-        Ok(self.inner.kill(reason).map_err(anyhow::Error::from)?)
-    }
-
-    #[pyo3(signature = (reason = None))]
     fn stop(&self, reason: Option<&str>) -> PyResult<()> {
         tracing::info!(actor_id = %self.inner.self_addr(), "stopping PyInstance");
         let reason = reason.unwrap_or("(no reason provided)");

--- a/monarch_rdma/src/rdma_manager_owner.rs
+++ b/monarch_rdma/src/rdma_manager_owner.rs
@@ -1794,7 +1794,7 @@ mod tests {
     /// and unknown reporters resolve nothing (asserted BEFORE the match, so a
     /// regression cannot hide behind the later resolution). The identical report
     /// through the subscriber route is a late duplicate that cannot rewrite the
-    /// cached error. Finally, killing the already-`Failed` source's real
+    /// cached error. Finally, aborting the already-`Failed` source's real
     /// controller (a `Failed` controller terminal) invalidates the overlapping
     /// pending view by proc-view overlap, with the sibling's own subscription
     /// removed. A dropped waiter's drained reply must not bounce into the owner
@@ -1998,22 +1998,22 @@ mod tests {
         );
 
         let ctrl_a_handle = ctrl_a.downcast_handle(client).expect("local A controller");
-        ctrl_a_handle.kill("test: kill A controller")?;
+        ctrl_a_handle.abort("test: abort A controller")?;
         let b_err = timeout(Duration::from_secs(30), rxb.recv())
             .await
-            .expect("B resolved after A-controller kill")?
+            .expect("B resolved after A-controller abort")?
             .expect_err("B fails via overlap from the Failed source");
         assert!(
             matches!(b_err, RdmaInitError::Supervision(_)),
             "B: {b_err:?}"
         );
-        // A is already a `Failed` source; killing its controller drives the
+        // A is already a `Failed` source; aborting its controller drives the
         // Failed-source + Failed-controller cell of RMO-17. A's controller
         // completes `Failed`.
         let a_status = ctrl_a_handle.await;
         assert!(
             matches!(a_status, ActorStatus::Failed(_)),
-            "A controller failed after kill: {a_status:?}",
+            "A controller failed after abort: {a_status:?}",
         );
         assert_eq!(
             probe(&owner_handle, client, view_c.clone()).await.state,
@@ -2294,7 +2294,7 @@ mod tests {
     /// real cleanup path. Cleanly stopping a `Ready` controller invalidates every
     /// still-`Pending` view sharing one of its per-proc managers, and only those;
     /// sibling subscriptions are removed first so the overlap cannot leak through
-    /// the subscriber stream. Killing a disjoint pending view's controller then
+    /// the subscriber stream. Aborting a disjoint pending view's controller then
     /// proves the error-terminal branch (RMO-14). Every terminal input keeps the
     /// owner alive (RMO-4) and leaves a terminal source and disjoint views
     /// unchanged (RMO-2).
@@ -2481,15 +2481,15 @@ mod tests {
             .await?;
         assert_eq!(ra2rx.recv().await?, Ok(()), "A source stays cached Ready");
 
-        // Self-termination path, error-terminal branch: kill D's own controller
+        // Self-termination path, error-terminal branch: abort D's own controller
         // so it completes as `Failed` (a crash, not a clean stop). The owner gates
         // on `is_terminal()`, so `Failed` drives the same resolution A's clean
         // `Stopped` did; D resolves directly (RMO-14).
         let ctrl_d_handle = ctrl_d.downcast_handle(client).expect("local D controller");
-        ctrl_d_handle.kill("test: kill D controller")?;
+        ctrl_d_handle.abort("test: abort D controller")?;
         let d_err = timeout(Duration::from_secs(30), rxd.recv())
             .await
-            .expect("D resolved after its controller was killed")?
+            .expect("D resolved after its controller was aborted")?
             .expect_err("D fails on its own controller termination");
         assert!(
             matches!(d_err, RdmaInitError::Supervision(_)),
@@ -2499,7 +2499,7 @@ mod tests {
         let d_status = ctrl_d_handle.await;
         assert!(
             matches!(d_status, ActorStatus::Failed(_)),
-            "D controller failed after kill: {d_status:?}",
+            "D controller failed after abort: {d_status:?}",
         );
 
         owner_handle.stop("test complete")?;

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -279,14 +279,6 @@ class Instance(abc.ABC):
         ...
 
     @abstractmethod
-    def kill(self, reason: Optional[str] = None) -> None:
-        """
-        Terminate the current actor with a failure. A supervision error
-        propagates to its creator.
-        """
-        ...
-
-    @abstractmethod
     def stop(self, reason: Optional[str] = None) -> None:
         """
         Stop this actor instance and its children gracefully. The
@@ -1295,7 +1287,7 @@ async def _dispatch_loop(
     Args:
         actor: The Python actor object that implements ``handle``.
         receiver: Channel receiver for queued messages.
-        self_instance: The actor's own Instance, used to kill self on
+        self_instance: The actor's own Instance, used to abort self on
             an unhandled exception.
     """
     while True:
@@ -1306,7 +1298,7 @@ async def _dispatch_loop(
             return
         except BaseException as e:
             reason = "".join(TracebackException.from_exception(e).format())
-            self_instance.kill(reason)
+            self_instance.abort(reason)
             raise
 
 

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -296,10 +296,10 @@ class Instance(abc.ABC):
         lifecycle pattern (map-reduce shards, batch processing,
         worker pools, etc.; see ``sleep_actors.py`` for an example).
 
-        This is observable in the mesh: on exit the actor emits
-        ``Signal::ChildStopped`` to its parent (always), so
-        ProcAgent *does* see the stop, and terminated snapshots
-        preserve post‑mortem state for introspection.
+        This is observable in the mesh: on exit the runtime emits an
+        ``ActorSupervisionEvent`` to the actor's supervisor, so ProcAgent
+        *does* see the stop, and terminated snapshots preserve post‑mortem
+        state for introspection.
 
         Use ``ActorMesh.stop()`` when you need coordinated, mesh-wide
         shutdown.

--- a/python/monarch/_src/actor/concurrent.py
+++ b/python/monarch/_src/actor/concurrent.py
@@ -60,7 +60,7 @@ def _cancelled_for_cleanup(record: _TaskRecord | None) -> bool:
 def _fail_actor(actor_instance: Any, exception: BaseException) -> None:
     reason = "".join(TracebackException.from_exception(exception).format())
     try:
-        actor_instance.kill(reason)
+        actor_instance.abort(reason)
     except Exception:
         # The actor's signal channel may already be closed if it has finished
         # stopping; there is then nothing left to fail.

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -306,14 +306,14 @@ def test_actor_init_exception_sync(mesh, actor_class, num_procs) -> None:
 @pytest.mark.timeout(60)
 @pytest.mark.parametrize("actor_class", [ExceptionActor, ExceptionActorSync])
 @isolate_in_subprocess
-async def test_broadcast_exception_with_no_reply_port_kills_actor(actor_class) -> None:
+async def test_broadcast_exception_with_no_reply_port_aborts_actor(actor_class) -> None:
     """A plain `Exception` from an endpoint invoked with *no reply port*
     (fire-and-forget `broadcast()`) fails the actor: the return is dropped, the
-    exception escapes through `DroppingPort.exception`, and the actor is killed,
+    exception escapes through `DroppingPort.exception`, and the actor is aborted,
     surfacing as a supervision fault at the client. Parametrized over both
-    dispatch modes because the kill reaches `Signal::Kill` by different paths
-    (direct: the endpoint task resolves `Err`; queue: `_dispatch_loop` calls
-    `self_instance.kill`). The existing broadcast-failure coverage uses a
+    dispatch modes because Abort reaches the actor by different paths (direct:
+    the endpoint task resolves `Err`; queue: `_dispatch_loop` calls
+    `self_instance.abort`). The existing broadcast-failure coverage uses a
     `BaseException`; this pins the plain-`Exception` path."""
     faults = []
     faulted = asyncio.Event()


### PR DESCRIPTION
Summary:

Replace the separate Kill and Abort vocabulary with one forced actor operation: Abort. Make `abort()` the primary API and retain `kill()` only as a compatibility alias.

Design invariant: every forced actor termination has one control signal, one terminal cause, and one result: `Abort` and `Aborted`. Callers and supervision no longer distinguish semantically identical forced-stop paths.

Update internal producers, consumers, status reporting, documentation, and tests to use the unified outcome without changing cancellation behavior.

Differential Revision: D115847493


