### PR TITLE
Remove the dead `ACTOR_MESH_CAST_DURATION` timer (#4676)

### DIFF
--- a/hyperactor_mesh/src/metrics.rs
+++ b/hyperactor_mesh/src/metrics.rs
@@ -8,12 +8,6 @@
 
 use hyperactor_telemetry::*;
 
-declare_static_timer!(
-    ACTOR_MESH_CAST_DURATION,
-    "actor_mesh_cast_duration",
-    TimeUnit::Micros
-);
-
 // Per-proc memory samples emitted on the periodic tick of
 // `Handler<RepublishIntrospect>` for `ProcAgent`, governed by
 // `PROCESS_MEMORY_METRIC_INTERVAL`. Values are bytes; the underlying

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -16,7 +16,7 @@ import inspect
 import logging
 import threading
 import warnings
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 from dataclasses import dataclass
 from functools import cache
 from pprint import pformat
@@ -171,7 +171,8 @@ class Instance(abc.ABC):
 
         return real_spawn(proc_mesh)
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def _mailbox(self) -> Mailbox:
         """
         This can be removed once we fix all the uses of mailbox to just use context instead.
@@ -185,7 +186,8 @@ class Instance(abc.ABC):
         """
         return self.actor_id.proc_id
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def actor_id(self) -> ActorAddr:
         """
         The actor_id of the current actor.


### PR DESCRIPTION
Summary:

D74476180 added `ACTOR_MESH_CAST_DURATION` together with its only call site in `actor_mesh.rs`. That call site is gone, and no reference to either the static or its `actor_mesh_cast_duration` metric name remains anywhere in fbsource. `hyperactor_mesh::metrics` is a private module, so the static is unreachable from outside the crate as well; being a `LazyLock`, it never even constructed its histogram, so nothing was emitted. `dead_code` stays quiet here because the static is generated by an external macro.

Reviewed By: thedavekwon

Differential Revision: D116302422


