### PR TITLE
Add the rdma benchmark's topology module (#4667)

### DIFF
--- a/monarch_rdma/src/action.rs
+++ b/monarch_rdma/src/action.rs
@@ -9,11 +9,10 @@
 //! Batched RDMA action layer.
 //!
 //! [`RdmaAction`] accumulates [`crate::RdmaOp`]s through `add_read_into_local`
-//! / `add_write_from_local`, validates the per-op sizes and the local
-//! memory ranges as ops are added, and then dispatches the queued ops
-//! across the available backends in parallel on [`RdmaAction::submit`].
+//! / `add_write_from_local`, validates the per-op sizes as ops are added,
+//! and then dispatches the queued ops across the available backends in
+//! parallel on [`RdmaAction::submit`].
 
-use std::collections::HashMap;
 use std::time::Duration;
 
 use hyperactor::context;
@@ -29,20 +28,15 @@ use crate::rdma_components::RdmaRemoteBuffer;
 /// A batch of RDMA operations submitted as a single unit.
 ///
 /// `RdmaAction` is a builder that accumulates read-into-local and
-/// write-from-local ops, performs eager validation (size check + local
-/// memory range race detection), and then runs them concurrently across
-/// the available backends on [`Self::submit`].
+/// write-from-local ops, checking each op's sizes as it is added, and then
+/// runs them concurrently across the available backends on
+/// [`Self::submit`].
 ///
-/// Local-memory race detection treats an `add_read_into_local` claim as a
-/// write to the local range and an `add_write_from_local` claim as a
-/// read; two reads of the same range merge into one claim, anything else
-/// errors. Remote-side ranges are deliberately not tracked.
+/// Overlap between the queued ops' memory ranges is not tracked, on either
+/// the local or the remote side. Two ops in one action that write the same
+/// range race, and it is the caller's job not to queue them.
 pub struct RdmaAction {
     entries: Vec<RdmaOp>,
-    // Claimed local address ranges keyed by `[start, end)`. The stored
-    // [`RdmaOpType`] doubles as the op-kind tag: `ReadIntoLocal` is a
-    // local write, `WriteFromLocal` is a local read.
-    local_claims: HashMap<(usize, usize), RdmaOpType>,
 }
 
 impl Default for RdmaAction {
@@ -55,18 +49,10 @@ impl RdmaAction {
     pub fn new() -> Self {
         Self {
             entries: Vec::new(),
-            local_claims: HashMap::new(),
         }
     }
 
-    /// True if this op writes to the local address range
-    /// (`ReadIntoLocal` reads remote data *into* local memory).
-    fn is_local_write(op_type: RdmaOpType) -> bool {
-        matches!(op_type, RdmaOpType::ReadIntoLocal)
-    }
-
-    /// Queue a read from `remote` into `local`. Records a local *write*
-    /// claim over the local memory range.
+    /// Queue a read from `remote` into `local`.
     pub fn add_read_into_local(
         &mut self,
         remote: RdmaRemoteBuffer,
@@ -79,7 +65,6 @@ impl RdmaAction {
                 remote.size,
             );
         }
-        self.record_claim(local.addr(), local.size(), RdmaOpType::ReadIntoLocal)?;
         self.entries.push(RdmaOp {
             op_type: RdmaOpType::ReadIntoLocal,
             local,
@@ -88,8 +73,7 @@ impl RdmaAction {
         Ok(self)
     }
 
-    /// Queue a write from `local` into `remote`. Records a local *read*
-    /// claim over the local memory range.
+    /// Queue a write from `local` into `remote`.
     pub fn add_write_from_local(
         &mut self,
         remote: RdmaRemoteBuffer,
@@ -102,7 +86,6 @@ impl RdmaAction {
                 remote.size,
             );
         }
-        self.record_claim(local.addr(), local.size(), RdmaOpType::WriteFromLocal)?;
         self.entries.push(RdmaOp {
             op_type: RdmaOpType::WriteFromLocal,
             local,
@@ -111,54 +94,13 @@ impl RdmaAction {
         Ok(self)
     }
 
-    fn record_claim(
-        &mut self,
-        addr: usize,
-        size: usize,
-        op_type: RdmaOpType,
-    ) -> Result<(), anyhow::Error> {
-        let mut start = addr;
-        let mut end = addr.saturating_add(size);
-        let new_is_write = Self::is_local_write(op_type);
-
-        // In one pass, we merge all entries that overlap with the new claim into a single entry.
-        // We then remove all the merged entries.
-        let mut to_remove: Vec<(usize, usize)> = Vec::new();
-        for (&(s, e), &existing) in self.local_claims.iter() {
-            if end <= s || e <= start {
-                continue;
-            }
-            if new_is_write || Self::is_local_write(existing) {
-                anyhow::bail!(
-                    "RdmaAction data race: existing {:?} claim at [{:#x}, {:#x}) overlaps new {:?} claim at [{:#x}, {:#x})",
-                    existing,
-                    s,
-                    e,
-                    op_type,
-                    start,
-                    end,
-                );
-            }
-            start = start.min(s);
-            end = end.max(e);
-            to_remove.push((s, e));
-        }
-
-        for k in &to_remove {
-            self.local_claims.remove(k);
-        }
-        self.local_claims.insert((start, end), op_type);
-        Ok(())
-    }
-
     /// Submit all queued ops. Ops are grouped by backend and each group
     /// is submitted in parallel. Safe to call more than once on the same
-    /// action — the queued ops and overlap claims are left intact.
+    /// action — the queued ops are left intact.
     ///
-    /// Takes `&mut self` so the borrow checker prevents two submit
-    /// futures from being alive on the same action simultaneously;
-    /// otherwise the local-range overlap detection would be meaningless
-    /// (two in-flight dispatches over the same claimed local memory).
+    /// Takes `&mut self` so the borrow checker prevents two submit futures
+    /// from being alive on the same action at once, which would put two
+    /// in-flight dispatches over the same local memory.
     pub async fn submit(
         &mut self,
         client: &(impl context::Actor + Send + Sync),
@@ -217,88 +159,5 @@ impl RdmaAction {
                 errors.join("\n")
             )
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Convenience: WRITE-kind claim (i.e. simulates `add_read_into_local`).
-    fn write_claim(action: &mut RdmaAction, addr: usize, size: usize) -> Result<(), anyhow::Error> {
-        action.record_claim(addr, size, RdmaOpType::ReadIntoLocal)
-    }
-
-    /// Convenience: READ-kind claim (i.e. simulates `add_write_from_local`).
-    fn read_claim(action: &mut RdmaAction, addr: usize, size: usize) -> Result<(), anyhow::Error> {
-        action.record_claim(addr, size, RdmaOpType::WriteFromLocal)
-    }
-
-    #[test]
-    fn disjoint_writes_ok() {
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        write_claim(&mut a, 0x2000, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 2);
-    }
-
-    #[test]
-    fn overlapping_writes_error() {
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        let err = write_claim(&mut a, 0x1080, 0x100).unwrap_err();
-        assert!(err.to_string().contains("data race"));
-    }
-
-    #[test]
-    fn overlapping_reads_merge() {
-        let mut a = RdmaAction::new();
-        read_claim(&mut a, 0x1000, 0x100).unwrap();
-        read_claim(&mut a, 0x1080, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 1);
-        let (&(start, end), kind) = a.local_claims.iter().next().unwrap();
-        assert_eq!(start, 0x1000);
-        assert_eq!(end, 0x1180);
-        assert_eq!(*kind, RdmaOpType::WriteFromLocal);
-    }
-
-    #[test]
-    fn cascading_reads_merge() {
-        // Two disjoint reads, then a third that bridges them — the cascade
-        // must absorb both pre-existing entries, not just the first.
-        let mut a = RdmaAction::new();
-        read_claim(&mut a, 0x1000, 0x100).unwrap();
-        read_claim(&mut a, 0x1200, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 2);
-        read_claim(&mut a, 0x1080, 0x200).unwrap();
-        assert_eq!(a.local_claims.len(), 1);
-        let (&(start, end), _) = a.local_claims.iter().next().unwrap();
-        assert_eq!(start, 0x1000);
-        assert_eq!(end, 0x1300);
-    }
-
-    #[test]
-    fn write_vs_read_errors() {
-        let mut a = RdmaAction::new();
-        read_claim(&mut a, 0x1000, 0x100).unwrap();
-        let err = write_claim(&mut a, 0x1080, 0x100).unwrap_err();
-        assert!(err.to_string().contains("data race"));
-    }
-
-    #[test]
-    fn read_vs_write_errors() {
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        let err = read_claim(&mut a, 0x1080, 0x100).unwrap_err();
-        assert!(err.to_string().contains("data race"));
-    }
-
-    #[test]
-    fn touching_ranges_do_not_overlap() {
-        // `[0,100)` and `[100,200)` are adjacent, not overlapping.
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        write_claim(&mut a, 0x1100, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 2);
     }
 }

--- a/python/benches/multihost_rdma/bench_topology.py
+++ b/python/benches/multihost_rdma/bench_topology.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Transfer topologies for the multi-host RDMA benchmark.
+
+A benchmark configuration is a directed graph whose vertices are procs. A
+:py:class:`Slot` is one proc, identified by its logical host index and its
+*lane* -- the proc's ordinal within its host, which for a GPU run is also its
+CUDA device ordinal. An :py:class:`Edge` means bytes move from the source
+slot's memory into the destination slot's memory. The graph is built in two
+independent steps: :py:func:`host_edges` turns a pattern name and a host count
+into a host graph, and :py:func:`expand_lanes` realizes each host edge as proc
+edges under a lane-pairing rule.
+
+Which side *initiates* the ibverbs ops is a separate axis. Under ``"write"``
+the source pushes into the destination's buffers; under ``"read"`` the
+destination pulls from the source's buffers. Both move the same bytes over the
+same edges, so a pattern and a direction compose freely.
+
+Memory follows from the graph, and :py:class:`SlotValues` is its shape. A slot
+that sends allocates one *outgoing* pool of ``concurrent_ops`` tensors shared by
+all of its out-edges, which is legal because an ``RDMAAction`` treats a
+write-from-local as a *read* claim on local memory and merges overlapping read
+claims. A slot that receives allocates one *incoming* pool per peer that sends
+to it, which is mandatory: an ``RDMAAction`` does not track remote ranges, so
+two initiators writing one remote buffer would corrupt it silently. Since an
+edge is exactly a pair of slots, incoming pools are keyed by the sending peer
+and no separate index is needed. :py:func:`allocation_for` is the single source
+of truth for what a slot allocates, so what the actors allocate and what
+:py:func:`plan_memory` charges them for cannot drift.
+
+This module imports only the standard library. It holds no monarch, torch, or
+RDMA state, and every function in it is pure, so the whole benchmark's
+topology, routing, resource, and validation logic is testable without a
+cluster. Buffer handles are opaque: :py:func:`plan_for` and
+:py:func:`compare_digests` never look inside them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+
+P2P: str = "p2p"
+FAN_OUT: str = "fan-out"
+FAN_IN: str = "fan-in"
+ALL_TO_ALL: str = "all-to-all"
+RING: str = "ring"
+PATTERNS: tuple[str, ...] = (P2P, FAN_OUT, FAN_IN, ALL_TO_ALL, RING)
+
+READ: str = "read"
+WRITE: str = "write"
+DIRECTIONS: tuple[str, ...] = (READ, WRITE)
+
+# How a host edge becomes proc edges. `same` pairs lane k with lane k, so a
+# transfer never leaves one pair of device ordinals. `shifted` pairs lane k with
+# lane k+shift, and `all` pairs every lane with every lane; both cross ordinals,
+# so whether they can connect at all depends on the cluster's NIC topology.
+SAME: str = "same"
+SHIFTED: str = "shifted"
+ALL: str = "all"
+PAIRINGS: tuple[str, ...] = (SAME, SHIFTED, ALL)
+
+COLD_QP: str = "cold_qp"
+RAMP: str = "ramp"
+WARM: str = "warm"
+
+# The phases the benchmark reports. `RAMP` is deliberately absent: those
+# iterations are discarded so that settling never lands in a warm percentile.
+PHASES: tuple[str, ...] = (COLD_QP, WARM)
+
+
+@dataclass(frozen=True, order=True)
+class Slot:
+    """One benchmark proc: its logical host index and its lane within that host."""
+
+    host: int
+    lane: int
+
+    def __str__(self) -> str:
+        return f"h{self.host}/l{self.lane}"
+
+
+@dataclass(frozen=True, order=True)
+class Edge:
+    """One directed flow. Bytes move src to dst whichever side initiates."""
+
+    src: Slot
+    dst: Slot
+
+    def __str__(self) -> str:
+        return f"{self.src} -> {self.dst}"
+
+
+def host_edges(pattern: str, num_hosts: int) -> list[tuple[int, int]]:
+    """The directed host graph for ``pattern`` over ``num_hosts`` hosts.
+
+    One host yields the loopback self-edge, whatever the pattern, which is how
+    the benchmark expresses a same-host transfer.
+
+    Above one host, ``p2p`` always uses hosts 0 and 1 and leaves the rest idle.
+    That is intentional: it keeps p2p available as a baseline in a sweep that
+    provisions enough hosts for the other patterns.
+    """
+    if pattern not in PATTERNS:
+        raise ValueError(f"unknown pattern {pattern!r}; expected one of {PATTERNS}")
+    if num_hosts < 1:
+        raise ValueError(f"num_hosts must be at least 1, got {num_hosts}")
+    if num_hosts == 1:
+        return [(0, 0)]
+    match pattern:
+        case "p2p":
+            return [(0, 1)]
+        case "fan-out":
+            return [(0, dst) for dst in range(1, num_hosts)]
+        case "fan-in":
+            return [(src, 0) for src in range(1, num_hosts)]
+        case "all-to-all":
+            return [
+                (src, dst)
+                for src in range(num_hosts)
+                for dst in range(num_hosts)
+                if src != dst
+            ]
+        case _:
+            return [(src, (src + 1) % num_hosts) for src in range(num_hosts)]
+
+
+def expand_lanes(
+    host_edge: tuple[int, int],
+    procs_per_host: int,
+    pairing: str = SAME,
+    shift: int = 1,
+) -> list[Edge]:
+    """Realize one host edge as proc edges under a lane-pairing rule."""
+    if pairing not in PAIRINGS:
+        raise ValueError(f"unknown pairing {pairing!r}; expected one of {PAIRINGS}")
+    if procs_per_host < 1:
+        raise ValueError(f"procs_per_host must be at least 1, got {procs_per_host}")
+    src_host, dst_host = host_edge
+    lanes = range(procs_per_host)
+    if pairing == ALL:
+        return [
+            Edge(Slot(src_host, src), Slot(dst_host, dst))
+            for src in lanes
+            for dst in lanes
+        ]
+    if pairing == SAME:
+        return [Edge(Slot(src_host, lane), Slot(dst_host, lane)) for lane in lanes]
+    if shift % procs_per_host == 0:
+        raise ValueError(
+            f"shift {shift} is a multiple of procs_per_host {procs_per_host}, so "
+            f"{SHIFTED!r} pairing would silently be {SAME!r}"
+        )
+    return [
+        Edge(Slot(src_host, lane), Slot(dst_host, (lane + shift) % procs_per_host))
+        for lane in lanes
+    ]
+
+
+@dataclass(frozen=True)
+class Topology:
+    """A benchmark configuration's proc graph, with its per-slot edge indices.
+
+    Build with :py:func:`build_topology` rather than directly, so ``edges`` is
+    sorted and deduplicated.
+    """
+
+    pattern: str
+    num_hosts: int
+    procs_per_host: int
+    pairing: str
+    shift: int
+    edges: tuple[Edge, ...]
+
+    _out: dict[Slot, tuple[Edge, ...]] = field(init=False, repr=False, compare=False)
+    _in: dict[Slot, tuple[Edge, ...]] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        out: dict[Slot, list[Edge]] = {}
+        incoming: dict[Slot, list[Edge]] = {}
+        for edge in self.edges:
+            out.setdefault(edge.src, []).append(edge)
+            incoming.setdefault(edge.dst, []).append(edge)
+        object.__setattr__(self, "_out", {s: tuple(e) for s, e in out.items()})
+        object.__setattr__(self, "_in", {s: tuple(e) for s, e in incoming.items()})
+
+    def slots(self) -> tuple[Slot, ...]:
+        """Every slot the graph touches, sorted. Idle procs are absent."""
+        return tuple(sorted(set(self._out) | set(self._in)))
+
+    def out_edges(self, slot: Slot) -> tuple[Edge, ...]:
+        """The edges ``slot`` sends on, sorted."""
+        return self._out.get(slot, ())
+
+    def in_edges(self, slot: Slot) -> tuple[Edge, ...]:
+        """The edges ``slot`` receives on, sorted."""
+        return self._in.get(slot, ())
+
+    def out_degree(self, slot: Slot) -> int:
+        return len(self.out_edges(slot))
+
+    def in_degree(self, slot: Slot) -> int:
+        return len(self.in_edges(slot))
+
+    def initiators(self, direction: str) -> tuple[Slot, ...]:
+        """The slots that issue ibverbs ops: sources under write, destinations
+        under read."""
+        _check_direction(direction)
+        return tuple(sorted(self._out if direction == WRITE else self._in))
+
+    def degree(self, slot: Slot, direction: str) -> int:
+        """How many edges ``slot`` initiates on under ``direction``.
+
+        Also the number of active, polling queue-pair actors the slot's proc
+        drives, since a queue pair is created lazily by the initiator and the
+        target's mirror is never polled.
+        """
+        _check_direction(direction)
+        return self.out_degree(slot) if direction == WRITE else self.in_degree(slot)
+
+    def max_degree(self, direction: str) -> int:
+        """The largest number of edges any one slot initiates on."""
+        return max((self.degree(s, direction) for s in self.slots()), default=0)
+
+
+def build_topology(
+    pattern: str,
+    num_hosts: int,
+    procs_per_host: int,
+    pairing: str = SAME,
+    shift: int = 1,
+) -> Topology:
+    """Build the proc graph for one benchmark configuration."""
+    edges = tuple(
+        sorted(
+            {
+                edge
+                for host_edge in host_edges(pattern, num_hosts)
+                for edge in expand_lanes(host_edge, procs_per_host, pairing, shift)
+            }
+        )
+    )
+    return Topology(
+        pattern=pattern,
+        num_hosts=num_hosts,
+        procs_per_host=procs_per_host,
+        pairing=pairing,
+        shift=shift,
+        edges=edges,
+    )
+
+
+def _check_direction(direction: str) -> None:
+    if direction not in DIRECTIONS:
+        raise ValueError(
+            f"unknown direction {direction!r}; expected one of {DIRECTIONS}"
+        )
+
+
+@dataclass(frozen=True)
+class SlotAllocation:
+    """What one slot must allocate.
+
+    ``sends`` is false for a slot with no out-edges -- a fan-out leaf -- which
+    therefore pays for its incoming pools only. A sending slot shares one
+    outgoing pool across every out-edge, so one is always enough.
+    """
+
+    sends: bool
+    receives_from: tuple[Slot, ...]
+    ops: int
+
+    @property
+    def tensors(self) -> int:
+        """Total tensors, each of which is registered as one RDMA buffer."""
+        return (self.ops if self.sends else 0) + len(self.receives_from) * self.ops
+
+
+def allocation_for(topo: Topology, slot: Slot, *, ops: int) -> SlotAllocation:
+    """What ``slot`` allocates. Independent of direction, so one allocation
+    serves both a read pass and a write pass."""
+    if ops < 1:
+        raise ValueError(f"concurrent_ops must be at least 1, got {ops}")
+    return SlotAllocation(
+        sends=topo.out_degree(slot) > 0,
+        receives_from=tuple(edge.src for edge in topo.in_edges(slot)),
+        ops=ops,
+    )
+
+
+def max_ops_per_action(topo: Topology, direction: str, *, ops: int) -> int:
+    """The most ops any one initiator batches into a single ``RDMAAction``:
+    one per out-edge (or in-edge) per concurrent op."""
+    return topo.max_degree(direction) * ops
+
+
+@dataclass(frozen=True)
+class MemoryPlan:
+    """One configuration's footprint, split by memory kind.
+
+    Device memory is charged per slot because each slot owns one GPU; host
+    memory is charged per host because the procs on a host share it. Unused
+    hosts and slots have no entry in the plan.
+    """
+
+    payload_bytes: int
+    buffers: dict[Slot, int]
+    device_bytes: dict[Slot, int]
+    host_bytes_per_host: dict[int, int]
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(self.device_bytes.values()) + sum(self.host_bytes_per_host.values())
+
+
+def plan_memory(
+    topo: Topology,
+    *,
+    ops: int,
+    payload_bytes: int,
+    source_on_gpu: bool,
+    dest_on_gpu: bool,
+) -> MemoryPlan:
+    """Charge every slot's tensors to device or host memory by their role."""
+    buffers: dict[Slot, int] = {}
+    device: dict[Slot, int] = {}
+    host: dict[int, int] = {slot.host: 0 for slot in topo.slots()}
+    for slot in topo.slots():
+        allocation = allocation_for(topo, slot, ops=ops)
+        outgoing = (ops if allocation.sends else 0) * payload_bytes
+        incoming = len(allocation.receives_from) * ops * payload_bytes
+        buffers[slot] = allocation.tensors
+        device[slot] = (outgoing if source_on_gpu else 0) + (
+            incoming if dest_on_gpu else 0
+        )
+        host[slot.host] += (0 if source_on_gpu else outgoing) + (
+            0 if dest_on_gpu else incoming
+        )
+    return MemoryPlan(
+        payload_bytes=payload_bytes,
+        buffers=buffers,
+        device_bytes=device,
+        host_bytes_per_host=host,
+    )
+
+
+def check_memory(
+    topo: Topology,
+    plan: MemoryPlan,
+    *,
+    max_device_bytes: int,
+    max_host_bytes: int,
+) -> None:
+    """Raise before anything is provisioned if the footprint will not fit.
+
+    Names the binding slot or host, its in-degree, and the largest payload
+    that would fit, so a bad flag combination fails on the client in
+    milliseconds instead of part-way into a multi-host allocation.
+    """
+    slot, device_bytes = max(plan.device_bytes.items(), key=lambda kv: kv[1])
+    if device_bytes > max_device_bytes:
+        raise ValueError(
+            f"{topo.pattern}: slot {slot} needs {_size(device_bytes)} of device "
+            f"memory, over the {_size(max_device_bytes)} budget. Its in-degree is "
+            f"{topo.in_degree(slot)}, its out-degree is {topo.out_degree(slot)}, "
+            f"and the payload is {_size(plan.payload_bytes)}; the largest payload "
+            "that fits is "
+            f"{_size(_fitting_payload(plan.payload_bytes, device_bytes, max_device_bytes))}"
+        )
+    host, host_bytes = max(plan.host_bytes_per_host.items(), key=lambda kv: kv[1])
+    if host_bytes > max_host_bytes:
+        raise ValueError(
+            f"{topo.pattern}: host {host} needs {_size(host_bytes)} of pinned host "
+            f"memory across its {topo.procs_per_host} procs, over the "
+            f"{_size(max_host_bytes)} budget. The payload is "
+            f"{_size(plan.payload_bytes)}; the largest payload that fits is "
+            f"{_size(_fitting_payload(plan.payload_bytes, host_bytes, max_host_bytes))}"
+        )
+
+
+def _fitting_payload(payload_bytes: int, needed: int, budget: int) -> int:
+    """The largest payload that would not exceed ``budget``.
+
+    A configuration's footprint is proportional to its payload, so scaling
+    ``payload_bytes`` by ``budget / needed`` lands on the budget.
+    """
+    return payload_bytes * budget // needed
+
+
+def _size(num_bytes: int) -> str:
+    """Bytes in the largest decimal unit that keeps the number legible."""
+    for unit, scale in (("TB", 10**12), ("GB", 10**9), ("MB", 10**6), ("KB", 10**3)):
+        if num_bytes >= scale:
+            return f"{num_bytes / scale:.2f} {unit}"
+    return f"{num_bytes} B"
+
+
+def bytes_per_iteration(topo: Topology, *, ops: int, payload_bytes: int) -> int:
+    """Bytes the whole graph moves in one iteration -- the numerator of the
+    aggregate throughput."""
+    return len(topo.edges) * ops * payload_bytes
+
+
+def initiator_bytes(
+    topo: Topology, slot: Slot, direction: str, *, ops: int, payload_bytes: int
+) -> int:
+    """Bytes one initiator moves in one iteration."""
+    return topo.degree(slot, direction) * ops * payload_bytes
+
+
+@dataclass(frozen=True)
+class SlotValues:
+    """One value per tensor one slot holds, grouped by role and keyed by peer.
+
+    ``outgoing`` covers the pool every out-edge sends from; ``incoming`` holds
+    one pool per peer that sends to this slot. The values are opaque: RDMA
+    buffers when the driver collects them from the actors, digests when it
+    collects them to check integrity.
+    """
+
+    outgoing: tuple[Any, ...]
+    incoming: dict[Slot, tuple[Any, ...]]
+
+
+@dataclass(frozen=True)
+class PushOp:
+    """Write ``outgoing[outgoing_index]`` into a remote buffer."""
+
+    remote: Any
+    outgoing_index: int
+
+
+@dataclass(frozen=True)
+class PullOp:
+    """Read a remote buffer into ``incoming[peer][op_index]``."""
+
+    remote: Any
+    peer: Slot
+    op_index: int
+
+
+@dataclass(frozen=True)
+class InitiatorPlan:
+    """Every op one slot issues in one iteration.
+
+    A flat list, so the actor's timed loop reads this and nothing else: it
+    never learns what a pattern, a direction, or a topology is.
+    """
+
+    push: tuple[PushOp, ...] = ()
+    pull: tuple[PullOp, ...] = ()
+
+    @property
+    def ops(self) -> int:
+        return len(self.push) + len(self.pull)
+
+
+def plan_for(
+    topo: Topology,
+    direction: str,
+    values: Mapping[Slot, SlotValues],
+    *,
+    ops: int,
+) -> dict[Slot, InitiatorPlan]:
+    """Route every edge to the ops its initiator must issue.
+
+    Under ``write`` an initiator targets the peer's incoming pool *reserved for
+    it*; under ``read`` it targets the peer's shared outgoing pool. Slots that
+    initiate nothing are absent from the result.
+    """
+    _check_direction(direction)
+    return {
+        slot: (
+            _push_plan(topo, slot, values, ops)
+            if direction == WRITE
+            else _pull_plan(topo, slot, values, ops)
+        )
+        for slot in topo.initiators(direction)
+    }
+
+
+def _push_plan(
+    topo: Topology, slot: Slot, values: Mapping[Slot, SlotValues], ops: int
+) -> InitiatorPlan:
+    push: list[PushOp] = []
+    for edge in topo.out_edges(slot):
+        incoming = values[edge.dst].incoming[edge.src]
+        if len(incoming) != ops:
+            raise ValueError(
+                f"{edge}: incoming pool has {len(incoming)} tensors, expected {ops}"
+            )
+        push.extend(PushOp(remote=incoming[op], outgoing_index=op) for op in range(ops))
+    return InitiatorPlan(push=tuple(push))
+
+
+def _pull_plan(
+    topo: Topology, slot: Slot, values: Mapping[Slot, SlotValues], ops: int
+) -> InitiatorPlan:
+    pull: list[PullOp] = []
+    for edge in topo.in_edges(slot):
+        outgoing = values[edge.src].outgoing
+        if len(outgoing) != ops:
+            raise ValueError(
+                f"{edge}: outgoing pool has {len(outgoing)} tensors, expected {ops}"
+            )
+        pull.extend(
+            PullOp(remote=outgoing[op], peer=edge.src, op_index=op) for op in range(ops)
+        )
+    return InitiatorPlan(pull=tuple(pull))
+
+
+def compare_digests(
+    topo: Topology, digests: Mapping[Slot, SlotValues]
+) -> tuple[int, list[str]]:
+    """Compare each edge's incoming pool against the pool it was sent from.
+
+    Returns ``(pairs_checked, mismatches)``. After a round every pair must
+    match. Before any transfer every pair must *mismatch*, which is the
+    negative control that proves the comparison is wired to the right slots.
+    """
+    checked = 0
+    mismatches: list[str] = []
+    for edge in topo.edges:
+        outgoing = digests[edge.src].outgoing
+        incoming = digests[edge.dst].incoming[edge.src]
+        if len(outgoing) != len(incoming):
+            raise ValueError(
+                f"{edge}: sender has {len(outgoing)} digests, receiver has {len(incoming)}"
+            )
+        for op, (want, got) in enumerate(zip(outgoing, incoming)):
+            checked += 1
+            if want != got:
+                mismatches.append(f"{edge} op {op}: sent={want} received={got}")
+    return checked, mismatches
+
+
+def phase_of(run_index: int, iteration: int, warmup: int) -> str:
+    """Which reporting phase an iteration belongs to.
+
+    Iteration 0 of the first run is ``cold_qp``: it pays the lazy queue-pair
+    handshake to every peer. A run's first ``warmup`` iterations are ``ramp``
+    and are discarded; the rest are ``warm``.
+    """
+    if run_index == 0 and iteration == 0:
+        return COLD_QP
+    return RAMP if iteration < warmup else WARM
+
+
+def describe(topo: Topology, direction: str, *, ops: int, payload_bytes: int) -> str:
+    """One line naming the graph and what each initiator will do on it."""
+    return (
+        f"{topo.pattern}: {topo.num_hosts}x{topo.procs_per_host} procs, "
+        f"{len(topo.edges)} edges, {topo.pairing} lanes, {direction}; "
+        f"initiators={len(topo.initiators(direction))}, "
+        f"max ops/action={max_ops_per_action(topo, direction, ops=ops)}, "
+        f"{_size(bytes_per_iteration(topo, ops=ops, payload_bytes=payload_bytes))} "
+        f"per iteration"
+    )
+
+
+def unused_hosts(topo: Topology) -> Sequence[int]:
+    """Hosts the job provisions that this pattern never touches."""
+    touched = {slot.host for slot in topo.slots()}
+    return tuple(host for host in range(topo.num_hosts) if host not in touched)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -17,6 +17,12 @@ import pytest
 
 _THIS_DIR = Path(__file__).parent
 
+# The multihost RDMA benchmark's modules import as bare names -- `bench_topology`,
+# not a dotted path -- so the owning directory needs to be added to `sys.path`.
+_BENCH_DIR = _THIS_DIR.parent / "benches" / "multihost_rdma"
+if str(_BENCH_DIR) not in sys.path:
+    sys.path.insert(0, str(_BENCH_DIR))
+
 collect_ignore: list[str] = []
 
 # FUSE and RDMA require Linux; skip these files on other platforms to avoid

--- a/python/tests/test_rdma.py
+++ b/python/tests/test_rdma.py
@@ -714,43 +714,6 @@ class ClientActor(Actor):
         await self.action.submit()
 
     @endpoint
-    async def perform_data_race(
-        self, buffer_a: RDMABuffer, buffer_b: RDMABuffer, buffer_c: RDMABuffer
-    ) -> None:
-        """Perform batched operations using RDMAAction across multiple remote actors"""
-
-        # Create RDMAAction instance
-        action = RDMAAction()
-
-        # Chain multiple operations across different remote actors
-        # Read from buffer A into local data_a
-        action.read_remote(self.data_a.view(torch.uint8).flatten(), buffer_a)
-
-        # # Write data_a to buffer B (modified data goes from A -> B) - Data race!
-        action.write_remote(buffer_b, self.data_a.view(torch.uint8).flatten())
-
-    @endpoint
-    async def perform_data_race_w_slices(
-        self, buffer_a: RDMABuffer, buffer_b: RDMABuffer, buffer_c: RDMABuffer
-    ) -> None:
-        """Perform batched operations using RDMAAction across multiple remote actors"""
-        assert self.size == 250, "Size must be 100 for this test"
-        # Create RDMAAction instance
-        action = RDMAAction()
-
-        # Chain multiple operations across different remote actors
-        # Read from buffer A into local data_a
-        action.read_remote(
-            self.data_a.view(torch.uint8)[0 : 100 * 4].flatten(), buffer_a
-        )
-        action.write_remote(
-            buffer_a, self.data_a.view(torch.uint8)[150 * 4 :].flatten()
-        )
-        action.read_remote(
-            self.data_a.view(torch.uint8)[75 * 4 : 175 * 4].flatten(), buffer_a
-        )
-
-    @endpoint
     async def get_local_data_sums(self) -> dict:
         """Get sums of local data for verification"""
         return {
@@ -940,41 +903,6 @@ async def test_rdma_action_second_call():
     # Verify that server B, C same as before
     assert 0.0 == await server_b.get_sum.call_one()
     assert sum_c_after == await server_c.get_sum.call_one()
-
-
-@rdma_backends
-async def test_rdma_action_data_races():
-    """Test RDMAAction with concurrent execution across multiple remote actors (2 remote + 1 local)"""
-
-    # Setup: Create 3 separate processes (2 remote + 1 local)
-    server_proc_1 = this_host().spawn_procs(per_host={"processes": 1})
-    server_proc_2 = this_host().spawn_procs(per_host={"processes": 1})
-    client_proc = this_host().spawn_procs(per_host={"processes": 1})
-
-    # Create actors on different processes
-    server_a = server_proc_1.spawn(
-        "server_a",
-        DataServerActor,
-        "A",
-    )  # Data filled with 65.0 (ASCII 'A')
-    server_b = server_proc_2.spawn(
-        "server_b", DataServerActor, "B"
-    )  # Data filled with 66.0 (ASCII 'B')
-    server_c = server_proc_1.spawn(
-        "server_c", DataServerActor, "C"
-    )  # Data filled with 67.0 (ASCII 'C')
-    client = client_proc.spawn("client", ClientActor, 250)
-
-    # Create RDMA buffers on each server
-    buffer_a = await server_a.create_buffer.call_one()
-    buffer_b = await server_b.create_buffer.call_one()
-    buffer_c = await server_c.create_buffer.call_one()
-
-    with pytest.raises(Exception):
-        await client.perform_data_race.call_one(buffer_a, buffer_b, buffer_c)
-
-    with pytest.raises(Exception):
-        await client.perform_data_race_w_slices.call_one(buffer_a, buffer_b, buffer_c)
 
 
 @rdma_backends

--- a/python/tests/test_rdma_action.py
+++ b/python/tests/test_rdma_action.py
@@ -133,27 +133,11 @@ class ActionClient(Actor):
         return False
 
     @endpoint
-    async def overlapping_writes_into_local_error(self, buffer: RDMABuffer) -> bool:
-        # Two `read_remote`s onto overlapping local destinations both write
-        # the same local memory: the new local-side claim algorithm must
-        # flag this as a race.
-        size = buffer.size()
-        slot = torch.zeros(size, dtype=torch.uint8, device=self.device)
-        action = RDMAAction()
-        action.read_remote(slot, buffer)
-        try:
-            action.read_remote(slot, buffer)
-        except ValueError:
-            return True
-        return False
-
-    @endpoint
     async def overlapping_reads_from_local_ok(
         self, buffer_a: RDMABuffer, buffer_b: RDMABuffer
     ) -> None:
-        # Two `write_remote`s using the same local memory range both *read*
-        # local memory — that is safe, and the new algorithm must let it
-        # through (the old python helper would have errored).
+        # Two `write_remote`s sharing one local source range, which is what a
+        # fan-out does: one buffer's contents sent to several peers.
         size = min(buffer_a.size(), buffer_b.size())
         slot = torch.zeros(size, dtype=torch.uint8, device=self.device)
         action = RDMAAction()
@@ -399,27 +383,9 @@ async def test_submit_validation_errors_surface(host_device, client_device) -> N
 @pytest.mark.parametrize(
     ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
 )
-async def test_overlapping_local_writes_are_a_race(host_device, client_device) -> None:
-    # Two `read_remote`s onto the same local destination are concurrent writes —
-    # the bug-fixed claim algorithm must flag this as a race.
-    size = 32
-    host, client = await _spawn_host_and_client(
-        num_buffers=1, size=size, host_device=host_device, client_device=client_device
-    )
-    (buffer,) = await host.create_buffers.call_one()
-    caught = await client.overlapping_writes_into_local_error.call_one(buffer)
-    assert caught, "Expected ValueError from two overlapping read_remote claims"
-
-
-@rdma_backends
-@pytest.mark.parametrize(
-    ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
-)
 async def test_overlapping_local_reads_are_ok(host_device, client_device) -> None:
-    # Two `write_remote`s from the same local source both *read* local memory —
-    # safe; today's python helper would have errored, the new one merges.
-    # Uses two distinct remote buffers so the test exercises the local-side
-    # read-merge without two writes landing on the same remote target.
+    # One local source range feeding two ops in a single action. The two remote
+    # buffers are distinct, so nothing writes the same range on either side.
     size = 32
     host, client = await _spawn_host_and_client(
         num_buffers=2, size=size, host_device=host_device, client_device=client_device

--- a/python/tests/test_rdma_bench_topology.py
+++ b/python/tests/test_rdma_bench_topology.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Tests for the multi-host RDMA benchmark's topology module.
+
+``bench_topology`` imports only the standard library, so these run in
+milliseconds with no cluster, no GPU, and no torch. They are the only
+automated coverage of the routing logic: a wrongly-wired peer is exactly what
+the RDMA layer cannot catch, because an ``RDMAAction`` deliberately does not
+track remote address ranges.
+"""
+
+from __future__ import annotations
+
+import bench_topology as bt
+import pytest
+
+
+GB: int = 1000**3
+MB: int = 1000**2
+
+
+def _all_patterns_edges(num_hosts: int) -> dict[str, list[tuple[int, int]]]:
+    return {p: bt.host_edges(p, num_hosts) for p in bt.PATTERNS}
+
+
+def test_host_edges_two_hosts() -> None:
+    assert _all_patterns_edges(2) == {
+        "p2p": [(0, 1)],
+        "fan-out": [(0, 1)],
+        "fan-in": [(1, 0)],
+        "all-to-all": [(0, 1), (1, 0)],
+        "ring": [(0, 1), (1, 0)],
+    }
+
+
+def test_host_edges_four_hosts() -> None:
+    edges = _all_patterns_edges(4)
+    assert edges["p2p"] == [(0, 1)], "p2p ignores the extra hosts"
+    assert edges["fan-out"] == [(0, 1), (0, 2), (0, 3)]
+    assert edges["fan-in"] == [(1, 0), (2, 0), (3, 0)]
+    assert edges["ring"] == [(0, 1), (1, 2), (2, 3), (3, 0)]
+    assert len(edges["all-to-all"]) == 12, "n(n-1) for n=4"
+
+
+def test_one_host_is_the_loopback_self_edge() -> None:
+    for pattern in bt.PATTERNS:
+        assert bt.host_edges(pattern, 1) == [(0, 0)], pattern
+
+
+@pytest.mark.parametrize("num_hosts", [2, 3, 4, 8])
+def test_all_to_all_is_complete_and_has_no_self_edges(num_hosts: int) -> None:
+    edges = bt.host_edges("all-to-all", num_hosts)
+    assert len(edges) == num_hosts * (num_hosts - 1)
+    assert len(set(edges)) == len(edges)
+    assert all(src != dst for src, dst in edges)
+
+
+@pytest.mark.parametrize("num_hosts", [2, 3, 4, 8])
+def test_ring_is_a_single_cycle_covering_every_host(num_hosts: int) -> None:
+    edges = bt.host_edges("ring", num_hosts)
+    assert len(edges) == num_hosts
+    assert {src for src, _ in edges} == set(range(num_hosts))
+    assert {dst for _, dst in edges} == set(range(num_hosts))
+
+    # Walking successors from 0 must visit every host exactly once and return.
+    successor = dict(edges)
+    seen = []
+    host = 0
+    for _ in range(num_hosts):
+        seen.append(host)
+        host = successor[host]
+    assert sorted(seen) == list(range(num_hosts)), "one cycle, not several"
+    assert host == 0
+
+
+@pytest.mark.parametrize("num_hosts", [2, 3, 4, 8])
+def test_fan_out_and_fan_in_are_transposes(num_hosts: int) -> None:
+    out = bt.host_edges("fan-out", num_hosts)
+    into = bt.host_edges("fan-in", num_hosts)
+    assert sorted((dst, src) for src, dst in out) == sorted(into)
+
+
+def test_host_edges_rejects_bad_input() -> None:
+    with pytest.raises(ValueError, match="unknown pattern 'torus'"):
+        bt.host_edges("torus", 4)
+    with pytest.raises(ValueError, match="num_hosts must be at least 1"):
+        bt.host_edges("ring", 0)
+    # The message names the valid set so a typo is self-correcting.
+    with pytest.raises(ValueError, match="all-to-all"):
+        bt.host_edges("alltoall", 4)
+
+
+def test_expand_lanes_same_stays_on_one_ordinal() -> None:
+    edges = bt.expand_lanes((0, 1), 4)
+    assert len(edges) == 4
+    assert all(e.src.lane == e.dst.lane for e in edges)
+    assert edges[0] == bt.Edge(bt.Slot(0, 0), bt.Slot(1, 0))
+
+
+def test_expand_lanes_shifted_crosses_ordinals() -> None:
+    edges = bt.expand_lanes((0, 1), 4, bt.SHIFTED, shift=1)
+    assert len(edges) == 4
+    assert all(e.src.lane != e.dst.lane for e in edges)
+    assert {e.dst.lane for e in edges} == {0, 1, 2, 3}, "still a permutation"
+
+    wrapped = bt.expand_lanes((0, 1), 4, bt.SHIFTED, shift=3)
+    assert bt.Edge(bt.Slot(0, 1), bt.Slot(1, 0)) in wrapped
+
+
+def test_expand_lanes_all_is_the_full_product() -> None:
+    edges = bt.expand_lanes((0, 1), 4, bt.ALL)
+    assert len(edges) == 16
+    assert len(set(edges)) == 16
+
+
+def test_expand_lanes_rejects_a_shift_that_is_really_same() -> None:
+    with pytest.raises(ValueError, match="multiple of procs_per_host"):
+        bt.expand_lanes((0, 1), 4, bt.SHIFTED, shift=4)
+    with pytest.raises(ValueError, match="multiple of procs_per_host"):
+        bt.expand_lanes((0, 1), 4, bt.SHIFTED, shift=0)
+    # One proc per host leaves no ordinal to shift to.
+    with pytest.raises(ValueError, match="multiple of procs_per_host"):
+        bt.expand_lanes((0, 1), 1, bt.SHIFTED, shift=1)
+
+
+def test_expand_lanes_rejects_bad_input() -> None:
+    with pytest.raises(ValueError, match="unknown pairing 'diagonal'"):
+        bt.expand_lanes((0, 1), 4, "diagonal")
+    with pytest.raises(ValueError, match="procs_per_host must be at least 1"):
+        bt.expand_lanes((0, 1), 0)
+
+
+def test_edges_are_canonical() -> None:
+    topo = bt.build_topology("all-to-all", 4, 4, bt.ALL)
+    assert topo.edges == tuple(sorted(set(topo.edges)))
+    assert len(topo.edges) == 12 * 16
+
+
+@pytest.mark.parametrize("pattern", bt.PATTERNS)
+@pytest.mark.parametrize("pairing", bt.PAIRINGS)
+def test_every_in_edge_comes_from_a_distinct_peer(pattern: str, pairing: str) -> None:
+    """What makes keying incoming pools by the sending peer unambiguous."""
+    topo = bt.build_topology(pattern, 4, 4, pairing)
+    for slot in topo.slots():
+        peers = [edge.src for edge in topo.in_edges(slot)]
+        assert len(set(peers)) == len(peers) == topo.in_degree(slot), slot
+
+
+@pytest.mark.parametrize("pattern", bt.PATTERNS)
+@pytest.mark.parametrize("pairing", bt.PAIRINGS)
+def test_degree_conservation(pattern: str, pairing: str) -> None:
+    topo = bt.build_topology(pattern, 4, 4, pairing)
+    slots = topo.slots()
+    assert sum(topo.out_degree(s) for s in slots) == len(topo.edges)
+    assert sum(topo.in_degree(s) for s in slots) == len(topo.edges)
+
+
+def test_degree_follows_the_initiator() -> None:
+    topo = bt.build_topology("fan-out", 5, 2)
+    root, leaf = bt.Slot(0, 0), bt.Slot(3, 0)
+
+    assert topo.degree(root, bt.WRITE) == 4, "the root pushes to every leaf"
+    assert topo.degree(root, bt.READ) == 0, "nothing is pushed to the root"
+    assert topo.degree(leaf, bt.READ) == 1, "each leaf pulls from the root"
+    assert topo.degree(leaf, bt.WRITE) == 0
+
+    assert topo.initiators(bt.WRITE) == (bt.Slot(0, 0), bt.Slot(0, 1))
+    assert len(topo.initiators(bt.READ)) == 8, "4 leaf hosts x 2 procs"
+    assert topo.max_degree(bt.WRITE) == 4
+    assert topo.max_degree(bt.READ) == 1
+
+
+def test_fan_in_mirrors_fan_out() -> None:
+    topo = bt.build_topology("fan-in", 5, 2)
+    root = bt.Slot(0, 0)
+    assert topo.degree(root, bt.READ) == 4, "the root pulls from every leaf"
+    assert topo.degree(root, bt.WRITE) == 0
+    assert topo.initiators(bt.READ) == (bt.Slot(0, 0), bt.Slot(0, 1))
+
+
+def test_all_to_all_and_ring_degrees() -> None:
+    mesh = bt.build_topology("all-to-all", 8, 8)
+    ring = bt.build_topology("ring", 8, 8)
+    for direction in bt.DIRECTIONS:
+        assert mesh.max_degree(direction) == 7
+        assert ring.max_degree(direction) == 1
+        assert len(mesh.initiators(direction)) == 64
+        assert len(ring.initiators(direction)) == 64
+
+
+def test_directions_are_validated() -> None:
+    topo = bt.build_topology("ring", 4, 2)
+    with pytest.raises(ValueError, match="unknown direction 'send'"):
+        topo.initiators("send")
+    with pytest.raises(ValueError, match="unknown direction"):
+        topo.degree(bt.Slot(0, 0), "recv")
+
+
+def test_unused_hosts() -> None:
+    assert bt.unused_hosts(bt.build_topology("p2p", 8, 4)) == (2, 3, 4, 5, 6, 7)
+    assert bt.unused_hosts(bt.build_topology("ring", 8, 4)) == ()
+
+
+def test_allocation_only_charges_for_roles_a_slot_has() -> None:
+    topo = bt.build_topology("fan-out", 4, 2)
+
+    root = bt.allocation_for(topo, bt.Slot(0, 0), ops=3)
+    assert root == bt.SlotAllocation(sends=True, receives_from=(), ops=3)
+    assert root.tensors == 3, "the root never receives, so it has no incoming pool"
+
+    leaf = bt.allocation_for(topo, bt.Slot(2, 0), ops=3)
+    assert leaf == bt.SlotAllocation(sends=False, receives_from=(bt.Slot(0, 0),), ops=3)
+    assert leaf.tensors == 3, "a leaf never sends, so it has no outgoing pool"
+
+    mesh = bt.build_topology("all-to-all", 8, 8)
+    every_other_host = bt.allocation_for(mesh, bt.Slot(0, 0), ops=1)
+    assert every_other_host.tensors == 8, "1 outgoing + 7 incoming"
+    assert len(set(every_other_host.receives_from)) == 7
+
+    loop = bt.allocation_for(bt.build_topology("p2p", 1, 2), bt.Slot(0, 0), ops=2)
+    assert loop == bt.SlotAllocation(
+        sends=True, receives_from=(bt.Slot(0, 0),), ops=2
+    ), "the self-edge makes a slot its own peer"
+
+    with pytest.raises(ValueError, match="concurrent_ops must be at least 1"):
+        bt.allocation_for(topo, bt.Slot(0, 0), ops=0)
+
+
+def test_max_ops_per_action_scales_with_concurrent_ops() -> None:
+    mesh = bt.build_topology("all-to-all", 8, 8)
+    assert mesh.max_degree(bt.WRITE) == 7, "edges, not ops"
+    assert bt.max_ops_per_action(mesh, bt.WRITE, ops=1) == 7
+    assert bt.max_ops_per_action(mesh, bt.WRITE, ops=4) == 28
+
+    ring = bt.build_topology("ring", 8, 8)
+    assert bt.max_ops_per_action(ring, bt.READ, ops=4) == 4
+
+
+def test_memory_plan_charges_each_pool_to_its_own_device() -> None:
+    """All four memory-kind configs, at more than one concurrent op.
+
+    Every slot of an 8-host all-to-all sends and receives, so with 2 ops it
+    holds 2 outgoing tensors and 2 in each of 7 incoming pools: 16 in all. The
+    per-host totals are eight times a slot's, one per proc.
+    """
+    topo = bt.build_topology("all-to-all", 8, 8)
+    slot = bt.Slot(0, 0)
+    kwargs = {"ops": 2, "payload_bytes": GB}
+
+    gpu = bt.plan_memory(topo, **kwargs, source_on_gpu=True, dest_on_gpu=True)
+    assert gpu.buffers[slot] == 16, "2 outgoing + 7 incoming pools of 2"
+    assert gpu.device_bytes[slot] == 16 * GB
+    assert gpu.host_bytes_per_host[0] == 0
+
+    cpu = bt.plan_memory(topo, **kwargs, source_on_gpu=False, dest_on_gpu=False)
+    assert cpu.buffers[slot] == 16, "the same tensors, charged elsewhere"
+    assert cpu.device_bytes[slot] == 0
+    assert cpu.host_bytes_per_host[0] == 128 * GB, "16 GB on each of 8 procs"
+
+    cpu2gpu = bt.plan_memory(topo, **kwargs, source_on_gpu=False, dest_on_gpu=True)
+    assert cpu2gpu.device_bytes[slot] == 14 * GB, "the incoming pools only"
+    assert cpu2gpu.host_bytes_per_host[0] == 16 * GB, "one outgoing pool per proc"
+
+    gpu2cpu = bt.plan_memory(topo, **kwargs, source_on_gpu=True, dest_on_gpu=False)
+    assert gpu2cpu.device_bytes[slot] == 2 * GB, "the outgoing pool only"
+    assert gpu2cpu.host_bytes_per_host[0] == 112 * GB
+
+
+def test_check_memory_names_the_binding_budget_and_a_payload_that_fits() -> None:
+    topo = bt.build_topology("all-to-all", 8, 8)
+    budgets = {"max_device_bytes": 40 * GB, "max_host_bytes": 256 * GB}
+
+    ok = bt.plan_memory(
+        topo, ops=1, payload_bytes=GB, source_on_gpu=True, dest_on_gpu=True
+    )
+    bt.check_memory(topo, ok, **budgets)
+
+    # 8 concurrent ops puts 64 GB on one card.
+    too_big = bt.plan_memory(
+        topo, ops=8, payload_bytes=GB, source_on_gpu=True, dest_on_gpu=True
+    )
+    with pytest.raises(ValueError) as excinfo:
+        bt.check_memory(topo, too_big, **budgets)
+    message = str(excinfo.value)
+    assert "device memory" in message
+    assert "in-degree is 7" in message
+    # The slot holds 64 payload-sized tensors: 8 outgoing, plus 8 in each of the
+    # 7 incoming pools. Its footprint is therefore 64 payloads, so the payload
+    # that exactly fills the 40 GB budget is 40/64 GB = 625 MB.
+    assert "625.00 MB" in message
+
+    # The cpu config trips the per-host budget while every card stays empty.
+    host_bound = bt.plan_memory(
+        topo, ops=6, payload_bytes=GB, source_on_gpu=False, dest_on_gpu=False
+    )
+    assert host_bound.device_bytes[bt.Slot(0, 0)] == 0
+    with pytest.raises(ValueError, match="pinned host memory across its 8 procs"):
+        bt.check_memory(topo, host_bound, **budgets)
+
+
+def test_check_memory_catches_the_all_pairing_blowup() -> None:
+    topo = bt.build_topology("all-to-all", 8, 8, bt.ALL)
+    assert topo.in_degree(bt.Slot(0, 0)) == 56, "7 peer hosts x 8 lanes"
+    plan = bt.plan_memory(
+        topo, ops=1, payload_bytes=GB, source_on_gpu=True, dest_on_gpu=True
+    )
+    with pytest.raises(ValueError, match="in-degree is 56"):
+        bt.check_memory(topo, plan, max_device_bytes=40 * GB, max_host_bytes=256 * GB)
+
+
+def test_byte_counts() -> None:
+    topo = bt.build_topology("ring", 4, 8)
+    assert bt.bytes_per_iteration(topo, ops=2, payload_bytes=MB) == 32 * 2 * MB
+    assert (
+        bt.initiator_bytes(topo, bt.Slot(0, 0), bt.WRITE, ops=2, payload_bytes=MB)
+        == 2 * MB
+    )
+
+    mesh = bt.build_topology("all-to-all", 8, 8)
+    assert bt.bytes_per_iteration(mesh, ops=1, payload_bytes=GB) == 448 * GB
+    assert (
+        bt.initiator_bytes(mesh, bt.Slot(3, 2), bt.READ, ops=1, payload_bytes=GB)
+        == 7 * GB
+    )
+
+
+def _string_values(topo: bt.Topology, ops: int) -> dict[bt.Slot, bt.SlotValues]:
+    """Stand-in for the RDMA buffers the actors would expose. Routing treats
+    handles as opaque, so strings exercise it exactly."""
+    values = {}
+    for slot in topo.slots():
+        allocation = bt.allocation_for(topo, slot, ops=ops)
+        values[slot] = bt.SlotValues(
+            outgoing=tuple(
+                f"{slot}:out{op}" for op in range(ops if allocation.sends else 0)
+            ),
+            incoming={
+                peer: tuple(f"{slot}:in[{peer}].{op}" for op in range(ops))
+                for peer in allocation.receives_from
+            },
+        )
+    return values
+
+
+def test_plan_for_write_targets_the_pool_the_peer_reserved_for_it() -> None:
+    topo = bt.build_topology("all-to-all", 3, 1)
+    values = _string_values(topo, ops=2)
+    plans = bt.plan_for(topo, bt.WRITE, values, ops=2)
+
+    slot = bt.Slot(0, 0)
+    assert set(plans) == set(topo.slots())
+    assert plans[slot].pull == (), "a write plan issues no reads"
+
+    expected = []
+    for edge in topo.out_edges(slot):
+        pool = values[edge.dst].incoming[slot]
+        expected.extend(
+            bt.PushOp(remote=pool[op], outgoing_index=op) for op in range(2)
+        )
+    assert plans[slot].push == tuple(expected)
+    assert plans[slot].ops == 4, "2 out-edges x 2 ops"
+
+    # Every writer into one destination must hit a different pool, which is the
+    # invariant the RDMA layer cannot check: it does not track remote ranges,
+    # so two initiators sharing a remote buffer would corrupt it silently.
+    destination = bt.Slot(2, 0)
+    remotes = [
+        op.remote
+        for edge in topo.in_edges(destination)
+        for op in plans[edge.src].push
+        if op.remote.startswith(str(destination))
+    ]
+    assert len(remotes) == len(set(remotes)) == 4
+
+
+def test_plan_for_read_targets_the_peer_shared_outgoing_pool() -> None:
+    topo = bt.build_topology("all-to-all", 3, 1)
+    values = _string_values(topo, ops=2)
+    plans = bt.plan_for(topo, bt.READ, values, ops=2)
+
+    slot = bt.Slot(1, 0)
+    assert plans[slot].push == (), "a read plan issues no writes"
+
+    expected = []
+    for edge in topo.in_edges(slot):
+        outgoing = values[edge.src].outgoing
+        expected.extend(
+            bt.PullOp(remote=outgoing[op], peer=edge.src, op_index=op)
+            for op in range(2)
+        )
+    assert plans[slot].pull == tuple(expected)
+
+    # Every read lands somewhere different: overlapping local write claims in
+    # one action are a hard error in the RDMA layer.
+    landings = {(op.peer, op.op_index) for op in plans[slot].pull}
+    assert len(landings) == plans[slot].ops
+
+
+@pytest.mark.parametrize("pattern", bt.PATTERNS)
+@pytest.mark.parametrize("direction", bt.DIRECTIONS)
+def test_plan_op_count_matches_degree(pattern: str, direction: str) -> None:
+    topo = bt.build_topology(pattern, 4, 2)
+    values = _string_values(topo, ops=3)
+    for slot, plan in bt.plan_for(topo, direction, values, ops=3).items():
+        assert plan.ops == topo.degree(slot, direction) * 3, slot
+
+
+def test_plan_for_the_self_edge_wires_a_slot_to_itself() -> None:
+    topo = bt.build_topology("p2p", 1, 2)
+    values = _string_values(topo, ops=1)
+    slot = bt.Slot(0, 1)
+
+    write = bt.plan_for(topo, bt.WRITE, values, ops=1)[slot]
+    assert write.push == (bt.PushOp(remote=f"{slot}:in[{slot}].0", outgoing_index=0),)
+
+    read = bt.plan_for(topo, bt.READ, values, ops=1)[slot]
+    assert read.pull == (bt.PullOp(remote=f"{slot}:out0", peer=slot, op_index=0),)
+
+
+def test_plan_for_rejects_a_bad_direction() -> None:
+    topo = bt.build_topology("ring", 4, 2)
+    with pytest.raises(ValueError, match="unknown direction"):
+        bt.plan_for(topo, "push", _string_values(topo, ops=1), ops=1)
+
+
+def _digests(
+    topo: bt.Topology, ops: int, *, transferred: bool
+) -> dict[bt.Slot, bt.SlotValues]:
+    """Digests as they would look before (``transferred=False``) and after a
+    successful round. An incoming pool either mirrors the peer that fills it or
+    still holds the zero-fill."""
+    digests = {}
+    for slot in topo.slots():
+        allocation = bt.allocation_for(topo, slot, ops=ops)
+        digests[slot] = bt.SlotValues(
+            outgoing=tuple(
+                f"digest-{slot}-{op}" for op in range(ops if allocation.sends else 0)
+            ),
+            incoming={
+                peer: (
+                    tuple(f"digest-{peer}-{op}" for op in range(ops))
+                    if transferred
+                    else tuple("zero" for _ in range(ops))
+                )
+                for peer in allocation.receives_from
+            },
+        )
+    return digests
+
+
+@pytest.mark.parametrize("pattern", bt.PATTERNS)
+def test_compare_digests_accepts_a_clean_round(pattern: str) -> None:
+    topo = bt.build_topology(pattern, 4, 2)
+    checked, mismatches = bt.compare_digests(topo, _digests(topo, 2, transferred=True))
+    assert mismatches == []
+    assert checked == len(topo.edges) * 2
+
+
+@pytest.mark.parametrize("pattern", bt.PATTERNS)
+def test_negative_control_every_pair_mismatches_before_a_transfer(
+    pattern: str,
+) -> None:
+    topo = bt.build_topology(pattern, 4, 2)
+    checked, mismatches = bt.compare_digests(topo, _digests(topo, 2, transferred=False))
+    assert len(mismatches) == checked, "the check must be able to fail"
+
+
+def test_compare_digests_catches_two_swapped_incoming_pools() -> None:
+    topo = bt.build_topology("all-to-all", 4, 1)
+    digests = _digests(topo, 1, transferred=True)
+
+    slot = bt.Slot(2, 0)
+    held = digests[slot]
+    first, second = sorted(held.incoming)[:2]
+    swapped = dict(held.incoming)
+    swapped[first], swapped[second] = swapped[second], swapped[first]
+    digests[slot] = bt.SlotValues(outgoing=held.outgoing, incoming=swapped)
+
+    _checked, mismatches = bt.compare_digests(topo, digests)
+    assert len(mismatches) == 2, "both swapped edges now disagree"
+    assert str(slot) in mismatches[0]
+    assert "op 0" in mismatches[0]
+
+
+def test_compare_digests_catches_an_untouched_incoming_pool() -> None:
+    topo = bt.build_topology("ring", 4, 1)
+    digests = _digests(topo, 2, transferred=True)
+    slot = bt.Slot(1, 0)
+    held = digests[slot]
+    peer = next(iter(held.incoming))
+    digests[slot] = bt.SlotValues(
+        outgoing=held.outgoing, incoming={peer: ("zero", "zero")}
+    )
+    _checked, mismatches = bt.compare_digests(topo, digests)
+    assert len(mismatches) == 2
+
+
+def test_phase_of() -> None:
+    # The cold iteration takes the place of the first ramp iteration, so a run
+    # is `warmup` + `warm` iterations long whichever run it is.
+    assert [bt.phase_of(0, i, warmup=3) for i in range(5)] == [
+        bt.COLD_QP,
+        bt.RAMP,
+        bt.RAMP,
+        bt.WARM,
+        bt.WARM,
+    ]
+    # Only the very first iteration of all is cold: every later run opens on a
+    # discarded iteration, since its queue pairs are already up.
+    assert [bt.phase_of(1, i, warmup=3) for i in range(5)] == [
+        bt.RAMP,
+        bt.RAMP,
+        bt.RAMP,
+        bt.WARM,
+        bt.WARM,
+    ]
+    # With no ramp at all the cold iteration takes a warm slot instead, so the
+    # first run reports one fewer warm iteration than the others.
+    assert [bt.phase_of(0, i, warmup=0) for i in range(3)] == [
+        bt.COLD_QP,
+        bt.WARM,
+        bt.WARM,
+    ]
+    assert [bt.phase_of(2, i, warmup=0) for i in range(3)] == [
+        bt.WARM,
+        bt.WARM,
+        bt.WARM,
+    ]
+    assert bt.RAMP not in bt.PHASES, "ramp samples are discarded, never reported"
+
+
+def test_describe_mentions_the_shape() -> None:
+    line = bt.describe(
+        bt.build_topology("fan-out", 4, 8), bt.WRITE, ops=2, payload_bytes=GB
+    )
+    assert "fan-out" in line
+    assert "4x8 procs" in line
+    assert "24 edges" in line
+    assert "same lanes" in line
+    assert "max ops/action=6" in line, "3 out-edges x 2 concurrent ops"
+    assert "48.00 GB per iteration" in line


### PR DESCRIPTION
Summary:

Groundwork for extending the multi-host RDMA benchmark past point-to-point
to fan-out, fan-in, all-to-all, and ring. Nothing calls this yet.

The benchmark's shape is currently a boolean — `cross_host` — and each
actor holds exactly one peer. The generalization needs a real graph, so this commit adds a directed graph over procs,
derived in two pure steps (pattern and host count to a host graph, then a
lane-pairing rule to proc edges), plus everything that follows from it —
degrees, per-slot memory layout, buffer routing, integrity comparison.

The point of the split is that this module imports only the standard library, so the routing/planning logic can be tested quickly without the need for specialized hardware.

Reviewed By: zdevito

Differential Revision: D115949455


