### PR TITLE
Add StoreJob (#4673)

### DIFF
--- a/docs/source/api/monarch.job.rst
+++ b/docs/source/api/monarch.job.rst
@@ -154,3 +154,9 @@ an AppDef and executes the training script across the mesh.
    :undoc-members:
    :show-inheritance:
    :exclude-members: __init__
+
+.. autoclass:: StoreJob
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: __init__

--- a/python/monarch/_src/job/spmd.py
+++ b/python/monarch/_src/job/spmd.py
@@ -7,9 +7,8 @@
 """
 Internal implementation of SPMD job primitives.
 
-Provides the :func:`serve` function and :class:`SPMDJob` class for launching
-torchrun-style SPMD training jobs. Parses torchrun arguments and creates a Monarch
-mesh to run the training script, replicating torchrun behavior.
+Provides jobs for launching torchrun-style SPMD training and for attaching the
+Job API to workers rendezvoused through a torch distributed store.
 """
 
 import argparse
@@ -23,6 +22,7 @@ from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
 from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
 from monarch._src.actor.bootstrap import attach_to_workers
+from monarch._src.actor.future import Future
 from monarch._src.actor.host_mesh import this_host
 from monarch._src.job.job import JobState, JobTrait
 from monarch._src.job.service_identity import (
@@ -33,6 +33,7 @@ from monarch._src.job.service_identity import (
     SERVICE_PROC_RANK_ENV,
 )
 from monarch._src.spmd.actor import SPMDActor
+from monarch._src.spmd.host_mesh import _worker_addrs_from_store, StoreLike
 from monarch._src.tools.commands import torchx_runner
 from torchx import specs
 from torchx.runner import Runner
@@ -399,6 +400,81 @@ def serve(
     )
 
     return job
+
+
+class StoreJob(JobTrait):
+    """Job API adapter for a torchrun-style distributed store rendezvous.
+
+    Call :meth:`from_store` collectively on every SPMD rank. Each local rank 0
+    spawns and publishes one Monarch worker. Global rank 0 receives a
+    ``StoreJob``; other ranks receive ``None``. Configure job components on
+    that returned job before calling :meth:`state`.
+
+    The enclosing SPMD allocation owns the worker subprocesses. ``kill()``
+    stops Job API sidecars but leaves workers running until their parent ranks
+    exit.
+    """
+
+    def __init__(self, worker_addrs: list[str], name: str) -> None:
+        super().__init__()
+        self._worker_addrs = worker_addrs
+        self._name = name
+
+    @classmethod
+    def from_store(
+        cls,
+        store: StoreLike,
+        *,
+        monarch_port: int = 0,
+        name: str = "monarch_worker",
+        transport: str = "ipc",
+        rank: int | None = None,
+        local_rank: int | None = None,
+        world_size: int | None = None,
+        local_world_size: int | None = None,
+    ) -> "StoreJob | None":
+        """Create a store-backed job, returning it only on global rank 0.
+
+        Rank topology defaults to ``RANK``, ``LOCAL_RANK``, ``WORLD_SIZE``,
+        and ``LOCAL_WORLD_SIZE``. Each value can be overridden by the matching
+        keyword argument.
+        """
+        worker_addrs = _worker_addrs_from_store(
+            store,
+            monarch_port=monarch_port,
+            name=name,
+            transport=transport,
+            rank=rank,
+            local_rank=local_rank,
+            world_size=world_size,
+            local_world_size=local_world_size,
+        )
+        if worker_addrs is None:
+            return None
+        return cls(worker_addrs, name)
+
+    def state(self, cached_path: str | None = None) -> JobState:
+        """Attach to workers and start configured components without caching."""
+        return super().state(cached_path)
+
+    def _create(self, client_script: str | None = None) -> None:
+        pass
+
+    def _state(self) -> JobState:
+        workers: list[str | Future[str]] = []
+        workers.extend(self._worker_addrs)
+        host_mesh = attach_to_workers(
+            ca="trust_all_connections",
+            workers=workers,
+            name=self._name,
+        )
+        return JobState({self._name: host_mesh})
+
+    def can_run(self, spec: JobTrait) -> bool:
+        return False
+
+    def _kill(self) -> None:
+        pass
 
 
 class SPMDJob(JobTrait):

--- a/python/monarch/_src/spmd/host_mesh.py
+++ b/python/monarch/_src/spmd/host_mesh.py
@@ -6,15 +6,13 @@
 
 # pyre-strict
 
-"""
-Stand up a Monarch host mesh from a torchrun/torchx-style SPMD entry point,
-without going through the Monarch job API.
+"""Worker rendezvous for store-backed SPMD jobs.
 
-:func:`host_mesh_from_store` is the public entry point: called collectively
-on every rank, it spawns a worker subprocess on each local rank 0, publishes
-the worker addresses through the caller-supplied store, and on global rank 0
-calls :func:`monarch.actor.attach_to_workers` to build the host mesh. Non-
-primary ranks return ``None``.
+The rendezvous is called collectively on every rank. It spawns a worker
+subprocess on each local rank 0, publishes the worker addresses through the
+caller-supplied store, and returns all addresses on global rank 0. Non-primary
+ranks return ``None``. The job layer attaches to those workers after running
+its pre-connect lifecycle components.
 
 Worker subprocesses are fire-and-forget. Each child inherits the read end
 of an ``os.pipe()`` whose write end stays open in the parent for the
@@ -46,9 +44,8 @@ from collections.abc import Mapping
 from typing import Final, Protocol
 
 from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
-from monarch._src.actor.host_mesh import HostMesh
 from monarch._src.job.service_identity import new_service_proc_id, service_proc_addr
-from monarch.actor import attach_to_workers, enable_transport
+from monarch.actor import enable_transport
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -64,8 +61,8 @@ _ADDR_ENV: Final[str] = "_MONARCH_WORKER_ADDR"
 _PARENT_WATCH_FD_ENV: Final[str] = "_MONARCH_WORKER_PARENT_WATCH_FD"
 
 
-class _StoreLike(Protocol):
-    """Subset of ``torch.distributed.Store`` used by :func:`host_mesh_from_store`."""
+class StoreLike(Protocol):
+    """Subset of ``torch.distributed.Store`` used for worker rendezvous."""
 
     def set(self, key: str, value: str | bytes) -> None: ...
     def get(self, key: str) -> bytes: ...
@@ -166,15 +163,15 @@ def _resolve_topology_field(override: int | None, env_name: str) -> int:
     value = os.environ.get(env_name)
     if value is None:
         raise RuntimeError(
-            f"host_mesh_from_store requires the {env_name} env var "
+            f"StoreJob.from_store requires the {env_name} env var "
             "(torchelastic: RANK, LOCAL_RANK, WORLD_SIZE, LOCAL_WORLD_SIZE) "
             "or the matching keyword argument"
         )
     return int(value)
 
 
-def host_mesh_from_store(
-    store: _StoreLike,
+def _worker_addrs_from_store(
+    store: StoreLike,
     *,
     monarch_port: int = 0,
     name: str = "monarch_worker",
@@ -183,15 +180,14 @@ def host_mesh_from_store(
     local_rank: int | None = None,
     world_size: int | None = None,
     local_world_size: int | None = None,
-) -> HostMesh | None:
-    """Stand up a Monarch host mesh from a torchrun/torchx-style SPMD context.
+) -> list[str] | None:
+    """Publish local workers and return every worker address on global rank 0.
 
     Must be called collectively on every rank of an SPMD job. Each local
     rank 0 spawns a ``run_worker_loop_forever`` subprocess on its host via
     :func:`_spawn_worker_process` and publishes the worker's listen address
-    into ``store``. Global rank 0 then reads every address out of the store
-    and calls :func:`monarch.actor.attach_to_workers` to build the host
-    mesh, which it returns. Non-primary ranks return ``None``.
+    into ``store``. Global rank 0 reads and returns every address. Non-primary
+    ranks return ``None``.
 
     Rank topology defaults to the standard torchelastic env vars
     (``RANK``, ``LOCAL_RANK``, ``WORLD_SIZE``, ``LOCAL_WORLD_SIZE``). Any
@@ -252,13 +248,7 @@ def host_mesh_from_store(
     if env_rank != 0:
         return None
 
-    worker_addrs = [store.get(_worker_addr_key(i)).decode() for i in range(num_hosts)]
-    return attach_to_workers(
-        name=name,
-        # Currently "trust_all_connections" is the only supported option.
-        ca="trust_all_connections",
-        workers=list(worker_addrs),
-    )
+    return [store.get(_worker_addr_key(i)).decode() for i in range(num_hosts)]
 
 
 def _spawn_worker_process(

--- a/python/monarch/job/spmd.py
+++ b/python/monarch/job/spmd.py
@@ -14,8 +14,9 @@ and creates a Monarch mesh to run the training script, replicating torchrun beha
 Key components:
 - :func:`serve`: Launch an SPMD job from a torchx AppDef
 - :class:`SPMDJob`: Job class wrapping torchx for SPMD workloads
+- :class:`StoreJob`: Job API adapter for a torch distributed store rendezvous
 """
 
-from monarch._src.job.spmd import serve, SPMDJob
+from monarch._src.job.spmd import serve, SPMDJob, StoreJob
 
-__all__ = ["serve", "SPMDJob"]
+__all__ = ["serve", "SPMDJob", "StoreJob"]

--- a/python/tests/test_spmd_host_mesh.py
+++ b/python/tests/test_spmd_host_mesh.py
@@ -13,16 +13,12 @@ import subprocess
 import sys
 import time
 from typing import Callable
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
-from monarch._src.spmd.host_mesh import (
-    _IN_PAR,
-    _spawn_worker_process,
-    _worker_addr_key,
-    host_mesh_from_store,
-)
+from monarch._src.spmd.host_mesh import _IN_PAR, _spawn_worker_process, _worker_addr_key
+from monarch.job.spmd import StoreJob
 
 
 def _pid_alive(pid: int) -> bool:
@@ -47,7 +43,7 @@ def _wait_for(
 
 class _InMemoryStore:
     """Minimal store with the subset of ``torch.distributed.Store`` that
-    :func:`host_mesh_from_store` consumes."""
+    :meth:`StoreJob.from_store` consumes."""
 
     def __init__(self) -> None:
         self._values: dict[str, bytes] = {}
@@ -98,7 +94,7 @@ def test_net_transports_require_explicit_port() -> None:
 @pytest.mark.parametrize(
     "missing", ["RANK", "LOCAL_RANK", "WORLD_SIZE", "LOCAL_WORLD_SIZE"]
 )
-def test_host_mesh_from_store_requires_torchelastic_env(
+def test_store_job_from_store_requires_torchelastic_env(
     monkeypatch: pytest.MonkeyPatch, missing: str
 ) -> None:
     # Every torchelastic env var must be present when no keyword override
@@ -110,10 +106,10 @@ def test_host_mesh_from_store_requires_torchelastic_env(
     monkeypatch.setenv("LOCAL_WORLD_SIZE", "1")
     monkeypatch.delenv(missing, raising=False)
     with pytest.raises(RuntimeError, match=missing):
-        host_mesh_from_store(_InMemoryStore())
+        StoreJob.from_store(_InMemoryStore())
 
 
-def test_host_mesh_from_store_kwargs_override_env(
+def test_store_job_from_store_kwargs_override_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Unset every env var, then pass all four topology values via
@@ -124,7 +120,7 @@ def test_host_mesh_from_store_kwargs_override_env(
 
     store = _InMemoryStore()
     assert (
-        host_mesh_from_store(
+        StoreJob.from_store(
             store,
             transport="ipc",
             rank=3,
@@ -136,7 +132,7 @@ def test_host_mesh_from_store_kwargs_override_env(
     )
 
 
-def test_host_mesh_from_store_validates_world_size(
+def test_store_job_from_store_validates_world_size(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("RANK", "0")
@@ -144,10 +140,10 @@ def test_host_mesh_from_store_validates_world_size(
     monkeypatch.setenv("WORLD_SIZE", "3")
     monkeypatch.setenv("LOCAL_WORLD_SIZE", "2")
     with pytest.raises(ValueError, match="divisible"):
-        host_mesh_from_store(_InMemoryStore())
+        StoreJob.from_store(_InMemoryStore())
 
 
-def test_host_mesh_from_store_non_local_rank_zero_is_passive(
+def test_store_job_from_store_non_local_rank_zero_is_passive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Rank with LOCAL_RANK != 0 and RANK != 0 spawns nothing and returns
@@ -160,35 +156,37 @@ def test_host_mesh_from_store_non_local_rank_zero_is_passive(
     monkeypatch.setenv("LOCAL_WORLD_SIZE", "2")
 
     store = _InMemoryStore()
-    assert host_mesh_from_store(store, transport="ipc") is None
+    assert StoreJob.from_store(store, transport="ipc") is None
     # This rank did not spawn; nobody published for group 1.
     assert _worker_addr_key(1) not in store._values
 
 
-@patch("monarch._src.spmd.host_mesh.attach_to_workers")
 @patch("monarch._src.spmd.host_mesh._spawn_worker_process")
 @patch("monarch._src.spmd.host_mesh.new_service_proc_id")
-def test_host_mesh_from_store_carries_worker_service_proc_identity(
+def test_store_job_carries_worker_service_proc_identity(
     mock_new_service_proc_id,
     mock_spawn_worker_process,
-    mock_attach_to_workers,
 ) -> None:
     service_proc_id = ProcId.from_string("service<2>")
     mock_new_service_proc_id.return_value = service_proc_id
     mock_spawn_worker_process.return_value = ("service<2>@ipc://worker-0", 123)
     expected_mesh = object()
-    mock_attach_to_workers.return_value = expected_mesh
     store = _InMemoryStore()
 
-    mesh = host_mesh_from_store(
-        store,
-        rank=0,
-        local_rank=0,
-        world_size=1,
-        local_world_size=1,
-    )
+    with patch(
+        "monarch._src.job.spmd.attach_to_workers", return_value=expected_mesh
+    ) as mock_attach_to_workers:
+        job = StoreJob.from_store(
+            store,
+            rank=0,
+            local_rank=0,
+            world_size=1,
+            local_world_size=1,
+        )
+        assert job is not None
+        state = job.state()
 
-    assert mesh is expected_mesh
+    assert state.monarch_worker is expected_mesh
     assert (
         mock_spawn_worker_process.call_args.kwargs["service_proc_id"] == service_proc_id
     )
@@ -196,6 +194,48 @@ def test_host_mesh_from_store_carries_worker_service_proc_identity(
         name="monarch_worker",
         ca="trust_all_connections",
         workers=["service<2>@ipc://worker-0"],
+    )
+
+
+def test_store_job_defers_attach_until_state() -> None:
+    store = _InMemoryStore()
+    host_mesh = MagicMock()
+
+    with (
+        patch(
+            "monarch._src.spmd.host_mesh._spawn_worker_process",
+            return_value=("ipc:///tmp/monarch_worker", 123),
+        ),
+        patch(
+            "monarch._src.job.spmd.attach_to_workers",
+            return_value=host_mesh,
+        ) as attach_to_workers,
+        patch(
+            "monarch._src.job.job_components.Mounts.ensure_open"
+        ) as ensure_mounts_open,
+    ):
+        job = StoreJob.from_store(
+            store,
+            rank=0,
+            local_rank=0,
+            world_size=1,
+            local_world_size=1,
+        )
+        assert job is not None
+        attach_to_workers.assert_not_called()
+
+        state = job.state()
+
+    attach_to_workers.assert_called_once_with(
+        ca="trust_all_connections",
+        workers=["ipc:///tmp/monarch_worker"],
+        name="monarch_worker",
+    )
+    assert state.monarch_worker is host_mesh
+    assert job.apply_id is not None
+    ensure_mounts_open.assert_called_once_with(
+        job.apply_id,
+        {"monarch_worker": host_mesh},
     )
 
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/torchstore/pull/179


Add `StoreJob.from_store` for torchrun-style rendezvous so Job API components run around host mesh attachment. Remove `host_mesh_from_store`, migrate TorchStore SPMD initialization and cleanup to `StoreJob`, preserve the optional-import compatibility error, and expose `configure_job` for telemetry and remote mounts.

Differential Revision: D116109890


