### PR TITLE
Add typed host service identity APIs (#4686)

### DIFF
--- a/docs/source/books/hyperactor-book/src/procs/host.md
+++ b/docs/source/books/hyperactor-book/src/procs/host.md
@@ -47,12 +47,11 @@ registered peer sender.
 gateway, so they reach each other—and the host reaches them—through the
 gateway's local `procs` table, with zero dialing.
 
-Their ids are *legacy pseudo-singletons*: literally the names `"service"` and
-`"local"`, identical across every host. A gateway can hold at most one proc per
-id, so a gateway can host at most one `service`/`local` pair—i.e. at most one
-host. `Host::new` uses `Gateway::global()`; callers that need more than one
-host in the same process, or need a pre-attached gateway, must use
-`Host::new_with_gateway`.
+`local_proc` always has a fresh instance id labeled `"local"`. Launchers can
+also give `service_proc` a fresh instance id labeled `"service"` through
+`Host::new_with_gateway`. The default remains the legacy `"service"`
+pseudo-singleton for compatibility. A gateway can contain multiple hosts only
+when each host has a distinct service proc id.
 
 ## Spawned children
 
@@ -79,8 +78,14 @@ let backend_addr = gateway.default_location().addr().clone();
 let frontend_handle = gateway.serve_with_listener(addr, listener)?;
 let frontend_addr = gateway.default_location().addr().clone();
 
-let service_proc = Proc::legacy_service_pseudo_singleton_on_gateway(gateway.clone());
-let local_proc = Proc::legacy_local_pseudo_singleton_on_gateway(gateway.clone());
+let service_proc = Proc::builder()
+    .proc_id(service_proc_id)
+    .shared_gateway(gateway.clone())
+    .build()?;
+let local_proc = Proc::builder()
+    .proc_id(ProcId::instance(Label::strip("local")))
+    .shared_gateway(gateway.clone())
+    .build()?;
 ```
 
 The backend address is passed to each child as its fallback route back to the
@@ -94,9 +99,9 @@ the frontend serve becomes the default location until a newer serve replaces it.
 
 ## Local proc invariant (LP-1)
 
-The local proc always exists as the singleton proc id `"local"` on the host
-gateway and is forwarded in-process, but it starts with zero actors. A
-`ProcAgent` and root client actor are added only when
+The local proc always exists as an instance proc with the label `"local"` on
+the host gateway and is routed through the gateway's local proc table, but it
+starts with zero actors. A `ProcAgent` and root client actor are added only when
 `HostMeshAgent::handle(GetLocalProc)` is first called.
 
 ## See Also

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -2578,7 +2578,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_gateway_serve_via_delivers_peeled_legacy_local_proc_destination() {
+    async fn test_gateway_serve_via_delivers_peeled_instance_proc_destination() {
         let server_gw = Gateway::new();
         let mut accept_handle = server_gw
             .serve_duplex(ChannelAddr::any(ChannelTransport::Unix))
@@ -2587,7 +2587,11 @@ mod tests {
 
         let client_gw = Gateway::new();
         let mut serve_via = client_gw.serve_via(server_addr).await.unwrap();
-        let client_proc = Proc::legacy_local_pseudo_singleton_on_gateway(client_gw.clone());
+        let client_proc = Proc::builder()
+            .proc_id(ProcId::anonymous())
+            .shared_gateway(client_gw.clone())
+            .build()
+            .unwrap();
         let client = client_proc.client("recv");
         let (port, mut rx) = client.bind_handler_port::<u64>();
         let PortLocation::Bound(via_dest) = port.location() else {
@@ -2670,7 +2674,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_gateway_serve_via_relay_delivers_to_client_legacy_local_proc() {
+    async fn test_gateway_serve_via_relay_delivers_to_client_instance_proc() {
         let relay_gw = Gateway::new();
         let mut accept_handle = relay_gw
             .serve_duplex(ChannelAddr::any(ChannelTransport::Unix))
@@ -2679,7 +2683,11 @@ mod tests {
 
         let client_gw = Gateway::new();
         let mut serve_via = client_gw.serve_via(relay_addr.clone()).await.unwrap();
-        let client_proc = Proc::legacy_local_pseudo_singleton_on_gateway(client_gw.clone());
+        let client_proc = Proc::builder()
+            .proc_id(ProcId::anonymous())
+            .shared_gateway(client_gw.clone())
+            .build()
+            .unwrap();
         let client = client_proc.client("recv");
         let (port, mut rx) = client.bind_handler_port::<u64>();
         let PortLocation::Bound(via_dest) = port.location() else {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -221,12 +221,6 @@ tokio::task_local! {
     static CURRENT_TASK_PROC: Proc;
 }
 
-/// Legacy singleton proc name used for host-local client actors.
-///
-/// This is not a true singleton: every host may have a `local` proc, so local
-/// delivery must compare both proc id and location for this id.
-pub const LEGACY_LOCAL_PROC_NAME: &str = "local";
-
 /// Legacy singleton proc name used for host system actors.
 ///
 /// This is not a true singleton: every host may have a `service` proc, so
@@ -883,12 +877,6 @@ impl Proc {
         Self::from_parts_unchecked(proc_id, gateway)
     }
 
-    /// Create the legacy host-local client proc pseudo-singleton on
-    /// a fresh gateway whose forwarder is `forwarder`.
-    pub fn legacy_local_pseudo_singleton(addr: ChannelAddr, forwarder: BoxedMailboxSender) -> Self {
-        Self::legacy_local_pseudo_singleton_on_gateway(Gateway::configured(addr.into(), forwarder))
-    }
-
     /// Create the legacy host system proc pseudo-singleton on a
     /// fresh gateway whose forwarder is `forwarder`.
     pub fn legacy_service_pseudo_singleton(
@@ -899,12 +887,6 @@ impl Proc {
             addr.into(),
             forwarder,
         ))
-    }
-
-    /// Create the legacy host-local client proc pseudo-singleton on
-    /// the provided shared gateway.
-    pub fn legacy_local_pseudo_singleton_on_gateway(gateway: Gateway) -> Self {
-        Self::legacy_pseudo_singleton_on_gateway(LEGACY_LOCAL_PROC_NAME, gateway)
     }
 
     /// Create the legacy host system proc pseudo-singleton on the
@@ -1838,10 +1820,9 @@ impl Proc {
 
 fn requires_location_for_local_delivery_identity(proc_id: &ProcId) -> bool {
     // Temporary hyperactor_mesh compatibility hack: host bootstrap
-    // still creates a `service` proc and a `local` proc in every host
-    // process, so those proc ids are not globally unique. Until those
-    // construction paths are assigned instance ids, local delivery for
-    // those two ids also compares the terminal channel address.
+    // still creates a `service` proc in every host process, so that proc id
+    // is not globally unique. Until all construction paths assign it an
+    // instance id, local delivery also compares the terminal channel address.
     is_legacy_pseudo_singleton_proc_id(proc_id)
 }
 
@@ -1882,10 +1863,7 @@ fn is_legacy_pseudo_singleton_proc_id(proc_id: &ProcId) -> bool {
 }
 
 fn is_legacy_pseudo_singleton_label(label: &Label) -> bool {
-    matches!(
-        label.as_str(),
-        LEGACY_SERVICE_PROC_NAME | LEGACY_LOCAL_PROC_NAME
-    )
+    label.as_str() == LEGACY_SERVICE_PROC_NAME
 }
 
 #[async_trait]
@@ -5880,26 +5858,18 @@ mod tests {
     }
 
     #[test]
-    fn test_local_delivery_service_and_local_compare_full_proc_addr() {
-        for name in [LEGACY_SERVICE_PROC_NAME, LEGACY_LOCAL_PROC_NAME] {
-            let local = ProcAddr::singleton(ChannelAddr::Local(1), name);
-            let same_id_other_location = ProcAddr::singleton(ChannelAddr::Local(2), name);
-            let proc = match name {
-                LEGACY_SERVICE_PROC_NAME => Proc::legacy_service_pseudo_singleton(
-                    ChannelAddr::Local(1),
-                    BoxedMailboxSender::new(PanickingMailboxSender),
-                ),
-                LEGACY_LOCAL_PROC_NAME => Proc::legacy_local_pseudo_singleton(
-                    ChannelAddr::Local(1),
-                    BoxedMailboxSender::new(PanickingMailboxSender),
-                ),
-                _ => unreachable!("test only covers legacy pseudo-singletons"),
-            };
+    fn test_local_delivery_legacy_service_compares_full_proc_addr() {
+        let local = ProcAddr::singleton(ChannelAddr::Local(1), LEGACY_SERVICE_PROC_NAME);
+        let same_id_other_location =
+            ProcAddr::singleton(ChannelAddr::Local(2), LEGACY_SERVICE_PROC_NAME);
+        let proc = Proc::legacy_service_pseudo_singleton(
+            ChannelAddr::Local(1),
+            BoxedMailboxSender::new(PanickingMailboxSender),
+        );
 
-            assert_eq!(local.id(), same_id_other_location.id());
-            assert!(proc.is_local_delivery_target(&local));
-            assert!(!proc.is_local_delivery_target(&same_id_other_location));
-        }
+        assert_eq!(local.id(), same_id_other_location.id());
+        assert!(proc.is_local_delivery_target(&local));
+        assert!(!proc.is_local_delivery_target(&same_id_other_location));
 
         let shared = ProcAddr::singleton(ChannelAddr::Local(1), "shared");
         let shared_other_location = ProcAddr::singleton(ChannelAddr::Local(2), "shared");
@@ -5920,16 +5890,14 @@ mod tests {
     }
 
     #[test]
-    fn test_legacy_pseudo_singletons_use_dedicated_constructors() {
-        for name in [LEGACY_SERVICE_PROC_NAME, LEGACY_LOCAL_PROC_NAME] {
-            let result = std::panic::catch_unwind(|| {
-                Proc::configured(
-                    ProcAddr::singleton(ChannelAddr::Local(1), name),
-                    BoxedMailboxSender::new(PanickingMailboxSender),
-                );
-            });
-            assert!(result.is_err());
-        }
+    fn test_legacy_service_pseudo_singleton_uses_dedicated_constructor() {
+        let result = std::panic::catch_unwind(|| {
+            Proc::configured(
+                ProcAddr::singleton(ChannelAddr::Local(1), LEGACY_SERVICE_PROC_NAME),
+                BoxedMailboxSender::new(PanickingMailboxSender),
+            );
+        });
+        assert!(result.is_err());
 
         let service = Proc::legacy_service_pseudo_singleton(
             ChannelAddr::Local(1),
@@ -5938,15 +5906,6 @@ mod tests {
         assert_eq!(
             service.proc_addr().id().uid().to_string(),
             LEGACY_SERVICE_PROC_NAME
-        );
-
-        let local = Proc::legacy_local_pseudo_singleton(
-            ChannelAddr::Local(2),
-            BoxedMailboxSender::new(PanickingMailboxSender),
-        );
-        assert_eq!(
-            local.proc_addr().id().uid().to_string(),
-            LEGACY_LOCAL_PROC_NAME
         );
     }
 

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -81,6 +81,7 @@ use crate::host::SingleTerminate;
 use crate::host::TerminateError;
 use crate::host::TerminateSummary;
 use crate::host::WaitError;
+use crate::host::legacy_service_proc_id;
 use crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
 use crate::host_mesh::host_agent::HostAgent;
 use crate::logging::OutputTarget;
@@ -299,7 +300,9 @@ impl DrainedHostShutdown {
 /// - `shutdown_handle` joins the host's accept loop and runs the
 ///   drain protocol; see [`HostShutdownHandle`].
 ///
-/// - `addr`: the listening address of the host; this is used for the frontend server.
+/// - `addr`: the service proc identity and direct host frontend listening
+///   address. The gateway remints the proc's final location after binding and
+///   optional `via` attachment; a source-routed input location is rejected.
 /// - `command`: optional bootstrap command to spawn procs, otherwise [`BootstrapProcManager::current`].
 /// - `config`: optional runtime config overlay.
 /// - `exit_on_shutdown`: if true, [`HostShutdownHandle::join`] will call `process::exit` after draining.
@@ -311,7 +314,7 @@ impl DrainedHostShutdown {
 ///   before any ref is minted — so refs advertise the routable `Via`
 ///   location (used by out-of-cluster clients).
 pub async fn host(
-    addr: ChannelAddr,
+    addr: ProcAddr,
     command: Option<BootstrapCommand>,
     config: Option<Attrs>,
     exit_on_shutdown: bool,
@@ -590,9 +593,9 @@ impl Bootstrap {
                 let (serve_addr, _) = local_proc_addr(&socket_dir_path, proc_id.id())?;
 
                 // The following is a modified host::spawn_proc to support direct
-                // dialing between local procs: 1) we bind each proc to a deterministic
-                // address in socket_dir_path; 2) we use LocalProcDialer to dial these
-                // addresses for local procs.
+                // dialing between spawned sibling procs: 1) we bind each proc to a
+                // deterministic address in socket_dir_path; 2) we use LocalProcDialer
+                // to dial those addresses directly.
                 let proc_sender = mailbox::LocalProcDialer::new(
                     local_addr.clone(),
                     socket_dir_path,
@@ -636,7 +639,7 @@ impl Bootstrap {
                 exit_on_shutdown,
             } => {
                 let (_agent_handle, shutdown) = host(
-                    addr,
+                    ProcAddr::new(legacy_service_proc_id(), addr.into()),
                     command,
                     config,
                     exit_on_shutdown,
@@ -3458,7 +3461,10 @@ mod tests {
         let temp_instance = temp_proc.client("temp");
 
         let handle = host(
-            ChannelAddr::any(ChannelTransport::Unix),
+            ProcAddr::new(
+                legacy_service_proc_id(),
+                ChannelAddr::any(ChannelTransport::Unix).into(),
+            ),
             Some(BootstrapCommand::test()),
             None,
             false,

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -26,21 +26,24 @@ use hyperactor::mailbox::TransportFailureReason;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::mailbox::UndeliverableReason;
 
-/// LocalProcDialer dials local procs directly through a configured socket
-/// directory.
+/// Dials local procs directly through a configured socket directory.
+///
+/// A same-host destination is direct-dialable when its deterministic socket
+/// exists in `socket_dir`. Other destinations are routed through the backend
+/// sender to the host gateway.
 #[derive(Debug)]
 pub(crate) struct LocalProcDialer {
     local_addr: ChannelAddr,
     socket_dir: PathBuf,
     backend_sender: MailboxClient,
-    local_senders: RwLock<HashMap<Uid, Result<MailboxClient, ChannelError>>>,
+    local_senders: RwLock<HashMap<Uid, MailboxClient>>,
 }
 
 impl LocalProcDialer {
-    /// Create a new local proc dialer. Any direct-addressed procs with a destination
-    /// address of `local_addr`, will instead be dialed through the direct sockets
-    /// present in `socket_dir`. Messages to other procs are forwarded through the
-    /// backend sender.
+    /// Create a new local proc dialer. Procs with a destination address of
+    /// `local_addr` are dialed through direct sockets when present in
+    /// `socket_dir`. Messages to other procs are forwarded through the backend
+    /// sender.
     pub(crate) fn new(
         local_addr: ChannelAddr,
         socket_dir: PathBuf,
@@ -53,6 +56,22 @@ impl LocalProcDialer {
             local_senders: RwLock::new(HashMap::new()),
         }
     }
+
+    fn return_dial_failure(
+        error: &ChannelError,
+        envelope: MessageEnvelope,
+        return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+    ) {
+        let destination = envelope.dest().clone();
+        let failure = DeliveryFailure::new(UndeliverableReason::Transport(TransportFailure::new(
+            destination.clone(),
+            TransportFailureReason::DialFailed {
+                addr: destination.actor_addr().proc_addr().addr().clone(),
+                error: error.to_string(),
+            },
+        )));
+        envelope.undeliverable(failure, return_handle);
+    }
 }
 
 #[async_trait]
@@ -63,52 +82,43 @@ impl MailboxSender for LocalProcDialer {
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
         let proc_ref = envelope.dest().actor_addr().proc_addr();
-        let addr = proc_ref.addr();
-        if addr == &self.local_addr
-            // ...and only non-system procs on that address; the rest are directly
-            // reachable through the backend address.
-            && proc_ref.uid().is_instance()
-        {
-            let key = proc_ref.id().pseudo_uid();
-            let senders = self.local_senders.read().unwrap();
-            let senders = if senders.contains_key(&key) {
-                senders
-            } else {
-                drop(senders);
-                let mut senders = self.local_senders.write().unwrap();
-                senders.entry(key.clone()).or_insert_with(|| {
-                    let (addr, path) = super::local_proc_addr(&self.socket_dir, proc_ref.id())
-                        .map_err(|e| ChannelError::InvalidAddress(e.to_string()))?;
-                    if !path.exists() {
-                        return Err(ChannelError::InvalidAddress(format!(
-                            "unix socket path '{}' does not exist",
-                            path.display()
-                        )));
-                    }
-                    MailboxClient::dial(addr)
-                });
-                drop(senders);
-                self.local_senders.read().unwrap()
-            };
+        if proc_ref.uid().is_singleton() {
+            self.backend_sender.post_unchecked(envelope, return_handle);
+            return;
+        }
 
-            match senders.get(&key).unwrap() {
-                Ok(sender) => sender.post_unchecked(envelope, return_handle),
-                Err(e) => {
-                    let failure = DeliveryFailure::new(UndeliverableReason::Transport(
-                        TransportFailure::new(
-                            envelope.dest().clone(),
-                            TransportFailureReason::DialFailed {
-                                addr: addr.clone(),
-                                error: e.to_string(),
-                            },
-                        ),
-                    ));
-                    envelope.undeliverable(failure, return_handle);
+        let addr = proc_ref.addr();
+        if addr == &self.local_addr {
+            let key = proc_ref.id().pseudo_uid();
+            {
+                let senders = self.local_senders.read().unwrap();
+                if let Some(sender) = senders.get(&key) {
+                    sender.post_unchecked(envelope, return_handle);
+                    return;
                 }
             }
-        } else {
-            self.backend_sender.post_unchecked(envelope, return_handle);
+
+            // Host-owned service procs do not bind deterministic child sockets.
+            if let Ok((local_addr, path)) = super::local_proc_addr(&self.socket_dir, proc_ref.id())
+                && path.exists()
+            {
+                let mut senders = self.local_senders.write().unwrap();
+                if let Some(sender) = senders.get(&key) {
+                    sender.post_unchecked(envelope, return_handle);
+                    return;
+                }
+                match MailboxClient::dial(local_addr) {
+                    Ok(sender) => {
+                        sender.post_unchecked(envelope, return_handle);
+                        senders.insert(key, sender);
+                    }
+                    Err(error) => Self::return_dial_failure(&error, envelope, return_handle),
+                }
+                return;
+            }
         }
+
+        self.backend_sender.post_unchecked(envelope, return_handle);
     }
 
     async fn flush(&self) -> Result<(), anyhow::Error> {
@@ -122,167 +132,167 @@ impl MailboxSender for LocalProcDialer {
 
 #[cfg(test)]
 mod tests {
-
-    use std::assert_matches;
-
     use hyperactor::Mailbox;
     use hyperactor::channel::ChannelAddr;
+    use hyperactor::channel::ChannelRx;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::channel::Rx;
     use hyperactor::channel::{self};
+    use hyperactor::id::Label;
     use hyperactor::testing::ids::test_actor_id;
     use hyperactor_config::Flattrs;
 
     use super::*;
     use crate::bootstrap::local_proc_addr;
+    use crate::host::SERVICE_PROC_NAME;
+    use crate::host::legacy_service_proc_id;
     use crate::mesh_id::ResourceId;
 
+    fn recording_dialer(
+        local_addr: ChannelAddr,
+        socket_dir: PathBuf,
+    ) -> (LocalProcDialer, ChannelRx<MessageEnvelope>) {
+        let (backend_addr, backend_rx) =
+            channel::serve::<MessageEnvelope>(ChannelTransport::Unix.any()).unwrap();
+        let dialer = LocalProcDialer::new(
+            local_addr,
+            socket_dir,
+            MailboxClient::dial(backend_addr).unwrap(),
+        );
+        (dialer, backend_rx)
+    }
+
     #[tokio::test]
-    async fn test_proc_dialer() {
+    async fn test_proc_dialer_routes_between_local_proc_sockets_in_both_directions() {
         let dir = tempfile::tempdir().unwrap();
         let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
         let first = hyperactor::ProcAddr::instance(local_addr.clone(), "first");
         let second = hyperactor::ProcAddr::instance(local_addr.clone(), "second");
-        let third = hyperactor::ProcAddr::instance(local_addr.clone(), "third");
         let (first_serve, _) = local_proc_addr(dir.path(), first.id()).unwrap();
         let (_first_addr, mut first_rx) = channel::serve::<MessageEnvelope>(first_serve).unwrap();
         let (second_serve, _) = local_proc_addr(dir.path(), second.id()).unwrap();
-        let (_second_addr, _second_rx) = channel::serve::<MessageEnvelope>(second_serve).unwrap();
-        let (backend_addr, mut backend_rx) =
-            channel::serve::<MessageEnvelope>(ChannelTransport::Unix.any()).unwrap();
-
-        // The dialer derives the socket path from each proc's pseudo_uid, so
-        // both ends must share the same ProcId.
-        let first_actor_id = first.actor_addr("actor");
-        let second_actor_id = second.actor_addr("actor");
-        let third_notexist_actor_id = third.actor_addr("actor");
-        let proc_dialer = LocalProcDialer::new(
-            local_addr.clone(),
-            dir.path().to_owned(),
-            MailboxClient::dial(backend_addr).unwrap(),
-        );
-
-        let (return_handle, mut return_rx) = Mailbox::new(test_actor_id("world_0", "proc"))
-            .open_port::<Undeliverable<MessageEnvelope>>();
-
-        // Existing address on the host:
-        let envelope = MessageEnvelope::new(
-            third_notexist_actor_id.clone(),
-            first_actor_id.port_addr(0.into()),
-            wirevalue::Any::serialize(&()).unwrap(),
-            Flattrs::new(),
-        );
-        proc_dialer.post(envelope.clone(), return_handle.clone());
-        assert_eq!(
-            first_rx.recv().await.unwrap().sender(),
-            &third_notexist_actor_id
-        );
-
-        // Nonexistant address on the host:
-        let envelope = MessageEnvelope::new(
-            second_actor_id.clone(),
-            third_notexist_actor_id.port_addr(0.into()),
-            wirevalue::Any::serialize(&()).unwrap(),
-            Flattrs::new(),
-        );
-        proc_dialer.post(envelope.clone(), return_handle.clone());
-        let envelope = return_rx
-            .recv()
-            .await
-            .unwrap()
-            .into_message()
-            .expect("expected returned envelope");
-        assert_matches!(
-            envelope
-                .root_delivery_failure()
-                .map(|failure| &failure.kind),
-            Some(hyperactor::mailbox::DeliveryFailureKind::Undeliverable(
-                UndeliverableReason::Transport(_)
-            ))
-        );
-
-        // Outside the host:
-        let envelope = MessageEnvelope::new(
-            second_actor_id.clone(),
-            test_actor_id("external_0", "actor").port_addr(0.into()),
-            wirevalue::Any::serialize(&()).unwrap(),
-            Flattrs::new(),
-        );
-        proc_dialer.post(envelope.clone(), return_handle.clone());
-        assert_eq!(backend_rx.recv().await.unwrap().sender(), &second_actor_id);
-
-        // System proc on the host (name must be exactly "system"):
-        let system_actor_id =
-            ResourceId::proc_addr_from_name(local_addr.clone(), "system").actor_addr("actor");
-        let envelope = MessageEnvelope::new(
-            second_actor_id.clone(),
-            system_actor_id.port_addr(0.into()),
-            wirevalue::Any::serialize(&()).unwrap(),
-            Flattrs::new(),
-        );
-        proc_dialer.post(envelope.clone(), return_handle.clone());
-        assert_eq!(backend_rx.recv().await.unwrap().sender(), &second_actor_id);
-    }
-
-    /// Same-host proc-to-proc traffic must keep using the direct
-    /// local-socket path even when destinations carry a `Via(uid,
-    /// Addr(host_addr))` source-routing prefix (the convention
-    /// `Host::spawn` now applies to every spawned child). The
-    /// `Via` should not push the envelope onto the slower backend
-    /// sender path.
-    #[tokio::test]
-    async fn test_proc_dialer_via_prefixed_dest() {
-        use hyperactor::Location;
-
-        let dir = tempfile::tempdir().unwrap();
-        let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
-
-        // Build two sibling procs with the via-prefixed location
-        // convention used by `Host::spawn`.
-        let make_proc = |name: &str| -> hyperactor::ProcAddr {
-            let bare = hyperactor::ProcAddr::instance(local_addr.clone(), name);
-            let via = Location::from(local_addr.clone()).with_via(bare.id().uid().clone());
-            hyperactor::ProcAddr::new(bare.id().clone(), via)
-        };
-        let first = make_proc("first");
-        let second = make_proc("second");
-        assert!(
-            first.location().as_via().is_some(),
-            "test setup: spawned-proc address must carry a via prefix"
-        );
-
-        let (first_serve, _) = local_proc_addr(dir.path(), first.id()).unwrap();
-        let (_first_addr, mut first_rx) = channel::serve::<MessageEnvelope>(first_serve).unwrap();
-
-        let (backend_addr, mut backend_rx) =
-            channel::serve::<MessageEnvelope>(ChannelTransport::Unix.any()).unwrap();
+        let (_second_addr, mut second_rx) =
+            channel::serve::<MessageEnvelope>(second_serve).unwrap();
+        let (proc_dialer, _backend_rx) =
+            recording_dialer(local_addr.clone(), dir.path().to_owned());
 
         let first_actor_id = first.actor_addr("actor");
         let second_actor_id = second.actor_addr("actor");
-        let proc_dialer = LocalProcDialer::new(
-            local_addr.clone(),
-            dir.path().to_owned(),
-            MailboxClient::dial(backend_addr).unwrap(),
-        );
         let (return_handle, _return_rx) = Mailbox::new(test_actor_id("world_0", "proc"))
             .open_port::<Undeliverable<MessageEnvelope>>();
 
-        // `second` → `first`, both via-prefixed. Expect the
-        // envelope on `first`'s local socket (direct path), not on
-        // the backend.
         let envelope = MessageEnvelope::new(
-            second_actor_id.clone(),
-            first_actor_id.port_addr(0.into()),
+            first_actor_id.clone(),
+            second_actor_id.port_addr(0.into()),
             wirevalue::Any::serialize(&()).unwrap(),
             Flattrs::new(),
         );
         proc_dialer.post(envelope, return_handle.clone());
-        assert_eq!(first_rx.recv().await.unwrap().sender(), &second_actor_id);
-        assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(50), backend_rx.recv())
-                .await
-                .is_err(),
-            "via-prefixed sibling traffic must not detour through the backend",
+        assert_eq!(second_rx.recv().await.unwrap().sender(), &first_actor_id);
+
+        let first_via = hyperactor::ProcAddr::new(
+            first.id().clone(),
+            hyperactor::Location::from(local_addr.clone()).with_via(first.id().uid().clone()),
         );
+        let envelope = MessageEnvelope::new(
+            second_actor_id.clone(),
+            first_via.actor_addr("actor").port_addr(0.into()),
+            wirevalue::Any::serialize(&()).unwrap(),
+            Flattrs::new(),
+        );
+        proc_dialer.post(envelope, return_handle);
+        assert_eq!(first_rx.recv().await.unwrap().sender(), &second_actor_id);
+    }
+
+    #[tokio::test]
+    async fn test_proc_dialer_routes_both_service_id_forms_through_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
+        let sender = hyperactor::ProcAddr::instance(local_addr.clone(), "sender");
+        let (proc_dialer, mut backend_rx) =
+            recording_dialer(local_addr.clone(), dir.path().to_owned());
+        let (return_handle, _return_rx) = Mailbox::new(test_actor_id("world_0", "proc"))
+            .open_port::<Undeliverable<MessageEnvelope>>();
+
+        let service_proc_ids = [
+            legacy_service_proc_id(),
+            hyperactor::ProcId::instance(Label::strip(SERVICE_PROC_NAME)),
+        ];
+        for service_proc_id in service_proc_ids {
+            let service_proc =
+                hyperactor::ProcAddr::new(service_proc_id, local_addr.clone().into());
+
+            let envelope = MessageEnvelope::new(
+                sender.actor_addr("actor"),
+                service_proc.actor_addr("actor").port_addr(0.into()),
+                wirevalue::Any::serialize(&()).unwrap(),
+                Flattrs::new(),
+            );
+            proc_dialer.post(envelope, return_handle.clone());
+
+            let forwarded = backend_rx.recv().await.unwrap();
+            assert_eq!(forwarded.dest().actor_addr().proc_addr(), service_proc);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_proc_dialer_routes_singletons_through_backend_when_socket_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
+        let sender = hyperactor::ProcAddr::instance(local_addr.clone(), "sender");
+        let singleton =
+            hyperactor::ProcAddr::new(legacy_service_proc_id(), local_addr.clone().into());
+        let (singleton_addr, _) = local_proc_addr(dir.path(), singleton.id()).unwrap();
+        let (_singleton_addr, _singleton_rx) =
+            channel::serve::<MessageEnvelope>(singleton_addr).unwrap();
+        let (proc_dialer, mut backend_rx) = recording_dialer(local_addr, dir.path().to_owned());
+        let (return_handle, _return_rx) = Mailbox::new(test_actor_id("world_0", "proc"))
+            .open_port::<Undeliverable<MessageEnvelope>>();
+
+        let envelope = MessageEnvelope::new(
+            sender.actor_addr("actor"),
+            singleton.actor_addr("actor").port_addr(0.into()),
+            wirevalue::Any::serialize(&()).unwrap(),
+            Flattrs::new(),
+        );
+        proc_dialer.post(envelope, return_handle);
+
+        let forwarded = backend_rx.recv().await.unwrap();
+        assert_eq!(forwarded.dest().actor_addr().proc_addr(), singleton);
+    }
+
+    #[tokio::test]
+    async fn test_proc_dialer_uses_backend_for_missing_or_remote_proc() {
+        let dir = tempfile::tempdir().unwrap();
+        let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
+        let sender = hyperactor::ProcAddr::instance(local_addr.clone(), "sender");
+        let missing = hyperactor::ProcAddr::instance(local_addr.clone(), "missing");
+        let (proc_dialer, mut backend_rx) = recording_dialer(local_addr, dir.path().to_owned());
+        let (return_handle, _return_rx) = Mailbox::new(test_actor_id("world_0", "proc"))
+            .open_port::<Undeliverable<MessageEnvelope>>();
+
+        let envelope = MessageEnvelope::new(
+            sender.actor_addr("actor"),
+            missing.actor_addr("actor").port_addr(0.into()),
+            wirevalue::Any::serialize(&()).unwrap(),
+            Flattrs::new(),
+        );
+        proc_dialer.post(envelope, return_handle.clone());
+        let forwarded = backend_rx.recv().await.unwrap();
+        assert_eq!(forwarded.dest().actor_addr().proc_addr(), missing);
+
+        let remote = ResourceId::proc_addr_from_name(
+            "tcp:4.5.6.7:456".parse::<ChannelAddr>().unwrap(),
+            "remote",
+        );
+        let envelope = MessageEnvelope::new(
+            sender.actor_addr("actor"),
+            remote.actor_addr("actor").port_addr(0.into()),
+            wirevalue::Any::serialize(&()).unwrap(),
+            Flattrs::new(),
+        );
+        proc_dialer.post(envelope, return_handle);
+        let forwarded = backend_rx.recv().await.unwrap();
+        assert_eq!(forwarded.dest().actor_addr().proc_addr(), remote);
     }
 }

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -14,8 +14,8 @@
 //! and frontend endpoints, multiplexes inbound traffic to in-process procs,
 //! and routes spawned child proc gateways through peer routes.
 //!
-//! Use [`Host::new`] or [`Host::new_with_gateway`] to construct a host, start
-//! its backend and frontend accept loops, then [`Host::spawn`] to create child procs.
+//! Use [`Host::new`] or [`Host::new_with_gateway`] to construct a host, start its
+//! backend and frontend accept loops, then [`Host::spawn`] to create child procs.
 //! Spawned children are returned as [`ProcAddr`] values whose location is
 //! advertised through this host's gateway.
 //!
@@ -74,8 +74,10 @@ use hyperactor::ActorAddr;
 use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
 use hyperactor::Gateway;
+use hyperactor::Location;
 use hyperactor::Proc;
 use hyperactor::ProcAddr;
+use hyperactor::ProcId;
 use hyperactor::actor::Binds;
 use hyperactor::actor::Referable;
 use hyperactor::channel;
@@ -88,9 +90,25 @@ use hyperactor::channel::Tx;
 use hyperactor::context;
 use hyperactor::gateway::GatewayServeHandle;
 use hyperactor::gateway::PeerAttachGuard;
+use hyperactor::id::Label;
 use hyperactor::mailbox::IntoBoxedMailboxSender as _;
 use hyperactor::mailbox::MailboxClient;
 use hyperactor::mailbox::MailboxServer;
+use tokio::process::Child;
+use tokio::process::Command;
+use tokio::sync::Mutex;
+
+use crate::mesh_id::ResourceId;
+
+/// Name of the system service proc on a host.
+///
+/// Hosts the admin actor layer: HostMeshAgent, MeshAdminAgent, and bridge.
+pub const SERVICE_PROC_NAME: &str = hyperactor::proc::LEGACY_SERVICE_PROC_NAME;
+
+pub(crate) fn legacy_service_proc_id() -> ProcId {
+    ProcId::singleton(Label::strip(SERVICE_PROC_NAME))
+}
+
 /// Name of the local client proc on a host.
 ///
 /// See LP-1 (lazy activation) in module doc.
@@ -99,16 +117,7 @@ use hyperactor::mailbox::MailboxServer;
 /// `GetLocalProc` is never sent, so the local proc remains empty
 /// throughout the program's lifetime. Code that inspects the local
 /// proc's actors must not assume they exist.
-pub use hyperactor::proc::LEGACY_LOCAL_PROC_NAME as LOCAL_PROC_NAME;
-/// Name of the system service proc on a host.
-///
-/// Hosts the admin actor layer: HostMeshAgent, MeshAdminAgent, and bridge.
-pub use hyperactor::proc::LEGACY_SERVICE_PROC_NAME as SERVICE_PROC_NAME;
-use tokio::process::Child;
-use tokio::process::Command;
-use tokio::sync::Mutex;
-
-use crate::mesh_id::ResourceId;
+pub const LOCAL_PROC_NAME: &str = "local";
 
 /// The type of error produced by host operations.
 #[derive(Debug, thiserror::Error)]
@@ -148,6 +157,14 @@ pub enum HostError {
     /// Attaching the gateway to a remote `serve_via` session failed.
     #[error("failed to attach gateway via session: {0}")]
     ViaAttachFailure(#[source] anyhow::Error),
+
+    /// Constructing a built-in proc failed.
+    #[error("failed to construct built-in proc: {0}")]
+    ProcConstructionFailure(#[source] anyhow::Error),
+
+    /// The service proc startup address contained a source route.
+    #[error("host service proc address must have a direct frontend location, got {0}")]
+    InvalidFrontendLocation(Location),
 }
 
 /// Client transport handles transferred to the bootstrap shutdown task.
@@ -244,19 +261,24 @@ impl<M: ProcManager> Host<M> {
         // host share one routing table with the rest of the process.
         // Callers that need a different gateway (e.g. via attach) build
         // it externally and pass it to [`new_with_gateway`].
-        Self::new_with_gateway(manager, addr, listener, Gateway::global().clone(), None).await
+        Self::new_with_gateway(
+            manager,
+            ProcAddr::new(legacy_service_proc_id(), addr.into()),
+            listener,
+            Gateway::global().clone(),
+            None,
+        )
+        .await
     }
 
-    /// Like [`new_with_default`], but uses a caller-provided
-    /// [`Gateway`] instead of creating one internally.
+    /// Like [`new_with_default`], but uses a caller-provided [`Gateway`] and
+    /// service [`ProcAddr`].
     ///
-    /// Serving the backend and frontend endpoints, choosing the frontend
-    /// transport, and adopting the frontend address as the gateway's
-    /// advertised location are all owned by the gateway. The host operates on
-    /// a vanilla gateway: it never inspects the transport nor rewrites the
-    /// gateway's location. Adopting the bound frontend address makes the
-    /// legacy pseudo-singleton proc ids (system, local) carry it so remote
-    /// hosts can reach them by name.
+    /// `addr` is a startup specification: its proc id becomes the service proc
+    /// identity, and its direct location is used to serve the frontend. The
+    /// final service proc location comes from the gateway after binding, so it
+    /// may differ because of an alias, an ephemeral address, or `via`. A
+    /// source-routed [`Location::Via`] is therefore rejected here.
     ///
     /// When `via` is `Some`, the gateway attaches to that remote duplex
     /// address with [`Gateway::serve_via`] *after* the local
@@ -269,11 +291,18 @@ impl<M: ProcManager> Host<M> {
     #[hyperactor::instrument(fields(addr=addr.to_string()))]
     pub async fn new_with_gateway(
         manager: M,
-        addr: ChannelAddr,
+        addr: ProcAddr,
         listener: Option<std::net::TcpListener>,
         gateway: Gateway,
         via: Option<ChannelAddr>,
     ) -> Result<Self, HostError> {
+        let service_proc_id = addr.id().clone();
+        let addr = match addr.location() {
+            Location::Addr(addr) => addr.clone(),
+            Location::Via(..) => {
+                return Err(HostError::InvalidFrontendLocation(addr.location().clone()));
+            }
+        };
         let mut backend_handle = Gateway::serve(&gateway, ChannelAddr::any(manager.transport()))?;
         let backend_addr = gateway.default_location().addr().clone();
 
@@ -306,6 +335,10 @@ impl<M: ProcManager> Host<M> {
             }
         };
         let frontend_addr = gateway.default_location().addr().clone();
+        assert!(
+            !matches!(frontend_addr, ChannelAddr::Alias { .. }),
+            "gateway frontend serve must canonicalize aliases"
+        );
 
         // Attach to the remote gateway after the local serves are live
         // but before any proc or actor ref is minted below. `serve_via`
@@ -341,8 +374,23 @@ impl<M: ProcManager> Host<M> {
         // gateway servers are live. The HostAgent is published only
         // after it binds its handler, so the brief unroutable window is
         // before normal clients can discover this host.
-        let service_proc = Proc::legacy_service_pseudo_singleton_on_gateway(gateway.clone());
-        let local_proc = Proc::legacy_local_pseudo_singleton_on_gateway(gateway.clone());
+        let expected_service_proc_addr =
+            ProcAddr::new(service_proc_id.clone(), gateway.default_location());
+        let service_proc = Proc::builder()
+            .proc_id(service_proc_id)
+            .shared_gateway(gateway.clone())
+            .build()
+            .map_err(HostError::ProcConstructionFailure)?;
+        assert_eq!(
+            service_proc.proc_addr(),
+            expected_service_proc_addr,
+            "service proc must use the gateway's active advertised location"
+        );
+        let local_proc = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip(LOCAL_PROC_NAME)))
+            .shared_gateway(gateway.clone())
+            .build()
+            .map_err(HostError::ProcConstructionFailure)?;
         let service_proc_id = service_proc.proc_addr().clone();
         let local_proc_id = local_proc.proc_addr().clone();
 
@@ -1639,9 +1687,21 @@ mod tests {
     use hyperactor::mailbox::DialMailboxRouter;
     use hyperactor::mailbox::MessageEnvelope;
     use hyperactor::port::Port;
+    #[cfg(fbcode_build)]
+    use hyperactor_config::attrs::Attrs;
 
     use super::testing::EchoActor;
     use super::*;
+    #[cfg(fbcode_build)]
+    use crate::bootstrap::BootstrapCommand;
+    #[cfg(fbcode_build)]
+    use crate::bootstrap::BootstrapProcConfig;
+    #[cfg(fbcode_build)]
+    use crate::bootstrap::BootstrapProcManager;
+    #[cfg(fbcode_build)]
+    use crate::config_dump::ConfigDump;
+    #[cfg(fbcode_build)]
+    use crate::config_dump::ConfigDumpResult;
 
     #[tokio::test]
     async fn test_basic() {
@@ -1708,6 +1768,79 @@ mod tests {
             rx.recv().await.unwrap(),
             "hello from the instance1".to_string()
         );
+    }
+
+    #[cfg(fbcode_build)]
+    async fn assert_bootstrap_child_round_trip(service_proc_id: ProcId) {
+        let manager = BootstrapProcManager::new(BootstrapCommand::test()).unwrap();
+        let mut host = Host::new_with_gateway(
+            manager,
+            ProcAddr::new(
+                service_proc_id,
+                ChannelAddr::any(ChannelTransport::Unix).into(),
+            ),
+            None,
+            Gateway::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let child_name = ResourceId::instance(Label::strip("route-child")).to_string();
+        let (_child_proc, child_agent) = host
+            .spawn(
+                child_name,
+                BootstrapProcConfig {
+                    create_rank: 0,
+                    client_config_override: Attrs::new(),
+                    proc_bind: None,
+                    bootstrap_command: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let service_client = host.system_proc().client("route-test");
+        let (reply_handle, reply_rx) = service_client
+            .mailbox()
+            .open_once_port::<ConfigDumpResult>();
+        child_agent.post(
+            &service_client,
+            ConfigDump {
+                result: reply_handle.bind(),
+            },
+        );
+        tokio::time::timeout(Duration::from_secs(5), reply_rx.recv())
+            .await
+            .expect("service-to-child request and child-to-service reply timed out")
+            .expect("config dump reply channel closed");
+
+        let summary = host
+            .terminate_children(
+                &service_client,
+                Duration::from_secs(2),
+                1,
+                "routing test complete",
+            )
+            .await;
+        assert_eq!(summary.failed, 0);
+        host.shutdown_servers().await;
+    }
+
+    #[tokio::test]
+    #[cfg(fbcode_build)]
+    async fn test_bootstrap_child_round_trip_with_legacy_service_proc() {
+        assert_bootstrap_child_round_trip(legacy_service_proc_id()).await;
+    }
+
+    #[tokio::test]
+    #[cfg(fbcode_build)]
+    async fn test_bootstrap_child_round_trip_with_instance_service_proc() {
+        let service_proc_id = ProcId::new(
+            Uid::Instance(0x5e12_71ce, Some(Label::strip(SERVICE_PROC_NAME))),
+            None,
+        );
+        assert_bootstrap_child_round_trip(service_proc_id).await;
     }
 
     #[tokio::test]
@@ -2268,6 +2401,89 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_explicit_service_and_local_proc_ids_are_instances() {
+        let proc_manager = LocalProcManager::new(|proc: Proc| async move {
+            Ok(proc.spawn_with_label::<()>("host_agent", ()))
+        });
+        let service_proc_id = ProcId::instance(hyperactor::id::Label::strip("service"));
+
+        let host = Host::new_with_gateway(
+            proc_manager,
+            ProcAddr::new(
+                service_proc_id.clone(),
+                ChannelAddr::any(ChannelTransport::Unix).into(),
+            ),
+            None,
+            Gateway::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(host.system_proc().proc_id(), &service_proc_id);
+        assert!(matches!(
+            host.local_proc().proc_id().uid(),
+            hyperactor::id::Uid::Instance(..)
+        ));
+        assert_eq!(
+            host.local_proc()
+                .proc_id()
+                .label()
+                .map(|label| label.as_str()),
+            Some(LOCAL_PROC_NAME)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_new_with_gateway_rejects_via_frontend_location() {
+        let proc_manager = LocalProcManager::new(|proc: Proc| async move {
+            Ok(proc.spawn_with_label::<()>("host_agent", ()))
+        });
+        let location = Location::from(ChannelAddr::any(ChannelTransport::Unix))
+            .with_via(Uid::instance(Label::strip("remote")));
+        let service_proc_addr = ProcAddr::new(legacy_service_proc_id(), location.clone());
+
+        let result =
+            Host::new_with_gateway(proc_manager, service_proc_addr, None, Gateway::new(), None)
+                .await;
+
+        assert!(matches!(
+            result,
+            Err(HostError::InvalidFrontendLocation(error_location))
+                if error_location == location
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_new_with_gateway_remints_service_proc_at_bound_address() {
+        let proc_manager = LocalProcManager::new(|proc: Proc| async move {
+            Ok(proc.spawn_with_label::<()>("host_agent", ()))
+        });
+        let service_proc_id = ProcId::instance(Label::strip("service"));
+        let startup_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:0").unwrap();
+        let mut host = Host::new_with_gateway(
+            proc_manager,
+            ProcAddr::new(service_proc_id.clone(), startup_addr.into()),
+            None,
+            Gateway::new(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ChannelAddr::Tcp(bound_addr) = host.addr() else {
+            panic!("expected TCP frontend address")
+        };
+        assert_ne!(bound_addr.port(), 0);
+        assert_eq!(
+            host.system_proc().proc_addr(),
+            ProcAddr::new(service_proc_id, Location::from(host.addr().clone()))
+        );
+
+        host.shutdown_servers().await;
+    }
+
+    #[tokio::test]
     async fn test_spawn_uses_latest_serve_location_after_prior_default_override() {
         let proc_manager = LocalProcManager::new(|proc: Proc| async move {
             Ok(proc.spawn_with_label::<()>("host_agent", ()))
@@ -2280,7 +2496,10 @@ mod tests {
 
         let mut host = Host::new_with_gateway(
             proc_manager,
-            ChannelAddr::any(ChannelTransport::Unix),
+            ProcAddr::new(
+                legacy_service_proc_id(),
+                ChannelAddr::any(ChannelTransport::Unix).into(),
+            ),
             None,
             gateway,
             None,
@@ -2307,7 +2526,10 @@ mod tests {
 
         let mut host = Host::new_with_gateway(
             proc_manager,
-            ChannelAddr::any(ChannelTransport::Unix),
+            ProcAddr::new(
+                legacy_service_proc_id(),
+                ChannelAddr::any(ChannelTransport::Unix).into(),
+            ),
             None,
             Gateway::new(),
             None,
@@ -2358,7 +2580,10 @@ mod tests {
         let fallback_location = gateway.default_location();
         let mut host = Host::new_with_gateway(
             proc_manager,
-            ChannelAddr::any(ChannelTransport::Unix),
+            ProcAddr::new(
+                legacy_service_proc_id(),
+                ChannelAddr::any(ChannelTransport::Unix).into(),
+            ),
             None,
             gateway.clone(),
             Some(remote_addr.clone()),

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -73,6 +73,7 @@ use std::time::Duration;
 
 use hyperactor::ActorAddr;
 use hyperactor::ProcAddr;
+use hyperactor::ProcId;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::context;
 use hyperactor_cast::cast_actor::CAST_ACTOR_NAME;
@@ -99,6 +100,7 @@ use crate::bootstrap::ProcBind;
 use crate::host::Host;
 use crate::host::LocalProcManager;
 use crate::host::SERVICE_PROC_NAME;
+use crate::host::legacy_service_proc_id;
 pub use crate::host_mesh::host_agent::HostAgent;
 use crate::host_mesh::host_agent::ProcManagerSpawnFn;
 use crate::host_mesh::host_agent::ProcState;
@@ -145,12 +147,16 @@ declare_attrs! {
     pub attr GET_PROC_STATE_MAX_IDLE: Duration = Duration::from_mins(1);
 }
 
-pub(crate) fn host_agent_ref(host_addr: ChannelAddr) -> ActorRef<HostAgent> {
-    let host_addr = host_addr.into_dial_addr();
-    ActorRef::attest(
-        ResourceId::proc_addr_from_name(host_addr, SERVICE_PROC_NAME)
-            .actor_addr(host_agent::HOST_MESH_AGENT_ACTOR_NAME),
-    )
+fn legacy_service_proc_addr(host_addr: ChannelAddr) -> ProcAddr {
+    ProcAddr::new(legacy_service_proc_id(), host_addr.into_dial_addr().into())
+}
+
+pub(crate) fn host_agent_ref(service_proc: ProcAddr) -> ActorRef<HostAgent> {
+    ActorRef::attest(service_proc.actor_addr(host_agent::HOST_MESH_AGENT_ACTOR_NAME))
+}
+
+pub(crate) fn legacy_host_agent_ref(host_addr: ChannelAddr) -> ActorRef<HostAgent> {
+    host_agent_ref(legacy_service_proc_addr(host_addr))
 }
 
 fn named_proc_on_host(agent: &ActorRef<HostAgent>, id: &ResourceId) -> ProcAddr {
@@ -335,9 +341,15 @@ impl HostMesh {
         // Use a dedicated gateway, not the process-wide global one. This
         // host coexists with the global-context singleton host (see
         // `global_context`), which owns the global gateway; sharing it
-        // would collide on the legacy `service`/`local` pseudo-singleton
-        // proc ids.
-        let host = Host::new_with_gateway(manager, addr, None, Gateway::new(), None).await?;
+        // would collide on the legacy `service` pseudo-singleton proc id.
+        let host = Host::new_with_gateway(
+            manager,
+            ProcAddr::new(legacy_service_proc_id(), addr.into()),
+            None,
+            Gateway::new(),
+            None,
+        )
+        .await?;
         let addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_mesh_agent = system_proc
@@ -409,9 +421,16 @@ impl HostMesh {
         let manager = LocalProcManager::new(spawn);
         // Each in-process host gets its own gateway, not the
         // process-wide global one. Several hosts coexist in one process
-        // here, and the legacy `service`/`local` pseudo-singleton proc
-        // ids would collide if they all attached to the same gateway.
-        let host = Host::new_with_gateway(manager, addr, None, Gateway::new(), None).await?;
+        // here, and the legacy `service` pseudo-singleton proc id would
+        // collide if they all attached to the same gateway.
+        let host = Host::new_with_gateway(
+            manager,
+            ProcAddr::new(legacy_service_proc_id(), addr.into()),
+            None,
+            Gateway::new(),
+            None,
+        )
+        .await?;
         let addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_mesh_agent = system_proc
@@ -522,6 +541,19 @@ impl HostMesh {
         addresses: Vec<ChannelAddr>,
     ) -> crate::Result<Self> {
         let mesh_ref = HostMeshRef::from_hosts(id, addresses);
+        let config = hyperactor_config::global::propagatable_attrs();
+        mesh_ref.push_config(cx, config).await?;
+        Ok(Self::take(mesh_ref))
+    }
+
+    /// Attach to workers using explicit service proc addresses.
+    pub async fn attach_with_service_procs(
+        cx: &impl context::Actor,
+        id: HostMeshId,
+        service_procs: Vec<ProcAddr>,
+    ) -> crate::Result<Self> {
+        let agents = service_procs.into_iter().map(host_agent_ref).collect();
+        let mesh_ref = HostMeshRef::from_host_agents(id, agents)?;
         let config = hyperactor_config::global::propagatable_attrs();
         mesh_ref.push_config(cx, config).await?;
         Ok(Self::take(mesh_ref))
@@ -891,18 +923,17 @@ impl HostMeshRef {
     }
 
     /// Create a unit HostMeshRef from a host mesh agent.
+    ///
+    /// Retains the service proc identity while canonicalizing the location to
+    /// its terminal dial address. Client-only via routes must not propagate
+    /// into addresses of procs spawned through this mesh.
     pub fn from_host_agent(id: HostMeshId, agent: ActorRef<HostAgent>) -> crate::Result<Self> {
         let region = Extent::unity().into();
-        // Canonicalize to the host's base dial address (as the deleted `HostRef`
-        // did via `into_dial_addr`). A client-attached `this_host` agent's
-        // location is `Via(client_gateway, addr)`; keeping that via hop makes it
-        // propagate into the locations of procs spawned on the host
-        // (`Via(child, Via(client_gateway, addr))`), which a *remote* host's
-        // gateway cannot peel — breaking reverse remote->local reachability. The
-        // bare dial address yields the single-hop `Via(child, addr)` the peer
-        // network routes both ways. Only the unit (this_host) path needs this;
-        // multi-host/allocated meshes carry their own dial addresses already.
-        let agent = host_agent_ref(agent.actor_addr().proc_addr().addr().clone());
+        let service_proc = agent.actor_addr().proc_addr();
+        let agent = host_agent_ref(ProcAddr::new(
+            service_proc.id().clone(),
+            service_proc.addr().clone().into_dial_addr().into(),
+        ));
         let host_agent_mesh = Self::host_agent_mesh_ref_from_agents(&region, vec![agent])?;
         Ok(Self {
             id,
@@ -924,7 +955,7 @@ impl HostMeshRef {
         region: &Region,
         host_addrs: Vec<ChannelAddr>,
     ) -> crate::Result<ActorMeshRef<HostAgent>> {
-        let agents = host_addrs.into_iter().map(host_agent_ref).collect();
+        let agents = host_addrs.into_iter().map(legacy_host_agent_ref).collect();
         Self::host_agent_mesh_ref_from_agents(region, agents)
     }
 
@@ -1096,6 +1127,23 @@ impl HostMeshRef {
                 subscriber,
             },
         )?)
+    }
+
+    pub(crate) fn forward_wait_rank_status(
+        &self,
+        cx: &impl context::Actor,
+        procs: impl IntoIterator<Item = ProcAddr>,
+        region: Region,
+        message: resource::WaitRankStatus,
+    ) -> anyhow::Result<()> {
+        for (view_rank, (create_rank, proc_id)) in region.slice().iter().zip(procs).enumerate() {
+            let mut message = message.clone();
+            message.id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
+            message.rank = resource::Rank::new(view_rank);
+            self.host_agent_for_proc_rank(&region, create_rank)
+                .post(cx, message);
+        }
+        Ok(())
     }
 
     /// Returns the host entries as `(addr_string, ActorRef<HostAgent>)` pairs.
@@ -1548,6 +1596,30 @@ impl HostMeshRef {
             .collect()
     }
 
+    fn host_agent_for_proc_rank(
+        &self,
+        proc_region: &Region,
+        create_rank: usize,
+    ) -> &ActorRef<HostAgent> {
+        let host_dims = self.region().labels().len();
+        assert!(
+            proc_region.labels().starts_with(self.region().labels()),
+            "proc mesh host dimensions must match its originating host mesh"
+        );
+
+        let host_rank = if host_dims == 0 {
+            0
+        } else {
+            // Proc meshes concatenate the host dimensions with the per-host
+            // dimensions. The last host dimension's stride is therefore the
+            // number of proc slots assigned to each host.
+            let procs_per_host = proc_region.slice().strides()[host_dims - 1];
+            create_rank / procs_per_host
+        };
+        self.get(host_rank)
+            .expect("proc rank must map to a host in its originating host mesh")
+    }
+
     /// Stop every proc in this proc mesh.
     ///
     /// On success returns the final per-rank `StatusMesh`, in which every
@@ -1558,6 +1630,8 @@ impl HostMeshRef {
     /// Returns `crate::Error::ProcMeshStopError` if any rank did not reach
     /// a terminal state within `PROC_STOP_MAX_IDLE`; the error carries the
     /// best-known per-rank statuses for the same purpose.
+    /// `region` must be the proc mesh's creation-time region because its ranks
+    /// determine which host owns each proc.
     #[hyperactor::instrument(fields(host_mesh=self.id.to_string(), proc_mesh=proc_mesh_id.to_string()))]
     pub(crate) async fn stop_proc_mesh(
         &self,
@@ -1567,12 +1641,17 @@ impl HostMeshRef {
         region: Region,
         reason: String,
     ) -> crate::Result<crate::StatusMesh> {
-        // Accumulator outputs full StatusMesh snapshots; seed with
-        // NotExist.
-        let mut proc_names = Vec::new();
+        let procs = procs.into_iter().collect::<Vec<_>>();
+        assert_eq!(
+            procs.len(),
+            region.num_ranks(),
+            "proc addresses must match the proc mesh region"
+        );
+        let proc_names = procs
+            .iter()
+            .map(|proc_id| ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned()))
+            .collect::<Vec<_>>();
         let num_ranks = region.num_ranks();
-        // Accumulator outputs full StatusMesh snapshots; seed with
-        // NotExist.
         let (port, rx) = cx.mailbox().open_accum_port_opts(
             crate::StatusMesh::from_single(region.clone(), Status::NotExist),
             StreamingReducerOpts {
@@ -1580,21 +1659,11 @@ impl HostMeshRef {
                 initial_update_interval: None,
             },
         );
-        // `procs` follows the current-view `ranks` order, so the enumeration
-        // index is each proc's rank in this view (RSP-1). Direct delivery stamps
-        // it explicitly (RSP-2); each HostAgent positions its reply overlay
-        // there.
-        for (view_rank, proc_id) in procs.into_iter().enumerate() {
-            let addr = proc_id.addr().clone();
-            // The name stored in HostAgent is not the same as the
-            // one stored in the ProcMesh. We instead take each proc id
-            // and map it to that particular agent.
+        let mut reply = port.bind();
+        reply.return_undeliverable(false);
+        for (view_rank, (create_rank, proc_id)) in region.slice().iter().zip(procs).enumerate() {
             let proc_resource_id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
-            proc_names.push(proc_resource_id.clone());
-
-            // Note that we don't send 1 message per host agent, we send 1 message
-            // per proc.
-            let host_agent = host_agent_ref(addr);
+            let host_agent = self.host_agent_for_proc_rank(&region, create_rank);
             host_agent.post(
                 cx,
                 resource::Stop {
@@ -1608,16 +1677,10 @@ impl HostMeshRef {
                     proc_resource_id,
                     resource::Rank::new(view_rank),
                     Status::Stopped,
-                    port.bind(),
+                    reply.clone(),
                 )
                 .await
-                .map_err(|e| crate::Error::CallError(host_agent.actor_addr().clone(), e))?;
-
-            tracing::info!(
-                name = "ProcMeshStatus",
-                %proc_id,
-                status = "Stop::Sent",
-            );
+                .map_err(|error| crate::Error::CallError(host_agent.actor_addr().clone(), error))?;
         }
         tracing::info!(
             name = "HostMeshStatus",
@@ -1825,12 +1888,18 @@ impl view::RankedSliceable for HostMeshRef {
 
 impl std::fmt::Display for HostMeshRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let legacy_service_proc_id = ResourceId::from_name(SERVICE_PROC_NAME).proc_id();
         write!(f, "{}:", self.id)?;
         for (rank, agent) in self.host_agent_mesh.values().enumerate() {
             if rank > 0 {
                 write!(f, ",")?;
             }
-            write!(f, "{}", agent.actor_addr().addr())?;
+            let proc_addr = agent.actor_addr().proc_addr();
+            if proc_addr.id() == &legacy_service_proc_id {
+                write!(f, "{}", proc_addr.addr())?;
+            } else {
+                write!(f, "{}", proc_addr)?;
+            }
         }
         write!(f, "@{}", self.region())
     }
@@ -1864,6 +1933,18 @@ impl From<crate::Error> for HostMeshRefParseError {
     }
 }
 
+fn parse_host_agent_ref(host_ref: &str) -> anyhow::Result<ActorRef<HostAgent>> {
+    if let Some((proc_id, host_addr)) = host_ref.split_once('@')
+        && let Ok(proc_id) = ProcId::from_str(proc_id)
+    {
+        let location = hyperactor::Location::from_str(host_addr)?;
+        return Ok(host_agent_ref(ProcAddr::new(proc_id, location)));
+    }
+
+    let host_addr = ChannelAddr::from_str(host_ref)?;
+    Ok(legacy_host_agent_ref(host_addr))
+}
+
 impl FromStr for HostMeshRef {
     type Err = HostMeshRefParseError;
 
@@ -1872,20 +1953,25 @@ impl FromStr for HostMeshRef {
 
         let id = HostMeshId::from_str(id_str)?;
 
-        let (host_addrs, region) = rest
-            .split_once('@')
+        let (host_refs, region) = rest
+            .rsplit_once('@')
             .ok_or(HostMeshRefParseError::MissingRegion)?;
-        let host_addrs = if host_addrs.trim().is_empty() {
+        let host_agents = if host_refs.trim().is_empty() {
             Vec::new()
         } else {
-            host_addrs
+            host_refs
                 .split(',')
-                .map(|host_addr| host_addr.trim())
-                .map(ChannelAddr::from_str)
-                .collect::<Result<Vec<_>, _>>()?
+                .map(str::trim)
+                .map(parse_host_agent_ref)
+                .collect::<anyhow::Result<Vec<_>>>()?
         };
         let region = region.parse()?;
-        Ok(HostMeshRef::new(id, region, host_addrs)?)
+        let host_agent_mesh = Self::host_agent_mesh_ref_from_agents(&region, host_agents)?;
+        Ok(Self {
+            id,
+            host_agent_mesh,
+            bootstrap_command: None,
+        })
     }
 }
 
@@ -2145,6 +2231,27 @@ mod tests {
         );
     }
 
+    #[cfg(fbcode_build)]
+    #[assert_no_process_leak]
+    #[tokio::test]
+    async fn test_proc_mesh_stop_routes_to_originating_host_agents() {
+        let instance = testing::instance();
+        let mut host_mesh = testing::host_mesh(2).await;
+        let mut proc_mesh = host_mesh
+            .spawn(instance, "stop-routing", extent!(gpus = 2), None, None)
+            .await
+            .expect("spawn proc mesh");
+
+        proc_mesh
+            .stop(instance, "test complete".to_string())
+            .await
+            .expect("stop proc mesh");
+        host_mesh
+            .shutdown(instance)
+            .await
+            .expect("shutdown host mesh");
+    }
+
     #[tokio::test]
     #[cfg(fbcode_build)]
     async fn test_client_config_override() {
@@ -2318,6 +2425,157 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_host_mesh_ref_serialization_preserves_service_proc_identity() {
+        let dial_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:26600").unwrap();
+        let service_proc_id: ProcId = "service<2>".parse().unwrap();
+        let agent = host_agent_ref(ProcAddr::new(
+            service_proc_id.clone(),
+            dial_addr.clone().into(),
+        ));
+        let mesh = HostMeshRef::from_host_agents(
+            HostMeshId::singleton(Label::new("explicit-service").unwrap()),
+            vec![agent],
+        )
+        .unwrap();
+
+        let serialized = serde_json::to_string(&mesh).unwrap();
+        let round_trip: HostMeshRef = serde_json::from_str(&serialized).unwrap();
+        let round_trip_agent = ndslice::view::Ranked::get(&round_trip, 0).unwrap();
+
+        assert_eq!(
+            round_trip_agent.actor_addr().proc_addr().id(),
+            &service_proc_id
+        );
+        assert_eq!(round_trip_agent.actor_addr().proc_addr().addr(), &dial_addr);
+    }
+
+    #[test]
+    fn test_host_mesh_ref_from_host_agent_preserves_identity_and_uses_direct_location() {
+        let dial_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:26600").unwrap();
+        let service_proc_id: ProcId = "service<2>".parse().unwrap();
+        let via_uid = ProcId::instance(Label::strip("client-gateway"))
+            .uid()
+            .clone();
+        let service_location = hyperactor::Location::from(dial_addr.clone()).with_via(via_uid);
+        let agent = host_agent_ref(ProcAddr::new(service_proc_id.clone(), service_location));
+
+        let mesh = HostMeshRef::from_host_agent(
+            HostMeshId::singleton(Label::new("explicit-service").unwrap()),
+            agent,
+        )
+        .unwrap();
+        let round_trip_agent = ndslice::view::Ranked::get(&mesh, 0).unwrap();
+
+        assert_eq!(
+            round_trip_agent.actor_addr().proc_addr().id(),
+            &service_proc_id
+        );
+        assert_eq!(
+            round_trip_agent.actor_addr().proc_addr().location(),
+            &hyperactor::Location::from(dial_addr)
+        );
+    }
+
+    #[test]
+    fn test_proc_rank_maps_to_originating_host_agent() {
+        let dial_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:26600").unwrap();
+        let service_proc_ids = [
+            "service<2>".parse::<ProcId>().unwrap(),
+            "service<3>".parse::<ProcId>().unwrap(),
+        ];
+        let agents = service_proc_ids
+            .iter()
+            .cloned()
+            .map(|proc_id| host_agent_ref(ProcAddr::new(proc_id, dial_addr.clone().into())))
+            .collect();
+        let hosts = HostMeshRef::from_host_agents(
+            HostMeshId::singleton(Label::new("hosts").unwrap()),
+            agents,
+        )
+        .unwrap();
+        let proc_region: Region = extent!(hosts = 2, gpus = 2).into();
+        let sliced = proc_region.range("gpus", 1..2).unwrap();
+
+        let owners = sliced
+            .slice()
+            .iter()
+            .map(|create_rank| {
+                hosts
+                    .host_agent_for_proc_rank(&sliced, create_rank)
+                    .actor_addr()
+                    .proc_addr()
+                    .id()
+                    .clone()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(owners, service_proc_ids);
+    }
+
+    #[test]
+    fn test_host_mesh_ref_string_preserves_service_proc_identity() {
+        let dial_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:26600").unwrap();
+        let service_proc_ids = vec![
+            "service<2>".parse::<ProcId>().unwrap(),
+            "service<3>".parse::<ProcId>().unwrap(),
+        ];
+        let agents = service_proc_ids
+            .iter()
+            .cloned()
+            .map(|proc_id| host_agent_ref(ProcAddr::new(proc_id, dial_addr.clone().into())))
+            .collect();
+        let mesh = HostMeshRef::from_host_agents(
+            HostMeshId::singleton(Label::new("explicit-services").unwrap()),
+            agents,
+        )
+        .unwrap();
+
+        let round_trip: HostMeshRef = mesh.to_string().parse().unwrap();
+        let round_trip_proc_ids = round_trip
+            .host_agent_mesh
+            .values()
+            .map(|agent| agent.actor_addr().proc_addr().id().clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(round_trip_proc_ids, service_proc_ids);
+        assert_eq!(round_trip.host_addrs(), vec![dial_addr.clone(), dial_addr]);
+    }
+
+    #[test]
+    fn test_host_mesh_ref_string_parses_unix_abstract_addresses() {
+        let dial_addr: ChannelAddr = "unix:@host-agent".parse().unwrap();
+        let service_proc_id: ProcId = "service<2>".parse().unwrap();
+        let agents = vec![
+            legacy_host_agent_ref(dial_addr.clone()),
+            host_agent_ref(ProcAddr::new(
+                service_proc_id.clone(),
+                dial_addr.clone().into(),
+            )),
+        ];
+        let mesh = HostMeshRef::from_host_agents(
+            HostMeshId::singleton(Label::new("unix-services").unwrap()),
+            agents,
+        )
+        .unwrap();
+
+        let round_trip: HostMeshRef = mesh.to_string().parse().unwrap();
+        let round_trip_proc_ids = round_trip
+            .host_agent_mesh
+            .values()
+            .map(|agent| agent.actor_addr().proc_addr().id().clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            round_trip_proc_ids,
+            vec![
+                ResourceId::from_name(SERVICE_PROC_NAME).proc_id(),
+                service_proc_id,
+            ]
+        );
+        assert_eq!(round_trip.host_addrs(), vec![dial_addr.clone(), dial_addr]);
+    }
+
     #[tokio::test]
     async fn test_sa1_empty_mesh_set_rejected() {
         let instance = testing::instance();
@@ -2345,8 +2603,8 @@ mod tests {
         let addr_a: ChannelAddr = "tcp:127.0.0.1:2001".parse().unwrap();
         let addr_b: ChannelAddr = "tcp:127.0.0.1:2002".parse().unwrap();
 
-        let ref_a = host_agent_ref(addr_a.clone());
-        let ref_b = host_agent_ref(addr_b.clone());
+        let ref_a = legacy_host_agent_ref(addr_a.clone());
+        let ref_b = legacy_host_agent_ref(addr_b.clone());
 
         let mut set = HostSet::new();
         set.insert(addr_a.to_string(), ref_a.clone());
@@ -2414,7 +2672,7 @@ mod tests {
         );
 
         // Client host entry overlaps with addr_a.
-        let client_ref = host_agent_ref(addr_a.clone());
+        let client_ref = legacy_host_agent_ref(addr_a.clone());
         let client_entries = vec![("client_addr".to_string(), client_ref)];
 
         let result = aggregate_hosts(&[&mesh], Some(client_entries));

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -268,9 +268,9 @@
 //! - **PS-12 (universal py-spy):** Worker procs and the service
 //!   proc can handle `PySpyDump`. Worker procs handle it via
 //!   ProcAgent; the service proc handles it via HostAgent (same
-//!   spawn-worker pattern). `pyspy_bridge` routes by proc name:
-//!   if `proc_id.base_name() == SERVICE_PROC_NAME`, the target
-//!   is `host_agent`; otherwise `proc_agent[0]`. Procs lacking
+//!   spawn-worker pattern). `pyspy_bridge` routes to a HostAgent
+//!   only when its exact actor identity is registered with the mesh
+//!   admin; all other procs route to `proc_agent[0]`. Procs lacking
 //!   either agent (e.g. mesh-admin) fast-fail via PS-13.
 //! - **PS-13 (defensive probe):** Before sending `PySpyDump`,
 //!   `pyspy_bridge` probes the selected actor with an introspect

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -344,6 +344,7 @@
 //! live invariant. It is not in this registry.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::io;
 use std::path::Path;
 use std::sync::Arc;
@@ -385,7 +386,6 @@ use typeuri::Named;
 
 use crate::config_dump::ConfigDump;
 use crate::config_dump::ConfigDumpResult;
-use crate::host::SERVICE_PROC_NAME;
 use crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
 use crate::host_mesh::host_agent::HostAgent;
 use crate::introspect::NodePayload;
@@ -859,6 +859,8 @@ struct BridgeState {
     /// Addr to the `MeshAdminAgent` actor that performs
     /// reference resolution.
     admin_ref: ActorRef<MeshAdminAgent>,
+    /// Exact actor identities of the HostAgents managed by this admin.
+    host_agents: HashSet<hyperactor::ActorAddr>,
     /// Dedicated client mailbox on system_proc for HTTP bridge reply
     /// ports. Using a separate `Instance<()>` avoids sharing the
     /// actor's own mailbox with the HTTP bridge and ensures the
@@ -1054,6 +1056,7 @@ impl Actor for MeshAdminAgent {
             mesh_admin_access_instructions(&admin_url, tls.as_ref().map(|(_, bundle)| bundle));
         let bridge_state = Arc::new(BridgeState {
             admin_ref: ActorRef::attest(this.self_addr().clone()),
+            host_agents: self.host_agents_by_actor_id.keys().cloned().collect(),
             bridge_cx,
             resolve_semaphore: tokio::sync::Semaphore::new(hyperactor_config::global::get(
                 crate::config::MESH_ADMIN_MAX_CONCURRENT_RESOLVES,
@@ -2319,19 +2322,18 @@ impl ResolvedProcHandler {
 /// Parse + route + attest. No probe. The single `ActorRef::attest`
 /// minting point. Used by `config_bridge` which intentionally skips
 /// the probe (CFG-4).
-fn route_proc_handler(raw_proc_reference: &str) -> Result<ResolvedProcHandler, ApiError> {
+fn route_proc_handler(
+    host_agents: &HashSet<hyperactor::ActorAddr>,
+    raw_proc_reference: &str,
+) -> Result<ResolvedProcHandler, ApiError> {
     let (_proc_reference, proc_id) = parse_proc_reference(raw_proc_reference)?;
-    let is_service = proc_id
-        .uid()
-        .as_singleton()
-        .is_some_and(|label| label.as_str() == SERVICE_PROC_NAME);
-    if is_service {
-        let agent_id = proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME);
-        Ok(ResolvedProcHandler::Host(ActorRef::attest(agent_id)))
-    } else {
-        let agent_id = proc_id.actor_addr(PROC_AGENT_ACTOR_NAME);
-        Ok(ResolvedProcHandler::Proc(ActorRef::attest(agent_id)))
+    let host_agent_id = proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME);
+    if host_agents.contains(&host_agent_id) {
+        return Ok(ResolvedProcHandler::Host(ActorRef::attest(host_agent_id)));
     }
+
+    let proc_agent_id = proc_id.actor_addr(PROC_AGENT_ACTOR_NAME);
+    Ok(ResolvedProcHandler::Proc(ActorRef::attest(proc_agent_id)))
 }
 
 /// Parse + route + attest + probe (PS-13).
@@ -2339,7 +2341,7 @@ async fn resolve_proc_handler(
     state: &BridgeState,
     raw_proc_reference: &str,
 ) -> Result<ResolvedProcHandler, ApiError> {
-    let handler = route_proc_handler(raw_proc_reference)?;
+    let handler = route_proc_handler(&state.host_agents, raw_proc_reference)?;
     let cx = &state.bridge_cx;
     if !probe_actor(cx, &handler.agent_id()).await? {
         return Err(ApiError::not_found(
@@ -2636,7 +2638,7 @@ async fn config_bridge(
     State(state): State<Arc<BridgeState>>,
     AxumPath(proc_reference): AxumPath<String>,
 ) -> Result<Json<ConfigDumpResult>, ApiError> {
-    let handler = route_proc_handler(&proc_reference)?;
+    let handler = route_proc_handler(&state.host_agents, &proc_reference)?;
     let timeout =
         hyperactor_config::global::get(crate::config::MESH_ADMIN_CONFIG_DUMP_BRIDGE_TIMEOUT);
     let result = handler.config_dump(&state.bridge_cx, timeout).await?;
@@ -3264,11 +3266,13 @@ mod advertised_host {
 mod tests {
     use std::net::SocketAddr;
 
+    use hyperactor::ProcId;
     use hyperactor::channel::ChannelAddr;
     use hyperactor::id::Label;
     use hyperactor::testing::ids::test_proc_id_with_addr;
 
     use super::*;
+    use crate::host::SERVICE_PROC_NAME;
     use crate::mesh_id::ResourceId;
 
     // Integration tests that spawn MeshAdminAgent must pass
@@ -4487,40 +4491,58 @@ mod tests {
         assert_eq!(parsed, proc_id);
     }
 
-    /// PS-12: service proc routes to HostAgent.
+    /// PS-12: a registered legacy service proc routes to HostAgent.
     #[test]
     fn route_proc_handler_service_proc_yields_host() {
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
         let proc_id = ResourceId::proc_addr_from_name(ChannelAddr::Tcp(addr), SERVICE_PROC_NAME);
-        let handler = route_proc_handler(&proc_id.to_string()).unwrap();
+        let host_agents = HashSet::from([proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME)]);
+        let handler = route_proc_handler(&host_agents, &proc_id.to_string()).unwrap();
         assert!(
             matches!(handler, ResolvedProcHandler::Host(_)),
-            "service proc should resolve to Host variant"
+            "a registered legacy service proc should resolve to Host"
         );
     }
 
-    /// PS-12: non-service proc routes to ProcAgent.
+    /// PS-12: an unregistered worker proc routes to ProcAgent.
     #[test]
     fn route_proc_handler_worker_proc_yields_proc() {
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
         let proc_id = test_proc_id_with_addr(ChannelAddr::Tcp(addr), "worker_0");
-        let handler = route_proc_handler(&proc_id.to_string()).unwrap();
+        let handler = route_proc_handler(&HashSet::new(), &proc_id.to_string()).unwrap();
         assert!(
             matches!(handler, ResolvedProcHandler::Proc(_)),
-            "non-service proc should resolve to Proc variant"
+            "an unregistered worker proc should resolve to Proc"
         );
     }
 
-    /// PS-12: a labeled instance named "service" is still a normal proc.
+    /// PS-12: a registered instance proc routes to HostAgent regardless of label.
     #[test]
-    fn route_proc_handler_service_instance_yields_proc() {
+    fn route_proc_handler_registered_instance_yields_host() {
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
-        let proc_id =
-            ResourceId::proc_addr_from_name(ChannelAddr::Tcp(addr), "service-deadbeefdeadbeef");
-        let handler = route_proc_handler(&proc_id.to_string()).unwrap();
+        let proc_id = ProcAddr::new(
+            ProcId::instance(Label::strip("host-control")),
+            ChannelAddr::Tcp(addr).into(),
+        );
+        let host_agents = HashSet::from([proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME)]);
+        let handler = route_proc_handler(&host_agents, &proc_id.to_string()).unwrap();
+        assert!(
+            matches!(handler, ResolvedProcHandler::Host(_)),
+            "a registered proc should resolve to Host regardless of its label"
+        );
+    }
+
+    #[test]
+    fn route_proc_handler_service_label_without_host_registration_yields_proc() {
+        let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+        let proc_id = ProcAddr::new(
+            ProcId::instance(Label::strip(SERVICE_PROC_NAME)),
+            ChannelAddr::Tcp(addr).into(),
+        );
+        let handler = route_proc_handler(&HashSet::new(), &proc_id.to_string()).unwrap();
         assert!(
             matches!(handler, ResolvedProcHandler::Proc(_)),
-            "service-labeled instance proc should resolve to Proc variant"
+            "an unregistered proc must not become a host service based on its label"
         );
     }
 }

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1469,16 +1469,10 @@ impl Controlled for ProcMeshRef {
         cx: &impl context::Actor,
         msg: resource::WaitRankStatus,
     ) -> anyhow::Result<()> {
-        // Direct fan-out (not a cast): one scalar rank cannot identify every
-        // recipient, so stamp each clone with the proc's rank in this view
-        // (RSP-2). `proc_ids()` follows the current-view `ranks` order, so the
-        // enumeration index is each recipient's consuming-view rank (RSP-1).
-        for (view_rank, proc_id) in self.proc_ids().enumerate() {
-            let mut msg = msg.clone();
-            msg.rank = resource::Rank::new(view_rank);
-            crate::host_mesh::host_agent_ref(proc_id.addr().clone()).post(cx, msg);
-        }
-        Ok(())
+        let hosts = self.hosts().ok_or_else(|| {
+            anyhow::anyhow!("ProcMeshController cannot wait without a backing host mesh")
+        })?;
+        hosts.forward_wait_rank_status(cx, self.proc_ids(), Ranked::region(self).clone(), msg)
     }
 
     async fn poll_states(

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -8,6 +8,9 @@
 
 use futures::future::try_join_all;
 use hyperactor::Gateway;
+use hyperactor::Location;
+use hyperactor::ProcAddr;
+use hyperactor::ProcId;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::id::Label;
 use hyperactor_mesh::bootstrap::BootstrapCommand;
@@ -22,6 +25,7 @@ use pyo3::PyAny;
 use pyo3::PyResult;
 use pyo3::Python;
 use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::PyValueError;
 use pyo3::pyfunction;
 use pyo3::types::PyAnyMethods;
 use pyo3::types::PyModule;
@@ -32,6 +36,66 @@ use crate::host_mesh::PyHostMesh;
 use crate::pytokio::PyPythonTask;
 use crate::runtime::GilSite;
 use crate::runtime::monarch_with_gil;
+
+const SERVICE_ADDRESS_FORMAT: &str = "expected a channel URL such as 'tcp://host:4444' or a ProcAddr such as 'service<2MuAHeDjLCEd>@tcp://host:4444'";
+
+fn legacy_service_proc_id() -> ProcId {
+    ProcId::singleton(Label::strip(hyperactor::proc::LEGACY_SERVICE_PROC_NAME))
+}
+
+fn service_address_parse_error(address: &str, error: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!("invalid worker address {address:?}: {error}; {SERVICE_ADDRESS_FORMAT}")
+}
+
+fn service_proc_id_and_location(address: &str) -> (ProcId, &str) {
+    // TODO: Remove this manual parse by either avoiding reserved-port addresses
+    // here or making listener-preserving ProcAddr parsing a first-class API.
+    if let Some((proc_id, location)) = address.split_once('@')
+        && let Ok(proc_id) = proc_id.parse::<ProcId>()
+    {
+        return (proc_id, location);
+    }
+
+    (legacy_service_proc_id(), address)
+}
+
+fn into_dial_location(location: Location) -> Location {
+    match location {
+        Location::Addr(addr) => addr.into_dial_addr().into(),
+        Location::Via(uid, inner) => into_dial_location(*inner).with_via(uid),
+    }
+}
+
+fn parse_service_proc_addr(address: &str) -> anyhow::Result<ProcAddr> {
+    let proc_addr = match address.parse::<ProcAddr>() {
+        Ok(proc_addr) => proc_addr,
+        Err(_) => address
+            .parse::<Location>()
+            .map(|location| ProcAddr::new(legacy_service_proc_id(), location))
+            .map_err(|error| service_address_parse_error(address, error))?,
+    };
+
+    Ok(ProcAddr::new(
+        proc_addr.id().clone(),
+        into_dial_location(proc_addr.location().clone()),
+    ))
+}
+
+/// Parses a service address without discarding serve-only resources.
+///
+/// [`ProcAddr`] contains the parsed [`ChannelAddr`], but it cannot retain the
+/// [`std::net::TcpListener`] adopted from an `fdNNN` address. Parsing the
+/// channel URL here preserves that listener for the host. We also cannot use
+/// [`ProcAddr::addr`] because it peels [`Location::Via`], which is not a valid
+/// frontend bind specification.
+fn parse_service_proc_addr_for_serve(
+    address: &str,
+) -> anyhow::Result<(ProcAddr, Option<std::net::TcpListener>)> {
+    let (proc_id, location) = service_proc_id_and_location(address);
+    let (addr, listener) = ChannelAddr::from_zmq_url_with_listener(location)
+        .map_err(|error| service_address_parse_error(address, error))?;
+    Ok((ProcAddr::new(proc_id, addr.into()), listener))
+}
 
 #[pyfunction]
 #[pyo3(signature = ())]
@@ -58,8 +122,8 @@ pub fn bootstrap_main(py: Python) -> PyResult<Bound<PyAny>> {
 
 #[pyfunction]
 pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPythonTask> {
-    let (addr, listener) = ChannelAddr::from_zmq_url_with_listener(address)?;
-
+    let (service_proc_addr, listener) = parse_service_proc_addr_for_serve(address)
+        .map_err(|error| PyValueError::new_err(error.to_string()))?;
     // Check if we're running in a PAR/XAR build by looking for FB_XAR_INVOKED_NAME environment variable
     let invoked_name = std::env::var("FB_XAR_INVOKED_NAME");
 
@@ -107,10 +171,17 @@ pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPyt
     });
 
     PyPythonTask::new(async move {
-        let (_agent_handle, shutdown) =
-            host(addr, command, None, true, listener, Gateway::new(), None)
-                .await
-                .map_pyerr()?;
+        let (_agent_handle, shutdown) = host(
+            service_proc_addr,
+            command,
+            None,
+            true,
+            listener,
+            Gateway::new(),
+            None,
+        )
+        .await
+        .map_pyerr()?;
         shutdown.stop_and_join().await;
         halt::<()>().await;
         Ok(())
@@ -118,6 +189,7 @@ pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPyt
 }
 
 #[pyfunction]
+#[pyo3(signature = (instance, workers, name=None))]
 pub fn attach_to_workers(
     instance: &crate::context::PyInstance,
     workers: Vec<Bound<'_, PyPythonTask>>,
@@ -137,20 +209,20 @@ pub fn attach_to_workers(
     PyPythonTask::new(async move {
         let results = try_join_all(tasks).await?;
 
-        let addresses: Result<Vec<ChannelAddr>, anyhow::Error> =
+        let service_procs: Result<Vec<ProcAddr>, anyhow::Error> =
             monarch_with_gil(GilSite::Bootstrap, |py| {
                 results
                     .into_iter()
                     .map(|result| {
-                        let url_str: String = result.bind(py).extract()?;
-                        Ok(ChannelAddr::from_zmq_url(&url_str)?.into_dial_addr())
+                        let address: String = result.bind(py).extract()?;
+                        parse_service_proc_addr(&address)
                     })
                     .collect()
             })
             .await;
-        let addresses = addresses?;
+        let service_procs = service_procs?;
 
-        let host_mesh = HostMesh::attach(&*instance, name, addresses)
+        let host_mesh = HostMesh::attach_with_service_procs(&*instance, name, service_procs)
             .await
             .map_err(|e| anyhow::anyhow!("attach failed: {}", e))?;
         Ok(PyHostMesh::new_owned(host_mesh))
@@ -180,4 +252,92 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
     hyperactor_mod.add_function(f)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bare_worker_address_uses_legacy_service_proc() {
+        let service_proc = parse_service_proc_addr("tcp://127.0.0.1:1234").unwrap();
+
+        assert_eq!(service_proc.id(), &legacy_service_proc_id());
+        assert_eq!(service_proc.location().to_string(), "tcp://127.0.0.1:1234");
+    }
+
+    #[test]
+    fn test_proc_worker_address_preserves_service_identity() {
+        let service_proc_id = ProcId::instance(Label::strip("service"));
+        let service_proc = ProcAddr::new(
+            service_proc_id.clone(),
+            ChannelAddr::from_zmq_url("tcp://127.0.0.1:1234")
+                .unwrap()
+                .into(),
+        );
+
+        let parsed = parse_service_proc_addr(&service_proc.to_string()).unwrap();
+
+        assert_eq!(parsed, service_proc);
+    }
+
+    #[test]
+    fn test_worker_address_disambiguates_proc_addr_from_channel_alias() {
+        let alias = "tcp://127.0.0.1:1234@tcp://0.0.0.0:1234";
+        let dial_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:1234").unwrap();
+        let legacy = parse_service_proc_addr(alias).unwrap();
+        assert_eq!(legacy.id(), &legacy_service_proc_id());
+        assert_eq!(legacy.addr(), &dial_addr);
+
+        let service_proc_id = ProcId::instance(Label::strip("service"));
+        let proc_address = format!("{service_proc_id}@{alias}");
+        let parsed = parse_service_proc_addr(&proc_address).unwrap();
+        assert_eq!(parsed.id(), &service_proc_id);
+        assert_eq!(parsed.addr(), &dial_addr);
+    }
+
+    #[test]
+    fn test_proc_worker_address_preserves_via_and_canonicalizes_alias() {
+        let service_proc_id = ProcId::instance(Label::strip("service"));
+        let via_uid = hyperactor::Uid::Instance(0x71a, Some(Label::strip("via")));
+        let alias = ChannelAddr::from_zmq_url("tcp://127.0.0.1:1234@tcp://0.0.0.0:1234").unwrap();
+        let service_proc = ProcAddr::new(
+            service_proc_id.clone(),
+            Location::from(alias).with_via(via_uid.clone()),
+        );
+
+        let parsed = parse_service_proc_addr(&service_proc.to_string()).unwrap();
+        let (parsed_via, inner) = parsed.location().as_via().unwrap();
+
+        assert_eq!(parsed.id(), &service_proc_id);
+        assert_eq!(parsed_via, &via_uid);
+        assert_eq!(inner.addr().to_zmq_url(), "tcp://127.0.0.1:1234");
+    }
+
+    #[test]
+    fn test_explicit_singleton_service_proc_is_accepted() {
+        let service_proc = parse_service_proc_addr("service@tcp://127.0.0.1:1234").unwrap();
+
+        assert_eq!(service_proc.id(), &legacy_service_proc_id());
+        assert_eq!(service_proc.location().to_string(), "tcp://127.0.0.1:1234");
+    }
+
+    #[test]
+    fn test_serve_worker_address_accepts_explicit_singleton() {
+        let (service_proc, listener) =
+            parse_service_proc_addr_for_serve("service@tcp://127.0.0.1:1234").unwrap();
+
+        assert_eq!(service_proc.id(), &legacy_service_proc_id());
+        assert_eq!(service_proc.location().to_string(), "tcp://127.0.0.1:1234");
+        assert!(listener.is_none());
+    }
+
+    #[test]
+    fn test_invalid_worker_address_error_includes_valid_formats() {
+        let error = parse_service_proc_addr("not an address").unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("invalid worker address \"not an address\""));
+        assert!(message.contains("tcp://host:4444"));
+        assert!(message.contains("service<2MuAHeDjLCEd>@tcp://host:4444"));
+    }
 }

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -17,6 +17,8 @@ use hyperactor::Endpoint as _;
 use hyperactor::Gateway;
 use hyperactor::Instance;
 use hyperactor::Proc;
+use hyperactor::ProcAddr;
+use hyperactor::ProcId;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::id::Label;
 use hyperactor_mesh::ProcMeshRef;
@@ -403,9 +405,13 @@ fn bootstrap_host(
         // flows back over the duplex. The host owns the resulting serve
         // handle and tears it down on drop.
         let gateway = Gateway::global().clone();
+        let service_proc_addr = ProcAddr::new(
+            ProcId::singleton(Label::strip(hyperactor::proc::LEGACY_SERVICE_PROC_NAME)),
+            default_bind_spec().binding_addr().into(),
+        );
 
         let (host_mesh_agent, shutdown_handle) = host(
-            default_bind_spec().binding_addr(),
+            service_proc_addr,
             Some(bootstrap_cmd),
             None,
             false,

--- a/python/monarch/_src/actor/bootstrap.py
+++ b/python/monarch/_src/actor/bootstrap.py
@@ -8,7 +8,7 @@
 
 
 from pathlib import Path
-from typing import List, Literal, Optional, Union
+from typing import Literal, Optional, Sequence, Union
 
 from monarch._rust_bindings.monarch_hyperactor.bootstrap import (
     attach_to_workers as _attach_to_workers,
@@ -47,12 +47,23 @@ def run_worker_loop_forever(
     Start a monarch server at "address" capable of letting this machine participate in
     a monarch process.
 
-    address is a zmq-style specifier for the place where the server will listen to connections, examples:
+    ``address`` accepts either of these string formats:
+
+    - A ZMQ-style channel URL. This uses the legacy ``service`` proc identity.
+    - A ProcAddr in ``<proc-id>@<channel-url>`` form. This uses the embedded
+      proc identity. An explicit legacy address such as
+      ``service@tcp://host:4444`` is equivalent to the bare channel URL.
+
+    Channel URL examples:
 
         tcp://*:4444 - listen on tcp port (NYI, use tls on connection when ca="trust_all_connections")
         metatls://*:4444 - listen on tcp port use ssl encryption via metatls
         ipc://some_unique_string - unix sockets
         inproc://3423 - connection only accessible within the process
+
+    A ProcAddr example:
+
+        service<2MuAHeDjLCEd>@tcp://worker-fqdn:4444
 
     To bind to one interface but advertise a different one, append the bind
     address after ``@``:
@@ -66,10 +77,13 @@ def run_worker_loop_forever(
     only for serving: after the worker starts, its host identity is the
     advertised address to the left of ``@``.
 
+    The bind alias can also be used inside a ProcAddr:
+
+        service<2MuAHeDjLCEd>@tcp://worker-fqdn:4444@tcp://0.0.0.0:4444
+
     The server will accept a connection to a new root client and enable it to
     use this machine as a host. If the client disconnects or cannot be contacted, this server
     kills all the current work and waits for a new connection.
-
 
     private_key is a tls private key file loaded as bytes used to establish secure connections.
     Things connecting to this machine must trust this private_key in the certificate authority file.
@@ -97,7 +111,7 @@ def attach_to_workers(
     *,
     private_key: PrivateKey = None,
     ca: CA,
-    workers: List[str | Future[str]],
+    workers: Sequence[str | Future[str]],
     name: Optional[str] = None,
 ) -> HostMesh:
     """
@@ -106,16 +120,20 @@ def attach_to_workers(
 
     This returns the host mesh immediately, and allows the logic for the hosts to
     connect to happen asynchronously. A separate future such as `await mesh.initialized` is
-    used to decide if we have successfully connected to all hosts. Workers are specified with the same zmq-style
-    specifier strings described in `run_worker_loop_forever`. They may be specified as monarch.actor.Future objects
-    so that an implementation can do some asynchronous work to discover where to connect.
+    used to decide if we have successfully connected to all hosts. Workers may
+    be strings or monarch.actor.Future objects that resolve to strings.
+
+    Each worker string accepts either of these formats:
+
+    - A ZMQ-style channel URL such as ``tcp://worker-fqdn:4444``. This uses the
+      legacy ``service`` proc identity.
+    - A ProcAddr in ``<proc-id>@<location>`` form, such as
+      ``service<2MuAHeDjLCEd>@tcp://worker-fqdn:4444``. This preserves the
+      embedded service proc identity and full location.
 
     If a worker string uses the alias form ``dial_to@bind_to``,
     ``attach_to_workers`` treats it as a reference to an already-serving
-    worker and stores only ``dial_to`` in the host mesh. The ``bind_to`` half
-    is a serve-side detail and is not part of the host, proc, or actor
-    identity.
-
+    worker. Dialing uses ``dial_to``; ``bind_to`` remains a serve-side detail.
 
     private_key is a tls private key file loaded as bytes used to establish secure connections.
     The workers must trust this private_key in their certificate authority file.


### PR DESCRIPTION
Summary:

Add typed host service identities while keeping the existing Python bootstrap call shapes backward compatible.

Allow each worker address string accepted by `run_worker_loop_forever` and `attach_to_workers` to be either a bare ZMQ channel URL or a full `ProcAddr`. Bare URLs retain the legacy `service` pseudo-singleton; full `ProcAddr` values carry a unique instance service identity and complete location. Reuse the existing `ProcAddr` parser, preserve bind aliases and adopted listeners on the worker serve path, canonicalize aliases for attach, reject explicit non-instance service identities, and document both public Python formats with actionable parse errors.

Make `bootstrap::host` and `Host::new_with_gateway` accept a `ProcAddr` startup specification. The host binds the supplied direct channel address, then remints the service proc at the gateway active advertised location after ephemeral-port resolution and optional via attachment. Reject a `Via` location as a frontend bind specification and assert that the constructed service proc carries the final gateway location. Both legacy and instance service identities use the normal shared-gateway `Proc` builder.

Make `HostMeshRef` preserve the exact `ActorRef<HostAgent>` supplied by bootstrap or attach, including service identity and full location. Route mesh-admin, proc stop, and status operations through those typed host references rather than reconstructing the legacy service identity.

Migrate the `local` pseudo-singleton to a labeled instance. Keep `LocalProcDialer` concrete: same-host child sockets are used when present, while legacy and instance host service procs, missing local procs, and remote destinations route through the backend gateway. Host-owned service procs do not bind deterministic child sockets.

Reviewed By: mariusae

Differential Revision: D115786101


