### PR TITLE
Remove unused type error suppressions - monarch

### DIFF
--- a/examples/rdma_pingpong/rdma_pingpong.py
+++ b/examples/rdma_pingpong/rdma_pingpong.py
@@ -37,18 +37,14 @@ class PingPongActor(Actor):
             self.data = torch.rand(n, dtype=torch.float32, device=device)
             self.recv_buf = torch.zeros(n, dtype=torch.float32, device=device)
         elif buffer_type == "bytearray":
-            # pyrefly: ignore [bad-assignment]
             self.data = bytearray(os.urandom(size_bytes))
-            # pyrefly: ignore [bad-assignment]
             self.recv_buf = bytearray(size_bytes)
         elif buffer_type == "memoryview":
             self._data_mmap = mmap.mmap(-1, size_bytes)
             self._data_mmap.write(os.urandom(size_bytes))
             self._data_mmap.seek(0)
-            # pyrefly: ignore [bad-assignment]
             self.data = self._data_mmap
             self._recv_mmap = mmap.mmap(-1, size_bytes)
-            # pyrefly: ignore [bad-assignment]
             self.recv_buf = self._recv_mmap
         else:
             raise ValueError(f"Unknown buffer_type: {buffer_type!r}")
@@ -56,6 +52,7 @@ class PingPongActor(Actor):
     @endpoint
     async def get_buffer(self) -> RDMABuffer:
         if self.buffer_type in ("cpu_tensor", "cuda_tensor"):
+            # pyrefly: ignore [missing-attribute]
             return RDMABuffer(self.data.view(torch.uint8).flatten())
         else:
             # pyrefly: ignore [bad-argument-type]
@@ -65,7 +62,9 @@ class PingPongActor(Actor):
     async def read_from(self, peer_buf: RDMABuffer) -> float:
         """Read peer's data into recv_buf, return elapsed seconds."""
         if self.buffer_type in ("cpu_tensor", "cuda_tensor"):
+            # pyrefly: ignore [missing-attribute]
             self.recv_buf.zero_()
+            # pyrefly: ignore [missing-attribute]
             local = self.recv_buf.view(torch.uint8).flatten()
         elif self.buffer_type == "bytearray":
             for i in range(len(self.recv_buf)):
@@ -89,6 +88,7 @@ class PingPongActor(Actor):
         if self.buffer_type in ("cpu_tensor", "cuda_tensor"):
             # .cpu() is a no-op on CPU tensors, required for cuda_tensor
             # since numpy doesn't accept CUDA storage.
+            # pyrefly: ignore [missing-attribute]
             raw = buf.cpu().numpy().tobytes()
         else:
             raw = bytes(buf)

--- a/python/benches/remotemount/bench_metadata_encoding.py
+++ b/python/benches/remotemount/bench_metadata_encoding.py
@@ -56,10 +56,11 @@ def make_synthetic_metadata(num_files: int, num_dirs: int = 0) -> dict[str, Any]
             file_attr["st_mode"] = 0o100644
             file_attr["st_size"] = 256
             file_attr["st_nlink"] = 1
-            # pyrefly: ignore [unsupported-operation]
             meta[f"/dir_{i}/sub_file_{j}.txt"] = {
                 "attr": file_attr,
+                # pyrefly: ignore [bad-assignment]
                 "global_offset": offset + j * 256,
+                # pyrefly: ignore [bad-assignment]
                 "file_len": 256,
             }
 
@@ -71,10 +72,11 @@ def make_synthetic_metadata(num_files: int, num_dirs: int = 0) -> dict[str, Any]
         file_attr["st_mode"] = 0o100644
         file_attr["st_size"] = file_size
         file_attr["st_nlink"] = 1
-        # pyrefly: ignore [unsupported-operation]
         meta[f"/file_{i}.bin"] = {
             "attr": file_attr,
+            # pyrefly: ignore [bad-assignment]
             "global_offset": offset,
+            # pyrefly: ignore [bad-assignment]
             "file_len": file_size,
         }
         offset += file_size

--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -64,7 +64,7 @@ class Philosopher(Actor):
     """A philosopher that alternates between thinking and eating."""
 
     def __init__(self, size: int) -> None:
-        # pyrefly: ignore [bad-assignment, bad-override]
+        # pyrefly: ignore [bad-assignment]
         self.size = size
         self.rank: int = 0
         self.left_status = ChopstickStatus.NONE

--- a/python/examples/stop_mesh.py
+++ b/python/examples/stop_mesh.py
@@ -57,7 +57,6 @@ async def async_main(num_procs: int) -> None:
         print(f"\n{num_procs} workers alive. Stopping the actor mesh...", flush=True)
 
         # Coordinated mesh-level stop.
-        # pyre-ignore[16]: `stop` is on `ActorMesh`, not the proxy type.
         await workers.stop("mesh stopped by example")
 
         print("Actor mesh stopped. Tombstones are now visible in the TUI (press h).")

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1289,7 +1289,7 @@ async def _handle_queued_message(actor: Any, msg: "QueuedMessage") -> None:
             msg.context,
             msg.method,
             msg.bytes,
-            panic_flag,  # pyre-ignore[6]: _QueuePanicFlag implements PanicFlag protocol
+            panic_flag,
             msg.local_state,
             msg.refs,
             msg.response_port,

--- a/python/monarch/_src/actor/waker.py
+++ b/python/monarch/_src/actor/waker.py
@@ -21,7 +21,6 @@ class Event(abc.ABC):
     _event_loop: asyncio.AbstractEventLoop | None
     _event: asyncio.Event | None
 
-    # pyrefly: ignore [unsupported-operation]
     async def wait(self) -> Literal[True]:
         """Wait for the event to be set. Once set, remains set until cleared.
 

--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -519,21 +519,18 @@ class RDMAAction:
     def __init__(self) -> None:
         self._inner: _RdmaAction = _RdmaAction()
 
-    # pyrefly: ignore [not-a-type]
     def read_remote(self, dst: "LocalMemory", src: RDMABuffer) -> "RDMAAction":
         """Queue a read from RDMA buffer ``src`` into local memory ``dst``."""
         handle = _make_local_memory_handle(dst)
         self._inner.add_read_into_local(remote=src._buffer, local=handle)
         return self
 
-    # pyrefly: ignore [not-a-type]
     def write_remote(self, dst: RDMABuffer, src: "LocalMemory") -> "RDMAAction":
         """Queue a write from local memory ``src`` into RDMA buffer ``dst``."""
         handle = _make_local_memory_handle(src)
         self._inner.add_write_from_local(remote=dst._buffer, local=handle)
         return self
 
-    # pyrefly: ignore [not-a-type]
     def fetch_add(self, src: RDMABuffer, dst: "LocalMemory", add: int) -> "RDMAAction":
         raise NotImplementedError("Not yet supported")
 
@@ -543,7 +540,6 @@ class RDMAAction:
         dst: "LocalMemory",
         compare: int,
         swap: int,
-        # pyrefly: ignore [not-a-type]
     ) -> "RDMAAction":
         raise NotImplementedError("Not yet supported")
 

--- a/python/monarch/cached_remote_function.py
+++ b/python/monarch/cached_remote_function.py
@@ -34,11 +34,9 @@ def _controller_autograd_function_forward(
             wire_ctx = autograd.function.FunctionCtx()
             # Track arg tensors that have requires_grad
             arg_tensors, _ = tree_flatten(args)
-            # pyrefly: ignore [missing-attribute]
             wire_ctx.args_requires_grads = []
             for i, arg in enumerate(arg_tensors):
                 if isinstance(arg, torch.Tensor) and arg.requires_grad:
-                    # pyrefly: ignore [missing-attribute]
                     wire_ctx.args_requires_grads.append(i)
             out, ctx_attrs, ctx_tensors = func(
                 autograd_function_class.__module__,

--- a/python/monarch/common/_coalescing.py
+++ b/python/monarch/common/_coalescing.py
@@ -267,7 +267,6 @@ def compile(fn=None, verify=True):
     """
     if fn is None:
         return lambda fn: compile(fn, verify)
-    # pyrefly: ignore [no-matching-overload]
     cache: Dict[Any, Recording] = defaultdict(list)
 
     @functools.wraps(fn)
@@ -277,12 +276,9 @@ def compile(fn=None, verify=True):
             return fn(*args, **kwargs)
 
         tensors, shape_key = hashable_tensor_flatten(args, kwargs)
-        # pyrefly: ignore [missing-attribute]
         input_group = TensorGroup([t._fake for t in tensors])
-        # pyrefly: ignore [missing-attribute]
         props = tuple((t.mesh, t.stream, t.requires_grad) for t in tensors)
         key = (shape_key, input_group.pattern, props)
-        # pyrefly: ignore [not-iterable]
         for entry in cache[key]:
             if entry.matches(input_group.tensors):
                 if entry.to_verify is not None:
@@ -294,7 +290,6 @@ def compile(fn=None, verify=True):
         entry = _record_and_define(fn, args, kwargs)
         if not verify:
             entry.to_verify = None
-        # pyrefly: ignore [missing-attribute]
         cache[key].append(entry)
         return entry.run(args, kwargs)
 

--- a/python/monarch/common/borrows.py
+++ b/python/monarch/common/borrows.py
@@ -64,7 +64,6 @@ class StorageAliases:
                     # on the origin stream. This does not happen automatically because
                     # borrows are not tracked as tensor aliases, but are instead treated
                     # as a kind of optimized copy or move.
-                    # pyrefly: ignore [bad-argument-type]
                     tensor.mesh.client.new_node(borrowed_from.aliases, (tensor,))
                 tensor.mesh._send(messages.BorrowLastUse(borrow._id))
 

--- a/python/monarch/common/client.py
+++ b/python/monarch/common/client.py
@@ -535,7 +535,6 @@ def tree_map_refs(first_ref: int, tree):
 class Recorder:
     def __init__(self):
         self.borrow_entries_created: Dict[int, Borrow] = {}
-        # pyrefly: ignore [bad-specialization]
         self.messages: List[Union[NDSlice, List[NDSlice]], NamedTuple] = []
         # these tables track the externally captured tensors that we
         # use and mutate whenever this recording is run.
@@ -543,7 +542,6 @@ class Recorder:
         self.mutates = {}  # ordered set
         self.creates: List[weakref.ref] = []
         self.tracebacks = []
-        # pyrefly: ignore [bad-assignment]
         self.first_ref: int = math.inf
         self.reference_recording: Optional["Recording"] = None
         # Map from formal tensor storage to its corresponding argument indices
@@ -596,7 +594,6 @@ class Recorder:
 
     @property
     def flat_messages(self):
-        # pyrefly: ignore [bad-argument-type]
         return flatten_messages(self.messages)
 
     def run_once(self, client: "Client"):
@@ -629,7 +626,6 @@ class Recorder:
             ),
             msg,
         )
-        # pyrefly: ignore [bad-argument-type]
         self.messages.append((ranks, msg))
         reference_recording = self.reference_recording
         if reference_recording is not None:
@@ -691,7 +687,6 @@ class Recorder:
             list(self.mutates.keys()),
             sorted(mutated_formal_indices),
             self.tracebacks,
-            # pyrefly: ignore [bad-argument-type]
             self.messages,
             nresults,
             nformals,

--- a/python/monarch/common/device_mesh.py
+++ b/python/monarch/common/device_mesh.py
@@ -77,7 +77,6 @@ class RemoteProcessGroup(Referenceable):
         self._split_comm_done.add(stream)
 
         msg = messages.SplitCommForProcessGroup(
-            # pyrefly: ignore [bad-argument-type]
             remote_process_group=self,
             stream=stream,
         )
@@ -341,7 +340,6 @@ class _ActiveMesh(TorchDispatchMode):
         fnstr = str(func)
         if fnstr in self.ignore:
             return func(*args, **kwargs)
-        # pyrefly: ignore [bad-index]
         if fnstr in self.allowed_local_accessors and not isinstance(args[0], Tensor):
             return func(*args, **kwargs)
         return _remote(func, propagate=func)(*args, **kwargs)

--- a/python/monarch/common/fake.py
+++ b/python/monarch/common/fake.py
@@ -27,7 +27,6 @@ def fake_call(fn, *args, **kwargs):
     First call (ThreadPoolExecutor init) will take the GIL and may block for long time!
     TODO: this will be replaced with something more performant
     """
-    # pyrefly: ignore [unknown-name]
     global _fake_mode_worker, fake_mode
 
     # # Calls FakeTensorMode while re-enabling version counter tracking

--- a/python/monarch/common/future.py
+++ b/python/monarch/common/future.py
@@ -95,7 +95,6 @@ class Future(Generic[T]):
                 except Exception:
                     logger.exception("exception in controller's Future callback")
         self._callbacks = None
-        # pyrefly: ignore [bad-assignment]
         self._client = None
 
     def _wait(self, timeout: Optional[float]):

--- a/python/monarch/common/mast.py
+++ b/python/monarch/common/mast.py
@@ -34,7 +34,6 @@ def _user_jobs(jobname=None):
     lines = []
     command = ["mast", "list-jobs", "--my", "--json"]
     if jobname is not None:
-        # pyrefly: ignore [bad-argument-type]
         command.append(["--job-name", jobname])
     for line in subprocess.check_output(command).split(b"\n"):
         if line:

--- a/python/monarch/common/tensor.py
+++ b/python/monarch/common/tensor.py
@@ -307,7 +307,7 @@ class Tensor(Referenceable, BaseTensor):
         with InputChecker(
             ts,
             lambda ts: (
-                # pyrefly: ignore [bad-argument-type, no-matching-overload]
+                # pyrefly: ignore [bad-argument-type]
                 f"reduce({next(ts)}, {dims}, reduction={reduction}, out={next(ts, None)})"
             ),
         ) as checker:
@@ -403,7 +403,7 @@ class MeshSliceTensor:
 
         with InputChecker(
             [self.tensor],
-            # pyrefly: ignore [bad-argument-type, no-matching-overload]
+            # pyrefly: ignore [bad-argument-type]
             lambda ts: f"{next(ts)}.to_mesh({mesh})",
         ) as checker:
             checker.check_no_requires_grad()
@@ -634,12 +634,10 @@ class InputChecker:
         error_names: Dict["Tensor", "str"] = {}
         for i, (t, errors) in enumerate(self.errors.items()):
             name = f"ERROR_{i}"
-            # pyrefly: ignore [unsupported-operation]
             error_names[t] = name
             error_info.append(f"{name}:\n")
             error_info.extend(errors)
 
-        # pyrefly: ignore [no-matching-overload]
         call = self.format(_Symbol(error_names.get(t, ".")) for t in self.tensors)
         msg = f"Incorrect arguments to monarch operation:\n\n  {call}\n\n{''.join(error_info)}"
         raise TypeError(msg)

--- a/python/monarch/controller/history.py
+++ b/python/monarch/controller/history.py
@@ -62,7 +62,6 @@ class History:
         while worklist:
             invocation = worklist.popleft()
             if invocation.fail(remote_exception):
-                # pyrefly: ignore [bad-argument-type]
                 worklist.extend(invocation.users)
 
     def rank_completed(

--- a/python/monarch/gradient_generator.py
+++ b/python/monarch/gradient_generator.py
@@ -35,7 +35,6 @@ class Context(NamedTuple):
             # doesn't work correctly and somehow inactivates the device mesh
             # if it is already enabled. This is a temporary workaround for
             # the demo.
-            # pyrefly: ignore [missing-attribute]
             activate_mesh = self.device_mesh.activate()
         else:
             activate_mesh = nullcontext()

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -101,7 +101,6 @@ class PdbWrapper(pdb.Pdb):
             # not the nested one inside session.run. This means that the local
             # variables are what gets printed, etc. To do this
             # we first execute up 2 to get to that frame.
-            # pyrefly: ignore [bad-argument-type]
             self.do_up(2)
         return r
 
@@ -570,7 +569,6 @@ def actor_rref(endpoint, pickling_state: PicklingState):
         result_msg = None
 
     actor_msg_kind, broker_id = _create_call_method_indirect_message(
-        # pyrefly: ignore [bad-argument-type]
         endpoint._name,
         # pyrefly: ignore [bad-argument-type]
         mesh.client,

--- a/python/monarch/monarch_dashboard/server/tests/test_db.py
+++ b/python/monarch/monarch_dashboard/server/tests/test_db.py
@@ -150,9 +150,7 @@ class GetActorTest(_DbTestBase):
 
     def test_no_status_fields(self):
         actor = db.get_actor(1)
-        # pyrefly: ignore [bad-argument-type]
         self.assertNotIn("latest_status", actor)
-        # pyrefly: ignore [bad-argument-type]
         self.assertNotIn("status_timestamp_us", actor)
 
     def test_nonexistent_actor(self):
@@ -169,9 +167,7 @@ class GetActorLatestStatusTest(_DbTestBase):
 
     def test_status_value_populated(self):
         status = db.get_actor_latest_status(1)
-        # pyrefly: ignore [unsupported-operation]
         self.assertIsNotNone(status["latest_status"])
-        # pyrefly: ignore [unsupported-operation]
         self.assertIsNotNone(status["status_timestamp_us"])
 
     def test_nonexistent_actor(self):

--- a/python/monarch/notebook.py
+++ b/python/monarch/notebook.py
@@ -108,7 +108,6 @@ class ControllerImporterServer:
                         )
                     elif isinstance(s.loader, ExtensionFileLoader):
                         with open(s.loader.path, "rb") as f:
-                            # pyrefly: ignore [bad-assignment]
                             s.loader = _ExtensionLoader(
                                 s.loader.name, s.loader.path, f.read()
                             )
@@ -683,7 +682,6 @@ def mast_mesh(
 
 
 def list_mast_jobs():
-    # pyrefly: ignore [missing-argument]
     for job in get_mast_notebook_jobs():
         print(job)
 

--- a/python/monarch/opaque_module.py
+++ b/python/monarch/opaque_module.py
@@ -140,17 +140,14 @@ class OpaqueModule:
 
     def __init__(self, *args, **kwargs):
         self._object = OpaqueObject(*args, **kwargs)
-        # pyrefly: ignore [bad-assignment]
         self._parameters: List[torch.Tensor] = None
 
     def parameters(self):
         if self._parameters is None:
             tensor_group_pattern = call_on_shard_and_fetch(
-                # pyrefly: ignore [bad-argument-type]
                 remote(_get_parameters_shape),
                 self._object,
             ).result()
-            # pyrefly: ignore [bad-assignment]
             self._parameters = [
                 p.requires_grad_(True)
                 for p in remote(
@@ -228,12 +225,10 @@ class OpaqueModule:
                         f.empty() if rg else None
                         for f, rg in zip(input_factories, requires_grad)
                     ),
-                    # pyrefly: ignore [bad-argument-type]
                 )(backward_ctx, all_grad_outputs)
                 return all_grad_inputs
 
         # apply unwraps the gradient tensors and inserts our custom block.
         flat_outputs = F.apply(*all_inputs)
-        # pyrefly: ignore [not-callable]
         result = unflatten_outputs(flat_outputs)
         return result

--- a/python/monarch/opaque_object.py
+++ b/python/monarch/opaque_object.py
@@ -83,7 +83,6 @@ class OpaqueObject(OpaqueRef):
 
     def call_method_on_shard_and_fetch(self, method_name, *args, **kwargs):
         return call_on_shard_and_fetch(
-            # pyrefly: ignore [bad-argument-type]
             remote(_invoke_method),
             self,
             method_name,

--- a/python/monarch/parallel/pipelining/runtime.py
+++ b/python/monarch/parallel/pipelining/runtime.py
@@ -311,12 +311,10 @@ class PipelineParallelism:
         assert len(pp_stages) == len(self.meshes)
         for stage_idx, stage in enumerate(pp_stages):
             for module in stage:
-                # pyrefly: ignore [missing-attribute]
                 state_dict = module.state_dict()
                 for k, v in state_dict.items():
                     if isinstance(v, Tensor):
                         state_dict[k] = v.to_mesh(self.meshes[stage_idx])
-                # pyrefly: ignore [missing-attribute]
                 module.load_state_dict(state_dict, assign=True)
 
     def copy_params_to_new_model(
@@ -369,7 +367,6 @@ class PipelineParallelism:
         optimizers = []
 
         for stage in self.stages:
-            # pyrefly: ignore [missing-attribute]
             params = list(chain(*[list(m.parameters()) for m in stage]))
             optimizers.append(
                 config_fn(
@@ -753,13 +750,10 @@ class PipelineParallelism:
                                 input_tensor=input_tensor,
                                 output_tensor=output_tensor,
                                 output_tensor_grad=borrow_output_tensor_grad,
-                                # pyrefly: ignore [bad-argument-type]
                                 y=microbatch_y[microbatch_id]
                                 if is_last_stage
                                 else None,
-                                # pyrefly: ignore [bad-argument-type]
                                 loss_layer=self.loss_layer if is_last_stage else None,
-                                # pyrefly: ignore [bad-argument-type]
                                 loss_list=self.loss_list if is_last_stage else None,
                                 model_chunk_id=model_chunk_id,
                                 microbatch_id=microbatch_id,
@@ -771,7 +765,6 @@ class PipelineParallelism:
                                 input_tensor_grad
                             )
                             if output_tensor_grad is not None:
-                                # pyrefly: ignore [unbound-name]
                                 output_tensor_grad_borrow.drop()
                     case _:
                         raise ValueError(f"{action=} is unknown or unsupported")

--- a/python/monarch/parallel/pipelining/scheduler.py
+++ b/python/monarch/parallel/pipelining/scheduler.py
@@ -203,7 +203,6 @@ def get_dora_schedule(
         num_stages=num_model_chunks * pipeline_parallel_size,
     )
 
-    # pyrefly: ignore [bad-argument-type]
     comms_str = _format_pipeline_order(lowered_comm_schedule)
     if dump_scheduler_ir:
         with open("lowered_comms.log", "w") as logf:

--- a/python/monarch/simulator/command_history.py
+++ b/python/monarch/simulator/command_history.py
@@ -308,41 +308,32 @@ class CommandHistory:
                     )
                 case "BorrowFirstUse":
                     borrow_id = getattr(msg, "borrow", None)
-                    # pyrefly: ignore [bad-index]
                     stream_name = ir._control.borrows_info[borrow_id].dst_stream_name
                     command_type = f"BorrowFirstUse: {borrow_id}"
                     devices = [worker_rank]
                     control_dependencies = [
-                        # pyrefly: ignore [bad-index]
                         ir._control.borrows_info[borrow_id].create_id
                     ]
-                    # pyrefly: ignore [bad-index]
                     ir._control.borrows_info[borrow_id].firstuse_id = command_id
                 case "BorrowLastUse":
                     borrow_id = getattr(msg, "borrow", None)
                     stream_name = src_stream_name = ir._control.borrows_info[
-                        # pyrefly: ignore [bad-index]
                         borrow_id
                     ].dst_stream_name
                     dst_stream_name = ir._control.borrows_info[
-                        # pyrefly: ignore [bad-index]
                         borrow_id
                     ].src_stream_name
                     command_type = f"BorrowLastUse: {borrow_id}"
                     devices = [worker_rank]
-                    # pyrefly: ignore [bad-index]
                     ir._control.borrows_info[borrow_id].lastuse_id = command_id
                 case "BorrowDrop":
                     borrow_id = getattr(msg, "borrow", None)
-                    # pyrefly: ignore [bad-index]
                     stream_name = ir._control.borrows_info[borrow_id].src_stream_name
                     command_type = f"BorrowDrop: {borrow_id}"
                     devices = [worker_rank]
                     control_dependencies = [
-                        # pyrefly: ignore [bad-index]
                         ir._control.borrows_info[borrow_id].lastuse_id
                     ]
-                    # pyrefly: ignore [bad-index]
                     ir._control.borrows_info[borrow_id].drop_id = command_id
 
             if dag_item_type in [
@@ -355,12 +346,10 @@ class CommandHistory:
             ]:
                 ir.insert_node(
                     worker_rank,
-                    # pyrefly: ignore [bad-argument-type]
                     stream_name,
                     command_id,
                     command_type,
                     devices,
-                    # pyrefly: ignore [bad-argument-type]
                     control_dependencies,
                     tb,
                 )

--- a/python/monarch/simulator/mock_controller.py
+++ b/python/monarch/simulator/mock_controller.py
@@ -80,7 +80,6 @@ class History:
         while worklist:
             invocation = worklist.popleft()
             if invocation.fail(remote_exception):
-                # pyrefly: ignore [bad-argument-type]
                 worklist.extend(invocation.users)
 
     def rank_completed(

--- a/python/monarch/simulator/simulator.py
+++ b/python/monarch/simulator/simulator.py
@@ -126,7 +126,6 @@ class SimulatorTraceMode(enum.Enum):
 
 def get_fake_tensor(x):
     if isinstance(x, (torch.Tensor, DTensorRef)):
-        # pyrefly: ignore [missing-attribute]
         return x._fake
     return x
 
@@ -137,7 +136,6 @@ def get_ids(tree):
     ids = {}
     for arg in tree_leaves(tree):
         if isinstance(arg, (torch.Tensor, DTensorRef)):
-            # pyrefly: ignore [missing-attribute]
             ids[arg.ref] = arg._fake
     return ids
 
@@ -189,7 +187,6 @@ class Simulator:
         if use_real_profiler:
             self.runtime_profiler = RuntimeProfiler(world_size=cuda_device_count)
         else:
-            # pyrefly: ignore [bad-assignment]
             self.runtime_profiler = FakeRuntimeProfiler(world_size=world_size)
         self.events: List[TraceEvent] = []
         self.command_id = 0
@@ -979,12 +976,10 @@ class SimulatorInterface:
 
     def upload(self):
         sim = self._ctrl.simulator
-        # pyrefly: ignore [missing-attribute]
         old, sim.upload_trace = sim.upload_trace, True
         try:
             self._ctrl.step()
         finally:
-            # pyrefly: ignore [missing-attribute]
             sim.upload_trace = old
 
     def _display_html(self, html_code):
@@ -1054,7 +1049,6 @@ class SimulatorInterface:
             tempfile.NamedTemporaryFile(suffix=".json", delete=False) as json_file,
             tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as memory_pkl,
         ):
-            # pyrefly: ignore [missing-attribute]
             sim._report(trace_path=json_file.name, memory_view_path=memory_pkl.name)
             self._display_trace(json_file.name, memory_pkl.name)
 

--- a/python/monarch/simulator/task.py
+++ b/python/monarch/simulator/task.py
@@ -199,7 +199,7 @@ class WorkerTaskManager(Task):
         self.task_id = itertools.count()
 
     def add(self, task: Task) -> int:
-        # pyrefly: ignore [bad-argument-type, no-matching-overload]
+        # pyrefly: ignore [bad-argument-type]
         task_id = next(self.task_id)
         self.tasks[task_id] = task
         task.task_id = task_id
@@ -251,7 +251,7 @@ class WorkerTaskManager(Task):
 
         ret = WorkerTaskManager()
         # Waste one to ensure all the cloned WorkerTaskManager has the same task_id.
-        # pyrefly: ignore [bad-argument-type, no-matching-overload]
+        # pyrefly: ignore [bad-argument-type]
         next_task_id = next(self.task_id)
         # pyrefly: ignore [bad-assignment]
         ret.task_id = itertools.count(next_task_id + 1)

--- a/python/monarch/worker/_testing_function.py
+++ b/python/monarch/worker/_testing_function.py
@@ -78,7 +78,6 @@ def has_nan(t):
 
 
 def new_barrier_hackery(threads):
-    # pyrefly: ignore [unknown-name]
     global _barrier
     _barrier = threading.Barrier(threads)
     return torch.zeros(1)
@@ -133,9 +132,7 @@ def isend(t, destination, group=None):
     if isinstance(group, SingleControllerProcessGroupWrapper):
         group = group.process_group
     req = dist.isend(t, destination.item(), group=group)
-    # pyrefly: ignore [missing-attribute]
     assert isinstance(req.is_completed(), bool)
-    # pyrefly: ignore [missing-attribute]
     req.wait()
     return torch.ones(1)
 
@@ -151,9 +148,7 @@ def irecv(t, src, group=None):
     if isinstance(group, SingleControllerProcessGroupWrapper):
         group = group.process_group
     req = dist.irecv(tensor=t, src=src.item(), group=group)
-    # pyrefly: ignore [missing-attribute]
     assert isinstance(req.is_completed(), bool)
-    # pyrefly: ignore [missing-attribute]
     req.wait()
     return torch.ones(1)
 

--- a/python/monarch/worker/compiled_block.py
+++ b/python/monarch/worker/compiled_block.py
@@ -96,7 +96,6 @@ class CompiledBlock:
 
     @property
     def recording_graph(self):
-        # pyrefly: ignore [bad-index]
         return self.graphs[self.recording_stream]
 
     @contextmanager
@@ -146,7 +145,6 @@ class CompiledBlock:
                 sym = Symbol(graph._graph_namespace.create_name(candidate, None))
                 external_names.append(sym.name)
                 external.append(x)
-                # pyrefly: ignore [unsupported-operation]
                 external_id_to_name[id(x)] = sym
                 return sym
 
@@ -163,7 +161,6 @@ class CompiledBlock:
                 if error_context is None or error_context.ident is None:
                     raise exc
                 exc = stream.report_error(
-                    # pyrefly: ignore [bad-argument-type]
                     stream.current_recording,
                     error_context.ident,
                     exc,

--- a/python/monarch/worker/debugger.py
+++ b/python/monarch/worker/debugger.py
@@ -29,7 +29,6 @@ def _set_trace(*, header=None):
     stream = _tls.stream
     if stream is None:
         _orig_set_trace(header=header)
-    # pyrefly: ignore [bad-argument-type]
     ds = PdbWrapper(stream, header)
     ds.set_trace()
 
@@ -51,7 +50,6 @@ class PdbWrapper(pdb.Pdb):
             # not the nested one inside session.run. This means that the local
             # variables are what gets printed, etc. To do this
             # we first execute up 2 to get to that frame.
-            # pyrefly: ignore [bad-argument-type]
             self.do_up(2)
         return r
 

--- a/python/monarch/worker/worker.py
+++ b/python/monarch/worker/worker.py
@@ -420,7 +420,6 @@ class Stream:
                 r.set(exc)
         finally:
             if _tls.tracing:
-                # pyre-fixme[8]: Attribute has type `ErrorContext`; used as `None`.
                 _tls.tracing.current_context = None
 
     @schedule_on_stream_thread(executes_on_error=False)
@@ -1073,7 +1072,6 @@ class Worker:
                 # responds to messages, with a strong guarentee of never
                 # getting stuck. For now we just run everything on this thread.
                 monitor(
-                    # pyrefly: ignore [bad-argument-type]
                     lambda: (
                         logger.error(
                             f"possible stall while waiting for message: recent messages: {debugq} "

--- a/python/monarch_supervisor/__init__.py
+++ b/python/monarch_supervisor/__init__.py
@@ -760,7 +760,6 @@ class Context(FilteredMessageQueue):
         connection_histogram = {}
         for connection in self._name_to_connection.values():
             state = connection.state.name
-            # pyrefly: ignore [unsupported-operation]
             connection_histogram[state] = connection_histogram.setdefault(state, 0) + 1
 
         status = Status(
@@ -777,7 +776,6 @@ class Context(FilteredMessageQueue):
             self._heartbeats,
             self._heartbeat_ttl_sum / self._heartbeats if self._heartbeats else 0,
             self._heartbeat_min_ttl,
-            # pyrefly: ignore [bad-argument-type]
             connection_histogram,
             avg_event_loop_time,
             max_event_loop_time,
@@ -982,7 +980,6 @@ class LocalMessageQueue(FilteredMessageQueue):
     async def recv_async(self) -> Letter:
         if self._async_socket is None:
             self._async_socket = zmq.asyncio.Socket.from_socket(self._sock)
-        # pyrefly: ignore [missing-attribute]
         return Letter(None, await self._async_socket.recv_pyobj())
 
     def send(self, message: Any) -> None:

--- a/python/tests/code_sync/test_auto_reload.py
+++ b/python/tests/code_sync/test_auto_reload.py
@@ -49,7 +49,7 @@ class TestAutoReloader(unittest.TestCase):
                 filename = workspace / "test_module.py"
                 write_text(filename, "foo = 1\n")
 
-                import test_module  # pyre-ignore: Undefined import [21]
+                import test_module
 
                 self.assertEqual(Path(test_module.__file__), filename)
                 self.assertEqual(test_module.foo, 1)
@@ -95,7 +95,7 @@ class TestAutoReloader(unittest.TestCase):
                 )
                 filename.unlink()
 
-                import test_module  # pyre-ignore: Undefined import [21]
+                import test_module
 
                 self.assertEqual(Path(test_module.__file__), pyc)
                 self.assertEqual(test_module.foo, 1)

--- a/python/tests/error_test_binary.py
+++ b/python/tests/error_test_binary.py
@@ -155,10 +155,8 @@ def error_endpoint(num_procs, sync_test_impl, sync_endpoint, endpoint_name, v1):
     )
 
     if sync_test_impl:
-        # pyrefly: ignore [bad-argument-count]
         _run_error_test_sync(num_procs, sync_endpoint, endpoint_name, v1)
     else:
-        # pyrefly: ignore [bad-argument-count]
         _run_error_test(num_procs, sync_endpoint, endpoint_name, v1)
 
 
@@ -167,7 +165,6 @@ def error_bootstrap():
     print("Started function error_bootstrap", flush=True)
     spawn_procs_on_this_host(
         {"gpus": 4},
-        # pyrefly: ignore [unexpected-keyword]
         env={"MONARCH_ERROR_DURING_BOOTSTRAP_FOR_TESTING": "1"},
     ).initialized.get()
 

--- a/python/tests/isolate_in_subprocess.py
+++ b/python/tests/isolate_in_subprocess.py
@@ -163,7 +163,6 @@ def isolate_in_subprocess(test_fn=None, *, env=None):
                 pytrace=False,
             )
 
-    # pyrefly: ignore [missing-attribute]
     wrapper.__wrapped__ = test_fn
     return wrapper
 

--- a/python/tests/rdma_load_test.py
+++ b/python/tests/rdma_load_test.py
@@ -242,11 +242,8 @@ class RDMATest(Actor):
                     return 0.0
                 return size_bytes / (time_seconds * 1e9)
 
-            # pyrefly: ignore [bad-argument-type]
             avg_throughput = calc_throughput_gbs(avg_size, avg_time)
-            # pyrefly: ignore [bad-argument-type]
             max_throughput = calc_throughput_gbs(avg_size, min_time)
-            # pyrefly: ignore [bad-argument-type]
             min_throughput = calc_throughput_gbs(avg_size, max_time)
 
             # Print results
@@ -295,11 +292,8 @@ class RDMATest(Actor):
                 return 0.0
             return size_bytes / (time_seconds * 1e9)
 
-        # pyrefly: ignore [bad-argument-type]
         avg_aggregate_tp = calc_throughput_gbs(avg_batch_size, avg_batch_time)
-        # pyrefly: ignore [bad-argument-type]
         max_aggregate_tp = calc_throughput_gbs(avg_batch_size, min_batch_time)
-        # pyrefly: ignore [bad-argument-type]
         min_aggregate_tp = calc_throughput_gbs(avg_batch_size, max_batch_time)
 
         print(f"\nAGGREGATE THROUGHPUT (concurrency={concurrency}, GB = 1000^3 bytes):")

--- a/python/tests/simulator/test_profiling.py
+++ b/python/tests/simulator/test_profiling.py
@@ -20,46 +20,28 @@ class TestRuntimeEstimator(unittest.TestCase):
         runtime = RuntimeEstimator()
 
         input_tensor = torch.rand(10, 10)
-        # pyrefly: ignore [missing-attribute]
         input_tensor.ref = 1
-        # pyrefly: ignore [missing-attribute]
         input_tensor._fake = None
         output_tensor = torch.rand(10, 10)
-        # pyrefly: ignore [missing-attribute]
         output_tensor.ref = 2
-        # pyrefly: ignore [missing-attribute]
         output_tensor._fake = None
 
         send_tensor = messages.SendTensor(
-            # pyrefly: ignore [bad-argument-type]
             result=output_tensor,
-            # pyrefly: ignore [bad-argument-type]
             from_ranks=[1],
-            # pyrefly: ignore [bad-argument-type]
             to_ranks=[2],
-            # pyrefly: ignore [bad-argument-type]
             tensor=input_tensor,
-            # pyrefly: ignore [bad-argument-type]
             factory=None,
-            # pyrefly: ignore [bad-argument-type]
             from_stream=None,
-            # pyrefly: ignore [bad-argument-type]
             to_stream=None,
         )
         reduce = messages.Reduce(
-            # pyrefly: ignore [bad-argument-type]
             result=output_tensor,
-            # pyrefly: ignore [bad-argument-type]
             local_tensor=input_tensor,
-            # pyrefly: ignore [bad-argument-type]
             factory=None,
-            # pyrefly: ignore [bad-argument-type]
             source_mesh=None,
-            # pyrefly: ignore [bad-argument-type]
             stream=None,
-            # pyrefly: ignore [bad-argument-type]
             dims=None,
-            # pyrefly: ignore [bad-argument-type]
             reduction=None,
             scatter=False,
             inplace=False,
@@ -68,19 +50,12 @@ class TestRuntimeEstimator(unittest.TestCase):
         call_function = messages.CallFunction(
             ident=1,
             result=None,
-            # pyrefly: ignore [bad-argument-type]
             mutates=None,
-            # pyrefly: ignore [bad-argument-type]
             function=None,
-            # pyrefly: ignore [bad-argument-type]
             args=None,
-            # pyrefly: ignore [bad-argument-type]
             kwargs=None,
-            # pyrefly: ignore [bad-argument-type]
             stream=None,
-            # pyrefly: ignore [bad-argument-type]
             device_mesh=None,
-            # pyrefly: ignore [bad-argument-type]
             remote_process_groups=None,
         )
 
@@ -106,7 +81,6 @@ class TestRuntimeEstimator(unittest.TestCase):
         self.assertEqual(runtime.get_runtime("wait_event"), 5_000)
 
         runtime.set_custom_timing(
-            # pyrefly: ignore [bad-argument-type]
             {
                 TimingType.SEND_TENSOR: lambda msg: 4_000,
                 TimingType.REDUCE: lambda msg: 5_000,

--- a/python/tests/simulator/test_simulator.py
+++ b/python/tests/simulator/test_simulator.py
@@ -95,7 +95,6 @@ class TestSimulator:
         mesh = monarch.Simulator(
             hosts=1,
             gpus=2,
-            # pyrefly: ignore [bad-argument-type]
             trace_path=trace_path,
             group_workers=group_workers,
             trace_mode=SimulatorTraceMode.EVERYTHING,
@@ -106,7 +105,6 @@ class TestSimulator:
             ac1 = torch.randn(100, 100)
             ac2 = torch.mm(ac1, ac1)
             ac3 = torch.nn.init.uniform_(ac2)
-            # pyrefly: ignore [bad-argument-type]
             borrow_ac3, borrow = other_stream.borrow(ac3, mutable=True)
             with other_stream.activate():
                 borrow_ac3.add_(borrow_ac3)

--- a/python/tests/simulator/test_task.py
+++ b/python/tests/simulator/test_task.py
@@ -47,22 +47,17 @@ class TestTask(unittest.TestCase):
 
         self.assertEqual(len(manager.tasks), 3)
         self.assertEqual(manager.tasks.keys(), cloned_manager.tasks.keys())
-        # pyrefly: ignore [bad-index]
         cloned_task2 = cloned_manager.tasks[task2.task_id]
         self.assertNotEqual(task2, cloned_task2)
         for k in kwargs.keys():
             self.assertEqual(getattr(cloned_task2, k), getattr(task2, k))
         self.assertEqual(cloned_task2.dependencies[0].task_id, task.task_id)
         self.assertNotEqual(cloned_task2.dependencies[0], task)
-        # pyrefly: ignore [bad-index]
         cloned_wait_task = cloned_manager.tasks[wait_task.task_id]
-        # pyrefly: ignore [unsupported-operation]
         self.assertEqual(cloned_wait_task.waits[0].task_id, task.task_id)
-        # pyrefly: ignore [unsupported-operation]
         self.assertNotEqual(cloned_wait_task.waits[0], task)
 
         self.assertEqual(len(collectives), 3)
-        # pyrefly: ignore [bad-index]
         cloned_collective_task = cloned_manager.tasks[collective_task.task_id]
         self.assertTrue(collective_task in collectives)
         self.assertTrue(cloned_collective_task in collectives)

--- a/python/tests/simulator/test_worker.py
+++ b/python/tests/simulator/test_worker.py
@@ -22,9 +22,7 @@ def create_test_tasks(fake_tensor_tracker) -> Tuple[Task, ...]:
     def fake():
         for i in range(4):
             tensor = torch.randn(100, 100).cuda()
-            # pyrefly: ignore [missing-attribute]
             tensor.ref = i
-            # pyrefly: ignore [missing-attribute]
             tensor._fake = tensor
             fake_tensor_tracker.add({i: tensor})
 
@@ -76,14 +74,12 @@ class TestWorker(unittest.TestCase):
         cloned_storage_tracker = worker.storage_tracker.clone()
         cloned_cpu_tensors = worker.cpu_tensors.clone(
             cloned_task_manager,
-            # pyrefly: ignore [bad-argument-type]
             cloned_storage_tracker,
         )
         cloned_stream = main_stream.clone(
             cloned_task_manager, cloned_storage_tracker, cloned_cpu_tensors
         )
 
-        # pyrefly: ignore [missing-attribute]
         self.assertEqual(cloned_stream.last_task.task_id, main_stream.last_task.task_id)
         self.assertEqual(len(cloned_stream.task_queue), len(main_stream.task_queue))
 

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -1428,7 +1428,6 @@ class ErrorActorWithSupervise(ErrorActor):
     @endpoint
     async def stop_subworker(self) -> None:
         """Stop the inner actor this one owns"""
-        # pyrefly: ignore [missing-attribute]
         await self.mesh.stop()
 
     @endpoint

--- a/python/tests/test_builtins_log.py
+++ b/python/tests/test_builtins_log.py
@@ -15,7 +15,6 @@ from monarch.builtins.log import log_remote, set_logging_level_remote
 
 @pytest.fixture(scope="module", autouse=True)
 def testing_context():
-    # pyrefly: ignore [unknown-name]
     global local
     with TestingContext() as local:
         yield
@@ -25,7 +24,6 @@ def testing_context():
 class TestLogFunctions:
     @classmethod
     def local_device_mesh(cls, num_hosts, gpu_per_host, activate=True):
-        # pyrefly: ignore [unknown-name]
         return local.local_device_mesh(
             num_hosts,
             gpu_per_host,

--- a/python/tests/test_builtins_random.py
+++ b/python/tests/test_builtins_random.py
@@ -43,7 +43,6 @@ class TestRandomFunctions:
 
     @classmethod
     def local_device_mesh(cls, num_hosts, gpu_per_host, activate=True):
-        # pyrefly: ignore [missing-attribute]
         return cls.local.local_device_mesh(
             num_hosts,
             gpu_per_host,

--- a/python/tests/test_coalescing.py
+++ b/python/tests/test_coalescing.py
@@ -39,7 +39,6 @@ def inspect(x):
 
 @pytest.fixture(scope="module", autouse=True)
 def testing_context():
-    # pyrefly: ignore [unknown-name]
     global local
     with TestingContext() as local:
         yield
@@ -341,7 +340,6 @@ class TestCoalescing:
                 c = add(torch.rand(3, 4))
 
             other = Stream("other")
-            # pyrefly: ignore [bad-argument-type]
             ab, borrow = other.borrow(a, mutable=True)
 
             with borrow:
@@ -351,7 +349,6 @@ class TestCoalescing:
             # test we can read it again
             add(torch.rand(3, 4))
 
-            # pyrefly: ignore [bad-argument-type]
             ab, borrow = other.borrow(a)
             with borrow:
                 add(torch.rand(3, 4))
@@ -363,7 +360,6 @@ class TestCoalescing:
                 with borrow:
                     add(c)
 
-            # pyrefly: ignore [missing-attribute]
             a.drop()
 
             with pytest.raises(TypeError, match="DROPPED"):
@@ -410,7 +406,6 @@ class TestCoalescing:
 
             foo()
             with pytest.raises(TypeError, match="DROPPED"):
-                # pyrefly: ignore [missing-attribute]
                 b.add(4)
 
     def test_across_mesh(self, backend_type):
@@ -483,7 +478,6 @@ class TestCoalescing:
             z_alias = z[0, :]
 
             mutated_inputs = (y, y_alias, z, z_alias)
-            # pyrefly: ignore [missing-attribute]
             mutated_aliases = set().union(*[t._aliases.aliases for t in mutated_inputs])
             all_inputs = (x_not_mutated, w_not_mutated) + mutated_inputs
             with patch.object(

--- a/python/tests/test_controller.py
+++ b/python/tests/test_controller.py
@@ -34,7 +34,6 @@ sys.excepthook = custom_excepthook
 
 @pytest.fixture(scope="module", autouse=True)
 def testing_context():
-    # pyrefly: ignore [unknown-name]
     global local
     with TestingContext() as local:
         yield
@@ -61,7 +60,6 @@ class TestController:
         gpu_per_host,
         activate=True,
     ):
-        # pyrefly: ignore [unknown-name]
         return local.local_device_mesh(
             N,
             gpu_per_host,
@@ -84,7 +82,6 @@ class TestController:
             t = torch.rand(10).cuda()
             with pytest.raises(TypeError, match="WRONG_STREAM"):
                 with other.activate():
-                    # pyrefly: ignore [missing-attribute]
                     t = t.reduce("host", "sum")
 
     def test_sub_mesh(self):
@@ -214,19 +211,15 @@ class TestController:
             with pytest.raises(
                 ValueError, match="Reduce expects the shape to be torch.Size."
             ):
-                # pyrefly: ignore [missing-attribute]
                 _ = inp.reduce("host", reduction="sum", scatter=True, out=out_incorrect)
 
-            # pyrefly: ignore [missing-attribute]
             reduce_out = inp.reduce("host", reduction="sum", scatter=True)
             local_out = fetch_shard(out).result()
             local_reduce_out = fetch_shard(reduce_out).result()
-            # pyrefly: ignore [missing-attribute]
             assert out._fake is not reduce_out._fake
             with no_mesh.activate():
                 assert not torch.equal(local_out, local_reduce_out)
 
-            # pyrefly: ignore [missing-attribute]
             reduce_out = inp.reduce("host", reduction="sum", scatter=True, out=out)
             local_out = fetch_shard(out).result()
             local_reduce_out = fetch_shard(reduce_out).result()
@@ -249,7 +242,6 @@ class TestController:
             x = torch.rand(3, 4).cuda()
             x.abs_()
             s = Stream("other")
-            # pyrefly: ignore [bad-argument-type]
             b, drop = s.borrow(x)
             with pytest.raises(TypeError, match="would be mutated"):
                 x.abs_()
@@ -257,7 +249,6 @@ class TestController:
                 _ = b.add(b)
             drop.drop()
             x.abs_()
-            # pyrefly: ignore [bad-argument-type]
             b, drop = s.borrow(x, mutable=True)
             with s.activate():
                 b.abs_()
@@ -272,12 +263,10 @@ class TestController:
 
             with sm0.activate():
                 x = torch.rand(3, 4, device="cuda")
-                # pyrefly: ignore [missing-attribute]
                 _ = x.to_mesh(sm1)
 
             a = torch.rand(3, 4, device="cuda")
 
-            # pyrefly: ignore [missing-attribute]
             b = a.slice_mesh(host=0)
             _ = b.to_mesh(sm0)
             _ = b.to_mesh(sm1)
@@ -288,7 +277,6 @@ class TestController:
                 subset = device_mesh.slice(**{dim: 1})
                 with subset.activate():
                     x = torch.rand(3, device="cuda")
-                    # pyrefly: ignore [missing-attribute]
                     y = x.to_mesh(device_mesh)
 
                 with subset.activate():
@@ -303,7 +291,6 @@ class TestController:
             subset = device_mesh.slice(host=1, gpu=1)
             with subset.activate():
                 x = torch.rand(3, device="cuda")
-                # pyrefly: ignore [missing-attribute]
                 y = x.to_mesh(device_mesh)
 
             with subset.activate():
@@ -407,7 +394,6 @@ class TestController:
             with ppmesh.activate():
                 with pp_meshes[0].activate():
                     x = torch.randn((3, 3), device="cuda")
-                    # pyrefly: ignore [bad-argument-type]
                     x_borrowed_tensor, x_borrow = p2p_stream.borrow(x)
                     with p2p_stream.activate():
                         y_on_mesh_1_p2p_stream = x_borrowed_tensor.to_mesh(pp_meshes[1])
@@ -424,7 +410,6 @@ class TestController:
     def test_to_mesh_cow(self):
         with self.local_device_mesh(2, 2) as mesh:
             t = torch.zeros((), device="cuda")
-            # pyrefly: ignore [missing-attribute]
             t2 = t.to_mesh(mesh)
             t.add_(1)
             assert monarch.inspect(t2).item() == 0
@@ -436,7 +421,6 @@ class TestController:
             m0 = mesh.slice(host=0)
             m1 = mesh.slice(host=1)
             with m0.activate():
-                # pyrefly: ignore [missing-attribute]
                 t2 = torch.rand(3, 4, device="cuda").to_mesh(m1, stream=other)
             with m1.activate(), other.activate():
                 # assert doesn't fail
@@ -446,7 +430,6 @@ class TestController:
         with self.local_device_mesh(2, 2) as _:
             x = torch.rand(4, 4).cuda()
             s = Stream("other")
-            # pyrefly: ignore [bad-argument-type]
             b, drop = s.borrow(x)
             drop.drop()
             with s.activate():
@@ -492,13 +475,11 @@ class TestController:
                 r0 = torch.rand(1, device=device)
                 if device == "cuda":
                     for d in ("host", "gpu"):
-                        # pyrefly: ignore [missing-attribute]
                         r0 = r0.reduce(d, reduction="stack")
                 monarch.random.set_state(s3)
                 r1 = torch.rand(1, device=device)
                 if device == "cuda":
                     for d in ("host", "gpu"):
-                        # pyrefly: ignore [missing-attribute]
                         r1 = r1.reduce(d, reduction="stack")
                 r2, r3 = monarch.inspect((r0, r1))
                 monarch.random.set_state(a)

--- a/python/tests/test_debugger.py
+++ b/python/tests/test_debugger.py
@@ -949,7 +949,6 @@ async def test_debug_cli():
                 assert (
                     breakpoints[i].function == "test_debugger._debugee_actor_internal"
                 )
-                # pyrefly: ignore [unsupported-operation]
                 assert breakpoints[i].lineno == initial_linenos[i] + 2
             else:
                 assert (

--- a/python/tests/test_grad_generator.py
+++ b/python/tests/test_grad_generator.py
@@ -26,7 +26,6 @@ class TestGradIter(TestCase):
         a, b = torch.std_mean(t + t2)
 
         r2 = torch.autograd.grad([a, b], [t2, t], retain_graph=True)
-        # pyrefly: ignore [missing-argument]
         r = list(GradientGenerator([a, b], [t2, t]))
         print(a, b)
         print(a.grad_fn, b.grad_fn)
@@ -61,7 +60,6 @@ class TestGradIter(TestCase):
         cgrads = torch.autograd.grad(
             [loss], [t, w3, w6, u, w2, w5], allow_unused=True, retain_graph=True
         )
-        # pyrefly: ignore [missing-argument]
         gi = GradientGenerator([loss], [t, w3, w6, u, w2, w5])
         grads = [*gi]
         self.checkEqual(grads, cgrads)
@@ -83,7 +81,6 @@ class TestGradIter(TestCase):
         t11 = t10.sum()
 
         cgrads = torch.autograd.grad([t11], [t2, t], retain_graph=True)
-        # pyrefly: ignore [missing-argument]
         gi = GradientGenerator([t11], [t2, t])
         grads = [*gi]
         self.checkEqual(grads, cgrads)
@@ -95,7 +92,6 @@ class TestGradIter(TestCase):
 
         r = (t * t3).sum()
         cgrads = torch.autograd.grad([r], [t, t2], retain_graph=True)
-        # pyrefly: ignore [missing-argument]
         gi = GradientGenerator([r], [t, t2])
         grads = [*gi]
         self.checkEqual(grads, cgrads)

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -1442,9 +1442,7 @@ def test_train_script_job_state_batch():
         job = LocalJob(("batch_launched_hosts",))
         job.apply(client_script=train_script)
         status = job.process.wait()
-        # pyrefly: ignore [no-matching-overload]
         stdout = open(os.path.join(job._log_dir, "stdout.log"), "r").read()
-        # pyrefly: ignore [no-matching-overload]
         stderr = open(os.path.join(job._log_dir, "stderr.log"), "r").read()
         assert status == 0, f"Job failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
         assert "batch_launched_hosts True" in stdout

--- a/python/tests/test_mock_cuda.py
+++ b/python/tests/test_mock_cuda.py
@@ -63,23 +63,19 @@ class TestMockCuda(TestCase):
 
     @unittest.skip("Disabled due to older version of driver")
     def test_turn_mock_on_and_off(self):
-        # pyrefly: ignore [not-iterable]
         cpu_y, cpu_dw, cpu_db = simple_forward_backward("cpu")
 
-        # pyrefly: ignore [not-iterable]
         real_y, real_dw, real_db = simple_forward_backward("cuda")
         self.assertTrue(torch.allclose(cpu_y, real_y.cpu()))
         self.assertTrue(torch.allclose(cpu_dw, real_dw.cpu()))
         self.assertTrue(torch.allclose(cpu_db, real_db.cpu()))
 
         with mock_cuda().mock_cuda_guard():
-            # pyrefly: ignore [not-iterable]
             mocked_y, mocked_dw, mocked_db = simple_forward_backward("cuda")
             self.assertFalse(torch.allclose(cpu_y, mocked_y.cpu()))
             self.assertFalse(torch.allclose(cpu_dw, mocked_dw.cpu()))
             self.assertFalse(torch.allclose(cpu_db, mocked_db.cpu()))
 
-        # pyrefly: ignore [not-iterable]
         real_y, real_dw, real_db = simple_forward_backward("cuda")
         self.assertTrue(torch.allclose(cpu_y, real_y.cpu()))
         self.assertTrue(torch.allclose(cpu_dw, real_dw.cpu()))

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1544,7 +1544,6 @@ def test_simple_bootstrap():
             procs.append(proc)
             workers.append(addr)
 
-        # pyrefly: ignore [bad-argument-type]
         hosts = attach_to_workers(ca="trust_all_connections", workers=workers)
 
         hello = hosts.spawn_procs().spawn("hello", Hello)
@@ -1629,7 +1628,6 @@ def test_config_propagates_to_host_agent():
             procs.append(proc)
             workers.append(addr)
 
-        # pyrefly: ignore [bad-argument-type]
         hosts = attach_to_workers(ca="trust_all_connections", workers=workers)
 
         # _spawn_admin() spawns MeshAdminAgent on the caller's local
@@ -1685,7 +1683,6 @@ def test_fd_bootstrap():
         # The client connects to the real port, not the fd syntax.
         workers.append(f"tcp://127.0.0.1:{port}")
 
-    # pyrefly: ignore [bad-argument-type]
     hosts = attach_to_workers(ca="trust_all_connections", workers=workers)
     hello = hosts.spawn_procs().spawn("hello", Hello)
 
@@ -1888,7 +1885,6 @@ def test_instance_name():
     logs.logger.error("HUH")
     assert "actor=<root>" in logs.contents
     try:
-        # pyrefly: ignore [bad-assignment]
         monarch.actor.config.prefix_python_logs_with_actor = False
         logs = CaptureLogs()
         logs.logger.error("HUH")

--- a/python/tests/test_rdma.py
+++ b/python/tests/test_rdma.py
@@ -88,24 +88,20 @@ def test_host_memory_handle_read_write():
     handle = _make_local_memory_handle(data)
 
     # read_at
-    # pyrefly: ignore [missing-attribute]
     result = handle.read_at(1, 3)
     assert list(result) == [2, 3, 4]
 
     # write_at
-    # pyrefly: ignore [missing-attribute]
     handle.write_at(0, bytes([10, 20]))
     assert data[0].item() == 10
     assert data[1].item() == 20
 
     # out-of-bounds read
     with pytest.raises(RuntimeError):
-        # pyrefly: ignore [missing-attribute]
         handle.read_at(3, 5)
 
     # out-of-bounds write
     with pytest.raises(RuntimeError):
-        # pyrefly: ignore [missing-attribute]
         handle.write_at(4, bytes([1, 2, 3]))
 
 
@@ -118,25 +114,20 @@ def test_device_memory_handle_read_write():
     handle = _make_local_memory_handle(data)
 
     # read_at
-    # pyrefly: ignore [missing-attribute]
     result = handle.read_at(1, 3)
     assert list(result) == [20, 30, 40]
 
     # write_at
-    # pyrefly: ignore [missing-attribute]
     handle.write_at(0, bytes([99, 88]))
-    # pyrefly: ignore [missing-attribute]
     readback = handle.read_at(0, 5)
     assert list(readback) == [99, 88, 30, 40, 50]
 
     # out-of-bounds read
     with pytest.raises(RuntimeError):
-        # pyrefly: ignore [missing-attribute]
         handle.read_at(3, 5)
 
     # out-of-bounds write
     with pytest.raises(RuntimeError):
-        # pyrefly: ignore [missing-attribute]
         handle.write_at(4, bytes([1, 2, 3]))
 
 
@@ -316,7 +307,6 @@ async def test_rdma_buffer_drop():
         @endpoint
         async def drop_buffer(self) -> None:
             """Drop an RDMABuffer"""
-            # pyrefly: ignore [missing-attribute]
             await self.buffer.drop()
             # Dropping the buffer means that the RDMA manager no longer
             # forcibly keeps the allocation alive, but as long as the original
@@ -569,7 +559,6 @@ async def test_rdma_concurrent_2gb_writes_in_order():
         @endpoint
         async def drop_buffer(self) -> None:
             """Drop an RDMABuffer"""
-            # pyrefly: ignore [missing-attribute]
             await self.rdma_buffer.drop()
 
         @endpoint
@@ -684,7 +673,7 @@ class ClientActor(Actor):
         self.data_b = torch.zeros(size, dtype=torch.float32)
         self.data_c = torch.zeros(size, dtype=torch.float32)
         self.action = None
-        # pyrefly: ignore [bad-assignment, bad-override]
+        # pyrefly: ignore [bad-assignment]
         self.size = size
 
     @endpoint

--- a/python/tests/test_rdma_unit.py
+++ b/python/tests/test_rdma_unit.py
@@ -523,7 +523,6 @@ async def _do_test(func, dtype, data_getter, controller_device, receiver_device)
         controller_device=controller_device,
         receiver_device=receiver_device,
         data_getter=partial(data_getter, device=controller_device, dtype=dtype),
-        # pyrefly: ignore [bad-argument-type]
         receiver_actor=None,
     )
     error = await func(controller)

--- a/python/tests/test_remote_functions.py
+++ b/python/tests/test_remote_functions.py
@@ -100,7 +100,6 @@ outer_remote_function_that_calls_inner = remote(
 
 @pytest.fixture(scope="module", autouse=True)
 def testing_context():
-    # pyrefly: ignore [unknown-name]
     global local
     with TestingContext() as local:
         yield
@@ -198,7 +197,6 @@ class TestRemoteFunctions(RemoteFunctionsTestBase):
             # z is broken on rank 1 but not others
             z = do_bogus_tensor_work(x, y, fail_rank=1)
             # test that rank 1 is still doing work despite z failing
-            # pyrefly: ignore [missing-attribute]
             a = (x + y).reduce("gpu")
             fetch_shard(a).result()
             # but z itself should fail, even if we do not fetch it from rank 1
@@ -226,7 +224,6 @@ class TestRemoteFunctions(RemoteFunctionsTestBase):
             # the wait on 'other'.
             other = Stream("other")
             t = new_barrier_hackery(2)
-            # pyrefly: ignore [bad-argument-type]
             t_other, borrow = other.borrow(t)
             with borrow:
                 with other.activate():
@@ -264,7 +261,6 @@ class TestRemoteFunctions(RemoteFunctionsTestBase):
             assert (
                 "an argument processed"
                 == call_on_shard_and_fetch(
-                    # pyrefly: ignore [bad-argument-type]
                     remote("monarch.worker._testing_function.do_some_processing"),
                     "an argument",
                 ).result()
@@ -324,11 +320,8 @@ class TestRemoteFunctions(RemoteFunctionsTestBase):
 
         assert torch.equal(local_0_f, torch.full_like(local_0_f, 2))
         assert torch.equal(local_0, torch.ones_like(local_0))
-        # pyrefly: ignore [bad-argument-type]
         assert torch.equal(grad_local_0, torch.ones_like(local_0))
-        # pyrefly: ignore [bad-argument-type]
         assert torch.equal(grad_local_1, torch.ones_like(local_0))
-        # pyrefly: ignore [bad-argument-type]
         assert torch.equal(grad_local_1_f, torch.ones_like(local_0))
 
     def test_cached_remote_aliases(self):
@@ -365,7 +358,6 @@ class TestRemoteFunctions(RemoteFunctionsTestBase):
 
         with self.local_device_mesh(2, 2):
             a = torch.ones(())
-            # pyrefly: ignore [bad-argument-type]
             assert call_on_shard_and_fetch(check, bar(a, a)).result()
             # ensure we do not attempt to pickle closures
             close()
@@ -409,7 +401,6 @@ class TestRemoteFunctions(RemoteFunctionsTestBase):
 
         with self.local_device_mesh(1, 1):
             # This should be a valid return than an exception to raise
-            # pyrefly: ignore [bad-argument-type]
             call_on_shard_and_fetch(simple).result()
 
     def test_opaque_object(self):
@@ -426,9 +417,7 @@ class TestRemoteFunctions(RemoteFunctionsTestBase):
             with monarch.no_mesh.activate():
                 assert torch.allclose(torch.full((3, 4), 5.0), result)
 
-            # pyrefly: ignore [missing-attribute]
             f.hi = 4
-            # pyrefly: ignore [missing-attribute]
             assert f.hi == 4
 
     def test_opaqueRef_key_deleted(self):
@@ -472,11 +461,8 @@ class TestRemoteFunctions(RemoteFunctionsTestBase):
             ig1, wg1, bg1 = monarch.inspect((input_.grad, weight.grad, bias.grad))
 
             with monarch.no_mesh.activate():
-                # pyrefly: ignore [bad-argument-type]
                 assert torch.allclose(ig0, ig1)
-                # pyrefly: ignore [bad-argument-type]
                 assert torch.allclose(wg0, wg1)
-                # pyrefly: ignore [bad-argument-type]
                 assert torch.allclose(bg0, bg1)
 
     def test_remote_function_failure_message_contains_traceback(self):
@@ -508,13 +494,11 @@ def return_them(x: torch.Tensor, y: torch.Tensor) -> Tuple[torch.Tensor, torch.T
 )
 class TestMeshSpecific(RemoteFunctionsTestBase):
     def test_value_mesh(self):
-        # pyrefly: ignore [bad-argument-type]
         with self.local_device_mesh(2, 2, "mesh") as device_mesh:
             x = device_mesh.rank("host")
             y = device_mesh.rank("gpu")
             r = return_them.call(x, y).get()
 
-        # pyrefly: ignore [not-iterable]
         for p, (h, g) in r:
             assert p["host"] == h.item()
             assert p["gpu"] == g.item()

--- a/python/tests/test_supervision_hierarchy.py
+++ b/python/tests/test_supervision_hierarchy.py
@@ -35,7 +35,6 @@ class Nest(Actor):
 
     @endpoint
     def nested(self, func: Callable[[], T]) -> T:
-        # pyrefly: ignore [bad-return]
         return self.nest.run.broadcast(func)
 
     @endpoint
@@ -78,7 +77,6 @@ class FaultCapture:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.failure_happened.wait(timeout=30)
-        # pyrefly: ignore [bad-assignment]
         monarch.actor.unhandled_fault_hook = self.original_hook
 
     def capture_fault(self, failure: MeshFailure) -> None:


### PR DESCRIPTION
Summary:
This diff was automatically generated by the Pyre per-target upgrade tool.

It removes `# pyre-fixme` or `pyrefly: ignore` comments that are no longer needed because the underlying type errors have been resolved.
Note that it will also aim to ensure type checking runs cleanly, and will add suppressions to existing type errors.

#pyreupgrade

Differential Revision: D116325132
