### PR TITLE
Replace deprecated `abstractproperty` in `actor_mesh.py` (#4675)

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -16,7 +16,7 @@ import inspect
 import logging
 import threading
 import warnings
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 from dataclasses import dataclass
 from functools import cache
 from pprint import pformat
@@ -171,7 +171,8 @@ class Instance(abc.ABC):
 
         return real_spawn(proc_mesh)
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def _mailbox(self) -> Mailbox:
         """
         This can be removed once we fix all the uses of mailbox to just use context instead.
@@ -185,7 +186,8 @@ class Instance(abc.ABC):
         """
         return self.actor_id.proc_id
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def actor_id(self) -> ActorAddr:
         """
         The actor_id of the current actor.


### PR DESCRIPTION
Summary:

`abstractproperty` has been deprecated since Python 3.3. Stack `property` on top of `abstractmethod` instead, for `Instance._mailbox` and `Instance.actor_id`.

https://docs.python.org/3/library/abc.html#abc.abstractproperty

Differential Revision: D116300600


