### PR TITLE
Add the rdma benchmark's participant actor

### DIFF
--- a/monarch_rdma/src/action.rs
+++ b/monarch_rdma/src/action.rs
@@ -9,11 +9,10 @@
 //! Batched RDMA action layer.
 //!
 //! [`RdmaAction`] accumulates [`crate::RdmaOp`]s through `add_read_into_local`
-//! / `add_write_from_local`, validates the per-op sizes and the local
-//! memory ranges as ops are added, and then dispatches the queued ops
-//! across the available backends in parallel on [`RdmaAction::submit`].
+//! / `add_write_from_local`, validates the per-op sizes as ops are added,
+//! and then dispatches the queued ops across the available backends in
+//! parallel on [`RdmaAction::submit`].
 
-use std::collections::HashMap;
 use std::time::Duration;
 
 use hyperactor::context;
@@ -29,20 +28,15 @@ use crate::rdma_components::RdmaRemoteBuffer;
 /// A batch of RDMA operations submitted as a single unit.
 ///
 /// `RdmaAction` is a builder that accumulates read-into-local and
-/// write-from-local ops, performs eager validation (size check + local
-/// memory range race detection), and then runs them concurrently across
-/// the available backends on [`Self::submit`].
+/// write-from-local ops, checking each op's sizes as it is added, and then
+/// runs them concurrently across the available backends on
+/// [`Self::submit`].
 ///
-/// Local-memory race detection treats an `add_read_into_local` claim as a
-/// write to the local range and an `add_write_from_local` claim as a
-/// read; two reads of the same range merge into one claim, anything else
-/// errors. Remote-side ranges are deliberately not tracked.
+/// Overlap between the queued ops' memory ranges is not tracked, on either
+/// the local or the remote side. Two ops in one action that write the same
+/// range race, and it is the caller's job not to queue them.
 pub struct RdmaAction {
     entries: Vec<RdmaOp>,
-    // Claimed local address ranges keyed by `[start, end)`. The stored
-    // [`RdmaOpType`] doubles as the op-kind tag: `ReadIntoLocal` is a
-    // local write, `WriteFromLocal` is a local read.
-    local_claims: HashMap<(usize, usize), RdmaOpType>,
 }
 
 impl Default for RdmaAction {
@@ -55,18 +49,10 @@ impl RdmaAction {
     pub fn new() -> Self {
         Self {
             entries: Vec::new(),
-            local_claims: HashMap::new(),
         }
     }
 
-    /// True if this op writes to the local address range
-    /// (`ReadIntoLocal` reads remote data *into* local memory).
-    fn is_local_write(op_type: RdmaOpType) -> bool {
-        matches!(op_type, RdmaOpType::ReadIntoLocal)
-    }
-
-    /// Queue a read from `remote` into `local`. Records a local *write*
-    /// claim over the local memory range.
+    /// Queue a read from `remote` into `local`.
     pub fn add_read_into_local(
         &mut self,
         remote: RdmaRemoteBuffer,
@@ -79,7 +65,6 @@ impl RdmaAction {
                 remote.size,
             );
         }
-        self.record_claim(local.addr(), local.size(), RdmaOpType::ReadIntoLocal)?;
         self.entries.push(RdmaOp {
             op_type: RdmaOpType::ReadIntoLocal,
             local,
@@ -88,8 +73,7 @@ impl RdmaAction {
         Ok(self)
     }
 
-    /// Queue a write from `local` into `remote`. Records a local *read*
-    /// claim over the local memory range.
+    /// Queue a write from `local` into `remote`.
     pub fn add_write_from_local(
         &mut self,
         remote: RdmaRemoteBuffer,
@@ -102,7 +86,6 @@ impl RdmaAction {
                 remote.size,
             );
         }
-        self.record_claim(local.addr(), local.size(), RdmaOpType::WriteFromLocal)?;
         self.entries.push(RdmaOp {
             op_type: RdmaOpType::WriteFromLocal,
             local,
@@ -111,54 +94,13 @@ impl RdmaAction {
         Ok(self)
     }
 
-    fn record_claim(
-        &mut self,
-        addr: usize,
-        size: usize,
-        op_type: RdmaOpType,
-    ) -> Result<(), anyhow::Error> {
-        let mut start = addr;
-        let mut end = addr.saturating_add(size);
-        let new_is_write = Self::is_local_write(op_type);
-
-        // In one pass, we merge all entries that overlap with the new claim into a single entry.
-        // We then remove all the merged entries.
-        let mut to_remove: Vec<(usize, usize)> = Vec::new();
-        for (&(s, e), &existing) in self.local_claims.iter() {
-            if end <= s || e <= start {
-                continue;
-            }
-            if new_is_write || Self::is_local_write(existing) {
-                anyhow::bail!(
-                    "RdmaAction data race: existing {:?} claim at [{:#x}, {:#x}) overlaps new {:?} claim at [{:#x}, {:#x})",
-                    existing,
-                    s,
-                    e,
-                    op_type,
-                    start,
-                    end,
-                );
-            }
-            start = start.min(s);
-            end = end.max(e);
-            to_remove.push((s, e));
-        }
-
-        for k in &to_remove {
-            self.local_claims.remove(k);
-        }
-        self.local_claims.insert((start, end), op_type);
-        Ok(())
-    }
-
     /// Submit all queued ops. Ops are grouped by backend and each group
     /// is submitted in parallel. Safe to call more than once on the same
-    /// action — the queued ops and overlap claims are left intact.
+    /// action — the queued ops are left intact.
     ///
-    /// Takes `&mut self` so the borrow checker prevents two submit
-    /// futures from being alive on the same action simultaneously;
-    /// otherwise the local-range overlap detection would be meaningless
-    /// (two in-flight dispatches over the same claimed local memory).
+    /// Takes `&mut self` so the borrow checker prevents two submit futures
+    /// from being alive on the same action at once, which would put two
+    /// in-flight dispatches over the same local memory.
     pub async fn submit(
         &mut self,
         client: &(impl context::Actor + Send + Sync),
@@ -217,88 +159,5 @@ impl RdmaAction {
                 errors.join("\n")
             )
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Convenience: WRITE-kind claim (i.e. simulates `add_read_into_local`).
-    fn write_claim(action: &mut RdmaAction, addr: usize, size: usize) -> Result<(), anyhow::Error> {
-        action.record_claim(addr, size, RdmaOpType::ReadIntoLocal)
-    }
-
-    /// Convenience: READ-kind claim (i.e. simulates `add_write_from_local`).
-    fn read_claim(action: &mut RdmaAction, addr: usize, size: usize) -> Result<(), anyhow::Error> {
-        action.record_claim(addr, size, RdmaOpType::WriteFromLocal)
-    }
-
-    #[test]
-    fn disjoint_writes_ok() {
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        write_claim(&mut a, 0x2000, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 2);
-    }
-
-    #[test]
-    fn overlapping_writes_error() {
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        let err = write_claim(&mut a, 0x1080, 0x100).unwrap_err();
-        assert!(err.to_string().contains("data race"));
-    }
-
-    #[test]
-    fn overlapping_reads_merge() {
-        let mut a = RdmaAction::new();
-        read_claim(&mut a, 0x1000, 0x100).unwrap();
-        read_claim(&mut a, 0x1080, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 1);
-        let (&(start, end), kind) = a.local_claims.iter().next().unwrap();
-        assert_eq!(start, 0x1000);
-        assert_eq!(end, 0x1180);
-        assert_eq!(*kind, RdmaOpType::WriteFromLocal);
-    }
-
-    #[test]
-    fn cascading_reads_merge() {
-        // Two disjoint reads, then a third that bridges them — the cascade
-        // must absorb both pre-existing entries, not just the first.
-        let mut a = RdmaAction::new();
-        read_claim(&mut a, 0x1000, 0x100).unwrap();
-        read_claim(&mut a, 0x1200, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 2);
-        read_claim(&mut a, 0x1080, 0x200).unwrap();
-        assert_eq!(a.local_claims.len(), 1);
-        let (&(start, end), _) = a.local_claims.iter().next().unwrap();
-        assert_eq!(start, 0x1000);
-        assert_eq!(end, 0x1300);
-    }
-
-    #[test]
-    fn write_vs_read_errors() {
-        let mut a = RdmaAction::new();
-        read_claim(&mut a, 0x1000, 0x100).unwrap();
-        let err = write_claim(&mut a, 0x1080, 0x100).unwrap_err();
-        assert!(err.to_string().contains("data race"));
-    }
-
-    #[test]
-    fn read_vs_write_errors() {
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        let err = read_claim(&mut a, 0x1080, 0x100).unwrap_err();
-        assert!(err.to_string().contains("data race"));
-    }
-
-    #[test]
-    fn touching_ranges_do_not_overlap() {
-        // `[0,100)` and `[100,200)` are adjacent, not overlapping.
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        write_claim(&mut a, 0x1100, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 2);
     }
 }

--- a/python/benches/multihost_rdma/bench_peer.py
+++ b/python/benches/multihost_rdma/bench_peer.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+The multi-host RDMA benchmark's participant actor.
+
+One :py:class:`Peer` runs in each proc, and works out for itself which
+:py:class:`~bench_topology.Slot` it is from its own position in its mesh. It
+allocates and registers its tensors, installs whatever ops the driver routed to
+it, and executes one iteration per call. It knows nothing about patterns,
+directions, runs, or phases: the driver hands it an
+:py:class:`~bench_topology.InitiatorPlan`, a flat list of ops over local keys
+and remote handles, and the timed path reads that and nothing else.
+
+Because every proc knows its own slot, the driver addresses them all at once:
+:py:meth:`Peer.setup` and :py:meth:`Peer.wire` take a mapping keyed by slot and
+each proc takes its own entry, so a configuration of any size is two casts
+rather than two calls per proc. A slot the pattern never touches is simply
+absent from the mapping, and that proc allocates nothing.
+
+The actor also holds **no peer actor handles**. ``read_remote`` and
+``write_remote`` need only the remote ``RDMABuffer``, so nothing on the timed
+path calls into another actor. That matters because the Python actor dispatch
+loop is serial -- an actor blocked inside one endpoint cannot service a call to
+another -- so a ring or an all-to-all, where every participant both sends and
+receives, would otherwise be a deadlock waiting to happen.
+
+Setup is two casts rather than one because an initiator's ops name its peers'
+buffers: every participant must finish :py:meth:`Peer.setup` before any of them
+can be given a plan by :py:meth:`Peer.wire`.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Mapping
+
+import torch
+import xxhash
+from bench_stats import Sample
+from bench_topology import InitiatorPlan, Slot, SlotAllocation, SlotValues
+from monarch.actor import Actor, context, endpoint
+from monarch.rdma import get_rdma_backend, RDMAAction, RDMABuffer
+
+
+VERIFY_OFF: str = "off"
+VERIFY_SAMPLED: str = "sampled"
+VERIFY_FULL: str = "full"
+VERIFY_MODES: tuple[str, ...] = (VERIFY_OFF, VERIFY_SAMPLED, VERIFY_FULL)
+
+
+class Peer(Actor):
+    """One benchmark participant, holding one slot's tensors and op list."""
+
+    def __init__(self) -> None:
+        # `Instance.rank` is where this proc sits in the mesh it was spawned
+        # into. A mesh over a single host carries no hosts dimension at all,
+        # which is the same thing as sitting at index zero of one.
+        rank = context().actor_instance.rank
+        host = rank["hosts"] if "hosts" in rank.extent.labels else 0
+        self.slot: Slot = Slot(host, rank["lanes"])
+        # Byte tensors, because an RDMA op moves opaque bytes. A slot's outgoing
+        # tensors live on the source device and its incoming ones on the
+        # destination device.
+        self.tensors: SlotValues[torch.Tensor] = _nothing()
+        self.buffers: SlotValues[RDMABuffer] = _nothing()
+        self.plan: InitiatorPlan = InitiatorPlan()
+
+    @endpoint
+    async def backend(self) -> str:
+        """The RDMA backend this proc actually resolved.
+
+        Checked against the requested transport so a silent TCP fallback fails
+        loudly instead of showing up as a hundred-fold outlier.
+        """
+        return get_rdma_backend()
+
+    @endpoint
+    async def setup(
+        self,
+        allocations: Mapping[Slot, SlotAllocation],
+        payload_bytes: int,
+        seed: int,
+        source_on_gpu: bool,
+        dest_on_gpu: bool,
+    ) -> tuple[float, SlotValues[RDMABuffer]]:
+        """Allocate this slot's tensors, fill them, and register them.
+
+        Returns the milliseconds registration alone took, which the driver
+        reports as ``register_ms``, along with the buffers it needs in order to
+        route everyone's ops.
+
+        The order is deliberate. Filling happens before registration so that it
+        stays out of the measurement, and every tensor is allocated before any
+        is registered: with expandable segments enabled and mlx5dv supported,
+        interleaving would make each new tensor incur a fresh registration and
+        risk falling back to the dmabuf path.
+        """
+        await self._reset()
+        allocation = allocations.get(self.slot)
+        if allocation is None:
+            return 0.0, self.buffers
+        outgoing_device = _device(source_on_gpu, self.slot.lane)
+        incoming_device = _device(dest_on_gpu, self.slot.lane)
+        self.tensors = SlotValues(
+            outgoing=tuple(
+                torch.empty(payload_bytes, dtype=torch.uint8, device=outgoing_device)
+                for _ in range(allocation.ops if allocation.sends else 0)
+            ),
+            incoming={
+                peer: tuple(
+                    torch.empty(
+                        payload_bytes, dtype=torch.uint8, device=incoming_device
+                    )
+                    for _ in range(allocation.ops)
+                )
+                for peer in allocation.receives_from
+            },
+        )
+        self._fill(seed)
+
+        started = time.perf_counter()
+        self.buffers = self.tensors.map(RDMABuffer)
+        return _ms(time.perf_counter() - started), self.buffers
+
+    def _fill(self, seed: int) -> None:
+        """Give the outgoing tensors random bytes and zero the incoming ones.
+
+        The bytes only have to be distinctive: a digest comparison checks that
+        what arrived matches what was sent, so content unique to this slot is
+        what makes a transfer routed to the wrong peer visible. Zeroing the
+        incoming tensors is what makes a transfer that never happened visible,
+        and it is what a pre-transfer digest comparison relies on to fail.
+        """
+        for tensor in self.tensors.outgoing:
+            generator = torch.Generator(device=tensor.device)
+            generator.manual_seed(_fill_seed(seed, self.slot))
+            tensor.random_(generator=generator)
+        for group in self.tensors.incoming.values():
+            for tensor in group:
+                tensor.zero_()
+
+    @endpoint
+    async def wire(self, plans: Mapping[Slot, InitiatorPlan]) -> None:
+        """Install the ops this slot will issue."""
+        self.plan = plans.get(self.slot, InitiatorPlan())
+
+    @endpoint
+    async def execute_iteration(self) -> Sample | None:
+        """Build one ``RDMAAction`` from the installed plan, submit it, and wait
+        for every op in it to complete.
+
+        ``None`` on a proc that initiates nothing, so the driver can cast to
+        every proc and keep only the measurements that mean something.
+        """
+        if not self.plan.ops:
+            return None
+        started = time.perf_counter()
+        action = RDMAAction()
+        for op in self.plan.push:
+            action.write_remote(op.remote, self.tensors.outgoing[op.outgoing_index])
+        for op in self.plan.pull:
+            action.read_remote(self.tensors.incoming[op.peer][op.op_index], op.remote)
+        built = time.perf_counter()
+        await action.submit()
+        finished = time.perf_counter()
+        return Sample(
+            slot=self.slot,
+            build_ms=_ms(built - started),
+            submit_ms=_ms(finished - built),
+        )
+
+    @endpoint
+    async def digest(self, mode: str, window_bytes: int) -> SlotValues[str]:
+        """Digest every tensor, in the same shape as the buffers.
+
+        ``full`` hashes every byte. ``sampled`` hashes a window at each end and
+        one in the middle, which is far cheaper than pulling gigabytes per proc
+        back across PCIe and still catches a wrong peer or a short transfer.
+        """
+        assert mode in (VERIFY_SAMPLED, VERIFY_FULL), f"cannot digest in mode {mode!r}"
+        return self.tensors.map(lambda tensor: _digest(tensor, mode, window_bytes))
+
+    @endpoint
+    async def reset(self) -> None:
+        """Release every registered buffer and forget every tensor."""
+        await self._reset()
+
+    async def _reset(self) -> None:
+        """The body of :py:meth:`reset`, callable from inside the actor: an
+        endpoint is not a plain method."""
+        for buffer in self.buffers.flat():
+            await buffer.drop()
+        self.buffers = _nothing()
+        self.tensors = _nothing()
+        self.plan = InitiatorPlan()
+
+
+def _nothing() -> SlotValues[Any]:
+    """A slot holding no tensors yet, or none at all."""
+    return SlotValues(outgoing=(), incoming={})
+
+
+def _ms(seconds: float) -> float:
+    return seconds * 1000.0
+
+
+def _device(use_gpu: bool, lane: int) -> str:
+    return f"cuda:{lane}" if use_gpu else "cpu"
+
+
+def _fill_seed(seed: int, slot: Slot) -> int:
+    """A generator seed unique to one ``(run seed, slot)``.
+
+    Two slots sharing a seed would fill identical bytes, and a transfer routed
+    to the wrong peer would then pass a digest comparison.
+    """
+    return (seed * 1_000_003 + slot.host * 1_009 + slot.lane) & 0x7FFF_FFFF
+
+
+def _digest(tensor: torch.Tensor, mode: str, window_bytes: int) -> str:
+    """An xxh64 digest of a tensor's bytes, over all of them or three windows."""
+    total = tensor.numel()
+    if mode == VERIFY_FULL:
+        windows = [tensor]
+    else:
+        width = min(max(window_bytes, 1), total)
+        middle = max((total - width) // 2, 0)
+        windows = [
+            tensor[:width],
+            tensor[middle : middle + width],
+            tensor[total - width :],
+        ]
+    digest = xxhash.xxh64()
+    for window in windows:
+        digest.update(window.cpu().numpy().tobytes())
+    return digest.hexdigest()

--- a/python/benches/multihost_rdma/bench_stats.py
+++ b/python/benches/multihost_rdma/bench_stats.py
@@ -67,16 +67,13 @@ class Sample:
     only part that measures the fabric. They are reported separately and only
     ``submit_ms`` is ever a throughput denominator.
 
-    ``error`` carries a failure back to the driver rather than raising inside
-    the actor, so a broken configuration aborts instead of leaving the driver
-    waiting for a reply that will never come.
+    The slot travels with the measurement because how many bytes it stands for
+    depends on how that slot fits into the topology of the run.
     """
 
     slot: Slot
-    iteration: int
     build_ms: float
     submit_ms: float
-    error: str | None = None
 
     @property
     def total_ms(self) -> float:

--- a/python/benches/multihost_rdma/bench_stats.py
+++ b/python/benches/multihost_rdma/bench_stats.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Measurements and reporting for the multi-host RDMA benchmark.
+
+The benchmark's timings nest three deep. An *iteration* is one ``RDMAAction``
+per initiator, submitted and awaited. A *run* is a set of freshly allocated
+tensors and freshly registered RDMA buffers, exercised for several iterations. A
+*phase* is a contiguous range of iterations within a run, pooled across runs, so
+that a first iteration against fresh buffers is never averaged together with a
+steady-state one.
+
+Two clocks are in play and the difference matters. A :py:class:`Sample` is what
+one initiator measured on its own clock. A *span* is what the driver measured on
+its clock: from releasing every initiator to receiving the last reply.
+Per-initiator throughput comes from the first, aggregate throughput from the
+second.
+
+Aggregate throughput is deliberately ``bytes_per_iteration / span``, not a sum
+of per-initiator rates. A sum of rates cannot be checked against any wall clock
+and silently assumes the initiators overlapped perfectly, so it flatters a
+skewed run. Dividing by the span is measured rather than reconstructed, and it
+is conservative: it includes release skew and the reply messages. That excess is
+reported as ``overhead_ms`` so a reader knows exactly how pessimistic the
+aggregate is, and ``submit_ms_std`` shows whether the initiators were balanced.
+
+A cold iteration's time is dominated by one-time setup rather than by moving
+bytes, so its throughput is not reported.
+
+Every duration here is in milliseconds. Like :py:mod:`bench_topology`, this
+module imports only the standard library.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+import statistics
+from dataclasses import dataclass, field, fields
+from typing import Any, Iterable, Sequence, TextIO
+
+from bench_topology import PHASES, Slot, WARM
+
+
+SCHEMA_VERSION: int = 2
+
+
+def _gbs(num_bytes: int, milliseconds: float) -> float:
+    """Decimal GB/s from a byte count and a duration in milliseconds."""
+    return num_bytes / (milliseconds * 1e6)
+
+
+@dataclass(frozen=True)
+class Sample:
+    """One initiator's measurement of one iteration, on the initiator's clock.
+
+    ``build_ms`` is the Python-side cost of assembling the ``RDMAAction``: one
+    call per op, before any byte moves. ``submit_ms`` runs from handing that
+    action to the RDMA layer until every op in it has completed, so it is the
+    only part that measures the fabric. They are reported separately and only
+    ``submit_ms`` is ever a throughput denominator.
+
+    ``error`` carries a failure back to the driver rather than raising inside
+    the actor, so a broken configuration aborts instead of leaving the driver
+    waiting for a reply that will never come.
+    """
+
+    slot: Slot
+    iteration: int
+    build_ms: float
+    submit_ms: float
+    error: str | None = None
+
+    @property
+    def total_ms(self) -> float:
+        """Everything the initiator spent, which the driver's span must cover."""
+        return self.build_ms + self.submit_ms
+
+
+def percentile(values: Sequence[float], pct: float) -> float:
+    """Nearest-rank percentile, no interpolation.
+
+    The same definition ``python/benches/rdma_orchestration/benchmark.py`` uses,
+    so numbers from the two benchmarks are comparable.
+    """
+    if not values:
+        raise ValueError("cannot take a percentile of no samples")
+    ordered = sorted(values)
+    rank = math.ceil(pct / 100.0 * len(ordered))
+    return ordered[max(rank, 1) - 1]
+
+
+@dataclass(frozen=True)
+class Stats:
+    """A sample set's shape. ``n`` travels with it so a single-sample median is
+    never mistaken for a converged one."""
+
+    n: int
+    median: float
+    mean: float
+    stdev: float
+    p90: float
+    maximum: float
+
+
+def summarize(values: Sequence[float]) -> Stats:
+    """Statistics over one sample set. Empty input gives an all-zero
+    ``Stats`` with ``n == 0``, which is how the CSV records a phase that
+    produced nothing."""
+    if not values:
+        return Stats(n=0, median=0.0, mean=0.0, stdev=0.0, p90=0.0, maximum=0.0)
+    return Stats(
+        n=len(values),
+        median=statistics.median(values),
+        mean=statistics.mean(values),
+        stdev=statistics.stdev(values) if len(values) > 1 else 0.0,
+        p90=percentile(values, 90),
+        maximum=max(values),
+    )
+
+
+@dataclass
+class PhaseRecord:
+    """Every measurement belonging to one phase of one ``(pattern, direction)``.
+
+    A *phase* is a contiguous range of iterations within a run, pooled across
+    the runs it appears in. Iteration 0 of a run against freshly spawned procs
+    is ``cold_qp``; a run's first ``warmup_iters_per_run`` iterations are the
+    ``ramp``, which is discarded; the rest are ``warm``.
+    :py:func:`bench_topology.phase_of` is that mapping, and it is the only place
+    the boundaries are decided.
+
+    ``build_ms`` and ``submit_ms`` hold one entry per initiator per iteration.
+    ``span_ms``, ``overhead_ms``, and ``agg_gbs`` hold one entry per iteration,
+    because one span covers every initiator at once.
+    """
+
+    build_ms: list[float] = field(default_factory=list)
+    submit_ms: list[float] = field(default_factory=list)
+    initiator_gbs: list[float] = field(default_factory=list)
+    span_ms: list[float] = field(default_factory=list)
+    agg_gbs: list[float] = field(default_factory=list)
+    overhead_ms: list[float] = field(default_factory=list)
+
+    def add_sample(self, sample: Sample, initiator_bytes: int) -> None:
+        """Record one initiator's iteration. ``initiator_bytes`` is what that
+        initiator moved, which depends on its degree."""
+        self.build_ms.append(sample.build_ms)
+        self.submit_ms.append(sample.submit_ms)
+        if sample.submit_ms > 0:
+            self.initiator_gbs.append(_gbs(initiator_bytes, sample.submit_ms))
+
+    def add_iteration(
+        self, span_ms: float, iteration_bytes: int, slowest_ms: float
+    ) -> None:
+        """Record the driver-clock span of one iteration.
+
+        ``slowest_ms`` is the largest ``Sample.total_ms`` in that iteration, so
+        the overhead is the part of the span no initiator was working during.
+        """
+        self.span_ms.append(span_ms)
+        self.overhead_ms.append(span_ms - slowest_ms)
+        if span_ms > 0:
+            self.agg_gbs.append(_gbs(iteration_bytes, span_ms))
+
+
+@dataclass
+class RunRecord:
+    """Everything the runs of one ``(pattern, direction)`` produced.
+
+    A *run* is one set of freshly allocated tensors and freshly registered RDMA
+    buffers, exercised for ``warmup_iters_per_run + warm_iters_per_run``
+    iterations. Repeating a run is what gives ``register_ms`` more than one
+    sample, but it does not reset a proc's queue pairs: those are keyed by peer
+    and outlive any buffer, so only a run against freshly spawned procs pays to
+    establish them. That is why another ``cold_qp`` sample costs a proc
+    respawn, counted by ``cold_proc_runs``, and cannot be had by adding runs.
+
+    Everything measured inside an iteration lives in ``phases``.
+    ``register_ms`` is the run's setup cost, kept out of every throughput
+    denominator and reported in its own columns.
+    """
+
+    # What registration costs: with the run's tensors already allocated, how
+    # long constructing all of that proc's RDMA buffers takes. Measured on the
+    # actor, one entry per run per proc, so the spread across procs shows how
+    # the cost tracks a proc's buffer count. Allocation itself is excluded.
+    register_ms: list[float] = field(default_factory=list)
+    phases: dict[str, PhaseRecord] = field(
+        default_factory=lambda: {phase: PhaseRecord() for phase in PHASES}
+    )
+    integrity_ok: bool | None = None
+    negative_control_ok: bool | None = None
+
+    def record(self, phase: str) -> PhaseRecord:
+        """The record for ``phase``, or a throwaway for a discarded ramp
+        iteration."""
+        return self.phases.get(phase, PhaseRecord())
+
+
+@dataclass(frozen=True)
+class KeyColumns:
+    """What a row identifies. Leading, so the CSV is scannable."""
+
+    pattern: str
+    direction: str
+    phase: str
+
+
+@dataclass(frozen=True)
+class ShapeColumns:
+    """The graph the row measured, and what it cost to hold."""
+
+    num_hosts: int
+    procs_per_host: int
+    lane_pairing: str
+    lane_shift: int
+    num_edges: int
+    num_initiators: int
+    max_degree: int
+    max_ops_per_action: int
+    max_in_degree: int
+    bytes_per_iteration: int
+    max_buffers_per_proc: int
+    max_device_bytes_per_proc: int
+    max_host_bytes_per_host: int
+
+
+@dataclass(frozen=True)
+class ConfigColumns:
+    """The invocation's provenance: enough to reproduce the row.
+
+    ``transport`` is the requested one, which the driver asserts every proc
+    actually resolved to, so it names both what was asked for and what ran.
+    """
+
+    schema_version: int
+    transport: str
+    tcp_serialized: int
+    source_device: str
+    dest_device: str
+    payload_size_mb: float
+    concurrent_ops: int
+    cold_proc_runs: int
+    runs: int
+    warmup_iters_per_run: int
+    warm_iters_per_run: int
+    local_sender: int
+    verify_mode: str
+    rdma_runtime_threads: str
+    integrity_ok: str
+    negative_control_ok: str
+
+
+@dataclass(frozen=True)
+class MetricColumns:
+    """One phase's numbers. Throughput is ``None`` -- an empty CSV cell -- on
+    cold rows."""
+
+    # One span per iteration, but one sample per initiator per iteration, so
+    # these are equal only for a single-initiator pattern. Both are reported
+    # because `submit_ms_*` is backed by the samples and `agg_gbs_*` by the
+    # spans, and a phase can be thin in one and not the other.
+    n_samples: int
+    n_spans: int
+    register_ms_median: float
+    register_ms_p90: float
+    build_ms_median: float
+    build_ms_p90: float
+    submit_ms_median: float
+    submit_ms_mean: float
+    submit_ms_std: float
+    submit_ms_p90: float
+    submit_ms_max: float
+    span_ms_median: float
+    span_ms_p90: float
+    overhead_ms_median: float
+    overhead_ms_p90: float
+    initiator_gbs_median: float | None
+    initiator_gbs_mean: float | None
+    initiator_gbs_std: float | None
+    initiator_gbs_p90: float | None
+    agg_gbs_median: float | None
+    agg_gbs_mean: float | None
+    agg_gbs_std: float | None
+    agg_gbs_p90: float | None
+
+
+def metrics_for(phase: str, runs: RunRecord) -> MetricColumns:
+    """Turn one phase's raw measurements into its row.
+
+    Blanks the throughput cells on every phase but ``warm``: a cold iteration
+    pays for fresh registrations, and the first one in a process also pays to
+    establish its queue pairs, so bytes divided by that time is not a bandwidth.
+    """
+    record = runs.phases[phase]
+    register = summarize(runs.register_ms)
+    build = summarize(record.build_ms)
+    submit = summarize(record.submit_ms)
+    span = summarize(record.span_ms)
+    overhead = summarize(record.overhead_ms)
+    initiator = summarize(record.initiator_gbs)
+    aggregate = summarize(record.agg_gbs)
+    warm = phase == WARM
+    return MetricColumns(
+        n_samples=submit.n,
+        n_spans=span.n,
+        register_ms_median=register.median,
+        register_ms_p90=register.p90,
+        build_ms_median=build.median,
+        build_ms_p90=build.p90,
+        submit_ms_median=submit.median,
+        submit_ms_mean=submit.mean,
+        submit_ms_std=submit.stdev,
+        submit_ms_p90=submit.p90,
+        submit_ms_max=submit.maximum,
+        span_ms_median=span.median,
+        span_ms_p90=span.p90,
+        overhead_ms_median=overhead.median,
+        overhead_ms_p90=overhead.p90,
+        initiator_gbs_median=initiator.median if warm else None,
+        initiator_gbs_mean=initiator.mean if warm else None,
+        initiator_gbs_std=initiator.stdev if warm else None,
+        initiator_gbs_p90=initiator.p90 if warm else None,
+        agg_gbs_median=aggregate.median if warm else None,
+        agg_gbs_mean=aggregate.mean if warm else None,
+        agg_gbs_std=aggregate.stdev if warm else None,
+        agg_gbs_p90=aggregate.p90 if warm else None,
+    )
+
+
+_SUMMARY_PARTS: tuple[Any, ...] = (
+    KeyColumns,
+    ShapeColumns,
+    ConfigColumns,
+    MetricColumns,
+)
+
+
+def _names(parts: Iterable[Any]) -> tuple[str, ...]:
+    return tuple(f.name for part in parts for f in fields(part))
+
+
+def _values(parts: Iterable[Any]) -> tuple[Any, ...]:
+    return tuple(getattr(part, f.name) for part in parts for f in fields(part))
+
+
+def summary_header() -> tuple[str, ...]:
+    """The summary CSV's columns, derived from the row dataclasses so the
+    header and the rows cannot drift apart."""
+    return _names(_SUMMARY_PARTS)
+
+
+def summary_row(
+    key: KeyColumns,
+    shape: ShapeColumns,
+    config: ConfigColumns,
+    metrics: MetricColumns,
+) -> tuple[Any, ...]:
+    """One summary CSV row, in ``summary_header`` order."""
+    return _values((key, shape, config, metrics))
+
+
+def write_rows(
+    stream: TextIO, header: Sequence[str], rows: Iterable[Sequence[Any]]
+) -> None:
+    """Write the complete record of every row as a CSV.
+
+    ``None`` becomes an empty cell, so a consumer reads a cold row's throughput
+    as missing rather than as zero. :py:func:`phase_table` renders that same
+    absence as a dash, because a dash is legible where an empty column is not,
+    and an empty cell parses where a dash does not.
+    """
+    writer = csv.writer(stream)
+    writer.writerow(header)
+    writer.writerows(rows)
+
+
+def _cell(value: float | None, width: int, digits: int = 2) -> str:
+    """A right-aligned number, or a dash where there is none. The CSV writes the
+    same absence as an empty cell; see :py:func:`write_rows`."""
+    return f"{'-':>{width}}" if value is None else f"{value:>{width}.{digits}f}"
+
+
+def phase_table(
+    rows: Sequence[tuple[KeyColumns, MetricColumns]],
+) -> list[str]:
+    """An abridged, human-readable digest of one pattern's results.
+
+    One line per ``(direction, phase)``, carrying only the numbers worth reading
+    at a glance; the CSV stays the complete record. The driver prints one of
+    these per pattern, under a banner naming the shape that produced it, which
+    is why the shape appears nowhere in the table itself and why every row must
+    come from the same pattern.
+
+    Cold rows show a dash where a warm row shows throughput, so a reader cannot
+    mistake a setup cost for a bandwidth.
+    """
+    patterns = {key.pattern for key, _ in rows}
+    assert len(patterns) <= 1, f"one table per pattern, got {sorted(patterns)}"
+    header = (
+        f"{'Dir':<6}{'Phase':<9}{'n':>5}{'build p50 (ms)':>15}"
+        f"{'submit p50 (ms)':>16}{'submit p90 (ms)':>16}{'span p50 (ms)':>14}"
+        f"{'ovhd p50 (ms)':>14}{'init (GB/s)':>12}{'agg (GB/s)':>11}"
+    )
+    lines = [header, "-" * len(header)]
+    for key, m in rows:
+        lines.append(
+            f"{key.direction:<6}{key.phase:<9}{m.n_samples:>5}"
+            f"{m.build_ms_median:>15.2f}{m.submit_ms_median:>16.2f}"
+            f"{m.submit_ms_p90:>16.2f}{m.span_ms_median:>14.2f}"
+            f"{m.overhead_ms_median:>14.2f}"
+            f"{_cell(m.initiator_gbs_median, 12)}{_cell(m.agg_gbs_median, 11)}"
+        )
+    return lines
+
+
+def cold_warm_ratio(runs: RunRecord, cold_phase: str) -> float | None:
+    """How much slower a cold iteration was than a warm one. ``None`` when either
+    pair has no samples."""
+    cold = runs.phases[cold_phase].submit_ms
+    warm = runs.phases[WARM].submit_ms
+    if not cold or not warm:
+        return None
+    warm_median = statistics.median(warm)
+    if warm_median <= 0:
+        return None
+    return statistics.median(cold) / warm_median

--- a/python/benches/multihost_rdma/bench_topology.py
+++ b/python/benches/multihost_rdma/bench_topology.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Transfer topologies for the multi-host RDMA benchmark.
+
+A benchmark configuration is a directed graph whose vertices are procs. A
+:py:class:`Slot` is one proc, identified by its logical host index and its
+*lane* -- the proc's ordinal within its host, which for a GPU run is also its
+CUDA device ordinal. An :py:class:`Edge` means bytes move from the source
+slot's memory into the destination slot's memory. The graph is built in two
+independent steps: :py:func:`host_edges` turns a pattern name and a host count
+into a host graph, and :py:func:`expand_lanes` realizes each host edge as proc
+edges under a lane-pairing rule.
+
+Which side *initiates* the ibverbs ops is a separate axis. Under ``"write"``
+the source pushes into the destination's buffers; under ``"read"`` the
+destination pulls from the source's buffers. Both move the same bytes over the
+same edges, so a pattern and a direction compose freely.
+
+Memory follows from the graph, and :py:class:`SlotValues` is its shape. A slot
+that sends allocates one *outgoing* pool of ``concurrent_ops`` tensors shared by
+all of its out-edges, which is legal because an ``RDMAAction`` treats a
+write-from-local as a *read* claim on local memory and merges overlapping read
+claims. A slot that receives allocates one *incoming* pool per peer that sends
+to it, which is mandatory: an ``RDMAAction`` does not track remote ranges, so
+two initiators writing one remote buffer would corrupt it silently. Since an
+edge is exactly a pair of slots, incoming pools are keyed by the sending peer
+and no separate index is needed. :py:func:`allocation_for` is the single source
+of truth for what a slot allocates, so what the actors allocate and what
+:py:func:`plan_memory` charges them for cannot drift.
+
+This module imports only the standard library. It holds no monarch, torch, or
+RDMA state, and every function in it is pure, so the whole benchmark's
+topology, routing, resource, and validation logic is testable without a
+cluster. Buffer handles are opaque: :py:func:`plan_for` and
+:py:func:`compare_digests` never look inside them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+
+P2P: str = "p2p"
+FAN_OUT: str = "fan-out"
+FAN_IN: str = "fan-in"
+ALL_TO_ALL: str = "all-to-all"
+RING: str = "ring"
+PATTERNS: tuple[str, ...] = (P2P, FAN_OUT, FAN_IN, ALL_TO_ALL, RING)
+
+READ: str = "read"
+WRITE: str = "write"
+DIRECTIONS: tuple[str, ...] = (READ, WRITE)
+
+# How a host edge becomes proc edges. `same` pairs lane k with lane k, so a
+# transfer never leaves one pair of device ordinals. `shifted` pairs lane k with
+# lane k+shift, and `all` pairs every lane with every lane; both cross ordinals,
+# so whether they can connect at all depends on the cluster's NIC topology.
+SAME: str = "same"
+SHIFTED: str = "shifted"
+ALL: str = "all"
+PAIRINGS: tuple[str, ...] = (SAME, SHIFTED, ALL)
+
+COLD_QP: str = "cold_qp"
+RAMP: str = "ramp"
+WARM: str = "warm"
+
+# The phases the benchmark reports. `RAMP` is deliberately absent: those
+# iterations are discarded so that settling never lands in a warm percentile.
+PHASES: tuple[str, ...] = (COLD_QP, WARM)
+
+
+@dataclass(frozen=True, order=True)
+class Slot:
+    """One benchmark proc: its logical host index and its lane within that host."""
+
+    host: int
+    lane: int
+
+    def __str__(self) -> str:
+        return f"h{self.host}/l{self.lane}"
+
+
+@dataclass(frozen=True, order=True)
+class Edge:
+    """One directed flow. Bytes move src to dst whichever side initiates."""
+
+    src: Slot
+    dst: Slot
+
+    def __str__(self) -> str:
+        return f"{self.src} -> {self.dst}"
+
+
+def host_edges(pattern: str, num_hosts: int) -> list[tuple[int, int]]:
+    """The directed host graph for ``pattern`` over ``num_hosts`` hosts.
+
+    One host yields the loopback self-edge, whatever the pattern, which is how
+    the benchmark expresses a same-host transfer.
+
+    Above one host, ``p2p`` always uses hosts 0 and 1 and leaves the rest idle.
+    That is intentional: it keeps p2p available as a baseline in a sweep that
+    provisions enough hosts for the other patterns.
+    """
+    if pattern not in PATTERNS:
+        raise ValueError(f"unknown pattern {pattern!r}; expected one of {PATTERNS}")
+    if num_hosts < 1:
+        raise ValueError(f"num_hosts must be at least 1, got {num_hosts}")
+    if num_hosts == 1:
+        return [(0, 0)]
+    match pattern:
+        case "p2p":
+            return [(0, 1)]
+        case "fan-out":
+            return [(0, dst) for dst in range(1, num_hosts)]
+        case "fan-in":
+            return [(src, 0) for src in range(1, num_hosts)]
+        case "all-to-all":
+            return [
+                (src, dst)
+                for src in range(num_hosts)
+                for dst in range(num_hosts)
+                if src != dst
+            ]
+        case _:
+            return [(src, (src + 1) % num_hosts) for src in range(num_hosts)]
+
+
+def expand_lanes(
+    host_edge: tuple[int, int],
+    procs_per_host: int,
+    pairing: str = SAME,
+    shift: int = 1,
+) -> list[Edge]:
+    """Realize one host edge as proc edges under a lane-pairing rule."""
+    if pairing not in PAIRINGS:
+        raise ValueError(f"unknown pairing {pairing!r}; expected one of {PAIRINGS}")
+    if procs_per_host < 1:
+        raise ValueError(f"procs_per_host must be at least 1, got {procs_per_host}")
+    src_host, dst_host = host_edge
+    lanes = range(procs_per_host)
+    if pairing == ALL:
+        return [
+            Edge(Slot(src_host, src), Slot(dst_host, dst))
+            for src in lanes
+            for dst in lanes
+        ]
+    if pairing == SAME:
+        return [Edge(Slot(src_host, lane), Slot(dst_host, lane)) for lane in lanes]
+    if shift % procs_per_host == 0:
+        raise ValueError(
+            f"shift {shift} is a multiple of procs_per_host {procs_per_host}, so "
+            f"{SHIFTED!r} pairing would silently be {SAME!r}"
+        )
+    return [
+        Edge(Slot(src_host, lane), Slot(dst_host, (lane + shift) % procs_per_host))
+        for lane in lanes
+    ]
+
+
+@dataclass(frozen=True)
+class Topology:
+    """A benchmark configuration's proc graph, with its per-slot edge indices.
+
+    Build with :py:func:`build_topology` rather than directly, so ``edges`` is
+    sorted and deduplicated.
+    """
+
+    pattern: str
+    num_hosts: int
+    procs_per_host: int
+    pairing: str
+    shift: int
+    edges: tuple[Edge, ...]
+
+    _out: dict[Slot, tuple[Edge, ...]] = field(init=False, repr=False, compare=False)
+    _in: dict[Slot, tuple[Edge, ...]] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        out: dict[Slot, list[Edge]] = {}
+        incoming: dict[Slot, list[Edge]] = {}
+        for edge in self.edges:
+            out.setdefault(edge.src, []).append(edge)
+            incoming.setdefault(edge.dst, []).append(edge)
+        object.__setattr__(self, "_out", {s: tuple(e) for s, e in out.items()})
+        object.__setattr__(self, "_in", {s: tuple(e) for s, e in incoming.items()})
+
+    def slots(self) -> tuple[Slot, ...]:
+        """Every slot the graph touches, sorted. Idle procs are absent."""
+        return tuple(sorted(set(self._out) | set(self._in)))
+
+    def out_edges(self, slot: Slot) -> tuple[Edge, ...]:
+        """The edges ``slot`` sends on, sorted."""
+        return self._out.get(slot, ())
+
+    def in_edges(self, slot: Slot) -> tuple[Edge, ...]:
+        """The edges ``slot`` receives on, sorted."""
+        return self._in.get(slot, ())
+
+    def out_degree(self, slot: Slot) -> int:
+        return len(self.out_edges(slot))
+
+    def in_degree(self, slot: Slot) -> int:
+        return len(self.in_edges(slot))
+
+    def initiators(self, direction: str) -> tuple[Slot, ...]:
+        """The slots that issue ibverbs ops: sources under write, destinations
+        under read."""
+        _check_direction(direction)
+        return tuple(sorted(self._out if direction == WRITE else self._in))
+
+    def degree(self, slot: Slot, direction: str) -> int:
+        """How many edges ``slot`` initiates on under ``direction``.
+
+        Also the number of active, polling queue-pair actors the slot's proc
+        drives, since a queue pair is created lazily by the initiator and the
+        target's mirror is never polled.
+        """
+        _check_direction(direction)
+        return self.out_degree(slot) if direction == WRITE else self.in_degree(slot)
+
+    def max_degree(self, direction: str) -> int:
+        """The largest number of edges any one slot initiates on."""
+        return max((self.degree(s, direction) for s in self.slots()), default=0)
+
+
+def build_topology(
+    pattern: str,
+    num_hosts: int,
+    procs_per_host: int,
+    pairing: str = SAME,
+    shift: int = 1,
+) -> Topology:
+    """Build the proc graph for one benchmark configuration."""
+    edges = tuple(
+        sorted(
+            {
+                edge
+                for host_edge in host_edges(pattern, num_hosts)
+                for edge in expand_lanes(host_edge, procs_per_host, pairing, shift)
+            }
+        )
+    )
+    return Topology(
+        pattern=pattern,
+        num_hosts=num_hosts,
+        procs_per_host=procs_per_host,
+        pairing=pairing,
+        shift=shift,
+        edges=edges,
+    )
+
+
+def _check_direction(direction: str) -> None:
+    if direction not in DIRECTIONS:
+        raise ValueError(
+            f"unknown direction {direction!r}; expected one of {DIRECTIONS}"
+        )
+
+
+@dataclass(frozen=True)
+class SlotAllocation:
+    """What one slot must allocate.
+
+    ``sends`` is false for a slot with no out-edges -- a fan-out leaf -- which
+    therefore pays for its incoming pools only. A sending slot shares one
+    outgoing pool across every out-edge, so one is always enough.
+    """
+
+    sends: bool
+    receives_from: tuple[Slot, ...]
+    ops: int
+
+    @property
+    def tensors(self) -> int:
+        """Total tensors, each of which is registered as one RDMA buffer."""
+        return (self.ops if self.sends else 0) + len(self.receives_from) * self.ops
+
+
+def allocation_for(topo: Topology, slot: Slot, *, ops: int) -> SlotAllocation:
+    """What ``slot`` allocates. Independent of direction, so one allocation
+    serves both a read pass and a write pass."""
+    if ops < 1:
+        raise ValueError(f"concurrent_ops must be at least 1, got {ops}")
+    return SlotAllocation(
+        sends=topo.out_degree(slot) > 0,
+        receives_from=tuple(edge.src for edge in topo.in_edges(slot)),
+        ops=ops,
+    )
+
+
+def max_ops_per_action(topo: Topology, direction: str, *, ops: int) -> int:
+    """The most ops any one initiator batches into a single ``RDMAAction``:
+    one per out-edge (or in-edge) per concurrent op."""
+    return topo.max_degree(direction) * ops
+
+
+@dataclass(frozen=True)
+class MemoryPlan:
+    """One configuration's footprint, split by memory kind.
+
+    Device memory is charged per slot because each slot owns one GPU; host
+    memory is charged per host because the procs on a host share it. Unused
+    hosts and slots have no entry in the plan.
+    """
+
+    payload_bytes: int
+    buffers: dict[Slot, int]
+    device_bytes: dict[Slot, int]
+    host_bytes_per_host: dict[int, int]
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(self.device_bytes.values()) + sum(self.host_bytes_per_host.values())
+
+
+def plan_memory(
+    topo: Topology,
+    *,
+    ops: int,
+    payload_bytes: int,
+    source_on_gpu: bool,
+    dest_on_gpu: bool,
+) -> MemoryPlan:
+    """Charge every slot's tensors to device or host memory by their role."""
+    buffers: dict[Slot, int] = {}
+    device: dict[Slot, int] = {}
+    host: dict[int, int] = {slot.host: 0 for slot in topo.slots()}
+    for slot in topo.slots():
+        allocation = allocation_for(topo, slot, ops=ops)
+        outgoing = (ops if allocation.sends else 0) * payload_bytes
+        incoming = len(allocation.receives_from) * ops * payload_bytes
+        buffers[slot] = allocation.tensors
+        device[slot] = (outgoing if source_on_gpu else 0) + (
+            incoming if dest_on_gpu else 0
+        )
+        host[slot.host] += (0 if source_on_gpu else outgoing) + (
+            0 if dest_on_gpu else incoming
+        )
+    return MemoryPlan(
+        payload_bytes=payload_bytes,
+        buffers=buffers,
+        device_bytes=device,
+        host_bytes_per_host=host,
+    )
+
+
+def check_memory(
+    topo: Topology,
+    plan: MemoryPlan,
+    *,
+    max_device_bytes: int,
+    max_host_bytes: int,
+) -> None:
+    """Raise before anything is provisioned if the footprint will not fit.
+
+    Names the binding slot or host, its in-degree, and the largest payload
+    that would fit, so a bad flag combination fails on the client in
+    milliseconds instead of part-way into a multi-host allocation.
+    """
+    slot, device_bytes = max(plan.device_bytes.items(), key=lambda kv: kv[1])
+    if device_bytes > max_device_bytes:
+        raise ValueError(
+            f"{topo.pattern}: slot {slot} needs {_size(device_bytes)} of device "
+            f"memory, over the {_size(max_device_bytes)} budget. Its in-degree is "
+            f"{topo.in_degree(slot)}, its out-degree is {topo.out_degree(slot)}, "
+            f"and the payload is {_size(plan.payload_bytes)}; the largest payload "
+            "that fits is "
+            f"{_size(_fitting_payload(plan.payload_bytes, device_bytes, max_device_bytes))}"
+        )
+    host, host_bytes = max(plan.host_bytes_per_host.items(), key=lambda kv: kv[1])
+    if host_bytes > max_host_bytes:
+        raise ValueError(
+            f"{topo.pattern}: host {host} needs {_size(host_bytes)} of pinned host "
+            f"memory across its {topo.procs_per_host} procs, over the "
+            f"{_size(max_host_bytes)} budget. The payload is "
+            f"{_size(plan.payload_bytes)}; the largest payload that fits is "
+            f"{_size(_fitting_payload(plan.payload_bytes, host_bytes, max_host_bytes))}"
+        )
+
+
+def _fitting_payload(payload_bytes: int, needed: int, budget: int) -> int:
+    """The largest payload that would not exceed ``budget``.
+
+    A configuration's footprint is proportional to its payload, so scaling
+    ``payload_bytes`` by ``budget / needed`` lands on the budget.
+    """
+    return payload_bytes * budget // needed
+
+
+def _size(num_bytes: int) -> str:
+    """Bytes in the largest decimal unit that keeps the number legible."""
+    for unit, scale in (("TB", 10**12), ("GB", 10**9), ("MB", 10**6), ("KB", 10**3)):
+        if num_bytes >= scale:
+            return f"{num_bytes / scale:.2f} {unit}"
+    return f"{num_bytes} B"
+
+
+def bytes_per_iteration(topo: Topology, *, ops: int, payload_bytes: int) -> int:
+    """Bytes the whole graph moves in one iteration -- the numerator of the
+    aggregate throughput."""
+    return len(topo.edges) * ops * payload_bytes
+
+
+def initiator_bytes(
+    topo: Topology, slot: Slot, direction: str, *, ops: int, payload_bytes: int
+) -> int:
+    """Bytes one initiator moves in one iteration."""
+    return topo.degree(slot, direction) * ops * payload_bytes
+
+
+@dataclass(frozen=True)
+class SlotValues:
+    """One value per tensor one slot holds, grouped by role and keyed by peer.
+
+    ``outgoing`` covers the pool every out-edge sends from; ``incoming`` holds
+    one pool per peer that sends to this slot. The values are opaque: RDMA
+    buffers when the driver collects them from the actors, digests when it
+    collects them to check integrity.
+    """
+
+    outgoing: tuple[Any, ...]
+    incoming: dict[Slot, tuple[Any, ...]]
+
+
+@dataclass(frozen=True)
+class PushOp:
+    """Write ``outgoing[outgoing_index]`` into a remote buffer."""
+
+    remote: Any
+    outgoing_index: int
+
+
+@dataclass(frozen=True)
+class PullOp:
+    """Read a remote buffer into ``incoming[peer][op_index]``."""
+
+    remote: Any
+    peer: Slot
+    op_index: int
+
+
+@dataclass(frozen=True)
+class InitiatorPlan:
+    """Every op one slot issues in one iteration.
+
+    A flat list, so the actor's timed loop reads this and nothing else: it
+    never learns what a pattern, a direction, or a topology is.
+    """
+
+    push: tuple[PushOp, ...] = ()
+    pull: tuple[PullOp, ...] = ()
+
+    @property
+    def ops(self) -> int:
+        return len(self.push) + len(self.pull)
+
+
+def plan_for(
+    topo: Topology,
+    direction: str,
+    values: Mapping[Slot, SlotValues],
+    *,
+    ops: int,
+) -> dict[Slot, InitiatorPlan]:
+    """Route every edge to the ops its initiator must issue.
+
+    Under ``write`` an initiator targets the peer's incoming pool *reserved for
+    it*; under ``read`` it targets the peer's shared outgoing pool. Slots that
+    initiate nothing are absent from the result.
+    """
+    _check_direction(direction)
+    return {
+        slot: (
+            _push_plan(topo, slot, values, ops)
+            if direction == WRITE
+            else _pull_plan(topo, slot, values, ops)
+        )
+        for slot in topo.initiators(direction)
+    }
+
+
+def _push_plan(
+    topo: Topology, slot: Slot, values: Mapping[Slot, SlotValues], ops: int
+) -> InitiatorPlan:
+    push: list[PushOp] = []
+    for edge in topo.out_edges(slot):
+        incoming = values[edge.dst].incoming[edge.src]
+        if len(incoming) != ops:
+            raise ValueError(
+                f"{edge}: incoming pool has {len(incoming)} tensors, expected {ops}"
+            )
+        push.extend(PushOp(remote=incoming[op], outgoing_index=op) for op in range(ops))
+    return InitiatorPlan(push=tuple(push))
+
+
+def _pull_plan(
+    topo: Topology, slot: Slot, values: Mapping[Slot, SlotValues], ops: int
+) -> InitiatorPlan:
+    pull: list[PullOp] = []
+    for edge in topo.in_edges(slot):
+        outgoing = values[edge.src].outgoing
+        if len(outgoing) != ops:
+            raise ValueError(
+                f"{edge}: outgoing pool has {len(outgoing)} tensors, expected {ops}"
+            )
+        pull.extend(
+            PullOp(remote=outgoing[op], peer=edge.src, op_index=op) for op in range(ops)
+        )
+    return InitiatorPlan(pull=tuple(pull))
+
+
+def compare_digests(
+    topo: Topology, digests: Mapping[Slot, SlotValues]
+) -> tuple[int, list[str]]:
+    """Compare each edge's incoming pool against the pool it was sent from.
+
+    Returns ``(pairs_checked, mismatches)``. After a round every pair must
+    match. Before any transfer every pair must *mismatch*, which is the
+    negative control that proves the comparison is wired to the right slots.
+    """
+    checked = 0
+    mismatches: list[str] = []
+    for edge in topo.edges:
+        outgoing = digests[edge.src].outgoing
+        incoming = digests[edge.dst].incoming[edge.src]
+        if len(outgoing) != len(incoming):
+            raise ValueError(
+                f"{edge}: sender has {len(outgoing)} digests, receiver has {len(incoming)}"
+            )
+        for op, (want, got) in enumerate(zip(outgoing, incoming)):
+            checked += 1
+            if want != got:
+                mismatches.append(f"{edge} op {op}: sent={want} received={got}")
+    return checked, mismatches
+
+
+def phase_of(run_index: int, iteration: int, warmup: int) -> str:
+    """Which reporting phase an iteration belongs to.
+
+    Iteration 0 of the first run is ``cold_qp``: it pays the lazy queue-pair
+    handshake to every peer. A run's first ``warmup`` iterations are ``ramp``
+    and are discarded; the rest are ``warm``.
+    """
+    if run_index == 0 and iteration == 0:
+        return COLD_QP
+    return RAMP if iteration < warmup else WARM
+
+
+def describe(topo: Topology, direction: str, *, ops: int, payload_bytes: int) -> str:
+    """One line naming the graph and what each initiator will do on it."""
+    return (
+        f"{topo.pattern}: {topo.num_hosts}x{topo.procs_per_host} procs, "
+        f"{len(topo.edges)} edges, {topo.pairing} lanes, {direction}; "
+        f"initiators={len(topo.initiators(direction))}, "
+        f"max ops/action={max_ops_per_action(topo, direction, ops=ops)}, "
+        f"{_size(bytes_per_iteration(topo, ops=ops, payload_bytes=payload_bytes))} "
+        f"per iteration"
+    )
+
+
+def unused_hosts(topo: Topology) -> Sequence[int]:
+    """Hosts the job provisions that this pattern never touches."""
+    touched = {slot.host for slot in topo.slots()}
+    return tuple(host for host in range(topo.num_hosts) if host not in touched)

--- a/python/benches/multihost_rdma/bench_topology.py
+++ b/python/benches/multihost_rdma/bench_topology.py
@@ -25,15 +25,14 @@ destination pulls from the source's buffers. Both move the same bytes over the
 same edges, so a pattern and a direction compose freely.
 
 Memory follows from the graph, and :py:class:`SlotValues` is its shape. A slot
-that sends allocates one *outgoing* pool of ``concurrent_ops`` tensors shared by
-all of its out-edges, which is legal because an ``RDMAAction`` treats a
-write-from-local as a *read* claim on local memory and merges overlapping read
-claims. A slot that receives allocates one *incoming* pool per peer that sends
-to it, which is mandatory: an ``RDMAAction`` does not track remote ranges, so
-two initiators writing one remote buffer would corrupt it silently. Since an
-edge is exactly a pair of slots, incoming pools are keyed by the sending peer
-and no separate index is needed. :py:func:`allocation_for` is the single source
-of truth for what a slot allocates, so what the actors allocate and what
+that sends allocates ``concurrent_ops`` *outgoing* tensors, shared by all of its
+out-edges: sharing is legal because an ``RDMAAction`` treats a write-from-local
+as a *read* claim on local memory and merges overlapping read claims. A slot
+that receives allocates that many *incoming* tensors for each peer that sends to
+it, and keeping them separate per peer is mandatory: an ``RDMAAction`` does not
+track remote ranges, so two initiators writing the same remote buffer would
+corrupt it silently. :py:func:`allocation_for` is the single source of truth for
+what a slot allocates, so what the actors allocate and what
 :py:func:`plan_memory` charges them for cannot drift.
 
 This module imports only the standard library. It holds no monarch, torch, or
@@ -46,7 +45,11 @@ cluster. Buffer handles are opaque: :py:func:`plan_for` and
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Generic, Iterator, Mapping, Sequence, TypeVar
+
+
+T = TypeVar("T")
+U = TypeVar("U")
 
 
 P2P: str = "p2p"
@@ -418,17 +421,38 @@ def initiator_bytes(
 
 
 @dataclass(frozen=True)
-class SlotValues:
-    """One value per tensor one slot holds, grouped by role and keyed by peer.
+class SlotValues(Generic[T]):
+    """One value per tensor a slot holds, grouped by role and keyed by peer.
 
-    ``outgoing`` covers the pool every out-edge sends from; ``incoming`` holds
-    one pool per peer that sends to this slot. The values are opaque: RDMA
-    buffers when the driver collects them from the actors, digests when it
-    collects them to check integrity.
+    ``outgoing`` covers the tensors every out-edge sends from; ``incoming``
+    holds one group per peer that sends to this slot. The element type varies
+    with what is being carried -- the tensors themselves, the RDMA buffers
+    registered over them, or digests of their bytes.
     """
 
-    outgoing: tuple[Any, ...]
-    incoming: dict[Slot, tuple[Any, ...]]
+    outgoing: tuple[T, ...]
+    incoming: dict[Slot, tuple[T, ...]]
+
+    def map(self, fn: Callable[[T], U]) -> "SlotValues[U]":
+        """Apply ``fn`` to every value, keeping the shape.
+
+        How a slot's tensors become its registered buffers, and how their
+        contents become digests, without either conversion being able to drop or
+        reorder a group.
+        """
+        return SlotValues(
+            outgoing=tuple(fn(value) for value in self.outgoing),
+            incoming={
+                peer: tuple(fn(value) for value in values)
+                for peer, values in self.incoming.items()
+            },
+        )
+
+    def flat(self) -> Iterator[T]:
+        """Every value, for when the grouping does not matter."""
+        yield from self.outgoing
+        for values in self.incoming.values():
+            yield from values
 
 
 @dataclass(frozen=True)
@@ -467,7 +491,7 @@ class InitiatorPlan:
 def plan_for(
     topo: Topology,
     direction: str,
-    values: Mapping[Slot, SlotValues],
+    values: Mapping[Slot, SlotValues[Any]],
     *,
     ops: int,
 ) -> dict[Slot, InitiatorPlan]:
@@ -489,7 +513,7 @@ def plan_for(
 
 
 def _push_plan(
-    topo: Topology, slot: Slot, values: Mapping[Slot, SlotValues], ops: int
+    topo: Topology, slot: Slot, values: Mapping[Slot, SlotValues[Any]], ops: int
 ) -> InitiatorPlan:
     push: list[PushOp] = []
     for edge in topo.out_edges(slot):
@@ -503,7 +527,7 @@ def _push_plan(
 
 
 def _pull_plan(
-    topo: Topology, slot: Slot, values: Mapping[Slot, SlotValues], ops: int
+    topo: Topology, slot: Slot, values: Mapping[Slot, SlotValues[Any]], ops: int
 ) -> InitiatorPlan:
     pull: list[PullOp] = []
     for edge in topo.in_edges(slot):
@@ -519,7 +543,7 @@ def _pull_plan(
 
 
 def compare_digests(
-    topo: Topology, digests: Mapping[Slot, SlotValues]
+    topo: Topology, digests: Mapping[Slot, SlotValues[str]]
 ) -> tuple[int, list[str]]:
     """Compare each edge's incoming pool against the pool it was sent from.
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -17,6 +17,12 @@ import pytest
 
 _THIS_DIR = Path(__file__).parent
 
+# The multihost RDMA benchmark's modules import as bare names -- `bench_topology`,
+# not a dotted path -- so the owning directory needs to be added to `sys.path`.
+_BENCH_DIR = _THIS_DIR.parent / "benches" / "multihost_rdma"
+if str(_BENCH_DIR) not in sys.path:
+    sys.path.insert(0, str(_BENCH_DIR))
+
 collect_ignore: list[str] = []
 
 # FUSE and RDMA require Linux; skip these files on other platforms to avoid

--- a/python/tests/test_rdma.py
+++ b/python/tests/test_rdma.py
@@ -714,43 +714,6 @@ class ClientActor(Actor):
         await self.action.submit()
 
     @endpoint
-    async def perform_data_race(
-        self, buffer_a: RDMABuffer, buffer_b: RDMABuffer, buffer_c: RDMABuffer
-    ) -> None:
-        """Perform batched operations using RDMAAction across multiple remote actors"""
-
-        # Create RDMAAction instance
-        action = RDMAAction()
-
-        # Chain multiple operations across different remote actors
-        # Read from buffer A into local data_a
-        action.read_remote(self.data_a.view(torch.uint8).flatten(), buffer_a)
-
-        # # Write data_a to buffer B (modified data goes from A -> B) - Data race!
-        action.write_remote(buffer_b, self.data_a.view(torch.uint8).flatten())
-
-    @endpoint
-    async def perform_data_race_w_slices(
-        self, buffer_a: RDMABuffer, buffer_b: RDMABuffer, buffer_c: RDMABuffer
-    ) -> None:
-        """Perform batched operations using RDMAAction across multiple remote actors"""
-        assert self.size == 250, "Size must be 100 for this test"
-        # Create RDMAAction instance
-        action = RDMAAction()
-
-        # Chain multiple operations across different remote actors
-        # Read from buffer A into local data_a
-        action.read_remote(
-            self.data_a.view(torch.uint8)[0 : 100 * 4].flatten(), buffer_a
-        )
-        action.write_remote(
-            buffer_a, self.data_a.view(torch.uint8)[150 * 4 :].flatten()
-        )
-        action.read_remote(
-            self.data_a.view(torch.uint8)[75 * 4 : 175 * 4].flatten(), buffer_a
-        )
-
-    @endpoint
     async def get_local_data_sums(self) -> dict:
         """Get sums of local data for verification"""
         return {
@@ -940,41 +903,6 @@ async def test_rdma_action_second_call():
     # Verify that server B, C same as before
     assert 0.0 == await server_b.get_sum.call_one()
     assert sum_c_after == await server_c.get_sum.call_one()
-
-
-@rdma_backends
-async def test_rdma_action_data_races():
-    """Test RDMAAction with concurrent execution across multiple remote actors (2 remote + 1 local)"""
-
-    # Setup: Create 3 separate processes (2 remote + 1 local)
-    server_proc_1 = this_host().spawn_procs(per_host={"processes": 1})
-    server_proc_2 = this_host().spawn_procs(per_host={"processes": 1})
-    client_proc = this_host().spawn_procs(per_host={"processes": 1})
-
-    # Create actors on different processes
-    server_a = server_proc_1.spawn(
-        "server_a",
-        DataServerActor,
-        "A",
-    )  # Data filled with 65.0 (ASCII 'A')
-    server_b = server_proc_2.spawn(
-        "server_b", DataServerActor, "B"
-    )  # Data filled with 66.0 (ASCII 'B')
-    server_c = server_proc_1.spawn(
-        "server_c", DataServerActor, "C"
-    )  # Data filled with 67.0 (ASCII 'C')
-    client = client_proc.spawn("client", ClientActor, 250)
-
-    # Create RDMA buffers on each server
-    buffer_a = await server_a.create_buffer.call_one()
-    buffer_b = await server_b.create_buffer.call_one()
-    buffer_c = await server_c.create_buffer.call_one()
-
-    with pytest.raises(Exception):
-        await client.perform_data_race.call_one(buffer_a, buffer_b, buffer_c)
-
-    with pytest.raises(Exception):
-        await client.perform_data_race_w_slices.call_one(buffer_a, buffer_b, buffer_c)
 
 
 @rdma_backends

--- a/python/tests/test_rdma_action.py
+++ b/python/tests/test_rdma_action.py
@@ -133,27 +133,11 @@ class ActionClient(Actor):
         return False
 
     @endpoint
-    async def overlapping_writes_into_local_error(self, buffer: RDMABuffer) -> bool:
-        # Two `read_remote`s onto overlapping local destinations both write
-        # the same local memory: the new local-side claim algorithm must
-        # flag this as a race.
-        size = buffer.size()
-        slot = torch.zeros(size, dtype=torch.uint8, device=self.device)
-        action = RDMAAction()
-        action.read_remote(slot, buffer)
-        try:
-            action.read_remote(slot, buffer)
-        except ValueError:
-            return True
-        return False
-
-    @endpoint
     async def overlapping_reads_from_local_ok(
         self, buffer_a: RDMABuffer, buffer_b: RDMABuffer
     ) -> None:
-        # Two `write_remote`s using the same local memory range both *read*
-        # local memory — that is safe, and the new algorithm must let it
-        # through (the old python helper would have errored).
+        # Two `write_remote`s sharing one local source range, which is what a
+        # fan-out does: one buffer's contents sent to several peers.
         size = min(buffer_a.size(), buffer_b.size())
         slot = torch.zeros(size, dtype=torch.uint8, device=self.device)
         action = RDMAAction()
@@ -399,27 +383,9 @@ async def test_submit_validation_errors_surface(host_device, client_device) -> N
 @pytest.mark.parametrize(
     ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
 )
-async def test_overlapping_local_writes_are_a_race(host_device, client_device) -> None:
-    # Two `read_remote`s onto the same local destination are concurrent writes —
-    # the bug-fixed claim algorithm must flag this as a race.
-    size = 32
-    host, client = await _spawn_host_and_client(
-        num_buffers=1, size=size, host_device=host_device, client_device=client_device
-    )
-    (buffer,) = await host.create_buffers.call_one()
-    caught = await client.overlapping_writes_into_local_error.call_one(buffer)
-    assert caught, "Expected ValueError from two overlapping read_remote claims"
-
-
-@rdma_backends
-@pytest.mark.parametrize(
-    ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
-)
 async def test_overlapping_local_reads_are_ok(host_device, client_device) -> None:
-    # Two `write_remote`s from the same local source both *read* local memory —
-    # safe; today's python helper would have errored, the new one merges.
-    # Uses two distinct remote buffers so the test exercises the local-side
-    # read-merge without two writes landing on the same remote target.
+    # One local source range feeding two ops in a single action. The two remote
+    # buffers are distinct, so nothing writes the same range on either side.
     size = 32
     host, client = await _spawn_host_and_client(
         num_buffers=2, size=size, host_device=host_device, client_device=client_device

--- a/python/tests/test_rdma_bench_peer.py
+++ b/python/tests/test_rdma_bench_peer.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+End-to-end tests for the multi-host RDMA benchmark's participant actor.
+
+These drive the sequence the driver will -- ``setup``, ``wire``,
+``execute_iteration``, ``digest`` -- against real registered buffers
+under ibverbs and tcp.
+
+A single host is enough. The ``shifted`` and ``all`` lane pairings turn a
+self-edge into genuine proc-to-proc edges, and ``all`` gives every slot several
+peers, which is where per-peer routing can go wrong.
+"""
+
+import os
+
+# More efficient RDMA support for CUDA tensors.
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+import bench_peer  # noqa: E402
+import bench_topology as bt  # noqa: E402
+import pytest  # noqa: E402
+import torch  # noqa: E402
+from monarch.actor import this_host  # noqa: E402
+from proc_mesh_test_utils import stop_all_proc_meshes  # noqa: E402, F401
+from rdma_test_utils import rdma_backends  # noqa: E402
+
+
+_LANES = 2
+_OPS = 2
+_PAYLOAD_BYTES = 4096
+_SEED = 7
+
+# The benchmark's four memory configurations, named as the CLI names them.
+DEVICE_VARIANTS: list[tuple[bool, bool]] = [
+    (False, False),
+    (True, True),
+    (False, True),
+    (True, False),
+]
+DEVICE_IDS = ["cpu", "gpu", "cpu2gpu", "gpu2cpu"]
+
+
+def _slot_of(point) -> bt.Slot:
+    """Which slot a value in a cast's result came from."""
+    host = point["hosts"] if "hosts" in point.extent.labels else 0
+    return bt.Slot(host, point["lanes"])
+
+
+def _spawn(lanes: int = _LANES):
+    procs = this_host().spawn_procs(per_host={"lanes": lanes})
+    return procs.spawn("peer", bench_peer.Peer)
+
+
+async def _drive(peers, topo, direction, *, source_on_gpu=False, dest_on_gpu=False):
+    """Allocate and register everywhere, then route and install the plans."""
+    allocations = {
+        slot: bt.allocation_for(topo, slot, ops=_OPS) for slot in topo.slots()
+    }
+    results = await peers.setup.call(
+        allocations, _PAYLOAD_BYTES, _SEED, source_on_gpu, dest_on_gpu
+    )
+    buffers = {_slot_of(point): value[1] for point, value in results.items()}
+    await peers.wire.call(bt.plan_for(topo, direction, buffers, ops=_OPS))
+    return results
+
+
+async def _compare(peers, topo):
+    digests = {
+        _slot_of(point): value
+        for point, value in (
+            await peers.digest.call(bench_peer.VERIFY_FULL, _PAYLOAD_BYTES)
+        ).items()
+    }
+    return bt.compare_digests(topo, digests)
+
+
+def _skip_without_cuda(source_on_gpu: bool, dest_on_gpu: bool) -> None:
+    if (source_on_gpu or dest_on_gpu) and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+
+@rdma_backends
+@pytest.mark.parametrize("direction", bt.DIRECTIONS)
+@pytest.mark.parametrize(
+    ("source_on_gpu", "dest_on_gpu"), DEVICE_VARIANTS, ids=DEVICE_IDS
+)
+async def test_every_edge_delivers_its_own_bytes(
+    direction, source_on_gpu, dest_on_gpu
+) -> None:
+    """Each slot ends up holding exactly what its peers sent it.
+
+    Under ``all`` pairing every slot both sends and receives on several edges,
+    so this fails if any op is routed to the wrong peer's memory -- the failure
+    the RDMA layer cannot detect for itself.
+    """
+    _skip_without_cuda(source_on_gpu, dest_on_gpu)
+    topo = bt.build_topology("p2p", 1, _LANES, bt.ALL)
+    peers = _spawn()
+    await _drive(
+        peers, topo, direction, source_on_gpu=source_on_gpu, dest_on_gpu=dest_on_gpu
+    )
+
+    # Nothing has moved yet, so every pair must disagree. Without this the test
+    # would still pass if the comparison were somehow against itself.
+    checked, mismatches = await _compare(peers, topo)
+    assert checked == len(topo.edges) * _OPS
+    assert len(mismatches) == checked, "incoming tensors start zeroed"
+
+    samples = await peers.execute_iteration.call()
+    assert all(sample is not None for _point, sample in samples.items())
+
+    _checked, mismatches = await _compare(peers, topo)
+    assert mismatches == []
+
+
+@rdma_backends
+@pytest.mark.parametrize("pairing", bt.PAIRINGS)
+async def test_every_lane_pairing_routes_correctly(pairing) -> None:
+    """``same`` keeps a slot talking to itself; ``shifted`` and ``all`` cross
+    proc boundaries, which is what makes this more than a loopback test."""
+    topo = bt.build_topology("p2p", 1, _LANES, pairing)
+    crosses = [edge for edge in topo.edges if edge.src != edge.dst]
+    assert bool(crosses) == (pairing != bt.SAME), "the pairing does what it says"
+
+    peers = _spawn()
+    await _drive(peers, topo, bt.WRITE)
+    await peers.execute_iteration.call()
+
+    _checked, mismatches = await _compare(peers, topo)
+    assert mismatches == []
+
+
+@rdma_backends
+async def test_a_proc_outside_the_topology_stays_idle() -> None:
+    """A pattern need not use every proc the job provisioned. Those procs are
+    absent from the mappings, allocate nothing, and report no measurement."""
+    topo = bt.build_topology("p2p", 1, _LANES, bt.ALL)
+    peers = _spawn(lanes=_LANES + 2)
+    await _drive(peers, topo, bt.WRITE)
+
+    samples = {
+        _slot_of(point): sample
+        for point, sample in (await peers.execute_iteration.call()).items()
+    }
+    assert set(topo.slots()) < set(samples), "more procs than the topology uses"
+    for slot, sample in samples.items():
+        if slot in topo.slots():
+            assert sample is not None and sample.slot == slot
+        else:
+            assert sample is None, f"{slot} initiates nothing"
+
+    _checked, mismatches = await _compare(peers, topo)
+    assert mismatches == []
+
+
+@rdma_backends
+async def test_a_run_can_be_repeated_against_fresh_buffers() -> None:
+    """What repeating a run relies on: setup reports its registration cost and
+    can be called again, releasing the previous buffers as it goes."""
+    topo = bt.build_topology("p2p", 1, _LANES, bt.ALL)
+    peers = _spawn()
+
+    for _run in range(2):
+        results = await _drive(peers, topo, bt.WRITE)
+        for _point, (register_ms, buffers) in results.items():
+            assert register_ms > 0.0, "registering real buffers takes measurable time"
+            expected = _OPS * (1 + _LANES)
+            assert len(list(buffers.flat())) == expected, "1 outgoing + 2 incoming"
+        await peers.execute_iteration.call()
+        _checked, mismatches = await _compare(peers, topo)
+        assert mismatches == []
+
+
+def test_fill_seeds_are_unique_per_run_and_slot() -> None:
+    """What makes a wrongly-routed transfer visible at all: two slots sharing a
+    seed would fill identical bytes, and a digest comparison would accept the
+    mix-up."""
+    seeds = [
+        bench_peer._fill_seed(run, bt.Slot(host, lane))
+        for run in range(8)
+        for host in range(16)
+        for lane in range(8)
+    ]
+    assert len(set(seeds)) == len(seeds)
+    assert all(0 <= seed <= 0x7FFF_FFFF for seed in seeds), "a valid torch seed"

--- a/python/tests/test_rdma_bench_stats.py
+++ b/python/tests/test_rdma_bench_stats.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Tests for the multi-host RDMA benchmark's statistics and reporting.
+
+``bench_stats`` imports only the standard library, so these run with no
+cluster.
+"""
+
+from __future__ import annotations
+
+import io
+
+import bench_stats as bs
+import bench_topology as bt
+import pytest
+
+
+GB: int = 1000**3
+
+
+def test_percentile_is_nearest_rank() -> None:
+    assert bs.percentile([5.0], 90) == 5.0
+    assert bs.percentile([1.0, 2.0], 90) == 2.0
+    assert bs.percentile([2.0, 1.0], 50) == 1.0, "sorts first"
+
+    nine = [float(i) for i in range(1, 10)]
+    assert bs.percentile(nine, 90) == 9.0
+    ten = [float(i) for i in range(1, 11)]
+    assert bs.percentile(ten, 90) == 9.0
+    eleven = [float(i) for i in range(1, 12)]
+    assert bs.percentile(eleven, 90) == 10.0
+
+    assert bs.percentile(ten, 100) == 10.0
+    assert bs.percentile(ten, 0) == 1.0, "rank clamps to the first element"
+
+    with pytest.raises(ValueError, match="percentile of no samples"):
+        bs.percentile([], 90)
+
+
+def test_summarize_handles_thin_sample_sets() -> None:
+    empty = bs.summarize([])
+    assert empty.n == 0
+    assert (empty.median, empty.mean, empty.stdev, empty.p90, empty.maximum) == (
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    )
+
+    one = bs.summarize([4.0])
+    assert one.n == 1
+    assert one.median == one.mean == one.p90 == one.maximum == 4.0
+    assert one.stdev == 0.0, "a single sample has no spread, not an error"
+
+    two = bs.summarize([1.0, 3.0])
+    assert two.n == 2
+    assert two.median == 2.0
+    assert two.mean == 2.0
+    assert two.stdev == pytest.approx(1.4142135, rel=1e-6)
+    assert two.maximum == 3.0
+
+
+def test_sample_total() -> None:
+    sample = bs.Sample(slot=bt.Slot(0, 0), iteration=3, build_ms=2.0, submit_ms=100.0)
+    assert sample.total_ms == pytest.approx(102.0)
+    assert sample.error is None
+
+
+def test_phase_record_derives_throughput_from_the_right_clock() -> None:
+    record = bs.PhaseRecord()
+    record.add_sample(
+        bs.Sample(bt.Slot(0, 0), 0, build_ms=1.0, submit_ms=500.0), initiator_bytes=GB
+    )
+    record.add_sample(
+        bs.Sample(bt.Slot(1, 0), 0, build_ms=1.0, submit_ms=1000.0),
+        initiator_bytes=2 * GB,
+    )
+    assert record.initiator_gbs == [2.0, 2.0], "each initiator's own bytes and clock"
+
+    # The span is longer than the slowest initiator: that excess is the overhead.
+    record.add_iteration(span_ms=1100.0, iteration_bytes=3 * GB, slowest_ms=1001.0)
+    assert record.agg_gbs == [pytest.approx(3 / 1.1)]
+    assert record.overhead_ms == [pytest.approx(99.0)]
+
+
+def test_aggregate_throughput_is_measured_against_the_span() -> None:
+    """Two initiators moving 1 GB each, one taking twice as long as the other.
+
+    The aggregate is the iteration's bytes over the span that actually elapsed,
+    which is 2 GB/s. Adding up the per-initiator rates would say 3 GB/s, a
+    figure no clock in the run supports; the two are built to differ here so
+    that the assertion pins which one is reported.
+    """
+    record = bs.PhaseRecord()
+    record.add_sample(
+        bs.Sample(bt.Slot(0, 0), 0, build_ms=0.0, submit_ms=500.0), initiator_bytes=GB
+    )
+    record.add_sample(
+        bs.Sample(bt.Slot(1, 0), 0, build_ms=0.0, submit_ms=1000.0), initiator_bytes=GB
+    )
+    record.add_iteration(span_ms=1000.0, iteration_bytes=2 * GB, slowest_ms=1000.0)
+
+    assert record.agg_gbs == [2.0]
+    assert sum(record.initiator_gbs) == 3.0, "the sum the span rules out"
+    assert record.overhead_ms == [0.0], "the span covered exactly the slowest"
+
+
+def test_zero_durations_do_not_produce_infinite_throughput() -> None:
+    record = bs.PhaseRecord()
+    record.add_sample(
+        bs.Sample(bt.Slot(0, 0), 0, build_ms=0.0, submit_ms=0.0), initiator_bytes=GB
+    )
+    record.add_iteration(span_ms=0.0, iteration_bytes=GB, slowest_ms=0.0)
+    assert record.initiator_gbs == []
+    assert record.agg_gbs == []
+    assert record.submit_ms == [0.0], "the sample is still counted"
+
+
+def test_run_record_discards_ramp_without_a_special_case() -> None:
+    runs = bs.RunRecord()
+    assert set(runs.phases) == set(bt.PHASES)
+
+    runs.record(bt.WARM).add_sample(
+        bs.Sample(bt.Slot(0, 0), 4, 0.0, 500.0), initiator_bytes=GB
+    )
+    runs.record(bt.RAMP).add_sample(
+        bs.Sample(bt.Slot(0, 0), 1, 0.0, 9000.0), initiator_bytes=GB
+    )
+
+    assert runs.phases[bt.WARM].submit_ms == [500.0]
+    assert bt.RAMP not in runs.phases, "the ramp record is a throwaway"
+
+
+_RUNS: int = 3
+_WARMUP_ITERS: int = 1
+_WARM_ITERS: int = 2
+_INITIATORS: tuple[bt.Slot, ...] = (bt.Slot(0, 0), bt.Slot(1, 0))
+
+# Per-phase submit time, so cold is visibly slower than warm and the ramp sits
+# between them. Every initiator in an iteration is given the same duration, so
+# the expected medians are exact.
+_SUBMIT_MS: dict[str, float] = {
+    bt.COLD_QP: 800.0,
+    bt.RAMP: 300.0,
+    bt.WARM: 200.0,
+}
+
+# Iterations per phase, given the shape above: only the first iteration of the
+# first run is cold_qp, and every run contributes its warm iterations.
+_ITERATIONS: dict[str, int] = {
+    bt.COLD_QP: 1,
+    bt.WARM: _RUNS * _WARM_ITERS,
+}
+
+
+def _run_record() -> bs.RunRecord:
+    """A record shaped like a real ``(pattern, direction)``.
+
+    Three runs of three iterations each, driven by two initiators, with phases
+    assigned by the same `phase_of` the driver uses. Every run ends on two warm
+    iterations and opens on a discarded ramp iteration, which in the first run
+    is the cold queue-pair iteration instead.
+    """
+    runs = bs.RunRecord()
+    for run in range(_RUNS):
+        # One registration measurement per proc per run.
+        runs.register_ms.extend(400.0 + 100.0 * run + 50.0 * i for i in range(2))
+        for iteration in range(_WARMUP_ITERS + _WARM_ITERS):
+            phase = bt.phase_of(run, iteration, _WARMUP_ITERS)
+            record = runs.record(phase)
+            submit_ms = _SUBMIT_MS[phase]
+            for slot in _INITIATORS:
+                record.add_sample(
+                    bs.Sample(slot, iteration, build_ms=2.0, submit_ms=submit_ms),
+                    initiator_bytes=GB,
+                )
+            record.add_iteration(
+                span_ms=submit_ms + 5.0,
+                iteration_bytes=2 * GB,
+                slowest_ms=submit_ms + 2.0,
+            )
+    return runs
+
+
+def test_run_record_fixture_has_the_shape_the_driver_produces() -> None:
+    runs = _run_record()
+    assert [len(runs.phases[p].span_ms) for p in bt.PHASES] == [1, 6]
+    assert len(runs.register_ms) == _RUNS * len(_INITIATORS)
+    assert bt.RAMP not in runs.phases, "the ramp iterations were discarded"
+
+
+def test_n_samples_counts_initiators_and_n_spans_counts_iterations() -> None:
+    """The two counts differ whenever a pattern has more than one initiator: an
+    iteration yields one span but one sample per initiator. Reported separately
+    because `submit_ms_*` is backed by the samples and `agg_gbs_*` by the spans.
+    """
+    runs = _run_record()
+    for phase, iterations in _ITERATIONS.items():
+        metrics = bs.metrics_for(phase, runs)
+        assert metrics.n_spans == iterations, phase
+        assert metrics.n_samples == iterations * len(_INITIATORS), phase
+        assert metrics.n_samples != metrics.n_spans, "two initiators, so distinct"
+
+
+def test_only_warm_rows_carry_throughput() -> None:
+    runs = _run_record()
+
+    warm = bs.metrics_for(bt.WARM, runs)
+    assert warm.agg_gbs_median == pytest.approx(2 / 0.205)
+    assert warm.initiator_gbs_median == pytest.approx(5.0)
+    assert warm.submit_ms_median == pytest.approx(200.0)
+
+    cold = bs.metrics_for(bt.COLD_QP, runs)
+    assert cold.agg_gbs_median is None
+    assert cold.agg_gbs_p90 is None
+    assert cold.initiator_gbs_median is None
+    assert cold.submit_ms_median > 0, "cold rows still report latency"
+    # Registration is a per-run cost, so every phase of a configuration reports
+    # the same spread over all six measurements.
+    assert cold.register_ms_median == pytest.approx(525.0)
+    assert cold.register_ms_p90 == pytest.approx(650.0)
+
+
+def test_cold_warm_ratio() -> None:
+    runs = _run_record()
+    assert bs.cold_warm_ratio(runs, bt.COLD_QP) == pytest.approx(4.0)
+
+    assert bs.cold_warm_ratio(bs.RunRecord(), bt.COLD_QP) is None, (
+        "no samples, no claim"
+    )
+
+
+def _columns() -> tuple[
+    bs.KeyColumns, bs.ShapeColumns, bs.ConfigColumns, bs.MetricColumns
+]:
+    topo = bt.build_topology("all-to-all", 4, 8)
+    return (
+        bs.KeyColumns(pattern=topo.pattern, direction=bt.WRITE, phase=bt.WARM),
+        bs.ShapeColumns(
+            num_hosts=topo.num_hosts,
+            procs_per_host=topo.procs_per_host,
+            lane_pairing=topo.pairing,
+            lane_shift=topo.shift,
+            num_edges=len(topo.edges),
+            num_initiators=len(topo.initiators(bt.WRITE)),
+            max_degree=topo.max_degree(bt.WRITE),
+            max_ops_per_action=bt.max_ops_per_action(topo, bt.WRITE, ops=1),
+            max_in_degree=3,
+            bytes_per_iteration=bt.bytes_per_iteration(topo, ops=1, payload_bytes=GB),
+            max_buffers_per_proc=4,
+            max_device_bytes_per_proc=4 * GB,
+            max_host_bytes_per_host=0,
+        ),
+        bs.ConfigColumns(
+            schema_version=bs.SCHEMA_VERSION,
+            transport="ibverbs",
+            tcp_serialized=0,
+            source_device="gpu",
+            dest_device="gpu",
+            payload_size_mb=1024.0,
+            concurrent_ops=1,
+            cold_proc_runs=1,
+            runs=3,
+            warmup_iters_per_run=3,
+            warm_iters_per_run=10,
+            local_sender=0,
+            verify_mode="sampled",
+            rdma_runtime_threads="16",
+            integrity_ok="True",
+            negative_control_ok="True",
+        ),
+        bs.metrics_for(bt.WARM, _run_record()),
+    )
+
+
+def test_summary_header_and_row_cannot_drift() -> None:
+    key, shape, config, metrics = _columns()
+    header = bs.summary_header()
+    row = bs.summary_row(key, shape, config, metrics)
+    assert len(header) == len(row)
+    assert len(header) == len(set(header)), "no duplicated column names"
+
+    # Leading columns identify the row, so the CSV is scannable.
+    assert header[:3] == ("pattern", "direction", "phase")
+    assert row[:3] == ("all-to-all", "write", "warm")
+    assert header[-1] == "agg_gbs_p90"
+
+
+def test_cold_rows_render_as_empty_cells_not_zeros() -> None:
+    key, shape, config, _ = _columns()
+    cold = bs.metrics_for(bt.COLD_QP, _run_record())
+
+    stream = io.StringIO()
+    bs.write_rows(
+        stream,
+        bs.summary_header(),
+        [bs.summary_row(key, shape, config, cold)],
+    )
+    header_line, row_line = stream.getvalue().splitlines()
+    columns = dict(zip(header_line.split(","), row_line.split(",")))
+    assert columns["agg_gbs_median"] == "", "empty, so nobody quotes a cold rate"
+    assert columns["initiator_gbs_p90"] == ""
+    assert float(columns["submit_ms_median"]) > 0
+    assert float(columns["register_ms_median"]) > 0, "cold rows keep registration"
+
+
+def test_phase_table_marks_cold_rows_with_a_dash() -> None:
+    runs = _run_record()
+    rows = [
+        (bs.KeyColumns("ring", bt.READ, phase), bs.metrics_for(phase, runs))
+        for phase in bt.PHASES
+    ]
+    lines = bs.phase_table(rows)
+    assert lines[0].startswith("Dir")
+    assert "build p50 (ms)" in lines[0], "every timing column names its unit"
+    assert "agg (GB/s)" in lines[0]
+    body = lines[2:]
+    assert len(body) == 2
+    assert body[0].split()[-1] == "-", "cold_qp has no aggregate throughput"
+    assert float(body[1].split()[-1]) > 0, "warm does"
+    assert "cold_qp" in body[0] and "warm" in body[1]

--- a/python/tests/test_rdma_bench_stats.py
+++ b/python/tests/test_rdma_bench_stats.py
@@ -70,18 +70,17 @@ def test_summarize_handles_thin_sample_sets() -> None:
 
 
 def test_sample_total() -> None:
-    sample = bs.Sample(slot=bt.Slot(0, 0), iteration=3, build_ms=2.0, submit_ms=100.0)
+    sample = bs.Sample(slot=bt.Slot(0, 0), build_ms=2.0, submit_ms=100.0)
     assert sample.total_ms == pytest.approx(102.0)
-    assert sample.error is None
 
 
 def test_phase_record_derives_throughput_from_the_right_clock() -> None:
     record = bs.PhaseRecord()
     record.add_sample(
-        bs.Sample(bt.Slot(0, 0), 0, build_ms=1.0, submit_ms=500.0), initiator_bytes=GB
+        bs.Sample(bt.Slot(0, 0), build_ms=1.0, submit_ms=500.0), initiator_bytes=GB
     )
     record.add_sample(
-        bs.Sample(bt.Slot(1, 0), 0, build_ms=1.0, submit_ms=1000.0),
+        bs.Sample(bt.Slot(1, 0), build_ms=1.0, submit_ms=1000.0),
         initiator_bytes=2 * GB,
     )
     assert record.initiator_gbs == [2.0, 2.0], "each initiator's own bytes and clock"
@@ -102,10 +101,10 @@ def test_aggregate_throughput_is_measured_against_the_span() -> None:
     """
     record = bs.PhaseRecord()
     record.add_sample(
-        bs.Sample(bt.Slot(0, 0), 0, build_ms=0.0, submit_ms=500.0), initiator_bytes=GB
+        bs.Sample(bt.Slot(0, 0), build_ms=0.0, submit_ms=500.0), initiator_bytes=GB
     )
     record.add_sample(
-        bs.Sample(bt.Slot(1, 0), 0, build_ms=0.0, submit_ms=1000.0), initiator_bytes=GB
+        bs.Sample(bt.Slot(1, 0), build_ms=0.0, submit_ms=1000.0), initiator_bytes=GB
     )
     record.add_iteration(span_ms=1000.0, iteration_bytes=2 * GB, slowest_ms=1000.0)
 
@@ -117,7 +116,7 @@ def test_aggregate_throughput_is_measured_against_the_span() -> None:
 def test_zero_durations_do_not_produce_infinite_throughput() -> None:
     record = bs.PhaseRecord()
     record.add_sample(
-        bs.Sample(bt.Slot(0, 0), 0, build_ms=0.0, submit_ms=0.0), initiator_bytes=GB
+        bs.Sample(bt.Slot(0, 0), build_ms=0.0, submit_ms=0.0), initiator_bytes=GB
     )
     record.add_iteration(span_ms=0.0, iteration_bytes=GB, slowest_ms=0.0)
     assert record.initiator_gbs == []
@@ -130,10 +129,10 @@ def test_run_record_discards_ramp_without_a_special_case() -> None:
     assert set(runs.phases) == set(bt.PHASES)
 
     runs.record(bt.WARM).add_sample(
-        bs.Sample(bt.Slot(0, 0), 4, 0.0, 500.0), initiator_bytes=GB
+        bs.Sample(bt.Slot(0, 0), 0.0, 500.0), initiator_bytes=GB
     )
     runs.record(bt.RAMP).add_sample(
-        bs.Sample(bt.Slot(0, 0), 1, 0.0, 9000.0), initiator_bytes=GB
+        bs.Sample(bt.Slot(0, 0), 0.0, 9000.0), initiator_bytes=GB
     )
 
     assert runs.phases[bt.WARM].submit_ms == [500.0]
@@ -180,7 +179,7 @@ def _run_record() -> bs.RunRecord:
             submit_ms = _SUBMIT_MS[phase]
             for slot in _INITIATORS:
                 record.add_sample(
-                    bs.Sample(slot, iteration, build_ms=2.0, submit_ms=submit_ms),
+                    bs.Sample(slot, build_ms=2.0, submit_ms=submit_ms),
                     initiator_bytes=GB,
                 )
             record.add_iteration(

--- a/python/tests/test_rdma_bench_topology.py
+++ b/python/tests/test_rdma_bench_topology.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Tests for the multi-host RDMA benchmark's topology module.
+
+``bench_topology`` imports only the standard library, so these run in
+milliseconds with no cluster, no GPU, and no torch. They are the only
+automated coverage of the routing logic: a wrongly-wired peer is exactly what
+the RDMA layer cannot catch, because an ``RDMAAction`` deliberately does not
+track remote address ranges.
+"""
+
+from __future__ import annotations
+
+import bench_topology as bt
+import pytest
+
+
+GB: int = 1000**3
+MB: int = 1000**2
+
+
+def _all_patterns_edges(num_hosts: int) -> dict[str, list[tuple[int, int]]]:
+    return {p: bt.host_edges(p, num_hosts) for p in bt.PATTERNS}
+
+
+def test_host_edges_two_hosts() -> None:
+    assert _all_patterns_edges(2) == {
+        "p2p": [(0, 1)],
+        "fan-out": [(0, 1)],
+        "fan-in": [(1, 0)],
+        "all-to-all": [(0, 1), (1, 0)],
+        "ring": [(0, 1), (1, 0)],
+    }
+
+
+def test_host_edges_four_hosts() -> None:
+    edges = _all_patterns_edges(4)
+    assert edges["p2p"] == [(0, 1)], "p2p ignores the extra hosts"
+    assert edges["fan-out"] == [(0, 1), (0, 2), (0, 3)]
+    assert edges["fan-in"] == [(1, 0), (2, 0), (3, 0)]
+    assert edges["ring"] == [(0, 1), (1, 2), (2, 3), (3, 0)]
+    assert len(edges["all-to-all"]) == 12, "n(n-1) for n=4"
+
+
+def test_one_host_is_the_loopback_self_edge() -> None:
+    for pattern in bt.PATTERNS:
+        assert bt.host_edges(pattern, 1) == [(0, 0)], pattern
+
+
+@pytest.mark.parametrize("num_hosts", [2, 3, 4, 8])
+def test_all_to_all_is_complete_and_has_no_self_edges(num_hosts: int) -> None:
+    edges = bt.host_edges("all-to-all", num_hosts)
+    assert len(edges) == num_hosts * (num_hosts - 1)
+    assert len(set(edges)) == len(edges)
+    assert all(src != dst for src, dst in edges)
+
+
+@pytest.mark.parametrize("num_hosts", [2, 3, 4, 8])
+def test_ring_is_a_single_cycle_covering_every_host(num_hosts: int) -> None:
+    edges = bt.host_edges("ring", num_hosts)
+    assert len(edges) == num_hosts
+    assert {src for src, _ in edges} == set(range(num_hosts))
+    assert {dst for _, dst in edges} == set(range(num_hosts))
+
+    # Walking successors from 0 must visit every host exactly once and return.
+    successor = dict(edges)
+    seen = []
+    host = 0
+    for _ in range(num_hosts):
+        seen.append(host)
+        host = successor[host]
+    assert sorted(seen) == list(range(num_hosts)), "one cycle, not several"
+    assert host == 0
+
+
+@pytest.mark.parametrize("num_hosts", [2, 3, 4, 8])
+def test_fan_out_and_fan_in_are_transposes(num_hosts: int) -> None:
+    out = bt.host_edges("fan-out", num_hosts)
+    into = bt.host_edges("fan-in", num_hosts)
+    assert sorted((dst, src) for src, dst in out) == sorted(into)
+
+
+def test_host_edges_rejects_bad_input() -> None:
+    with pytest.raises(ValueError, match="unknown pattern 'torus'"):
+        bt.host_edges("torus", 4)
+    with pytest.raises(ValueError, match="num_hosts must be at least 1"):
+        bt.host_edges("ring", 0)
+    # The message names the valid set so a typo is self-correcting.
+    with pytest.raises(ValueError, match="all-to-all"):
+        bt.host_edges("alltoall", 4)
+
+
+def test_expand_lanes_same_stays_on_one_ordinal() -> None:
+    edges = bt.expand_lanes((0, 1), 4)
+    assert len(edges) == 4
+    assert all(e.src.lane == e.dst.lane for e in edges)
+    assert edges[0] == bt.Edge(bt.Slot(0, 0), bt.Slot(1, 0))
+
+
+def test_expand_lanes_shifted_crosses_ordinals() -> None:
+    edges = bt.expand_lanes((0, 1), 4, bt.SHIFTED, shift=1)
+    assert len(edges) == 4
+    assert all(e.src.lane != e.dst.lane for e in edges)
+    assert {e.dst.lane for e in edges} == {0, 1, 2, 3}, "still a permutation"
+
+    wrapped = bt.expand_lanes((0, 1), 4, bt.SHIFTED, shift=3)
+    assert bt.Edge(bt.Slot(0, 1), bt.Slot(1, 0)) in wrapped
+
+
+def test_expand_lanes_all_is_the_full_product() -> None:
+    edges = bt.expand_lanes((0, 1), 4, bt.ALL)
+    assert len(edges) == 16
+    assert len(set(edges)) == 16
+
+
+def test_expand_lanes_rejects_a_shift_that_is_really_same() -> None:
+    with pytest.raises(ValueError, match="multiple of procs_per_host"):
+        bt.expand_lanes((0, 1), 4, bt.SHIFTED, shift=4)
+    with pytest.raises(ValueError, match="multiple of procs_per_host"):
+        bt.expand_lanes((0, 1), 4, bt.SHIFTED, shift=0)
+    # One proc per host leaves no ordinal to shift to.
+    with pytest.raises(ValueError, match="multiple of procs_per_host"):
+        bt.expand_lanes((0, 1), 1, bt.SHIFTED, shift=1)
+
+
+def test_expand_lanes_rejects_bad_input() -> None:
+    with pytest.raises(ValueError, match="unknown pairing 'diagonal'"):
+        bt.expand_lanes((0, 1), 4, "diagonal")
+    with pytest.raises(ValueError, match="procs_per_host must be at least 1"):
+        bt.expand_lanes((0, 1), 0)
+
+
+def test_edges_are_canonical() -> None:
+    topo = bt.build_topology("all-to-all", 4, 4, bt.ALL)
+    assert topo.edges == tuple(sorted(set(topo.edges)))
+    assert len(topo.edges) == 12 * 16
+
+
+@pytest.mark.parametrize("pattern", bt.PATTERNS)
+@pytest.mark.parametrize("pairing", bt.PAIRINGS)
+def test_every_in_edge_comes_from_a_distinct_peer(pattern: str, pairing: str) -> None:
+    """What makes keying incoming pools by the sending peer unambiguous."""
+    topo = bt.build_topology(pattern, 4, 4, pairing)
+    for slot in topo.slots():
+        peers = [edge.src for edge in topo.in_edges(slot)]
+        assert len(set(peers)) == len(peers) == topo.in_degree(slot), slot
+
+
+@pytest.mark.parametrize("pattern", bt.PATTERNS)
+@pytest.mark.parametrize("pairing", bt.PAIRINGS)
+def test_degree_conservation(pattern: str, pairing: str) -> None:
+    topo = bt.build_topology(pattern, 4, 4, pairing)
+    slots = topo.slots()
+    assert sum(topo.out_degree(s) for s in slots) == len(topo.edges)
+    assert sum(topo.in_degree(s) for s in slots) == len(topo.edges)
+
+
+def test_degree_follows_the_initiator() -> None:
+    topo = bt.build_topology("fan-out", 5, 2)
+    root, leaf = bt.Slot(0, 0), bt.Slot(3, 0)
+
+    assert topo.degree(root, bt.WRITE) == 4, "the root pushes to every leaf"
+    assert topo.degree(root, bt.READ) == 0, "nothing is pushed to the root"
+    assert topo.degree(leaf, bt.READ) == 1, "each leaf pulls from the root"
+    assert topo.degree(leaf, bt.WRITE) == 0
+
+    assert topo.initiators(bt.WRITE) == (bt.Slot(0, 0), bt.Slot(0, 1))
+    assert len(topo.initiators(bt.READ)) == 8, "4 leaf hosts x 2 procs"
+    assert topo.max_degree(bt.WRITE) == 4
+    assert topo.max_degree(bt.READ) == 1
+
+
+def test_fan_in_mirrors_fan_out() -> None:
+    topo = bt.build_topology("fan-in", 5, 2)
+    root = bt.Slot(0, 0)
+    assert topo.degree(root, bt.READ) == 4, "the root pulls from every leaf"
+    assert topo.degree(root, bt.WRITE) == 0
+    assert topo.initiators(bt.READ) == (bt.Slot(0, 0), bt.Slot(0, 1))
+
+
+def test_all_to_all_and_ring_degrees() -> None:
+    mesh = bt.build_topology("all-to-all", 8, 8)
+    ring = bt.build_topology("ring", 8, 8)
+    for direction in bt.DIRECTIONS:
+        assert mesh.max_degree(direction) == 7
+        assert ring.max_degree(direction) == 1
+        assert len(mesh.initiators(direction)) == 64
+        assert len(ring.initiators(direction)) == 64
+
+
+def test_directions_are_validated() -> None:
+    topo = bt.build_topology("ring", 4, 2)
+    with pytest.raises(ValueError, match="unknown direction 'send'"):
+        topo.initiators("send")
+    with pytest.raises(ValueError, match="unknown direction"):
+        topo.degree(bt.Slot(0, 0), "recv")
+
+
+def test_unused_hosts() -> None:
+    assert bt.unused_hosts(bt.build_topology("p2p", 8, 4)) == (2, 3, 4, 5, 6, 7)
+    assert bt.unused_hosts(bt.build_topology("ring", 8, 4)) == ()
+
+
+def test_allocation_only_charges_for_roles_a_slot_has() -> None:
+    topo = bt.build_topology("fan-out", 4, 2)
+
+    root = bt.allocation_for(topo, bt.Slot(0, 0), ops=3)
+    assert root == bt.SlotAllocation(sends=True, receives_from=(), ops=3)
+    assert root.tensors == 3, "the root never receives, so it has no incoming pool"
+
+    leaf = bt.allocation_for(topo, bt.Slot(2, 0), ops=3)
+    assert leaf == bt.SlotAllocation(sends=False, receives_from=(bt.Slot(0, 0),), ops=3)
+    assert leaf.tensors == 3, "a leaf never sends, so it has no outgoing pool"
+
+    mesh = bt.build_topology("all-to-all", 8, 8)
+    every_other_host = bt.allocation_for(mesh, bt.Slot(0, 0), ops=1)
+    assert every_other_host.tensors == 8, "1 outgoing + 7 incoming"
+    assert len(set(every_other_host.receives_from)) == 7
+
+    loop = bt.allocation_for(bt.build_topology("p2p", 1, 2), bt.Slot(0, 0), ops=2)
+    assert loop == bt.SlotAllocation(
+        sends=True, receives_from=(bt.Slot(0, 0),), ops=2
+    ), "the self-edge makes a slot its own peer"
+
+    with pytest.raises(ValueError, match="concurrent_ops must be at least 1"):
+        bt.allocation_for(topo, bt.Slot(0, 0), ops=0)
+
+
+def test_max_ops_per_action_scales_with_concurrent_ops() -> None:
+    mesh = bt.build_topology("all-to-all", 8, 8)
+    assert mesh.max_degree(bt.WRITE) == 7, "edges, not ops"
+    assert bt.max_ops_per_action(mesh, bt.WRITE, ops=1) == 7
+    assert bt.max_ops_per_action(mesh, bt.WRITE, ops=4) == 28
+
+    ring = bt.build_topology("ring", 8, 8)
+    assert bt.max_ops_per_action(ring, bt.READ, ops=4) == 4
+
+
+def test_memory_plan_charges_each_pool_to_its_own_device() -> None:
+    """All four memory-kind configs, at more than one concurrent op.
+
+    Every slot of an 8-host all-to-all sends and receives, so with 2 ops it
+    holds 2 outgoing tensors and 2 in each of 7 incoming pools: 16 in all. The
+    per-host totals are eight times a slot's, one per proc.
+    """
+    topo = bt.build_topology("all-to-all", 8, 8)
+    slot = bt.Slot(0, 0)
+    kwargs = {"ops": 2, "payload_bytes": GB}
+
+    gpu = bt.plan_memory(topo, **kwargs, source_on_gpu=True, dest_on_gpu=True)
+    assert gpu.buffers[slot] == 16, "2 outgoing + 7 incoming pools of 2"
+    assert gpu.device_bytes[slot] == 16 * GB
+    assert gpu.host_bytes_per_host[0] == 0
+
+    cpu = bt.plan_memory(topo, **kwargs, source_on_gpu=False, dest_on_gpu=False)
+    assert cpu.buffers[slot] == 16, "the same tensors, charged elsewhere"
+    assert cpu.device_bytes[slot] == 0
+    assert cpu.host_bytes_per_host[0] == 128 * GB, "16 GB on each of 8 procs"
+
+    cpu2gpu = bt.plan_memory(topo, **kwargs, source_on_gpu=False, dest_on_gpu=True)
+    assert cpu2gpu.device_bytes[slot] == 14 * GB, "the incoming pools only"
+    assert cpu2gpu.host_bytes_per_host[0] == 16 * GB, "one outgoing pool per proc"
+
+    gpu2cpu = bt.plan_memory(topo, **kwargs, source_on_gpu=True, dest_on_gpu=False)
+    assert gpu2cpu.device_bytes[slot] == 2 * GB, "the outgoing pool only"
+    assert gpu2cpu.host_bytes_per_host[0] == 112 * GB
+
+
+def test_check_memory_names_the_binding_budget_and_a_payload_that_fits() -> None:
+    topo = bt.build_topology("all-to-all", 8, 8)
+    budgets = {"max_device_bytes": 40 * GB, "max_host_bytes": 256 * GB}
+
+    ok = bt.plan_memory(
+        topo, ops=1, payload_bytes=GB, source_on_gpu=True, dest_on_gpu=True
+    )
+    bt.check_memory(topo, ok, **budgets)
+
+    # 8 concurrent ops puts 64 GB on one card.
+    too_big = bt.plan_memory(
+        topo, ops=8, payload_bytes=GB, source_on_gpu=True, dest_on_gpu=True
+    )
+    with pytest.raises(ValueError) as excinfo:
+        bt.check_memory(topo, too_big, **budgets)
+    message = str(excinfo.value)
+    assert "device memory" in message
+    assert "in-degree is 7" in message
+    # The slot holds 64 payload-sized tensors: 8 outgoing, plus 8 in each of the
+    # 7 incoming pools. Its footprint is therefore 64 payloads, so the payload
+    # that exactly fills the 40 GB budget is 40/64 GB = 625 MB.
+    assert "625.00 MB" in message
+
+    # The cpu config trips the per-host budget while every card stays empty.
+    host_bound = bt.plan_memory(
+        topo, ops=6, payload_bytes=GB, source_on_gpu=False, dest_on_gpu=False
+    )
+    assert host_bound.device_bytes[bt.Slot(0, 0)] == 0
+    with pytest.raises(ValueError, match="pinned host memory across its 8 procs"):
+        bt.check_memory(topo, host_bound, **budgets)
+
+
+def test_check_memory_catches_the_all_pairing_blowup() -> None:
+    topo = bt.build_topology("all-to-all", 8, 8, bt.ALL)
+    assert topo.in_degree(bt.Slot(0, 0)) == 56, "7 peer hosts x 8 lanes"
+    plan = bt.plan_memory(
+        topo, ops=1, payload_bytes=GB, source_on_gpu=True, dest_on_gpu=True
+    )
+    with pytest.raises(ValueError, match="in-degree is 56"):
+        bt.check_memory(topo, plan, max_device_bytes=40 * GB, max_host_bytes=256 * GB)
+
+
+def test_byte_counts() -> None:
+    topo = bt.build_topology("ring", 4, 8)
+    assert bt.bytes_per_iteration(topo, ops=2, payload_bytes=MB) == 32 * 2 * MB
+    assert (
+        bt.initiator_bytes(topo, bt.Slot(0, 0), bt.WRITE, ops=2, payload_bytes=MB)
+        == 2 * MB
+    )
+
+    mesh = bt.build_topology("all-to-all", 8, 8)
+    assert bt.bytes_per_iteration(mesh, ops=1, payload_bytes=GB) == 448 * GB
+    assert (
+        bt.initiator_bytes(mesh, bt.Slot(3, 2), bt.READ, ops=1, payload_bytes=GB)
+        == 7 * GB
+    )
+
+
+def _string_values(topo: bt.Topology, ops: int) -> dict[bt.Slot, bt.SlotValues]:
+    """Stand-in for the RDMA buffers the actors would expose. Routing treats
+    handles as opaque, so strings exercise it exactly."""
+    values = {}
+    for slot in topo.slots():
+        allocation = bt.allocation_for(topo, slot, ops=ops)
+        values[slot] = bt.SlotValues(
+            outgoing=tuple(
+                f"{slot}:out{op}" for op in range(ops if allocation.sends else 0)
+            ),
+            incoming={
+                peer: tuple(f"{slot}:in[{peer}].{op}" for op in range(ops))
+                for peer in allocation.receives_from
+            },
+        )
+    return values
+
+
+def test_plan_for_write_targets_the_pool_the_peer_reserved_for_it() -> None:
+    topo = bt.build_topology("all-to-all", 3, 1)
+    values = _string_values(topo, ops=2)
+    plans = bt.plan_for(topo, bt.WRITE, values, ops=2)
+
+    slot = bt.Slot(0, 0)
+    assert set(plans) == set(topo.slots())
+    assert plans[slot].pull == (), "a write plan issues no reads"
+
+    expected = []
+    for edge in topo.out_edges(slot):
+        pool = values[edge.dst].incoming[slot]
+        expected.extend(
+            bt.PushOp(remote=pool[op], outgoing_index=op) for op in range(2)
+        )
+    assert plans[slot].push == tuple(expected)
+    assert plans[slot].ops == 4, "2 out-edges x 2 ops"
+
+    # Every writer into one destination must hit a different pool, which is the
+    # invariant the RDMA layer cannot check: it does not track remote ranges,
+    # so two initiators sharing a remote buffer would corrupt it silently.
+    destination = bt.Slot(2, 0)
+    remotes = [
+        op.remote
+        for edge in topo.in_edges(destination)
+        for op in plans[edge.src].push
+        if op.remote.startswith(str(destination))
+    ]
+    assert len(remotes) == len(set(remotes)) == 4
+
+
+def test_plan_for_read_targets_the_peer_shared_outgoing_pool() -> None:
+    topo = bt.build_topology("all-to-all", 3, 1)
+    values = _string_values(topo, ops=2)
+    plans = bt.plan_for(topo, bt.READ, values, ops=2)
+
+    slot = bt.Slot(1, 0)
+    assert plans[slot].push == (), "a read plan issues no writes"
+
+    expected = []
+    for edge in topo.in_edges(slot):
+        outgoing = values[edge.src].outgoing
+        expected.extend(
+            bt.PullOp(remote=outgoing[op], peer=edge.src, op_index=op)
+            for op in range(2)
+        )
+    assert plans[slot].pull == tuple(expected)
+
+    # Every read lands somewhere different: overlapping local write claims in
+    # one action are a hard error in the RDMA layer.
+    landings = {(op.peer, op.op_index) for op in plans[slot].pull}
+    assert len(landings) == plans[slot].ops
+
+
+@pytest.mark.parametrize("pattern", bt.PATTERNS)
+@pytest.mark.parametrize("direction", bt.DIRECTIONS)
+def test_plan_op_count_matches_degree(pattern: str, direction: str) -> None:
+    topo = bt.build_topology(pattern, 4, 2)
+    values = _string_values(topo, ops=3)
+    for slot, plan in bt.plan_for(topo, direction, values, ops=3).items():
+        assert plan.ops == topo.degree(slot, direction) * 3, slot
+
+
+def test_plan_for_the_self_edge_wires_a_slot_to_itself() -> None:
+    topo = bt.build_topology("p2p", 1, 2)
+    values = _string_values(topo, ops=1)
+    slot = bt.Slot(0, 1)
+
+    write = bt.plan_for(topo, bt.WRITE, values, ops=1)[slot]
+    assert write.push == (bt.PushOp(remote=f"{slot}:in[{slot}].0", outgoing_index=0),)
+
+    read = bt.plan_for(topo, bt.READ, values, ops=1)[slot]
+    assert read.pull == (bt.PullOp(remote=f"{slot}:out0", peer=slot, op_index=0),)
+
+
+def test_plan_for_rejects_a_bad_direction() -> None:
+    topo = bt.build_topology("ring", 4, 2)
+    with pytest.raises(ValueError, match="unknown direction"):
+        bt.plan_for(topo, "push", _string_values(topo, ops=1), ops=1)
+
+
+def _digests(
+    topo: bt.Topology, ops: int, *, transferred: bool
+) -> dict[bt.Slot, bt.SlotValues]:
+    """Digests as they would look before (``transferred=False``) and after a
+    successful round. An incoming pool either mirrors the peer that fills it or
+    still holds the zero-fill."""
+    digests = {}
+    for slot in topo.slots():
+        allocation = bt.allocation_for(topo, slot, ops=ops)
+        digests[slot] = bt.SlotValues(
+            outgoing=tuple(
+                f"digest-{slot}-{op}" for op in range(ops if allocation.sends else 0)
+            ),
+            incoming={
+                peer: (
+                    tuple(f"digest-{peer}-{op}" for op in range(ops))
+                    if transferred
+                    else tuple("zero" for _ in range(ops))
+                )
+                for peer in allocation.receives_from
+            },
+        )
+    return digests
+
+
+@pytest.mark.parametrize("pattern", bt.PATTERNS)
+def test_compare_digests_accepts_a_clean_round(pattern: str) -> None:
+    topo = bt.build_topology(pattern, 4, 2)
+    checked, mismatches = bt.compare_digests(topo, _digests(topo, 2, transferred=True))
+    assert mismatches == []
+    assert checked == len(topo.edges) * 2
+
+
+@pytest.mark.parametrize("pattern", bt.PATTERNS)
+def test_negative_control_every_pair_mismatches_before_a_transfer(
+    pattern: str,
+) -> None:
+    topo = bt.build_topology(pattern, 4, 2)
+    checked, mismatches = bt.compare_digests(topo, _digests(topo, 2, transferred=False))
+    assert len(mismatches) == checked, "the check must be able to fail"
+
+
+def test_compare_digests_catches_two_swapped_incoming_pools() -> None:
+    topo = bt.build_topology("all-to-all", 4, 1)
+    digests = _digests(topo, 1, transferred=True)
+
+    slot = bt.Slot(2, 0)
+    held = digests[slot]
+    first, second = sorted(held.incoming)[:2]
+    swapped = dict(held.incoming)
+    swapped[first], swapped[second] = swapped[second], swapped[first]
+    digests[slot] = bt.SlotValues(outgoing=held.outgoing, incoming=swapped)
+
+    _checked, mismatches = bt.compare_digests(topo, digests)
+    assert len(mismatches) == 2, "both swapped edges now disagree"
+    assert str(slot) in mismatches[0]
+    assert "op 0" in mismatches[0]
+
+
+def test_compare_digests_catches_an_untouched_incoming_pool() -> None:
+    topo = bt.build_topology("ring", 4, 1)
+    digests = _digests(topo, 2, transferred=True)
+    slot = bt.Slot(1, 0)
+    held = digests[slot]
+    peer = next(iter(held.incoming))
+    digests[slot] = bt.SlotValues(
+        outgoing=held.outgoing, incoming={peer: ("zero", "zero")}
+    )
+    _checked, mismatches = bt.compare_digests(topo, digests)
+    assert len(mismatches) == 2
+
+
+def test_phase_of() -> None:
+    # The cold iteration takes the place of the first ramp iteration, so a run
+    # is `warmup` + `warm` iterations long whichever run it is.
+    assert [bt.phase_of(0, i, warmup=3) for i in range(5)] == [
+        bt.COLD_QP,
+        bt.RAMP,
+        bt.RAMP,
+        bt.WARM,
+        bt.WARM,
+    ]
+    # Only the very first iteration of all is cold: every later run opens on a
+    # discarded iteration, since its queue pairs are already up.
+    assert [bt.phase_of(1, i, warmup=3) for i in range(5)] == [
+        bt.RAMP,
+        bt.RAMP,
+        bt.RAMP,
+        bt.WARM,
+        bt.WARM,
+    ]
+    # With no ramp at all the cold iteration takes a warm slot instead, so the
+    # first run reports one fewer warm iteration than the others.
+    assert [bt.phase_of(0, i, warmup=0) for i in range(3)] == [
+        bt.COLD_QP,
+        bt.WARM,
+        bt.WARM,
+    ]
+    assert [bt.phase_of(2, i, warmup=0) for i in range(3)] == [
+        bt.WARM,
+        bt.WARM,
+        bt.WARM,
+    ]
+    assert bt.RAMP not in bt.PHASES, "ramp samples are discarded, never reported"
+
+
+def test_describe_mentions_the_shape() -> None:
+    line = bt.describe(
+        bt.build_topology("fan-out", 4, 8), bt.WRITE, ops=2, payload_bytes=GB
+    )
+    assert "fan-out" in line
+    assert "4x8 procs" in line
+    assert "24 edges" in line
+    assert "same lanes" in line
+    assert "max ops/action=6" in line, "3 out-edges x 2 concurrent ops"
+    assert "48.00 GB per iteration" in line


### PR DESCRIPTION
Summary:
Third piece of the multi-pattern RDMA benchmark, and the first that touches
RDMA. A `Peer` runs in each proc, works out which slot it is from its own
position in its mesh, allocates and registers its tensors, and executes one
iteration on demand. Nothing drives it yet.

Two properties are load-bearing rather than incidental. The actor holds no
peer actor handles, because `read_remote` and `write_remote` need only the
remote buffer: nothing on the timed path calls into another actor, which
matters because the Python actor dispatch loop is serial, so a ring or an
all-to-all — where every participant both sends and receives — would
otherwise be a deadlock waiting to happen. And it knows nothing about
patterns, directions, runs, or phases; it executes a flat op list the driver
routed to it. Since each proc knows its own slot, setup and wiring are two
casts over a slot-keyed mapping rather than two calls per proc.

`SlotValues` becomes generic here so one shape can carry a slot's tensors,
the buffers registered over them, and digests of their contents, with `map`
making it impossible for a conversion to drop or reorder a group. `Sample`
loses two fields that nothing consumed once measurements came back as return
values instead of over a port.

Reviewed By: zdevito

Differential Revision: D116101308


