### PR TITLE
Adopt unique host identities in launchers (#4687)

### DIFF
--- a/docs/source/books/hyperactor-book/src/procs/host.md
+++ b/docs/source/books/hyperactor-book/src/procs/host.md
@@ -47,12 +47,11 @@ registered peer sender.
 gateway, so they reach each other—and the host reaches them—through the
 gateway's local `procs` table, with zero dialing.
 
-Their ids are *legacy pseudo-singletons*: literally the names `"service"` and
-`"local"`, identical across every host. A gateway can hold at most one proc per
-id, so a gateway can host at most one `service`/`local` pair—i.e. at most one
-host. `Host::new` uses `Gateway::global()`; callers that need more than one
-host in the same process, or need a pre-attached gateway, must use
-`Host::new_with_gateway`.
+`local_proc` always has a fresh instance id labeled `"local"`. Launchers can
+also give `service_proc` a fresh instance id labeled `"service"` through
+`Host::new_with_gateway`. The default remains the legacy `"service"`
+pseudo-singleton for compatibility. A gateway can contain multiple hosts only
+when each host has a distinct service proc id.
 
 ## Spawned children
 
@@ -79,8 +78,14 @@ let backend_addr = gateway.default_location().addr().clone();
 let frontend_handle = gateway.serve_with_listener(addr, listener)?;
 let frontend_addr = gateway.default_location().addr().clone();
 
-let service_proc = Proc::legacy_service_pseudo_singleton_on_gateway(gateway.clone());
-let local_proc = Proc::legacy_local_pseudo_singleton_on_gateway(gateway.clone());
+let service_proc = Proc::builder()
+    .proc_id(service_proc_id)
+    .shared_gateway(gateway.clone())
+    .build()?;
+let local_proc = Proc::builder()
+    .proc_id(ProcId::instance(Label::strip("local")))
+    .shared_gateway(gateway.clone())
+    .build()?;
 ```
 
 The backend address is passed to each child as its fallback route back to the
@@ -94,9 +99,9 @@ the frontend serve becomes the default location until a newer serve replaces it.
 
 ## Local proc invariant (LP-1)
 
-The local proc always exists as the singleton proc id `"local"` on the host
-gateway and is forwarded in-process, but it starts with zero actors. A
-`ProcAgent` and root client actor are added only when
+The local proc always exists as an instance proc with the label `"local"` on
+the host gateway and is routed through the gateway's local proc table, but it
+starts with zero actors. A `ProcAgent` and root client actor are added only when
 `HostMeshAgent::handle(GetLocalProc)` is first called.
 
 ## See Also

--- a/docs/source/examples/getting_started.py
+++ b/docs/source/examples/getting_started.py
@@ -135,6 +135,16 @@ counters.slice(gpus=slice(0, 4)).increment.broadcast()
 print(counters.get_value.call().get())
 
 
+# Standalone helper for the getting-started example. This was previously
+# `monarch.actor.hosts_from_config` (now removed from public API). It is
+# kept here as an example of how a config-driven HostMesh could be built
+# and is not part of Monarch's public API.
+import os
+import subprocess
+import sys
+import tempfile
+
+from monarch._src.job.service_identity import new_service_proc_id
 # %%
 # ``broadcast`` and ``call`` are the most commonly used adverbs. The ``call_one`` adverb we used
 # earlier is actually just a special case of ``call``, asserting that you know there is only
@@ -148,13 +158,55 @@ print(counters.get_value.call().get())
 # machines are obtained depends on the scheduling system (Slurm, Kubernetes, SkyPilot, etc.),
 # but these schedulers are typically encapsulated in a config file.
 
-from monarch.actor import context, HostMesh, hosts_from_config
+from monarch.actor import context, HostMesh
+
+
+def hosts_from_config(name: str) -> HostMesh:
+    """
+    Get the host mesh 'name' from the monarch configuration for the project.
+
+    This config can be modified so that the same code can create meshes from scheduler sources,
+    and different sizes etc.
+
+    WARNING: This function is a standin so that our getting_started example code works. The real implementation
+    needs an RFC design.
+    """
+    num_hosts = 2
+    tmpdir = tempfile.mkdtemp(prefix="monarch_hosts_from_config_")
+    workers = []
+    service_proc_ids = []
+    for i in range(num_hosts):
+        addr = f"ipc://{tmpdir}/{name}_{i}"
+        service_proc_id = new_service_proc_id()
+        env = {**os.environ}
+        cmd = [
+            sys.executable,
+            "-c",
+            "from monarch._rust_bindings.monarch_hyperactor.proc import ProcId; "
+            "from monarch.actor import run_worker_loop_forever; "
+            f'run_worker_loop_forever(address="{addr}", '
+            f"service_proc_id=ProcId.from_string({str(service_proc_id)!r}), "
+            'ca="trust_all_connections")',
+        ]
+        subprocess.Popen(cmd, env=env, start_new_session=True)
+        workers.append(addr)
+        service_proc_ids.append(service_proc_id)
+
+    from monarch._src.actor.bootstrap import attach_to_workers
+
+    return attach_to_workers(
+        name=name,
+        ca="trust_all_connections",
+        # pyrefly: ignore [bad-argument-type]
+        workers=workers,
+        service_proc_ids=service_proc_ids,
+    )
 
 
 # %%
 # We obtain the mesh of hosts for the job by loading that config:
 
-hosts: HostMesh = hosts_from_config("MONARCH_HOSTS")  # NYI: hosts_from_config
+hosts: HostMesh = hosts_from_config("MONARCH_HOSTS")  # example helper, not public API
 print(hosts.extent)
 
 # An extent is the logical shape of a mesh. It is an ordered map, specifying the size of

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -2578,7 +2578,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_gateway_serve_via_delivers_peeled_legacy_local_proc_destination() {
+    async fn test_gateway_serve_via_delivers_peeled_instance_proc_destination() {
         let server_gw = Gateway::new();
         let mut accept_handle = server_gw
             .serve_duplex(ChannelAddr::any(ChannelTransport::Unix))
@@ -2587,7 +2587,11 @@ mod tests {
 
         let client_gw = Gateway::new();
         let mut serve_via = client_gw.serve_via(server_addr).await.unwrap();
-        let client_proc = Proc::legacy_local_pseudo_singleton_on_gateway(client_gw.clone());
+        let client_proc = Proc::builder()
+            .proc_id(ProcId::anonymous())
+            .shared_gateway(client_gw.clone())
+            .build()
+            .unwrap();
         let client = client_proc.client("recv");
         let (port, mut rx) = client.bind_handler_port::<u64>();
         let PortLocation::Bound(via_dest) = port.location() else {
@@ -2670,7 +2674,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_gateway_serve_via_relay_delivers_to_client_legacy_local_proc() {
+    async fn test_gateway_serve_via_relay_delivers_to_client_instance_proc() {
         let relay_gw = Gateway::new();
         let mut accept_handle = relay_gw
             .serve_duplex(ChannelAddr::any(ChannelTransport::Unix))
@@ -2679,7 +2683,11 @@ mod tests {
 
         let client_gw = Gateway::new();
         let mut serve_via = client_gw.serve_via(relay_addr.clone()).await.unwrap();
-        let client_proc = Proc::legacy_local_pseudo_singleton_on_gateway(client_gw.clone());
+        let client_proc = Proc::builder()
+            .proc_id(ProcId::anonymous())
+            .shared_gateway(client_gw.clone())
+            .build()
+            .unwrap();
         let client = client_proc.client("recv");
         let (port, mut rx) = client.bind_handler_port::<u64>();
         let PortLocation::Bound(via_dest) = port.location() else {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -221,12 +221,6 @@ tokio::task_local! {
     static CURRENT_TASK_PROC: Proc;
 }
 
-/// Legacy singleton proc name used for host-local client actors.
-///
-/// This is not a true singleton: every host may have a `local` proc, so local
-/// delivery must compare both proc id and location for this id.
-pub const LEGACY_LOCAL_PROC_NAME: &str = "local";
-
 /// Legacy singleton proc name used for host system actors.
 ///
 /// This is not a true singleton: every host may have a `service` proc, so
@@ -883,12 +877,6 @@ impl Proc {
         Self::from_parts_unchecked(proc_id, gateway)
     }
 
-    /// Create the legacy host-local client proc pseudo-singleton on
-    /// a fresh gateway whose forwarder is `forwarder`.
-    pub fn legacy_local_pseudo_singleton(addr: ChannelAddr, forwarder: BoxedMailboxSender) -> Self {
-        Self::legacy_local_pseudo_singleton_on_gateway(Gateway::configured(addr.into(), forwarder))
-    }
-
     /// Create the legacy host system proc pseudo-singleton on a
     /// fresh gateway whose forwarder is `forwarder`.
     pub fn legacy_service_pseudo_singleton(
@@ -899,12 +887,6 @@ impl Proc {
             addr.into(),
             forwarder,
         ))
-    }
-
-    /// Create the legacy host-local client proc pseudo-singleton on
-    /// the provided shared gateway.
-    pub fn legacy_local_pseudo_singleton_on_gateway(gateway: Gateway) -> Self {
-        Self::legacy_pseudo_singleton_on_gateway(LEGACY_LOCAL_PROC_NAME, gateway)
     }
 
     /// Create the legacy host system proc pseudo-singleton on the
@@ -1838,10 +1820,9 @@ impl Proc {
 
 fn requires_location_for_local_delivery_identity(proc_id: &ProcId) -> bool {
     // Temporary hyperactor_mesh compatibility hack: host bootstrap
-    // still creates a `service` proc and a `local` proc in every host
-    // process, so those proc ids are not globally unique. Until those
-    // construction paths are assigned instance ids, local delivery for
-    // those two ids also compares the terminal channel address.
+    // still creates a `service` proc in every host process, so that proc id
+    // is not globally unique. Until all construction paths assign it an
+    // instance id, local delivery also compares the terminal channel address.
     is_legacy_pseudo_singleton_proc_id(proc_id)
 }
 
@@ -1882,10 +1863,7 @@ fn is_legacy_pseudo_singleton_proc_id(proc_id: &ProcId) -> bool {
 }
 
 fn is_legacy_pseudo_singleton_label(label: &Label) -> bool {
-    matches!(
-        label.as_str(),
-        LEGACY_SERVICE_PROC_NAME | LEGACY_LOCAL_PROC_NAME
-    )
+    label.as_str() == LEGACY_SERVICE_PROC_NAME
 }
 
 #[async_trait]
@@ -5883,26 +5861,18 @@ mod tests {
     }
 
     #[test]
-    fn test_local_delivery_service_and_local_compare_full_proc_addr() {
-        for name in [LEGACY_SERVICE_PROC_NAME, LEGACY_LOCAL_PROC_NAME] {
-            let local = ProcAddr::singleton(ChannelAddr::Local(1), name);
-            let same_id_other_location = ProcAddr::singleton(ChannelAddr::Local(2), name);
-            let proc = match name {
-                LEGACY_SERVICE_PROC_NAME => Proc::legacy_service_pseudo_singleton(
-                    ChannelAddr::Local(1),
-                    BoxedMailboxSender::new(PanickingMailboxSender),
-                ),
-                LEGACY_LOCAL_PROC_NAME => Proc::legacy_local_pseudo_singleton(
-                    ChannelAddr::Local(1),
-                    BoxedMailboxSender::new(PanickingMailboxSender),
-                ),
-                _ => unreachable!("test only covers legacy pseudo-singletons"),
-            };
+    fn test_local_delivery_legacy_service_compares_full_proc_addr() {
+        let local = ProcAddr::singleton(ChannelAddr::Local(1), LEGACY_SERVICE_PROC_NAME);
+        let same_id_other_location =
+            ProcAddr::singleton(ChannelAddr::Local(2), LEGACY_SERVICE_PROC_NAME);
+        let proc = Proc::legacy_service_pseudo_singleton(
+            ChannelAddr::Local(1),
+            BoxedMailboxSender::new(PanickingMailboxSender),
+        );
 
-            assert_eq!(local.id(), same_id_other_location.id());
-            assert!(proc.is_local_delivery_target(&local));
-            assert!(!proc.is_local_delivery_target(&same_id_other_location));
-        }
+        assert_eq!(local.id(), same_id_other_location.id());
+        assert!(proc.is_local_delivery_target(&local));
+        assert!(!proc.is_local_delivery_target(&same_id_other_location));
 
         let shared = ProcAddr::singleton(ChannelAddr::Local(1), "shared");
         let shared_other_location = ProcAddr::singleton(ChannelAddr::Local(2), "shared");
@@ -5923,16 +5893,14 @@ mod tests {
     }
 
     #[test]
-    fn test_legacy_pseudo_singletons_use_dedicated_constructors() {
-        for name in [LEGACY_SERVICE_PROC_NAME, LEGACY_LOCAL_PROC_NAME] {
-            let result = std::panic::catch_unwind(|| {
-                Proc::configured(
-                    ProcAddr::singleton(ChannelAddr::Local(1), name),
-                    BoxedMailboxSender::new(PanickingMailboxSender),
-                );
-            });
-            assert!(result.is_err());
-        }
+    fn test_legacy_service_pseudo_singleton_uses_dedicated_constructor() {
+        let result = std::panic::catch_unwind(|| {
+            Proc::configured(
+                ProcAddr::singleton(ChannelAddr::Local(1), LEGACY_SERVICE_PROC_NAME),
+                BoxedMailboxSender::new(PanickingMailboxSender),
+            );
+        });
+        assert!(result.is_err());
 
         let service = Proc::legacy_service_pseudo_singleton(
             ChannelAddr::Local(1),
@@ -5941,15 +5909,6 @@ mod tests {
         assert_eq!(
             service.proc_addr().id().uid().to_string(),
             LEGACY_SERVICE_PROC_NAME
-        );
-
-        let local = Proc::legacy_local_pseudo_singleton(
-            ChannelAddr::Local(2),
-            BoxedMailboxSender::new(PanickingMailboxSender),
-        );
-        assert_eq!(
-            local.proc_addr().id().uid().to_string(),
-            LEGACY_LOCAL_PROC_NAME
         );
     }
 

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -43,6 +43,7 @@ use hyperactor::Endpoint as _;
 use hyperactor::Gateway;
 use hyperactor::Label;
 use hyperactor::ProcAddr;
+use hyperactor::ProcId;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelError;
@@ -81,6 +82,7 @@ use crate::host::SingleTerminate;
 use crate::host::TerminateError;
 use crate::host::TerminateSummary;
 use crate::host::WaitError;
+use crate::host::legacy_service_proc_id;
 use crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
 use crate::host_mesh::host_agent::HostAgent;
 use crate::logging::OutputTarget;
@@ -310,6 +312,7 @@ impl DrainedHostShutdown {
 ///   with `serve_via` during bootstrap — after the local serves but
 ///   before any ref is minted — so refs advertise the routable `Via`
 ///   location (used by out-of-cluster clients).
+/// - `service_proc_id`: optional caller-provided identity for the service proc.
 pub async fn host(
     addr: ChannelAddr,
     command: Option<BootstrapCommand>,
@@ -318,6 +321,7 @@ pub async fn host(
     listener: Option<std::net::TcpListener>,
     gateway: Gateway,
     via: Option<ChannelAddr>,
+    service_proc_id: Option<ProcId>,
 ) -> anyhow::Result<(ActorHandle<HostAgent>, HostShutdownHandle)> {
     if let Some(attrs) = config {
         hyperactor_config::global::set(hyperactor_config::global::Source::Runtime, attrs);
@@ -332,7 +336,9 @@ pub async fn host(
     };
     let manager = BootstrapProcManager::new(command)?;
 
-    let host = Host::new_with_gateway(manager, addr, listener, gateway, via).await?;
+    let service_proc_id = service_proc_id.unwrap_or_else(legacy_service_proc_id);
+    let host =
+        Host::new_with_gateway(manager, addr, listener, gateway, via, service_proc_id).await?;
     let addr = host.addr().clone();
 
     // The ShutdownHost handler sends the active client transports back here
@@ -590,9 +596,9 @@ impl Bootstrap {
                 let (serve_addr, _) = local_proc_addr(&socket_dir_path, proc_id.id())?;
 
                 // The following is a modified host::spawn_proc to support direct
-                // dialing between local procs: 1) we bind each proc to a deterministic
-                // address in socket_dir_path; 2) we use LocalProcDialer to dial these
-                // addresses for local procs.
+                // dialing between spawned sibling procs: 1) we bind each proc to a
+                // deterministic address in socket_dir_path; 2) we use LocalProcDialer
+                // to dial those addresses directly.
                 let proc_sender = mailbox::LocalProcDialer::new(
                     local_addr.clone(),
                     socket_dir_path,
@@ -642,6 +648,7 @@ impl Bootstrap {
                     exit_on_shutdown,
                     None,
                     Gateway::global().clone(),
+                    None,
                     None,
                 )
                 .await?;
@@ -3461,6 +3468,7 @@ mod tests {
             false,
             None,
             Gateway::global().clone(),
+            None,
             None,
         )
         .await

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -26,21 +26,24 @@ use hyperactor::mailbox::TransportFailureReason;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::mailbox::UndeliverableReason;
 
-/// LocalProcDialer dials local procs directly through a configured socket
-/// directory.
+/// Dials local procs directly through a configured socket directory.
+///
+/// A same-host destination is direct-dialable when its deterministic socket
+/// exists in `socket_dir`. Other destinations are routed through the backend
+/// sender to the host gateway.
 #[derive(Debug)]
 pub(crate) struct LocalProcDialer {
     local_addr: ChannelAddr,
     socket_dir: PathBuf,
     backend_sender: MailboxClient,
-    local_senders: RwLock<HashMap<Uid, Result<MailboxClient, ChannelError>>>,
+    local_senders: RwLock<HashMap<Uid, MailboxClient>>,
 }
 
 impl LocalProcDialer {
-    /// Create a new local proc dialer. Any direct-addressed procs with a destination
-    /// address of `local_addr`, will instead be dialed through the direct sockets
-    /// present in `socket_dir`. Messages to other procs are forwarded through the
-    /// backend sender.
+    /// Create a new local proc dialer. Procs with a destination address of
+    /// `local_addr` are dialed through direct sockets when present in
+    /// `socket_dir`. Messages to other procs are forwarded through the backend
+    /// sender.
     pub(crate) fn new(
         local_addr: ChannelAddr,
         socket_dir: PathBuf,
@@ -53,6 +56,22 @@ impl LocalProcDialer {
             local_senders: RwLock::new(HashMap::new()),
         }
     }
+
+    fn return_dial_failure(
+        error: &ChannelError,
+        envelope: MessageEnvelope,
+        return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+    ) {
+        let destination = envelope.dest().clone();
+        let failure = DeliveryFailure::new(UndeliverableReason::Transport(TransportFailure::new(
+            destination.clone(),
+            TransportFailureReason::DialFailed {
+                addr: destination.actor_addr().proc_addr().addr().clone(),
+                error: error.to_string(),
+            },
+        )));
+        envelope.undeliverable(failure, return_handle);
+    }
 }
 
 #[async_trait]
@@ -64,51 +83,36 @@ impl MailboxSender for LocalProcDialer {
     ) {
         let proc_ref = envelope.dest().actor_addr().proc_addr();
         let addr = proc_ref.addr();
-        if addr == &self.local_addr
-            // ...and only non-system procs on that address; the rest are directly
-            // reachable through the backend address.
-            && proc_ref.uid().is_instance()
-        {
+        if addr == &self.local_addr {
             let key = proc_ref.id().pseudo_uid();
-            let senders = self.local_senders.read().unwrap();
-            let senders = if senders.contains_key(&key) {
-                senders
-            } else {
-                drop(senders);
-                let mut senders = self.local_senders.write().unwrap();
-                senders.entry(key.clone()).or_insert_with(|| {
-                    let (addr, path) = super::local_proc_addr(&self.socket_dir, proc_ref.id())
-                        .map_err(|e| ChannelError::InvalidAddress(e.to_string()))?;
-                    if !path.exists() {
-                        return Err(ChannelError::InvalidAddress(format!(
-                            "unix socket path '{}' does not exist",
-                            path.display()
-                        )));
-                    }
-                    MailboxClient::dial(addr)
-                });
-                drop(senders);
-                self.local_senders.read().unwrap()
-            };
-
-            match senders.get(&key).unwrap() {
-                Ok(sender) => sender.post_unchecked(envelope, return_handle),
-                Err(e) => {
-                    let failure = DeliveryFailure::new(UndeliverableReason::Transport(
-                        TransportFailure::new(
-                            envelope.dest().clone(),
-                            TransportFailureReason::DialFailed {
-                                addr: addr.clone(),
-                                error: e.to_string(),
-                            },
-                        ),
-                    ));
-                    envelope.undeliverable(failure, return_handle);
+            {
+                let senders = self.local_senders.read().unwrap();
+                if let Some(sender) = senders.get(&key) {
+                    sender.post_unchecked(envelope, return_handle);
+                    return;
                 }
             }
-        } else {
-            self.backend_sender.post_unchecked(envelope, return_handle);
+
+            if let Ok((local_addr, path)) = super::local_proc_addr(&self.socket_dir, proc_ref.id())
+                && path.exists()
+            {
+                let mut senders = self.local_senders.write().unwrap();
+                if let Some(sender) = senders.get(&key) {
+                    sender.post_unchecked(envelope, return_handle);
+                    return;
+                }
+                match MailboxClient::dial(local_addr) {
+                    Ok(sender) => {
+                        sender.post_unchecked(envelope, return_handle);
+                        senders.insert(key, sender);
+                    }
+                    Err(error) => Self::return_dial_failure(&error, envelope, return_handle),
+                }
+                return;
+            }
         }
+
+        self.backend_sender.post_unchecked(envelope, return_handle);
     }
 
     async fn flush(&self) -> Result<(), anyhow::Error> {
@@ -122,9 +126,6 @@ impl MailboxSender for LocalProcDialer {
 
 #[cfg(test)]
 mod tests {
-
-    use std::assert_matches;
-
     use hyperactor::Mailbox;
     use hyperactor::channel::ChannelAddr;
     use hyperactor::channel::ChannelTransport;
@@ -141,9 +142,10 @@ mod tests {
     async fn test_proc_dialer() {
         let dir = tempfile::tempdir().unwrap();
         let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
-        let first = hyperactor::ProcAddr::instance(local_addr.clone(), "first");
-        let second = hyperactor::ProcAddr::instance(local_addr.clone(), "second");
-        let third = hyperactor::ProcAddr::instance(local_addr.clone(), "third");
+        let make_proc = |name: &str| hyperactor::ProcAddr::instance(local_addr.clone(), name);
+        let first = make_proc("first");
+        let second = make_proc("second");
+        let third = make_proc("third");
         let (first_serve, _) = local_proc_addr(dir.path(), first.id()).unwrap();
         let (_first_addr, mut first_rx) = channel::serve::<MessageEnvelope>(first_serve).unwrap();
         let (second_serve, _) = local_proc_addr(dir.path(), second.id()).unwrap();
@@ -162,7 +164,7 @@ mod tests {
             MailboxClient::dial(backend_addr).unwrap(),
         );
 
-        let (return_handle, mut return_rx) = Mailbox::new(test_actor_id("world_0", "proc"))
+        let (return_handle, _return_rx) = Mailbox::new(test_actor_id("world_0", "proc"))
             .open_port::<Undeliverable<MessageEnvelope>>();
 
         // Existing address on the host:
@@ -178,7 +180,25 @@ mod tests {
             &third_notexist_actor_id
         );
 
-        // Nonexistant address on the host:
+        // A via-prefixed address for the same proc still resolves to its
+        // deterministic direct socket.
+        let first_via = hyperactor::ProcAddr::new(
+            first.id().clone(),
+            hyperactor::Location::from(local_addr.clone()).with_via(first.id().uid().clone()),
+        );
+        let envelope = MessageEnvelope::new(
+            third_notexist_actor_id.clone(),
+            first_via.actor_addr("actor").port_addr(0.into()),
+            wirevalue::Any::serialize(&()).unwrap(),
+            Flattrs::new(),
+        );
+        proc_dialer.post(envelope, return_handle.clone());
+        assert_eq!(
+            first_rx.recv().await.unwrap().sender(),
+            &third_notexist_actor_id
+        );
+
+        // Missing direct socket on the host uses the backend:
         let envelope = MessageEnvelope::new(
             second_actor_id.clone(),
             third_notexist_actor_id.port_addr(0.into()),
@@ -186,20 +206,7 @@ mod tests {
             Flattrs::new(),
         );
         proc_dialer.post(envelope.clone(), return_handle.clone());
-        let envelope = return_rx
-            .recv()
-            .await
-            .unwrap()
-            .into_message()
-            .expect("expected returned envelope");
-        assert_matches!(
-            envelope
-                .root_delivery_failure()
-                .map(|failure| &failure.kind),
-            Some(hyperactor::mailbox::DeliveryFailureKind::Undeliverable(
-                UndeliverableReason::Transport(_)
-            ))
-        );
+        assert_eq!(backend_rx.recv().await.unwrap().sender(), &second_actor_id);
 
         // Outside the host:
         let envelope = MessageEnvelope::new(
@@ -224,41 +231,14 @@ mod tests {
         assert_eq!(backend_rx.recv().await.unwrap().sender(), &second_actor_id);
     }
 
-    /// Same-host proc-to-proc traffic must keep using the direct
-    /// local-socket path even when destinations carry a `Via(uid,
-    /// Addr(host_addr))` source-routing prefix (the convention
-    /// `Host::spawn` now applies to every spawned child). The
-    /// `Via` should not push the envelope onto the slower backend
-    /// sender path.
     #[tokio::test]
-    async fn test_proc_dialer_via_prefixed_dest() {
-        use hyperactor::Location;
-
+    async fn test_proc_dialer_without_socket_uses_backend() {
         let dir = tempfile::tempdir().unwrap();
         let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
-
-        // Build two sibling procs with the via-prefixed location
-        // convention used by `Host::spawn`.
-        let make_proc = |name: &str| -> hyperactor::ProcAddr {
-            let bare = hyperactor::ProcAddr::instance(local_addr.clone(), name);
-            let via = Location::from(local_addr.clone()).with_via(bare.id().uid().clone());
-            hyperactor::ProcAddr::new(bare.id().clone(), via)
-        };
-        let first = make_proc("first");
-        let second = make_proc("second");
-        assert!(
-            first.location().as_via().is_some(),
-            "test setup: spawned-proc address must carry a via prefix"
-        );
-
-        let (first_serve, _) = local_proc_addr(dir.path(), first.id()).unwrap();
-        let (_first_addr, mut first_rx) = channel::serve::<MessageEnvelope>(first_serve).unwrap();
-
+        let sender = hyperactor::ProcAddr::instance(local_addr.clone(), "sender");
+        let host_local = hyperactor::ProcAddr::instance(local_addr.clone(), "local");
         let (backend_addr, mut backend_rx) =
             channel::serve::<MessageEnvelope>(ChannelTransport::Unix.any()).unwrap();
-
-        let first_actor_id = first.actor_addr("actor");
-        let second_actor_id = second.actor_addr("actor");
         let proc_dialer = LocalProcDialer::new(
             local_addr.clone(),
             dir.path().to_owned(),
@@ -267,22 +247,18 @@ mod tests {
         let (return_handle, _return_rx) = Mailbox::new(test_actor_id("world_0", "proc"))
             .open_port::<Undeliverable<MessageEnvelope>>();
 
-        // `second` → `first`, both via-prefixed. Expect the
-        // envelope on `first`'s local socket (direct path), not on
-        // the backend.
         let envelope = MessageEnvelope::new(
-            second_actor_id.clone(),
-            first_actor_id.port_addr(0.into()),
+            sender.actor_addr("actor"),
+            host_local.actor_addr("actor").port_addr(0.into()),
             wirevalue::Any::serialize(&()).unwrap(),
             Flattrs::new(),
         );
-        proc_dialer.post(envelope, return_handle.clone());
-        assert_eq!(first_rx.recv().await.unwrap().sender(), &second_actor_id);
-        assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(50), backend_rx.recv())
-                .await
-                .is_err(),
-            "via-prefixed sibling traffic must not detour through the backend",
-        );
+        proc_dialer.post(envelope, return_handle);
+
+        let forwarded = tokio::time::timeout(std::time::Duration::from_secs(1), backend_rx.recv())
+            .await
+            .expect("destination without a socket must be forwarded to the backend")
+            .expect("backend channel closed before receiving forwarded message");
+        assert_eq!(forwarded.dest().actor_addr().proc_addr(), host_local);
     }
 }

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -14,8 +14,8 @@
 //! and frontend endpoints, multiplexes inbound traffic to in-process procs,
 //! and routes spawned child proc gateways through peer routes.
 //!
-//! Use [`Host::new`] or [`Host::new_with_gateway`] to construct a host, start
-//! its backend and frontend accept loops, then [`Host::spawn`] to create child procs.
+//! Use [`Host::new`] or [`Host::new_with_gateway`] to construct a host, start its
+//! backend and frontend accept loops, then [`Host::spawn`] to create child procs.
 //! Spawned children are returned as [`ProcAddr`] values whose location is
 //! advertised through this host's gateway.
 //!
@@ -76,6 +76,7 @@ use hyperactor::ActorRef;
 use hyperactor::Gateway;
 use hyperactor::Proc;
 use hyperactor::ProcAddr;
+use hyperactor::ProcId;
 use hyperactor::actor::Binds;
 use hyperactor::actor::Referable;
 use hyperactor::channel;
@@ -88,9 +89,25 @@ use hyperactor::channel::Tx;
 use hyperactor::context;
 use hyperactor::gateway::GatewayServeHandle;
 use hyperactor::gateway::PeerAttachGuard;
+use hyperactor::id::Label;
 use hyperactor::mailbox::IntoBoxedMailboxSender as _;
 use hyperactor::mailbox::MailboxClient;
 use hyperactor::mailbox::MailboxServer;
+use tokio::process::Child;
+use tokio::process::Command;
+use tokio::sync::Mutex;
+
+use crate::mesh_id::ResourceId;
+
+/// Name of the system service proc on a host.
+///
+/// Hosts the admin actor layer: HostMeshAgent, MeshAdminAgent, and bridge.
+pub const SERVICE_PROC_NAME: &str = hyperactor::proc::LEGACY_SERVICE_PROC_NAME;
+
+pub(crate) fn legacy_service_proc_id() -> ProcId {
+    ProcId::singleton(Label::strip(SERVICE_PROC_NAME))
+}
+
 /// Name of the local client proc on a host.
 ///
 /// See LP-1 (lazy activation) in module doc.
@@ -99,16 +116,7 @@ use hyperactor::mailbox::MailboxServer;
 /// `GetLocalProc` is never sent, so the local proc remains empty
 /// throughout the program's lifetime. Code that inspects the local
 /// proc's actors must not assume they exist.
-pub use hyperactor::proc::LEGACY_LOCAL_PROC_NAME as LOCAL_PROC_NAME;
-/// Name of the system service proc on a host.
-///
-/// Hosts the admin actor layer: HostMeshAgent, MeshAdminAgent, and bridge.
-pub use hyperactor::proc::LEGACY_SERVICE_PROC_NAME as SERVICE_PROC_NAME;
-use tokio::process::Child;
-use tokio::process::Command;
-use tokio::sync::Mutex;
-
-use crate::mesh_id::ResourceId;
+pub const LOCAL_PROC_NAME: &str = "local";
 
 /// The type of error produced by host operations.
 #[derive(Debug, thiserror::Error)]
@@ -148,6 +156,10 @@ pub enum HostError {
     /// Attaching the gateway to a remote `serve_via` session failed.
     #[error("failed to attach gateway via session: {0}")]
     ViaAttachFailure(#[source] anyhow::Error),
+
+    /// Constructing a built-in proc failed.
+    #[error("failed to construct built-in proc: {0}")]
+    ProcConstructionFailure(#[source] anyhow::Error),
 }
 
 /// Client transport handles transferred to the bootstrap shutdown task.
@@ -244,19 +256,26 @@ impl<M: ProcManager> Host<M> {
         // host share one routing table with the rest of the process.
         // Callers that need a different gateway (e.g. via attach) build
         // it externally and pass it to [`new_with_gateway`].
-        Self::new_with_gateway(manager, addr, listener, Gateway::global().clone(), None).await
+        Self::new_with_gateway(
+            manager,
+            addr,
+            listener,
+            Gateway::global().clone(),
+            None,
+            legacy_service_proc_id(),
+        )
+        .await
     }
 
-    /// Like [`new_with_default`], but uses a caller-provided
-    /// [`Gateway`] instead of creating one internally.
+    /// Like [`new_with_default`], but uses a caller-provided [`Gateway`] and
+    /// requires the caller to choose the service proc identity.
     ///
     /// Serving the backend and frontend endpoints, choosing the frontend
     /// transport, and adopting the frontend address as the gateway's
     /// advertised location are all owned by the gateway. The host operates on
     /// a vanilla gateway: it never inspects the transport nor rewrites the
     /// gateway's location. Adopting the bound frontend address makes the
-    /// legacy pseudo-singleton proc ids (system, local) carry it so remote
-    /// hosts can reach them by name.
+    /// built-in proc ids carry it so remote hosts can reach them.
     ///
     /// When `via` is `Some`, the gateway attaches to that remote duplex
     /// address with [`Gateway::serve_via`] *after* the local
@@ -273,6 +292,7 @@ impl<M: ProcManager> Host<M> {
         listener: Option<std::net::TcpListener>,
         gateway: Gateway,
         via: Option<ChannelAddr>,
+        service_proc_id: ProcId,
     ) -> Result<Self, HostError> {
         let mut backend_handle = Gateway::serve(&gateway, ChannelAddr::any(manager.transport()))?;
         let backend_addr = gateway.default_location().addr().clone();
@@ -341,8 +361,16 @@ impl<M: ProcManager> Host<M> {
         // gateway servers are live. The HostAgent is published only
         // after it binds its handler, so the brief unroutable window is
         // before normal clients can discover this host.
-        let service_proc = Proc::legacy_service_pseudo_singleton_on_gateway(gateway.clone());
-        let local_proc = Proc::legacy_local_pseudo_singleton_on_gateway(gateway.clone());
+        let service_proc = Proc::builder()
+            .proc_id(service_proc_id)
+            .shared_gateway(gateway.clone())
+            .build()
+            .map_err(HostError::ProcConstructionFailure)?;
+        let local_proc = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip(LOCAL_PROC_NAME)))
+            .shared_gateway(gateway.clone())
+            .build()
+            .map_err(HostError::ProcConstructionFailure)?;
         let service_proc_id = service_proc.proc_addr().clone();
         let local_proc_id = local_proc.proc_addr().clone();
 
@@ -2268,6 +2296,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_explicit_service_and_local_proc_ids_are_instances() {
+        let proc_manager = LocalProcManager::new(|proc: Proc| async move {
+            Ok(proc.spawn_with_label::<()>("host_agent", ()))
+        });
+        let service_proc_id = ProcId::instance(hyperactor::id::Label::strip("service"));
+
+        let host = Host::new_with_gateway(
+            proc_manager,
+            ChannelAddr::any(ChannelTransport::Unix),
+            None,
+            Gateway::new(),
+            None,
+            service_proc_id.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(host.system_proc().proc_id(), &service_proc_id);
+        assert!(matches!(
+            host.local_proc().proc_id().uid(),
+            hyperactor::id::Uid::Instance(..)
+        ));
+        assert_eq!(
+            host.local_proc()
+                .proc_id()
+                .label()
+                .map(|label| label.as_str()),
+            Some(LOCAL_PROC_NAME)
+        );
+    }
+
+    #[tokio::test]
     async fn test_spawn_uses_latest_serve_location_after_prior_default_override() {
         let proc_manager = LocalProcManager::new(|proc: Proc| async move {
             Ok(proc.spawn_with_label::<()>("host_agent", ()))
@@ -2284,6 +2344,7 @@ mod tests {
             None,
             gateway,
             None,
+            legacy_service_proc_id(),
         )
         .await
         .unwrap();
@@ -2311,6 +2372,7 @@ mod tests {
             None,
             Gateway::new(),
             None,
+            legacy_service_proc_id(),
         )
         .await
         .unwrap();
@@ -2362,6 +2424,7 @@ mod tests {
             None,
             gateway.clone(),
             Some(remote_addr.clone()),
+            legacy_service_proc_id(),
         )
         .await
         .unwrap();

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -73,6 +73,7 @@ use std::time::Duration;
 
 use hyperactor::ActorAddr;
 use hyperactor::ProcAddr;
+use hyperactor::ProcId;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::context;
 use hyperactor_cast::cast_actor::CAST_ACTOR_NAME;
@@ -99,6 +100,7 @@ use crate::bootstrap::ProcBind;
 use crate::host::Host;
 use crate::host::LocalProcManager;
 use crate::host::SERVICE_PROC_NAME;
+use crate::host::legacy_service_proc_id;
 pub use crate::host_mesh::host_agent::HostAgent;
 use crate::host_mesh::host_agent::ProcManagerSpawnFn;
 use crate::host_mesh::host_agent::ProcState;
@@ -145,12 +147,16 @@ declare_attrs! {
     pub attr GET_PROC_STATE_MAX_IDLE: Duration = Duration::from_mins(1);
 }
 
-pub(crate) fn host_agent_ref(host_addr: ChannelAddr) -> ActorRef<HostAgent> {
-    let host_addr = host_addr.into_dial_addr();
-    ActorRef::attest(
-        ResourceId::proc_addr_from_name(host_addr, SERVICE_PROC_NAME)
-            .actor_addr(host_agent::HOST_MESH_AGENT_ACTOR_NAME),
-    )
+fn legacy_service_proc_addr(host_addr: ChannelAddr) -> ProcAddr {
+    ProcAddr::new(legacy_service_proc_id(), host_addr.into_dial_addr().into())
+}
+
+pub(crate) fn host_agent_ref(service_proc: ProcAddr) -> ActorRef<HostAgent> {
+    ActorRef::attest(service_proc.actor_addr(host_agent::HOST_MESH_AGENT_ACTOR_NAME))
+}
+
+pub(crate) fn legacy_host_agent_ref(host_addr: ChannelAddr) -> ActorRef<HostAgent> {
+    host_agent_ref(legacy_service_proc_addr(host_addr))
 }
 
 fn named_proc_on_host(agent: &ActorRef<HostAgent>, id: &ResourceId) -> ProcAddr {
@@ -335,9 +341,16 @@ impl HostMesh {
         // Use a dedicated gateway, not the process-wide global one. This
         // host coexists with the global-context singleton host (see
         // `global_context`), which owns the global gateway; sharing it
-        // would collide on the legacy `service`/`local` pseudo-singleton
-        // proc ids.
-        let host = Host::new_with_gateway(manager, addr, None, Gateway::new(), None).await?;
+        // would collide on the legacy `service` pseudo-singleton proc id.
+        let host = Host::new_with_gateway(
+            manager,
+            addr,
+            None,
+            Gateway::new(),
+            None,
+            legacy_service_proc_id(),
+        )
+        .await?;
         let addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_mesh_agent = system_proc
@@ -409,9 +422,17 @@ impl HostMesh {
         let manager = LocalProcManager::new(spawn);
         // Each in-process host gets its own gateway, not the
         // process-wide global one. Several hosts coexist in one process
-        // here, and the legacy `service`/`local` pseudo-singleton proc
-        // ids would collide if they all attached to the same gateway.
-        let host = Host::new_with_gateway(manager, addr, None, Gateway::new(), None).await?;
+        // here, and the legacy `service` pseudo-singleton proc id would
+        // collide if they all attached to the same gateway.
+        let host = Host::new_with_gateway(
+            manager,
+            addr,
+            None,
+            Gateway::new(),
+            None,
+            legacy_service_proc_id(),
+        )
+        .await?;
         let addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_mesh_agent = system_proc
@@ -522,6 +543,19 @@ impl HostMesh {
         addresses: Vec<ChannelAddr>,
     ) -> crate::Result<Self> {
         let mesh_ref = HostMeshRef::from_hosts(id, addresses);
+        let config = hyperactor_config::global::propagatable_attrs();
+        mesh_ref.push_config(cx, config).await?;
+        Ok(Self::take(mesh_ref))
+    }
+
+    /// Attach to workers using explicit service proc addresses.
+    pub async fn attach_with_service_procs(
+        cx: &impl context::Actor,
+        id: HostMeshId,
+        service_procs: Vec<ProcAddr>,
+    ) -> crate::Result<Self> {
+        let agents = service_procs.into_iter().map(host_agent_ref).collect();
+        let mesh_ref = HostMeshRef::from_host_agents(id, agents)?;
         let config = hyperactor_config::global::propagatable_attrs();
         mesh_ref.push_config(cx, config).await?;
         Ok(Self::take(mesh_ref))
@@ -893,16 +927,6 @@ impl HostMeshRef {
     /// Create a unit HostMeshRef from a host mesh agent.
     pub fn from_host_agent(id: HostMeshId, agent: ActorRef<HostAgent>) -> crate::Result<Self> {
         let region = Extent::unity().into();
-        // Canonicalize to the host's base dial address (as the deleted `HostRef`
-        // did via `into_dial_addr`). A client-attached `this_host` agent's
-        // location is `Via(client_gateway, addr)`; keeping that via hop makes it
-        // propagate into the locations of procs spawned on the host
-        // (`Via(child, Via(client_gateway, addr))`), which a *remote* host's
-        // gateway cannot peel — breaking reverse remote->local reachability. The
-        // bare dial address yields the single-hop `Via(child, addr)` the peer
-        // network routes both ways. Only the unit (this_host) path needs this;
-        // multi-host/allocated meshes carry their own dial addresses already.
-        let agent = host_agent_ref(agent.actor_addr().proc_addr().addr().clone());
         let host_agent_mesh = Self::host_agent_mesh_ref_from_agents(&region, vec![agent])?;
         Ok(Self {
             id,
@@ -924,7 +948,7 @@ impl HostMeshRef {
         region: &Region,
         host_addrs: Vec<ChannelAddr>,
     ) -> crate::Result<ActorMeshRef<HostAgent>> {
-        let agents = host_addrs.into_iter().map(host_agent_ref).collect();
+        let agents = host_addrs.into_iter().map(legacy_host_agent_ref).collect();
         Self::host_agent_mesh_ref_from_agents(region, agents)
     }
 
@@ -1096,6 +1120,23 @@ impl HostMeshRef {
                 subscriber,
             },
         )?)
+    }
+
+    pub(crate) fn forward_wait_rank_status(
+        &self,
+        cx: &impl context::Actor,
+        procs: impl IntoIterator<Item = ProcAddr>,
+        region: Region,
+        message: resource::WaitRankStatus,
+    ) -> anyhow::Result<()> {
+        for (view_rank, (create_rank, proc_id)) in region.slice().iter().zip(procs).enumerate() {
+            let mut message = message.clone();
+            message.id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
+            message.rank = resource::Rank::new(view_rank);
+            self.host_agent_for_proc_rank(&region, create_rank)
+                .post(cx, message);
+        }
+        Ok(())
     }
 
     /// Returns the host entries as `(addr_string, ActorRef<HostAgent>)` pairs.
@@ -1548,6 +1589,30 @@ impl HostMeshRef {
             .collect()
     }
 
+    fn host_agent_for_proc_rank(
+        &self,
+        proc_region: &Region,
+        create_rank: usize,
+    ) -> &ActorRef<HostAgent> {
+        let host_dims = self.region().labels().len();
+        assert!(
+            proc_region.labels().starts_with(self.region().labels()),
+            "proc mesh host dimensions must match its originating host mesh"
+        );
+
+        let host_rank = if host_dims == 0 {
+            0
+        } else {
+            // Proc meshes concatenate the host dimensions with the per-host
+            // dimensions. The last host dimension's stride is therefore the
+            // number of proc slots assigned to each host.
+            let procs_per_host = proc_region.slice().strides()[host_dims - 1];
+            create_rank / procs_per_host
+        };
+        self.get(host_rank)
+            .expect("proc rank must map to a host in its originating host mesh")
+    }
+
     /// Stop every proc in this proc mesh.
     ///
     /// On success returns the final per-rank `StatusMesh`, in which every
@@ -1567,12 +1632,17 @@ impl HostMeshRef {
         region: Region,
         reason: String,
     ) -> crate::Result<crate::StatusMesh> {
-        // Accumulator outputs full StatusMesh snapshots; seed with
-        // NotExist.
-        let mut proc_names = Vec::new();
+        let procs = procs.into_iter().collect::<Vec<_>>();
+        assert_eq!(
+            procs.len(),
+            region.num_ranks(),
+            "proc addresses must match the proc mesh region"
+        );
+        let proc_names = procs
+            .iter()
+            .map(|proc_id| ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned()))
+            .collect::<Vec<_>>();
         let num_ranks = region.num_ranks();
-        // Accumulator outputs full StatusMesh snapshots; seed with
-        // NotExist.
         let (port, rx) = cx.mailbox().open_accum_port_opts(
             crate::StatusMesh::from_single(region.clone(), Status::NotExist),
             StreamingReducerOpts {
@@ -1580,21 +1650,11 @@ impl HostMeshRef {
                 initial_update_interval: None,
             },
         );
-        // `procs` follows the current-view `ranks` order, so the enumeration
-        // index is each proc's rank in this view (RSP-1). Direct delivery stamps
-        // it explicitly (RSP-2); each HostAgent positions its reply overlay
-        // there.
-        for (view_rank, proc_id) in procs.into_iter().enumerate() {
-            let addr = proc_id.addr().clone();
-            // The name stored in HostAgent is not the same as the
-            // one stored in the ProcMesh. We instead take each proc id
-            // and map it to that particular agent.
+        let mut reply = port.bind();
+        reply.return_undeliverable(false);
+        for (view_rank, (create_rank, proc_id)) in region.slice().iter().zip(procs).enumerate() {
             let proc_resource_id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
-            proc_names.push(proc_resource_id.clone());
-
-            // Note that we don't send 1 message per host agent, we send 1 message
-            // per proc.
-            let host_agent = host_agent_ref(addr);
+            let host_agent = self.host_agent_for_proc_rank(&region, create_rank);
             host_agent.post(
                 cx,
                 resource::Stop {
@@ -1608,16 +1668,10 @@ impl HostMeshRef {
                     proc_resource_id,
                     resource::Rank::new(view_rank),
                     Status::Stopped,
-                    port.bind(),
+                    reply.clone(),
                 )
                 .await
-                .map_err(|e| crate::Error::CallError(host_agent.actor_addr().clone(), e))?;
-
-            tracing::info!(
-                name = "ProcMeshStatus",
-                %proc_id,
-                status = "Stop::Sent",
-            );
+                .map_err(|error| crate::Error::CallError(host_agent.actor_addr().clone(), error))?;
         }
         tracing::info!(
             name = "HostMeshStatus",
@@ -1825,12 +1879,18 @@ impl view::RankedSliceable for HostMeshRef {
 
 impl std::fmt::Display for HostMeshRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let legacy_service_proc_id = ResourceId::from_name(SERVICE_PROC_NAME).proc_id();
         write!(f, "{}:", self.id)?;
         for (rank, agent) in self.host_agent_mesh.values().enumerate() {
             if rank > 0 {
                 write!(f, ",")?;
             }
-            write!(f, "{}", agent.actor_addr().addr())?;
+            let proc_addr = agent.actor_addr().proc_addr();
+            if proc_addr.id() == &legacy_service_proc_id {
+                write!(f, "{}", proc_addr.addr())?;
+            } else {
+                write!(f, "{}", proc_addr)?;
+            }
         }
         write!(f, "@{}", self.region())
     }
@@ -1864,6 +1924,18 @@ impl From<crate::Error> for HostMeshRefParseError {
     }
 }
 
+fn parse_host_agent_ref(host_ref: &str) -> anyhow::Result<ActorRef<HostAgent>> {
+    if let Some((proc_id, host_addr)) = host_ref.split_once('@')
+        && let Ok(proc_id) = ProcId::from_str(proc_id)
+    {
+        let location = hyperactor::Location::from_str(host_addr)?;
+        return Ok(host_agent_ref(ProcAddr::new(proc_id, location)));
+    }
+
+    let host_addr = ChannelAddr::from_str(host_ref)?;
+    Ok(legacy_host_agent_ref(host_addr))
+}
+
 impl FromStr for HostMeshRef {
     type Err = HostMeshRefParseError;
 
@@ -1872,20 +1944,25 @@ impl FromStr for HostMeshRef {
 
         let id = HostMeshId::from_str(id_str)?;
 
-        let (host_addrs, region) = rest
-            .split_once('@')
+        let (host_refs, region) = rest
+            .rsplit_once('@')
             .ok_or(HostMeshRefParseError::MissingRegion)?;
-        let host_addrs = if host_addrs.trim().is_empty() {
+        let host_agents = if host_refs.trim().is_empty() {
             Vec::new()
         } else {
-            host_addrs
+            host_refs
                 .split(',')
-                .map(|host_addr| host_addr.trim())
-                .map(ChannelAddr::from_str)
-                .collect::<Result<Vec<_>, _>>()?
+                .map(str::trim)
+                .map(parse_host_agent_ref)
+                .collect::<anyhow::Result<Vec<_>>>()?
         };
         let region = region.parse()?;
-        Ok(HostMeshRef::new(id, region, host_addrs)?)
+        let host_agent_mesh = Self::host_agent_mesh_ref_from_agents(&region, host_agents)?;
+        Ok(Self {
+            id,
+            host_agent_mesh,
+            bootstrap_command: None,
+        })
     }
 }
 
@@ -2145,6 +2222,27 @@ mod tests {
         );
     }
 
+    #[cfg(fbcode_build)]
+    #[assert_no_process_leak]
+    #[tokio::test]
+    async fn test_proc_mesh_stop_routes_to_originating_host_agents() {
+        let instance = testing::instance();
+        let mut host_mesh = testing::host_mesh(2).await;
+        let mut proc_mesh = host_mesh
+            .spawn(instance, "stop-routing", extent!(gpus = 2), None, None)
+            .await
+            .expect("spawn proc mesh");
+
+        proc_mesh
+            .stop(instance, "test complete".to_string())
+            .await
+            .expect("stop proc mesh");
+        host_mesh
+            .shutdown(instance)
+            .await
+            .expect("shutdown host mesh");
+    }
+
     #[tokio::test]
     #[cfg(fbcode_build)]
     async fn test_client_config_override() {
@@ -2318,6 +2416,160 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_host_mesh_ref_serialization_preserves_service_proc_identity() {
+        let dial_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:26600").unwrap();
+        let service_proc_id: ProcId = "service<2>".parse().unwrap();
+        let agent = host_agent_ref(ProcAddr::new(
+            service_proc_id.clone(),
+            dial_addr.clone().into(),
+        ));
+        let mesh = HostMeshRef::from_host_agents(
+            HostMeshId::singleton(Label::new("explicit-service").unwrap()),
+            vec![agent],
+        )
+        .unwrap();
+
+        let serialized = serde_json::to_string(&mesh).unwrap();
+        let round_trip: HostMeshRef = serde_json::from_str(&serialized).unwrap();
+        let round_trip_agent = ndslice::view::Ranked::get(&round_trip, 0).unwrap();
+
+        assert_eq!(
+            round_trip_agent.actor_addr().proc_addr().id(),
+            &service_proc_id
+        );
+        assert_eq!(round_trip_agent.actor_addr().proc_addr().addr(), &dial_addr);
+    }
+
+    #[test]
+    fn test_host_mesh_ref_from_host_agent_preserves_service_proc_addr() {
+        let dial_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:26600").unwrap();
+        let service_proc_id: ProcId = "service<2>".parse().unwrap();
+        let via_uid = ProcId::instance(Label::strip("client-gateway"))
+            .uid()
+            .clone();
+        let service_location = hyperactor::Location::from(dial_addr).with_via(via_uid);
+        let agent = host_agent_ref(ProcAddr::new(
+            service_proc_id.clone(),
+            service_location.clone(),
+        ));
+
+        let mesh = HostMeshRef::from_host_agent(
+            HostMeshId::singleton(Label::new("explicit-service").unwrap()),
+            agent,
+        )
+        .unwrap();
+        let round_trip_agent = ndslice::view::Ranked::get(&mesh, 0).unwrap();
+
+        assert_eq!(
+            round_trip_agent.actor_addr().proc_addr().id(),
+            &service_proc_id
+        );
+        assert_eq!(
+            round_trip_agent.actor_addr().proc_addr().location(),
+            &service_location
+        );
+    }
+
+    #[test]
+    fn test_proc_rank_maps_to_originating_host_agent() {
+        let dial_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:26600").unwrap();
+        let service_proc_ids = [
+            "service<2>".parse::<ProcId>().unwrap(),
+            "service<3>".parse::<ProcId>().unwrap(),
+        ];
+        let agents = service_proc_ids
+            .iter()
+            .cloned()
+            .map(|proc_id| host_agent_ref(ProcAddr::new(proc_id, dial_addr.clone().into())))
+            .collect();
+        let hosts = HostMeshRef::from_host_agents(
+            HostMeshId::singleton(Label::new("hosts").unwrap()),
+            agents,
+        )
+        .unwrap();
+        let proc_region: Region = extent!(hosts = 2, gpus = 2).into();
+        let sliced = proc_region.range("gpus", 1..2).unwrap();
+
+        let owners = sliced
+            .slice()
+            .iter()
+            .map(|create_rank| {
+                hosts
+                    .host_agent_for_proc_rank(&sliced, create_rank)
+                    .actor_addr()
+                    .proc_addr()
+                    .id()
+                    .clone()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(owners, service_proc_ids);
+    }
+
+    #[test]
+    fn test_host_mesh_ref_string_preserves_service_proc_identity() {
+        let dial_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:26600").unwrap();
+        let service_proc_ids = vec![
+            "service<2>".parse::<ProcId>().unwrap(),
+            "service<3>".parse::<ProcId>().unwrap(),
+        ];
+        let agents = service_proc_ids
+            .iter()
+            .cloned()
+            .map(|proc_id| host_agent_ref(ProcAddr::new(proc_id, dial_addr.clone().into())))
+            .collect();
+        let mesh = HostMeshRef::from_host_agents(
+            HostMeshId::singleton(Label::new("explicit-services").unwrap()),
+            agents,
+        )
+        .unwrap();
+
+        let round_trip: HostMeshRef = mesh.to_string().parse().unwrap();
+        let round_trip_proc_ids = round_trip
+            .host_agent_mesh
+            .values()
+            .map(|agent| agent.actor_addr().proc_addr().id().clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(round_trip_proc_ids, service_proc_ids);
+        assert_eq!(round_trip.host_addrs(), vec![dial_addr.clone(), dial_addr]);
+    }
+
+    #[test]
+    fn test_host_mesh_ref_string_parses_unix_abstract_addresses() {
+        let dial_addr: ChannelAddr = "unix:@host-agent".parse().unwrap();
+        let service_proc_id: ProcId = "service<2>".parse().unwrap();
+        let agents = vec![
+            legacy_host_agent_ref(dial_addr.clone()),
+            host_agent_ref(ProcAddr::new(
+                service_proc_id.clone(),
+                dial_addr.clone().into(),
+            )),
+        ];
+        let mesh = HostMeshRef::from_host_agents(
+            HostMeshId::singleton(Label::new("unix-services").unwrap()),
+            agents,
+        )
+        .unwrap();
+
+        let round_trip: HostMeshRef = mesh.to_string().parse().unwrap();
+        let round_trip_proc_ids = round_trip
+            .host_agent_mesh
+            .values()
+            .map(|agent| agent.actor_addr().proc_addr().id().clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            round_trip_proc_ids,
+            vec![
+                ResourceId::from_name(SERVICE_PROC_NAME).proc_id(),
+                service_proc_id,
+            ]
+        );
+        assert_eq!(round_trip.host_addrs(), vec![dial_addr.clone(), dial_addr]);
+    }
+
     #[tokio::test]
     async fn test_sa1_empty_mesh_set_rejected() {
         let instance = testing::instance();
@@ -2345,8 +2597,8 @@ mod tests {
         let addr_a: ChannelAddr = "tcp:127.0.0.1:2001".parse().unwrap();
         let addr_b: ChannelAddr = "tcp:127.0.0.1:2002".parse().unwrap();
 
-        let ref_a = host_agent_ref(addr_a.clone());
-        let ref_b = host_agent_ref(addr_b.clone());
+        let ref_a = legacy_host_agent_ref(addr_a.clone());
+        let ref_b = legacy_host_agent_ref(addr_b.clone());
 
         let mut set = HostSet::new();
         set.insert(addr_a.to_string(), ref_a.clone());
@@ -2414,7 +2666,7 @@ mod tests {
         );
 
         // Client host entry overlaps with addr_a.
-        let client_ref = host_agent_ref(addr_a.clone());
+        let client_ref = legacy_host_agent_ref(addr_a.clone());
         let client_entries = vec![("client_addr".to_string(), client_ref)];
 
         let result = aggregate_hosts(&[&mesh], Some(client_entries));

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -268,9 +268,9 @@
 //! - **PS-12 (universal py-spy):** Worker procs and the service
 //!   proc can handle `PySpyDump`. Worker procs handle it via
 //!   ProcAgent; the service proc handles it via HostAgent (same
-//!   spawn-worker pattern). `pyspy_bridge` routes by proc name:
-//!   if `proc_id.base_name() == SERVICE_PROC_NAME`, the target
-//!   is `host_agent`; otherwise `proc_agent[0]`. Procs lacking
+//!   spawn-worker pattern). `pyspy_bridge` routes to a HostAgent
+//!   only when its exact actor identity is registered with the mesh
+//!   admin; all other procs route to `proc_agent[0]`. Procs lacking
 //!   either agent (e.g. mesh-admin) fast-fail via PS-13.
 //! - **PS-13 (defensive probe):** Before sending `PySpyDump`,
 //!   `pyspy_bridge` probes the selected actor with an introspect

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -344,6 +344,7 @@
 //! live invariant. It is not in this registry.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::io;
 use std::path::Path;
 use std::sync::Arc;
@@ -385,7 +386,6 @@ use typeuri::Named;
 
 use crate::config_dump::ConfigDump;
 use crate::config_dump::ConfigDumpResult;
-use crate::host::SERVICE_PROC_NAME;
 use crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
 use crate::host_mesh::host_agent::HostAgent;
 use crate::introspect::NodePayload;
@@ -859,6 +859,8 @@ struct BridgeState {
     /// Addr to the `MeshAdminAgent` actor that performs
     /// reference resolution.
     admin_ref: ActorRef<MeshAdminAgent>,
+    /// Exact actor identities of the HostAgents managed by this admin.
+    host_agents: HashSet<hyperactor::ActorAddr>,
     /// Dedicated client mailbox on system_proc for HTTP bridge reply
     /// ports. Using a separate `Instance<()>` avoids sharing the
     /// actor's own mailbox with the HTTP bridge and ensures the
@@ -1054,6 +1056,7 @@ impl Actor for MeshAdminAgent {
             mesh_admin_access_instructions(&admin_url, tls.as_ref().map(|(_, bundle)| bundle));
         let bridge_state = Arc::new(BridgeState {
             admin_ref: ActorRef::attest(this.self_addr().clone()),
+            host_agents: self.host_agents_by_actor_id.keys().cloned().collect(),
             bridge_cx,
             resolve_semaphore: tokio::sync::Semaphore::new(hyperactor_config::global::get(
                 crate::config::MESH_ADMIN_MAX_CONCURRENT_RESOLVES,
@@ -2319,19 +2322,18 @@ impl ResolvedProcHandler {
 /// Parse + route + attest. No probe. The single `ActorRef::attest`
 /// minting point. Used by `config_bridge` which intentionally skips
 /// the probe (CFG-4).
-fn route_proc_handler(raw_proc_reference: &str) -> Result<ResolvedProcHandler, ApiError> {
+fn route_proc_handler(
+    host_agents: &HashSet<hyperactor::ActorAddr>,
+    raw_proc_reference: &str,
+) -> Result<ResolvedProcHandler, ApiError> {
     let (_proc_reference, proc_id) = parse_proc_reference(raw_proc_reference)?;
-    let is_service = proc_id
-        .uid()
-        .as_singleton()
-        .is_some_and(|label| label.as_str() == SERVICE_PROC_NAME);
-    if is_service {
-        let agent_id = proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME);
-        Ok(ResolvedProcHandler::Host(ActorRef::attest(agent_id)))
-    } else {
-        let agent_id = proc_id.actor_addr(PROC_AGENT_ACTOR_NAME);
-        Ok(ResolvedProcHandler::Proc(ActorRef::attest(agent_id)))
+    let host_agent_id = proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME);
+    if host_agents.contains(&host_agent_id) {
+        return Ok(ResolvedProcHandler::Host(ActorRef::attest(host_agent_id)));
     }
+
+    let proc_agent_id = proc_id.actor_addr(PROC_AGENT_ACTOR_NAME);
+    Ok(ResolvedProcHandler::Proc(ActorRef::attest(proc_agent_id)))
 }
 
 /// Parse + route + attest + probe (PS-13).
@@ -2339,7 +2341,7 @@ async fn resolve_proc_handler(
     state: &BridgeState,
     raw_proc_reference: &str,
 ) -> Result<ResolvedProcHandler, ApiError> {
-    let handler = route_proc_handler(raw_proc_reference)?;
+    let handler = route_proc_handler(&state.host_agents, raw_proc_reference)?;
     let cx = &state.bridge_cx;
     if !probe_actor(cx, &handler.agent_id()).await? {
         return Err(ApiError::not_found(
@@ -2636,7 +2638,7 @@ async fn config_bridge(
     State(state): State<Arc<BridgeState>>,
     AxumPath(proc_reference): AxumPath<String>,
 ) -> Result<Json<ConfigDumpResult>, ApiError> {
-    let handler = route_proc_handler(&proc_reference)?;
+    let handler = route_proc_handler(&state.host_agents, &proc_reference)?;
     let timeout =
         hyperactor_config::global::get(crate::config::MESH_ADMIN_CONFIG_DUMP_BRIDGE_TIMEOUT);
     let result = handler.config_dump(&state.bridge_cx, timeout).await?;
@@ -3264,11 +3266,13 @@ mod advertised_host {
 mod tests {
     use std::net::SocketAddr;
 
+    use hyperactor::ProcId;
     use hyperactor::channel::ChannelAddr;
     use hyperactor::id::Label;
     use hyperactor::testing::ids::test_proc_id_with_addr;
 
     use super::*;
+    use crate::host::SERVICE_PROC_NAME;
     use crate::mesh_id::ResourceId;
 
     // Integration tests that spawn MeshAdminAgent must pass
@@ -4487,40 +4491,58 @@ mod tests {
         assert_eq!(parsed, proc_id);
     }
 
-    /// PS-12: service proc routes to HostAgent.
+    /// PS-12: a registered legacy service proc routes to HostAgent.
     #[test]
     fn route_proc_handler_service_proc_yields_host() {
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
         let proc_id = ResourceId::proc_addr_from_name(ChannelAddr::Tcp(addr), SERVICE_PROC_NAME);
-        let handler = route_proc_handler(&proc_id.to_string()).unwrap();
+        let host_agents = HashSet::from([proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME)]);
+        let handler = route_proc_handler(&host_agents, &proc_id.to_string()).unwrap();
         assert!(
             matches!(handler, ResolvedProcHandler::Host(_)),
-            "service proc should resolve to Host variant"
+            "a registered legacy service proc should resolve to Host"
         );
     }
 
-    /// PS-12: non-service proc routes to ProcAgent.
+    /// PS-12: an unregistered worker proc routes to ProcAgent.
     #[test]
     fn route_proc_handler_worker_proc_yields_proc() {
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
         let proc_id = test_proc_id_with_addr(ChannelAddr::Tcp(addr), "worker_0");
-        let handler = route_proc_handler(&proc_id.to_string()).unwrap();
+        let handler = route_proc_handler(&HashSet::new(), &proc_id.to_string()).unwrap();
         assert!(
             matches!(handler, ResolvedProcHandler::Proc(_)),
-            "non-service proc should resolve to Proc variant"
+            "an unregistered worker proc should resolve to Proc"
         );
     }
 
-    /// PS-12: a labeled instance named "service" is still a normal proc.
+    /// PS-12: a registered instance proc routes to HostAgent regardless of label.
     #[test]
-    fn route_proc_handler_service_instance_yields_proc() {
+    fn route_proc_handler_registered_instance_yields_host() {
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
-        let proc_id =
-            ResourceId::proc_addr_from_name(ChannelAddr::Tcp(addr), "service-deadbeefdeadbeef");
-        let handler = route_proc_handler(&proc_id.to_string()).unwrap();
+        let proc_id = ProcAddr::new(
+            ProcId::instance(Label::strip("host-control")),
+            ChannelAddr::Tcp(addr).into(),
+        );
+        let host_agents = HashSet::from([proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME)]);
+        let handler = route_proc_handler(&host_agents, &proc_id.to_string()).unwrap();
+        assert!(
+            matches!(handler, ResolvedProcHandler::Host(_)),
+            "a registered proc should resolve to Host regardless of its label"
+        );
+    }
+
+    #[test]
+    fn route_proc_handler_service_label_without_host_registration_yields_proc() {
+        let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+        let proc_id = ProcAddr::new(
+            ProcId::instance(Label::strip(SERVICE_PROC_NAME)),
+            ChannelAddr::Tcp(addr).into(),
+        );
+        let handler = route_proc_handler(&HashSet::new(), &proc_id.to_string()).unwrap();
         assert!(
             matches!(handler, ResolvedProcHandler::Proc(_)),
-            "service-labeled instance proc should resolve to Proc variant"
+            "an unregistered proc must not become a host service based on its label"
         );
     }
 }

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1469,16 +1469,10 @@ impl Controlled for ProcMeshRef {
         cx: &impl context::Actor,
         msg: resource::WaitRankStatus,
     ) -> anyhow::Result<()> {
-        // Direct fan-out (not a cast): one scalar rank cannot identify every
-        // recipient, so stamp each clone with the proc's rank in this view
-        // (RSP-2). `proc_ids()` follows the current-view `ranks` order, so the
-        // enumeration index is each recipient's consuming-view rank (RSP-1).
-        for (view_rank, proc_id) in self.proc_ids().enumerate() {
-            let mut msg = msg.clone();
-            msg.rank = resource::Rank::new(view_rank);
-            crate::host_mesh::host_agent_ref(proc_id.addr().clone()).post(cx, msg);
-        }
-        Ok(())
+        let hosts = self.hosts().ok_or_else(|| {
+            anyhow::anyhow!("ProcMeshController cannot wait without a backing host mesh")
+        })?;
+        hosts.forward_wait_rank_status(cx, self.proc_ids(), Ranked::region(self).clone(), msg)
     }
 
     async fn poll_states(

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -8,8 +8,10 @@
 
 use futures::future::try_join_all;
 use hyperactor::Gateway;
+use hyperactor::ProcAddr;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::id::Label;
+use hyperactor::id::Uid;
 use hyperactor_mesh::bootstrap::BootstrapCommand;
 use hyperactor_mesh::bootstrap::bootstrap;
 use hyperactor_mesh::bootstrap::halt;
@@ -19,9 +21,11 @@ use hyperactor_mesh::mesh_id::HostMeshId;
 use monarch_types::MapPyErr;
 use pyo3::Bound;
 use pyo3::PyAny;
+use pyo3::PyRef;
 use pyo3::PyResult;
 use pyo3::Python;
 use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::PyValueError;
 use pyo3::pyfunction;
 use pyo3::types::PyAnyMethods;
 use pyo3::types::PyModule;
@@ -29,6 +33,7 @@ use pyo3::types::PyModuleMethods;
 use pyo3::wrap_pyfunction;
 
 use crate::host_mesh::PyHostMesh;
+use crate::proc::PyProcId;
 use crate::pytokio::PyPythonTask;
 use crate::runtime::GilSite;
 use crate::runtime::monarch_with_gil;
@@ -57,9 +62,22 @@ pub fn bootstrap_main(py: Python) -> PyResult<Bound<PyAny>> {
 }
 
 #[pyfunction]
-pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPythonTask> {
+#[pyo3(signature = (address, service_proc_id=None))]
+pub fn run_worker_loop_forever(
+    _py: Python<'_>,
+    address: &str,
+    service_proc_id: Option<&PyProcId>,
+) -> PyResult<PyPythonTask> {
     let (addr, listener) = ChannelAddr::from_zmq_url_with_listener(address)?;
-
+    let service_proc_id = service_proc_id.map(|proc_id| proc_id.inner.clone());
+    if service_proc_id
+        .as_ref()
+        .is_some_and(|proc_id| !matches!(proc_id.uid(), Uid::Instance(..)))
+    {
+        return Err(PyValueError::new_err(
+            "service_proc_id must have an instance UID",
+        ));
+    }
     // Check if we're running in a PAR/XAR build by looking for FB_XAR_INVOKED_NAME environment variable
     let invoked_name = std::env::var("FB_XAR_INVOKED_NAME");
 
@@ -107,10 +125,18 @@ pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPyt
     });
 
     PyPythonTask::new(async move {
-        let (_agent_handle, shutdown) =
-            host(addr, command, None, true, listener, Gateway::new(), None)
-                .await
-                .map_pyerr()?;
+        let (_agent_handle, shutdown) = host(
+            addr,
+            command,
+            None,
+            true,
+            listener,
+            Gateway::new(),
+            None,
+            service_proc_id,
+        )
+        .await
+        .map_pyerr()?;
         shutdown.stop_and_join().await;
         halt::<()>().await;
         Ok(())
@@ -118,11 +144,37 @@ pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPyt
 }
 
 #[pyfunction]
+#[pyo3(signature = (instance, workers, name=None, service_proc_ids=None))]
 pub fn attach_to_workers(
     instance: &crate::context::PyInstance,
     workers: Vec<Bound<'_, PyPythonTask>>,
     name: Option<&str>,
+    service_proc_ids: Option<Vec<PyRef<'_, PyProcId>>>,
 ) -> PyResult<PyPythonTask> {
+    let service_proc_ids = service_proc_ids.map(|proc_ids| {
+        proc_ids
+            .into_iter()
+            .map(|proc_id| proc_id.inner.clone())
+            .collect::<Vec<_>>()
+    });
+    let worker_count = workers.len();
+    if let Some(service_proc_ids) = &service_proc_ids
+        && service_proc_ids.len() != worker_count
+    {
+        return Err(PyValueError::new_err(format!(
+            "worker/service proc id count mismatch: {worker_count} workers, {} ids",
+            service_proc_ids.len()
+        )));
+    }
+    if service_proc_ids.as_ref().is_some_and(|proc_ids| {
+        proc_ids
+            .iter()
+            .any(|proc_id| !matches!(proc_id.uid(), Uid::Instance(..)))
+    }) {
+        return Err(PyValueError::new_err(
+            "service_proc_ids must all have instance UIDs",
+        ));
+    }
     let tasks = workers
         .into_iter()
         .map(|x| x.borrow_mut().take_task())
@@ -150,9 +202,18 @@ pub fn attach_to_workers(
             .await;
         let addresses = addresses?;
 
-        let host_mesh = HostMesh::attach(&*instance, name, addresses)
-            .await
-            .map_err(|e| anyhow::anyhow!("attach failed: {}", e))?;
+        let host_mesh = match service_proc_ids {
+            Some(service_proc_ids) => {
+                let service_procs = addresses
+                    .into_iter()
+                    .zip(service_proc_ids)
+                    .map(|(address, proc_id)| ProcAddr::new(proc_id, address.into()))
+                    .collect();
+                HostMesh::attach_with_service_procs(&*instance, name, service_procs).await
+            }
+            None => HostMesh::attach(&*instance, name, addresses).await,
+        }
+        .map_err(|e| anyhow::anyhow!("attach failed: {}", e))?;
         Ok(PyHostMesh::new_owned(host_mesh))
     })
 }

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -412,6 +412,7 @@ fn bootstrap_host(
             None,
             gateway,
             via_addr,
+            None,
         )
         .await
         .map_err(|e| PyException::new_err(e.to_string()))?;

--- a/python/monarch/_rust_bindings/monarch_hyperactor/bootstrap.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/bootstrap.pyi
@@ -14,6 +14,7 @@ CA = Union[bytes, Path, Literal["trust_all_connections"]]
 
 from monarch._rust_bindings.monarch_hyperactor.context import Instance
 from monarch._rust_bindings.monarch_hyperactor.host_mesh import HostMesh
+from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 
 def bootstrap_main() -> int:
@@ -21,9 +22,12 @@ def bootstrap_main() -> int:
     with sys.exit()."""
     ...
 
-def run_worker_loop_forever(address: str) -> PythonTask[None]: ...
+def run_worker_loop_forever(
+    address: str, service_proc_id: Optional[ProcId] = None
+) -> PythonTask[None]: ...
 def attach_to_workers(
     instance: Instance,
     workers: List[PythonTask[str]],
     name: Optional[str] = None,
+    service_proc_ids: Optional[List[ProcId]] = None,
 ) -> PythonTask[HostMesh]: ...

--- a/python/monarch/_src/actor/bootstrap.py
+++ b/python/monarch/_src/actor/bootstrap.py
@@ -8,13 +8,14 @@
 
 
 from pathlib import Path
-from typing import List, Literal, Optional, Union
+from typing import Literal, Optional, Sequence, Union
 
 from monarch._rust_bindings.monarch_hyperactor.bootstrap import (
     attach_to_workers as _attach_to_workers,
     run_worker_loop_forever as _run_worker_loop_forever,
 )
 from monarch._rust_bindings.monarch_hyperactor.host_mesh import HostMesh as HyHostMesh
+from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
 from monarch._src.actor.actor_mesh import _Lazy
@@ -42,6 +43,7 @@ def run_worker_loop_forever(
     private_key: PrivateKey = None,
     ca: CA,
     address: str,
+    service_proc_id: Optional[ProcId] = None,
 ) -> None:
     """
     Start a monarch server at "address" capable of letting this machine participate in
@@ -70,6 +72,11 @@ def run_worker_loop_forever(
     use this machine as a host. If the client disconnects or cannot be contacted, this server
     kills all the current work and waits for a new connection.
 
+    service_proc_id identifies this worker's host service proc. Launchers that
+    supply it must pass the same value to ``attach_to_workers``. Unlike the
+    legacy ``service`` identity, an instance-specific ID is independent of the
+    address used to reach the worker.
+
 
     private_key is a tls private key file loaded as bytes used to establish secure connections.
     Things connecting to this machine must trust this private_key in the certificate authority file.
@@ -90,15 +97,16 @@ def run_worker_loop_forever(
             "implementation does not get the host name right if it was specified as a wild card. We have to fix this"
         )
 
-    _run_worker_loop_forever(address).block_on()
+    _run_worker_loop_forever(address, service_proc_id=service_proc_id).block_on()
 
 
 def attach_to_workers(
     *,
     private_key: PrivateKey = None,
     ca: CA,
-    workers: List[str | Future[str]],
+    workers: Sequence[str | Future[str]],
     name: Optional[str] = None,
+    service_proc_ids: Optional[Sequence[ProcId]] = None,
 ) -> HostMesh:
     """
     Create a host mesh that is connected to the list of workers
@@ -115,6 +123,10 @@ def attach_to_workers(
     worker and stores only ``dial_to`` in the host mesh. The ``bind_to`` half
     is a serve-side detail and is not part of the host, proc, or actor
     identity.
+
+    If ``service_proc_ids`` is provided, it must contain the service proc ID
+    used by each corresponding worker. Those IDs become part of the host-agent
+    references stored and serialized by the returned host mesh.
 
 
     private_key is a tls private key file loaded as bytes used to establish secure connections.
@@ -136,7 +148,12 @@ def attach_to_workers(
 
     instance = context().actor_instance._as_rust()
     host_mesh: PythonTask[HyHostMesh] = _attach_to_workers(
-        instance, workers_tasks, name=name
+        instance,
+        workers_tasks,
+        name=name,
+        service_proc_ids=(
+            list(service_proc_ids) if service_proc_ids is not None else None
+        ),
     )
     extent = Extent(["hosts"], [len(workers)])
     hm = HostMesh(

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -7,9 +7,6 @@
 # pyre-strict
 
 import os
-import subprocess
-import sys
-import tempfile
 from typing import Any, Awaitable, Callable, Dict, Literal, Optional, Tuple
 
 from monarch._rust_bindings.monarch_hyperactor.host_mesh import (
@@ -511,39 +508,3 @@ def _spawn_admin(
         return admin_url, admin_ref
 
     return Future._from_coro(task())
-
-
-def hosts_from_config(name: str) -> HostMesh:
-    """
-    Get the host mesh 'name' from the monarch configuration for the project.
-
-    This config can be modified so that the same code can create meshes from scheduler sources,
-    and different sizes etc.
-
-    WARNING: This function is a standin so that our getting_started example code works. The real implementation
-    needs an RFC design.
-    """
-    num_hosts = 2
-    tmpdir = tempfile.mkdtemp(prefix="monarch_hosts_from_config_")
-    workers = []
-    for i in range(num_hosts):
-        addr = f"ipc://{tmpdir}/{name}_{i}"
-        env = {**os.environ}
-        cmd = [
-            sys.executable,
-            "-c",
-            "from monarch.actor import run_worker_loop_forever; "
-            f'run_worker_loop_forever(address="{addr}", '
-            'ca="trust_all_connections")',
-        ]
-        subprocess.Popen(cmd, env=env, start_new_session=True)
-        workers.append(addr)
-
-    from monarch._src.actor.bootstrap import attach_to_workers
-
-    return attach_to_workers(
-        name=name,
-        ca="trust_all_connections",
-        # pyrefly: ignore [bad-argument-type]
-        workers=workers,
-    )

--- a/python/monarch/_src/job/_process_worker.py
+++ b/python/monarch/_src/job/_process_worker.py
@@ -16,10 +16,12 @@ variables.
 
 import os
 
+from monarch._src.job.service_identity import service_proc_id_from_env
 from monarch.actor import run_worker_loop_forever
 
 if __name__ == "__main__":
     run_worker_loop_forever(
         address=os.environ["_MONARCH_WORKER_ADDR"],
+        service_proc_id=service_proc_id_from_env(),
         ca="trust_all_connections",
     )

--- a/python/monarch/_src/job/_slurm_batch.py
+++ b/python/monarch/_src/job/_slurm_batch.py
@@ -28,11 +28,14 @@ from typing import List, Optional
 
 from monarch._src.job._batch_env import MONARCH_BATCH_JOB_ENV
 
+
 # Bootstraps one monarch worker bound to this node's hostname. Passed as python
 # ``-c`` argv (no shell), so quoting inside is irrelevant.
 _WORKER_BOOTSTRAP: str = (
-    "import socket; from monarch.actor import run_worker_loop_forever; "
+    "import os, socket; from monarch.actor import run_worker_loop_forever; "
+    "from monarch._src.job.service_identity import ranked_service_proc_id_from_env; "
     'run_worker_loop_forever(address=f"tcp://{socket.gethostname()}:%d", '
+    'service_proc_id=ranked_service_proc_id_from_env(rank_env="SLURM_NODEID"), '
     'ca="trust_all_connections")'
 )
 

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -21,11 +21,13 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence
 
+from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job, MONARCH_BATCH_JOB_ENV
 from monarch._src.job._telemetry_query_client import QueryEngineClient
 from monarch._src.job.job_components import JobComponents, MeshAdminConfig
 from monarch._src.job.job_sidecar import stop_job_sidecar
+from monarch._src.job.service_identity import new_service_proc_id
 from monarch._src.job.telemetry_config import TelemetryConfig
 
 # note: the jobs api is intended as a library so it should
@@ -1084,6 +1086,7 @@ class BatchJob(JobTrait):
 class ProcessState(NamedTuple):
     pid: int
     channel: str
+    service_proc_id: ProcId
 
 
 class LoginJob(JobTrait):
@@ -1107,6 +1110,7 @@ class LoginJob(JobTrait):
                 name=name,
                 ca="trust_all_connections",
                 workers=[self._host_to_pid[v].channel for v in values],
+                service_proc_ids=[self._host_to_pid[v].service_proc_id for v in values],
             )
             for name, values in self._meshes.items()
         }
@@ -1191,14 +1195,21 @@ class SSHJob(LoginJob):
 
     def _start_host(self, host: str) -> ProcessState:
         addr = f"{self._scheme}://{host}:{self._port}"
-        startup = f'from monarch.actor import run_worker_loop_forever; run_worker_loop_forever(address={repr(addr)}, ca="trust_all_connections")'
+        service_proc_id = new_service_proc_id()
+        startup = (
+            "from monarch._rust_bindings.monarch_hyperactor.proc import ProcId; "
+            "from monarch.actor import run_worker_loop_forever; "
+            f"run_worker_loop_forever(address={addr!r}, "
+            f"service_proc_id=ProcId.from_string({str(service_proc_id)!r}), "
+            'ca="trust_all_connections")'
+        )
 
         command = f"{shlex.quote(self._python_exe)} -c {shlex.quote(startup)}"
         proc = subprocess.Popen(
             ["ssh", *self._ssh_args, host, "-n", command],
             start_new_session=True,
         )
-        return ProcessState(proc.pid, addr)
+        return ProcessState(proc.pid, addr, service_proc_id)
 
     def can_run(self, spec):
         return (

--- a/python/monarch/_src/job/kubernetes.py
+++ b/python/monarch/_src/job/kubernetes.py
@@ -28,8 +28,16 @@ except ImportError:
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
+from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job.job import JobState, JobTrait
+from monarch._src.job.service_identity import (
+    deserialize_service_proc_ids,
+    new_service_proc_id,
+    serialize_service_proc_ids,
+    SERVICE_PROC_IDS_ENV,
+    SERVICE_PROC_RANK_ENV,
+)
 from monarch.actor import attach
 
 
@@ -56,11 +64,16 @@ _MONARCHMESH_PLURAL = "monarchmeshes"
 _WORKER_BOOTSTRAP_SCRIPT: str = textwrap.dedent("""\
     import os
     import socket
+    from monarch._src.job.service_identity import ranked_service_proc_id_from_env
     from monarch.actor import run_worker_loop_forever
     port = os.environ.get("MONARCH_PORT", "26600")
     hostname = socket.getfqdn()
     address = f"tcp://{hostname}:{port}@tcp://0.0.0.0:{port}"
-    run_worker_loop_forever(address=address, ca="trust_all_connections")
+    run_worker_loop_forever(
+        address=address,
+        service_proc_id=ranked_service_proc_id_from_env(),
+        ca="trust_all_connections",
+    )
 """)
 
 
@@ -184,6 +197,7 @@ class _MeshConfigRequired(TypedDict):
 class _MeshConfig(_MeshConfigRequired, total=False):
     labels: dict[str, str]
     annotations: dict[str, str]
+    image_spec: ImageSpec
     pod_template: client.V1PodTemplateSpec
 
 
@@ -234,6 +248,7 @@ class KubernetesJob(JobTrait):
         self._kubeconfig: KubeConfig = kubeconfig or KubeConfig()
         self._attach_to = attach_to
         self._meshes: dict[str, _MeshConfig] = {}
+        self._service_proc_ids: dict[str, list[ProcId]] = {}
         self._port_forward_processes: list[subprocess.Popen[str]] = []
         super().__init__()
 
@@ -334,9 +349,7 @@ class KubernetesJob(JobTrait):
             mesh_entry["annotations"] = annotations
 
         if image_spec is not None:
-            mesh_entry["pod_template"] = self._build_worker_pod_template(
-                image_spec, port
-            )
+            mesh_entry["image_spec"] = image_spec
         elif pod_template is not None:
             mesh_entry["pod_template"] = pod_template
 
@@ -360,6 +373,11 @@ class KubernetesJob(JobTrait):
         provisioned = {
             name: cfg for name, cfg in self._meshes.items() if cfg.get("provisioned")
         }
+        if self._service_proc_ids:
+            raise RuntimeError(
+                "KubernetesJob._create should be called once; "
+                "_service_proc_ids already set"
+            )
         if not provisioned:
             return
 
@@ -369,9 +387,59 @@ class KubernetesJob(JobTrait):
         api = client.CustomObjectsApi(api_client)
 
         for mesh_name, mesh_config in provisioned.items():
-            pod_template_dict = api_client.sanitize_for_serialization(
-                mesh_config["pod_template"]
-            )
+            pod_template = mesh_config.get("pod_template")
+            image_spec = mesh_config.get("image_spec")
+            if image_spec is not None:
+                # If the CRD already exists, reuse its service proc IDs so
+                # we stay in sync with the already-running pods. This mirrors
+                # the metadata roundtrip used in the yardstick MAST launcher.
+                service_proc_ids: list[ProcId] | None = None
+                try:
+                    existing = api.get_namespaced_custom_object(
+                        group=_MONARCHMESH_GROUP,
+                        version=_MONARCHMESH_VERSION,
+                        namespace=self._namespace,
+                        plural=_MONARCHMESH_PLURAL,
+                        name=mesh_name,
+                    )
+                    containers = (
+                        existing.get("spec", {})
+                        .get("podTemplate", {})
+                        .get("spec", {})
+                        .get("containers", [])
+                    )
+                    if containers:
+                        for env_var in containers[0].get("env", []):
+                            if env_var.get("name") == SERVICE_PROC_IDS_ENV:
+                                serialized = env_var.get("value")
+                                if serialized:
+                                    try:
+                                        candidate = deserialize_service_proc_ids(
+                                            serialized
+                                        )
+                                        if (
+                                            len(candidate)
+                                            == mesh_config["num_replicas"]
+                                        ):
+                                            service_proc_ids = candidate
+                                    except Exception:
+                                        pass
+                                break
+                except ApiException as e:
+                    if e.status != 404:
+                        raise
+
+                if service_proc_ids is None:
+                    service_proc_ids = [
+                        new_service_proc_id()
+                        for _ in range(mesh_config["num_replicas"])
+                    ]
+                self._service_proc_ids[mesh_name] = service_proc_ids
+                pod_template = self._build_worker_pod_template(
+                    image_spec, mesh_config["port"], service_proc_ids
+                )
+            assert pod_template is not None
+            pod_template_dict = api_client.sanitize_for_serialization(pod_template)
             metadata: dict[str, Any] = {
                 "name": mesh_name,
                 "namespace": self._namespace,
@@ -420,6 +488,7 @@ class KubernetesJob(JobTrait):
     def _build_worker_pod_template(
         image_spec: ImageSpec,
         port: int,
+        service_proc_ids: list[ProcId],
     ) -> client.V1PodTemplateSpec:
         """
         Build a V1PodTemplateSpec for the MonarchMesh CRD.
@@ -430,6 +499,7 @@ class KubernetesJob(JobTrait):
         Args:
             image_spec: ImageSpec with container image and optional resources.
             port: Monarch worker port.
+            service_proc_ids: Service process identities indexed by pod rank.
 
         Returns:
             V1PodTemplateSpec suitable for the ``podTemplate`` CRD field.
@@ -441,7 +511,21 @@ class KubernetesJob(JobTrait):
                 requests=k8s_resources,
                 limits=k8s_resources,
             )
-        env = [client.V1EnvVar(name="MONARCH_PORT", value=str(port))]
+        env = [
+            client.V1EnvVar(name="MONARCH_PORT", value=str(port)),
+            client.V1EnvVar(
+                name=SERVICE_PROC_RANK_ENV,
+                value_from=client.V1EnvVarSource(
+                    field_ref=client.V1ObjectFieldSelector(
+                        field_path="metadata.labels['apps.kubernetes.io/pod-index']"
+                    )
+                ),
+            ),
+            client.V1EnvVar(
+                name=SERVICE_PROC_IDS_ENV,
+                value=serialize_service_proc_ids(service_proc_ids),
+            ),
+        ]
         container = client.V1Container(
             name="worker",
             image=image_spec.image,
@@ -779,11 +863,13 @@ class KubernetesJob(JobTrait):
             for mesh_name, pods in all_mesh_pods.items():
                 # Create worker addresses using discovered IPs and ports
                 workers = [f"tcp://{pod.ip}:{pod.port}" for pod in pods]
+                service_proc_ids = self._service_proc_ids.get(mesh_name)
                 # Create host mesh by attaching to workers
                 host_mesh = attach_to_workers(
                     name=mesh_name,
                     ca="trust_all_connections",
                     workers=workers,  # type: ignore[arg-type]
+                    service_proc_ids=service_proc_ids,
                 )
                 host_meshes[mesh_name] = host_mesh
         except Exception:

--- a/python/monarch/_src/job/process.py
+++ b/python/monarch/_src/job/process.py
@@ -21,6 +21,7 @@ from typing import Callable, Dict, List, Optional, Union
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.future import Future
 from monarch._src.job.job import JobState, JobTrait, ProcessState
+from monarch._src.job.service_identity import new_service_proc_id, SERVICE_PROC_ID_ENV
 
 logger = logging.getLogger(__name__)
 
@@ -142,9 +143,12 @@ class ProcessJob(JobTrait):
                 for i in range(count):
                     host_key = f"{mesh_name}_{i}"
                     addr = f"ipc://{self._tmpdir}/{host_key}"
+                    service_proc_id = new_service_proc_id()
                     env = {**os.environ, "HYPERACTOR_PROCESS_NAME": host_key}
                     if self._env is not None:
                         env.update(self._env)
+                    env["_MONARCH_WORKER_ADDR"] = addr
+                    env[SERVICE_PROC_ID_ENV] = str(service_proc_id)
                     if _IN_PAR:
                         # In PAR/XAR mode, sys.executable is the bare
                         # Python interpreter which cannot import modules
@@ -152,14 +156,16 @@ class ProcessJob(JobTrait):
                         # (sys.argv[0]) with PAR_MAIN_OVERRIDE pointing
                         # to the worker module.
                         env["PAR_MAIN_OVERRIDE"] = _PROCESS_WORKER_MODULE
-                        env["_MONARCH_WORKER_ADDR"] = addr
                         cmd = [sys.argv[0]]
                     else:
                         cmd = [
                             sys.executable,
                             "-c",
+                            "from monarch._src.job.service_identity import "
+                            "service_proc_id_from_env; "
                             "from monarch.actor import run_worker_loop_forever; "
                             f'run_worker_loop_forever(address="{addr}", '
+                            "service_proc_id=service_proc_id_from_env(), "
                             'ca="trust_all_connections")',
                         ]
                     proc = subprocess.Popen(
@@ -170,7 +176,9 @@ class ProcessJob(JobTrait):
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
                     )
-                    self._host_to_pid[host_key] = ProcessState(proc.pid, addr)
+                    self._host_to_pid[host_key] = ProcessState(
+                        proc.pid, addr, service_proc_id
+                    )
                     logger.info(
                         "ProcessJob: spawned worker pid=%d mesh=%s rank=%d addr=%s",
                         proc.pid,
@@ -243,6 +251,10 @@ class ProcessJob(JobTrait):
                 name=mesh_name,
                 ca="trust_all_connections",
                 workers=workers,
+                service_proc_ids=[
+                    self._host_to_pid[f"{mesh_name}_{i}"].service_proc_id
+                    for i in range(count)
+                ],
             )
 
         return JobState(host_meshes)

--- a/python/monarch/_src/job/service_identity.py
+++ b/python/monarch/_src/job/service_identity.py
@@ -1,0 +1,99 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Helpers for per-host ``service`` ProcId generation and propagation.
+
+Each Monarch host runs a singleton ``HostAgent`` at ``service``. To avoid
+frontend-address disambiguation (host A dials host B via different hostname/
+IP strings), every host is given a unique ``ProcId(Uid.instance("service"))``
+at launch. The launcher allocates one ProcId per host, passes it to the
+worker via env, and the client passes the same IDs to ``attach_to_workers``.
+
+Env transport:
+* Per-host launchers (ProcessJob, host_mesh_from_store) set
+  ``MONARCH_SERVICE_PROC_ID`` per Popen and workers read it via
+  ``service_proc_id_from_env()`` (returns ``None`` if absent for legacy
+  fallback).
+* Role-level launchers (MAST, Kubernetes, Slurm, SPMD) can only set env once
+  per Role/StatefulSet/sbatch for many replicas. They share
+  ``MONARCH_SERVICE_PROC_IDS`` as a JSON list plus
+  ``MONARCH_SERVICE_PROC_RANK`` (replica_id/SLURM_NODEID/pod-index) and
+  workers read ``ranked_service_proc_id_from_env()`` → ``list[rank]``.
+  The worker always receives a single ProcId; the JSON list is just
+  transport because there is no pre-determined per-host random source
+  both sides can derive without extra coordination.
+"""
+
+import json
+import os
+from collections.abc import Sequence
+
+from monarch._rust_bindings.monarch_hyperactor.proc import ProcId, Uid
+
+
+# Role-level launchers (MAST, Kubernetes, Slurm, SPMD) set env once per
+# Role/StatefulSet/sbatch for many hosts. The scheduler only interpolates
+# rank (replica_id/SLURM_NODEID/pod-index) per replica, not per-host
+# arbitrary values, so all replicas share the same MONARCH_SERVICE_PROC_IDS
+# JSON list and each host selects its single ID via MONARCH_SERVICE_PROC_RANK
+# (ranked_service_proc_id_from_env). Per-host launchers (ProcessJob,
+# host_mesh_from_store) set MONARCH_SERVICE_PROC_ID directly per Popen and
+# use service_proc_id_from_env. Worker always receives a single ProcId; the
+# list is just transport. JSON list is used because there is no
+# pre-determined per-host random source both client and hosts can derive
+# reliably without extra coordination.
+SERVICE_PROC_ID_ENV = "MONARCH_SERVICE_PROC_ID"
+SERVICE_PROC_IDS_ENV = "MONARCH_SERVICE_PROC_IDS"
+SERVICE_PROC_RANK_ENV = "MONARCH_SERVICE_PROC_RANK"
+
+
+def new_service_proc_id() -> ProcId:
+    """Return a fresh instance ProcId for a worker's host service."""
+    return ProcId(Uid.instance("service"))
+
+
+def serialize_service_proc_ids(proc_ids: Sequence[ProcId]) -> str:
+    """Serialize service ProcIds for a launcher environment variable."""
+    return json.dumps([str(proc_id) for proc_id in proc_ids])
+
+
+def deserialize_service_proc_ids(serialized: str) -> list[ProcId]:
+    """Deserialize service ProcIds at a launcher boundary."""
+    return [ProcId.from_string(proc_id) for proc_id in json.loads(serialized)]
+
+
+def service_proc_id_from_env() -> ProcId | None:
+    """Load one service ProcId passed through a launcher environment.
+
+    Returns None if the env var is not set, allowing callers to fall back
+    to legacy address-based routing.
+    """
+    serialized = os.environ.get(SERVICE_PROC_ID_ENV)
+    if serialized is None:
+        return None
+    return ProcId.from_string(serialized)
+
+
+def ranked_service_proc_id_from_env(
+    *, rank_env: str = SERVICE_PROC_RANK_ENV
+) -> ProcId | None:
+    """Select a service ProcId from a ranked launcher environment.
+
+    Returns None if the env var is not set, allowing callers to fall back
+    to legacy address-based routing.
+    """
+    serialized = os.environ.get(SERVICE_PROC_IDS_ENV)
+    if serialized is None:
+        return None
+    proc_ids = deserialize_service_proc_ids(serialized)
+    rank_str = os.environ.get(rank_env)
+    if rank_str is None:
+        return None
+    rank = int(rank_str)
+    return proc_ids[rank]

--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -16,10 +16,16 @@ from typing import Any, Dict, FrozenSet, List, Optional, Sequence
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
+from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job
 from monarch._src.job._slurm_batch import _WORKER_BOOTSTRAP
 from monarch._src.job.job import BatchJob, JobState, JobTrait
+from monarch._src.job.service_identity import (
+    new_service_proc_id,
+    serialize_service_proc_ids,
+    SERVICE_PROC_IDS_ENV,
+)
 from monarch.actor import attach
 
 
@@ -120,6 +126,7 @@ class SlurmJob(JobTrait):
         # Track the single SLURM job ID and all allocated hostnames
         self._slurm_job_id: Optional[str] = None
         self._all_hostnames: List[str] = []
+        self._service_proc_ids: list[ProcId] = []
         super().__init__()
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
@@ -155,6 +162,7 @@ class SlurmJob(JobTrait):
         instead of submitting a new one.
         """
         total_nodes = sum(self._meshes.values())
+        self._ensure_service_proc_ids(total_nodes)
         if client_script is not None:
             # Dumped before submit: the job id isn't known yet, and the client
             # resolves it from $SLURM_JOB_ID anyway.
@@ -167,6 +175,7 @@ class SlurmJob(JobTrait):
         self, num_nodes: int, client_script: Optional[str] = None
     ) -> str:
         """Submit a SLURM job for all nodes."""
+        self._ensure_service_proc_ids(num_nodes)
         unique_job_name = f"{self._job_name}_{os.getpid()}"
 
         # Create log directory if it doesn't exist
@@ -230,6 +239,10 @@ class SlurmJob(JobTrait):
                 sbatch_directives.append(f"#SBATCH {arg}")
 
         batch_script = "\n".join(sbatch_directives)
+        batch_script += (
+            f"\nexport {SERVICE_PROC_IDS_ENV}="
+            f"{shlex.quote(serialize_service_proc_ids(self._service_proc_ids))}\n"
+        )
         if client_script is None:
             # Workers only; an external controller attaches and manages the
             # lifetime. Shares _WORKER_BOOTSTRAP with the batch runner.
@@ -274,6 +287,10 @@ class SlurmJob(JobTrait):
 
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Failed to submit SLURM job: {e.stderr}") from e
+
+    def _ensure_service_proc_ids(self, num_nodes: int) -> None:
+        if len(self._service_proc_ids) != num_nodes:
+            self._service_proc_ids = [new_service_proc_id() for _ in range(num_nodes)]
 
     def _get_job_info_json(self, job_id: str) -> Optional[Dict[str, Any]]:
         """Get job information using squeue --json."""
@@ -362,6 +379,7 @@ class SlurmJob(JobTrait):
             job_id = self._resolved_job_id()
             if job_id is None:
                 raise RuntimeError("SLURM job ID is not set")
+
             total_nodes = sum(self._meshes.values())
             self._all_hostnames = self._wait_for_job_start(
                 job_id, total_nodes, timeout=self._job_start_timeout
@@ -383,6 +401,9 @@ class SlurmJob(JobTrait):
             mesh_hostnames = self._all_hostnames[
                 hostname_idx : hostname_idx + num_nodes
             ]
+            service_proc_ids = self._service_proc_ids[
+                hostname_idx : hostname_idx + num_nodes
+            ]
             hostname_idx += num_nodes
 
             workers = [f"tcp://{hostname}:{self._port}" for hostname in mesh_hostnames]
@@ -390,6 +411,7 @@ class SlurmJob(JobTrait):
                 name=mesh_name,
                 ca="trust_all_connections",
                 workers=workers,  # type: ignore[arg-type]
+                service_proc_ids=service_proc_ids,
             )
 
             host_meshes[mesh_name] = host_mesh

--- a/python/monarch/_src/job/spmd.py
+++ b/python/monarch/_src/job/spmd.py
@@ -21,11 +21,19 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
+from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.host_mesh import this_host
 from monarch._src.job.job import JobState, JobTrait
+from monarch._src.job.service_identity import (
+    new_service_proc_id,
+    serialize_service_proc_ids,
+    SERVICE_PROC_IDS_ENV,
+    SERVICE_PROC_RANK_ENV,
+)
 from monarch._src.spmd.actor import SPMDActor
 from monarch._src.tools.commands import torchx_runner
+from torchx import specs
 from torchx.runner import Runner
 from torchx.specs import AppDef, AppState, Role
 
@@ -319,8 +327,16 @@ def serve(
 
     # Cache original entrypoints before modifying
     original_roles = []
+    service_proc_ids_by_role: dict[str, list[ProcId]] = {}
     scheme = "metatls" if scheduler.startswith("mast") else "tcp"
-    for role in appdef.roles:
+    if len(appdef.roles) > 1:
+        warnings.warn(
+            "SPMDJob currently only uses service proc IDs for the first role; "
+            f"got {len(appdef.roles)} roles, only {appdef.roles[0].name!r} will be "
+            "given coordinated identities. Other roles will use legacy fallback.",
+            stacklevel=2,
+        )
+    for idx, role in enumerate(appdef.roles):
         original_roles.append(
             {
                 "entrypoint": role.entrypoint,
@@ -328,12 +344,28 @@ def serve(
             }
         )
 
+        # Only the first role is used by SPMDJob._state (which inspects
+        # status.roles[0]). Generating IDs for other roles would leave workers
+        # with fixed identities that the client never uses, so restrict to idx==0.
+        if idx == 0:
+            service_proc_ids = [new_service_proc_id() for _ in range(role.num_replicas)]
+            service_proc_ids_by_role[role.name] = service_proc_ids
+            role.env[SERVICE_PROC_IDS_ENV] = serialize_service_proc_ids(
+                service_proc_ids
+            )
+            role.env[SERVICE_PROC_RANK_ENV] = specs.macros.replica_id
+
         role.args = [
             "python",
             "-X",
             "faulthandler",
             "-c",
-            f'import socket; from monarch.actor import run_worker_loop_forever; run_worker_loop_forever(ca="trust_all_connections", address=f"{scheme}://{{socket.getfqdn()}}:26600")',
+            "import os, socket; "
+            "from monarch._src.job.service_identity import ranked_service_proc_id_from_env; "
+            "from monarch.actor import run_worker_loop_forever; "
+            f'run_worker_loop_forever(ca="trust_all_connections", '
+            f"service_proc_id=ranked_service_proc_id_from_env() if {SERVICE_PROC_IDS_ENV!r} in os.environ else None, "
+            f'address=f"{scheme}://{{socket.getfqdn()}}:26600")',
         ]
 
     # Fall back to cwd if no workspace defined in appdef
@@ -360,6 +392,9 @@ def serve(
         scheduler=scheduler,
         workspace=workspace,
         original_roles=original_roles,
+        service_proc_ids=(
+            service_proc_ids_by_role[appdef.roles[0].name] if appdef.roles else None
+        ),
     )
 
     return job
@@ -378,12 +413,14 @@ class SPMDJob(JobTrait):
         scheduler: str,
         workspace: Optional[str] = None,
         original_roles: Optional[List[Dict[str, Any]]] = None,
+        service_proc_ids: list[ProcId] | None = None,
     ):
         super().__init__()
         self._app_handle = handle
         self._scheduler = scheduler
         self._workspace = workspace
         self._original_roles = original_roles or []
+        self._service_proc_ids = service_proc_ids
         self._hostnames: Optional[List[str]] = None
 
     def _get_runner(self) -> Runner:
@@ -459,16 +496,19 @@ class SPMDJob(JobTrait):
         assert status is not None and status.roles and status.roles[0].replicas
 
         # Extract hostnames from status
-        hostnames = [
-            replica.hostname
-            for replica in sorted(status.roles[0].replicas, key=lambda r: r.id)
-        ]
+        replicas = sorted(status.roles[0].replicas, key=lambda r: r.id)
+        hostnames = [replica.hostname for replica in replicas]
         self._hostnames = hostnames
 
         configure(default_transport=_get_channel_transport(self._scheduler))
         workers = attach_to_workers(
             ca="trust_all_connections",
             workers=[_get_worker_addr(self._scheduler, h) for h in hostnames],
+            service_proc_ids=(
+                [self._service_proc_ids[replica.id] for replica in replicas]
+                if self._service_proc_ids is not None
+                else None
+            ),
         )
 
         return JobState({"workers": workers})

--- a/python/monarch/_src/spmd/_worker_entry.py
+++ b/python/monarch/_src/spmd/_worker_entry.py
@@ -23,6 +23,7 @@ import os
 import sys
 import threading
 
+from monarch._src.job.service_identity import service_proc_id_from_env
 from monarch._src.spmd.host_mesh import _ADDR_ENV, _PARENT_WATCH_FD_ENV
 from monarch.actor import run_worker_loop_forever
 
@@ -68,7 +69,11 @@ def main() -> None:
             daemon=True,
             name="monarch-worker-parent-watch",
         ).start()
-    run_worker_loop_forever(address=addr, ca="trust_all_connections")
+    run_worker_loop_forever(
+        address=addr,
+        service_proc_id=service_proc_id_from_env(),
+        ca="trust_all_connections",
+    )
 
 
 if __name__ == "__main__":

--- a/python/monarch/_src/spmd/host_mesh.py
+++ b/python/monarch/_src/spmd/host_mesh.py
@@ -45,7 +45,9 @@ import threading
 from collections.abc import Mapping
 from typing import Final, Protocol
 
+from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
 from monarch._src.actor.host_mesh import HostMesh
+from monarch._src.job.service_identity import new_service_proc_id, SERVICE_PROC_ID_ENV
 from monarch.actor import attach_to_workers, enable_transport
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -157,6 +159,10 @@ def _worker_addr_key(group_rank: int) -> str:
     return f"monarch/spmd/workers/{group_rank}"
 
 
+def _worker_service_proc_id_key(group_rank: int) -> str:
+    return f"monarch/spmd/service_proc_ids/{group_rank}"
+
+
 def _resolve_topology_field(override: int | None, env_name: str) -> int:
     """Pick a torchelastic topology value from an override or from the env."""
     if override is not None:
@@ -238,22 +244,32 @@ def host_mesh_from_store(
     enable_transport(transport)
 
     if env_local_rank == 0:
+        service_proc_id = new_service_proc_id()
         addr, _pid = _spawn_worker_process(
             transport=transport,
             monarch_port=monarch_port,
             name=f"{name}_{group_rank}",
+            service_proc_id=service_proc_id,
         )
         store.set(_worker_addr_key(group_rank), addr.encode())
+        store.set(
+            _worker_service_proc_id_key(group_rank), str(service_proc_id).encode()
+        )
 
     if env_rank != 0:
         return None
 
     worker_addrs = [store.get(_worker_addr_key(i)).decode() for i in range(num_hosts)]
+    service_proc_ids = [
+        ProcId.from_string(store.get(_worker_service_proc_id_key(i)).decode())
+        for i in range(num_hosts)
+    ]
     return attach_to_workers(
         name=name,
         # Currently "trust_all_connections" is the only supported option.
         ca="trust_all_connections",
         workers=list(worker_addrs),
+        service_proc_ids=service_proc_ids,
     )
 
 
@@ -263,6 +279,7 @@ def _spawn_worker_process(
     monarch_port: int = 0,
     name: str = "monarch_worker",
     env: Mapping[str, str] | None = None,
+    service_proc_id: ProcId | None = None,
 ) -> tuple[str, int]:
     """Spawn a ``run_worker_loop_forever`` subprocess.
 
@@ -302,6 +319,15 @@ def _spawn_worker_process(
     }
     if env is not None:
         child_env.update(env)
+    if service_proc_id is None:
+        logger.warning(
+            "_spawn_worker_process called without service_proc_id for %s; "
+            "allocating a fresh ephemeral ID which will not be coordinated "
+            "with attach_to_workers. Pass an explicit ProcId to ensure routing.",
+            name,
+        )
+        service_proc_id = new_service_proc_id()
+    child_env[SERVICE_PROC_ID_ENV] = str(service_proc_id)
 
     if _IN_PAR:
         # sys.executable in PAR/XAR is the bare interpreter and cannot import

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -42,7 +42,6 @@ from monarch._src.actor.future import Future
 from monarch._src.actor.host_mesh import (
     default_bootstrap_cmd,
     HostMesh,
-    hosts_from_config,
     this_host,
     this_proc,
 )
@@ -76,7 +75,6 @@ __all__ = [
     "default_bootstrap_cmd",
     "HostMesh",
     "context",
-    "hosts_from_config",
     "Port",
     "PortReceiver",
     "Endpoint",

--- a/python/tests/_src/job/test_kubernetes.py
+++ b/python/tests/_src/job/test_kubernetes.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import pickle
 import unittest
 from tempfile import NamedTemporaryFile
 from unittest.mock import MagicMock, patch
@@ -32,6 +33,12 @@ from monarch._src.job.kubernetes import (
     ImageSpec,
     KubeConfig,
     KubernetesJob,
+)
+from monarch._src.job.service_identity import (
+    new_service_proc_id,
+    serialize_service_proc_ids,
+    SERVICE_PROC_IDS_ENV,
+    SERVICE_PROC_RANK_ENV,
 )
 
 
@@ -155,9 +162,12 @@ class TestAddMesh(unittest.TestCase):
 
     def test_image_marks_provisioned(self) -> None:
         job = self._make_job()
-        job.add_mesh("workers", num_replicas=2, image_spec=ImageSpec("myimage:latest"))
+        image_spec = ImageSpec("myimage:latest")
+        job.add_mesh("workers", num_replicas=2, image_spec=image_spec)
         self.assertTrue(job._meshes["workers"]["provisioned"])
-        self.assertIn("pod_template", job._meshes["workers"])
+        self.assertEqual(job._meshes["workers"]["image_spec"], image_spec)
+        self.assertNotIn("pod_template", job._meshes["workers"])
+        self.assertEqual(job._service_proc_ids, {})
 
     def test_pod_template_marks_provisioned(self) -> None:
         job = self._make_job()
@@ -322,6 +332,14 @@ class TestCreate(unittest.TestCase):
 
         job._create(None)
 
+        service_proc_ids = job._service_proc_ids["workers"]
+        self.assertEqual(len(service_proc_ids), 3)
+        self.assertEqual(len(set(service_proc_ids)), 3)
+        pod_template = mock_api_client.sanitize_for_serialization.call_args.args[0]
+        self.assertEqual(
+            pod_template.spec.containers[0].env[2].value,
+            serialize_service_proc_ids(service_proc_ids),
+        )
         mock_api.create_namespaced_custom_object.assert_called_once()
         call_kwargs = mock_api.create_namespaced_custom_object.call_args
         self.assertEqual(call_kwargs.kwargs["group"], _MONARCHMESH_GROUP)
@@ -529,8 +547,11 @@ class TestBuildWorkerPodTemplate(unittest.TestCase):
     """Tests for KubernetesJob._build_worker_pod_template."""
 
     def test_basic_pod_template(self) -> None:
+        service_proc_ids = [new_service_proc_id()]
         template = KubernetesJob._build_worker_pod_template(
-            ImageSpec("myimage:latest"), port=26600
+            ImageSpec("myimage:latest"),
+            port=26600,
+            service_proc_ids=service_proc_ids,
         )
         self.assertEqual(len(template.spec.containers), 1)
         container = template.spec.containers[0]
@@ -539,13 +560,25 @@ class TestBuildWorkerPodTemplate(unittest.TestCase):
         self.assertEqual(
             container.command, ["python", "-u", "-c", _WORKER_BOOTSTRAP_SCRIPT]
         )
-        self.assertEqual(len(container.env), 1)
+        self.assertEqual(len(container.env), 3)
         self.assertEqual(container.env[0].name, "MONARCH_PORT")
         self.assertEqual(container.env[0].value, "26600")
+        self.assertEqual(container.env[1].name, SERVICE_PROC_RANK_ENV)
+        self.assertEqual(
+            container.env[1].value_from.field_ref.field_path,
+            "metadata.labels['apps.kubernetes.io/pod-index']",
+        )
+        self.assertEqual(container.env[2].name, SERVICE_PROC_IDS_ENV)
+        self.assertEqual(
+            container.env[2].value,
+            serialize_service_proc_ids(service_proc_ids),
+        )
         self.assertIsNone(container.resources)
 
     def test_custom_port_in_env(self) -> None:
-        template = KubernetesJob._build_worker_pod_template(ImageSpec("img"), port=9999)
+        template = KubernetesJob._build_worker_pod_template(
+            ImageSpec("img"), port=9999, service_proc_ids=[new_service_proc_id()]
+        )
         self.assertEqual(template.spec.containers[0].env[0].value, "9999")
 
     def test_resources_set(self) -> None:
@@ -555,6 +588,7 @@ class TestBuildWorkerPodTemplate(unittest.TestCase):
                 resources={"cpu": "4", "memory": "8Gi", "nvidia.com/gpu": 2},
             ),
             port=26600,
+            service_proc_ids=[new_service_proc_id()],
         )
         container = template.spec.containers[0]
         expected = {"cpu": "4", "memory": "8Gi", "nvidia.com/gpu": "2"}
@@ -1106,6 +1140,27 @@ class TestCanRun(unittest.TestCase):
         spec.add_mesh("workers", num_replicas=1)
         self.assertTrue(job.can_run(spec))
 
+    @patch.object(KubernetesJob, "_wait_for_ready_pods", return_value=[])
+    def test_matching_provisioned_job_reuses_cached_service_proc_ids(
+        self,
+        mock_wait_for_ready_pods: MagicMock,
+    ) -> None:
+        cached = self._make_job()
+        cached.add_mesh("workers", 2, image_spec=ImageSpec("image"))
+        service_proc_ids = [new_service_proc_id(), new_service_proc_id()]
+        cached._service_proc_ids["workers"] = service_proc_ids
+        cached._status = "running"
+        restored = pickle.loads(pickle.dumps(cached))
+
+        spec = self._make_job()
+        spec.add_mesh("workers", 2, image_spec=ImageSpec("image"))
+
+        self.assertTrue(restored.can_run(spec))
+        self.assertEqual(
+            restored._service_proc_ids["workers"],
+            service_proc_ids,
+        )
+
     @patch(
         "monarch._src.job.kubernetes.config.load_incluster_config",
         side_effect=RuntimeError("not in cluster"),
@@ -1290,6 +1345,7 @@ class TestStateOutOfCluster(unittest.TestCase):
         forwarded_pod = mock_port_forward.call_args[0][0]
         self.assertEqual(forwarded_pod.name, "mesh1-0")
         mock_attach.assert_called_once_with("tcp://127.0.0.1:45678")
+        self.assertIsNone(mock_attach_to_workers.call_args.kwargs["service_proc_ids"])
 
     @patch("monarch._src.job.kubernetes.attach_to_workers")
     @patch("monarch._src.job.kubernetes.attach")
@@ -1311,6 +1367,8 @@ class TestStateOutOfCluster(unittest.TestCase):
         job.add_mesh(
             "mesh1", 2, image_spec=ImageSpec("ghcr.io/meta-pytorch/monarch:latest")
         )
+        service_proc_ids = [new_service_proc_id(), new_service_proc_id()]
+        job._service_proc_ids["mesh1"] = service_proc_ids
 
         self._mock_watch_for_pods(
             mock_watch_cls,
@@ -1331,6 +1389,10 @@ class TestStateOutOfCluster(unittest.TestCase):
         forwarded_pod = mock_port_forward.call_args[0][0]
         self.assertEqual(forwarded_pod.name, "mesh1-0")
         mock_attach.assert_called_once_with("tcp://127.0.0.1:55555")
+        self.assertEqual(
+            mock_attach_to_workers.call_args.kwargs["service_proc_ids"],
+            service_proc_ids,
+        )
 
     @patch("monarch._src.job.kubernetes.attach_to_workers")
     @patch("monarch._src.job.kubernetes.attach")

--- a/python/tests/_src/job/test_slurm.py
+++ b/python/tests/_src/job/test_slurm.py
@@ -15,6 +15,11 @@ from unittest.mock import patch
 import pytest
 from monarch._src.job import _slurm_batch
 from monarch._src.job.job import BatchJob, job_load
+from monarch._src.job.service_identity import (
+    new_service_proc_id,
+    serialize_service_proc_ids,
+    SERVICE_PROC_IDS_ENV,
+)
 from monarch._src.job.slurm import SlurmJob
 
 
@@ -123,8 +128,9 @@ def test_external_controller_mode_has_no_client(tmp_path, monkeypatch):
     script = _submitted_script(mock)
     assert "srun" in script
     assert "run_worker_loop_forever" in script
-    assert "_slurm_batch" not in script
+    assert "-m monarch._src.job._slurm_batch" not in script
     assert "MONARCH_BATCH_JOB" not in script
+    assert f"export {SERVICE_PROC_IDS_ENV}=" in script
     assert not (tmp_path / ".monarch" / "job_state.pkl").exists()
 
 
@@ -206,6 +212,57 @@ def test_in_cluster_state_does_not_attach_client_gateway():
         _make_job().state(cached_path=None)
 
     attach.assert_not_called()
+
+
+def test_worker_bootstrap_uses_preallocated_service_proc_id(monkeypatch):
+    service_proc_ids = [new_service_proc_id() for _ in range(8)]
+    monkeypatch.setenv(
+        SERVICE_PROC_IDS_ENV, serialize_service_proc_ids(service_proc_ids)
+    )
+    monkeypatch.setenv("SLURM_NODEID", "7")
+
+    with (
+        patch("socket.gethostname", return_value="worker-a"),
+        patch("monarch.actor.run_worker_loop_forever") as run_worker,
+    ):
+        exec(_slurm_batch._WORKER_BOOTSTRAP % 22222, {})
+
+    run_worker.assert_called_once_with(
+        address="tcp://worker-a:22222",
+        service_proc_id=service_proc_ids[7],
+        ca="trust_all_connections",
+    )
+
+
+def test_state_pairs_controller_addresses_with_worker_service_proc_ids():
+    job = _make_job()
+    job._slurm_job_id = "12345"
+    job._all_hostnames = ["worker-a", "worker-b"]
+    job._ensure_service_proc_ids(2)
+    service_proc_ids = list(job._service_proc_ids)
+
+    with (
+        patch.object(job, "_jobs_active", return_value=True),
+        patch(
+            "monarch._src.job.slurm.attach_to_workers", return_value=object()
+        ) as attach,
+    ):
+        job._state()
+
+    assert attach.call_count == 2
+    assert attach.call_args_list[0].kwargs["workers"] == ["tcp://worker-a:22222"]
+    assert attach.call_args_list[0].kwargs["service_proc_ids"] == [service_proc_ids[0]]
+    assert attach.call_args_list[1].kwargs["workers"] == ["tcp://worker-b:22222"]
+    assert attach.call_args_list[1].kwargs["service_proc_ids"] == [service_proc_ids[1]]
+
+
+def test_same_slurm_coordinates_get_distinct_service_proc_ids() -> None:
+    first = _make_job()
+    second = _make_job()
+    first._ensure_service_proc_ids(2)
+    second._ensure_service_proc_ids(2)
+
+    assert set(first._service_proc_ids).isdisjoint(second._service_proc_ids)
 
 
 def test_submit_raises_when_job_id_unparseable(tmp_path, monkeypatch):

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -34,6 +34,7 @@ from monarch._src.actor.pickle import flatten, unflatten
 from monarch._src.actor.proc_mesh import get_or_spawn_controller
 from monarch._src.job.job import ProcessState
 from monarch._src.job.process import ProcessJob
+from monarch._src.job.service_identity import new_service_proc_id
 from monarch.config import configured
 from scoped_state import scoped_state
 
@@ -728,6 +729,7 @@ class DuplexProcessJob(ProcessJob):
             for i in range(count):
                 host_key = f"{mesh_name}_{i}"
                 addr = f"ipc://{self._tmpdir}/{host_key}"
+                service_proc_id = new_service_proc_id()
                 worker_env = {**os.environ, "HYPERACTOR_PROCESS_NAME": host_key}
                 if self._env is not None:
                     worker_env.update(self._env)
@@ -735,12 +737,16 @@ class DuplexProcessJob(ProcessJob):
                 cmd = [
                     sys.executable,
                     "-c",
+                    "from monarch._rust_bindings.monarch_hyperactor.proc import ProcId; "
                     "from monarch.actor import run_worker_loop_forever; "
                     f'run_worker_loop_forever(address="{addr}", '
+                    f"service_proc_id=ProcId.from_string({str(service_proc_id)!r}), "
                     'ca="trust_all_connections")',
                 ]
                 proc = subprocess.Popen(cmd, env=worker_env, start_new_session=True)
-                self._host_to_pid[host_key] = ProcessState(proc.pid, addr)
+                self._host_to_pid[host_key] = ProcessState(
+                    proc.pid, addr, service_proc_id
+                )
 
         # Wait for the first worker's frontend socket to appear.
         # The duplex server is now on the same address as the frontend.

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -19,12 +19,13 @@ import threading
 import time
 import types
 from dataclasses import dataclass
-from typing import cast, Dict, Optional, Sequence
+from typing import Any, cast, Dict, Optional, Sequence
 from unittest.mock import MagicMock, patch
 
 import monarch._src.job._job_sidecar_worker as js_worker
 import monarch._src.job.job_sidecar as js
 import pytest
+from monarch._rust_bindings.monarch_hyperactor.proc import ProcId, Uid
 
 # Import directly from _src since job module isn't properly exposed
 from monarch._src.job.job import (
@@ -43,7 +44,53 @@ from monarch._src.job.job_components import JobComponent, JobComponents, MountCo
 from monarch._src.job.mount_config import Mounts
 from monarch._src.job.process import ProcessJob
 from monarch._src.job.process_guard import _Shutdown, _wait_for_socket
+from monarch._src.job.service_identity import (
+    deserialize_service_proc_ids,
+    new_service_proc_id,
+    serialize_service_proc_ids,
+)
 from monarch.actor import Future, HostMesh
+
+
+def test_service_proc_ids_are_instance_identities() -> None:
+    first = new_service_proc_id()
+    second = new_service_proc_id()
+
+    assert isinstance(first, ProcId)
+    assert first != second
+    assert first.label == "service"
+    assert first.uid.is_instance
+    assert str(first).startswith("service<") and str(first).endswith(">")
+    assert ProcId.from_string(str(first)) == first
+    assert pickle.loads(pickle.dumps(first)) == first
+    assert deserialize_service_proc_ids(
+        serialize_service_proc_ids([first, second])
+    ) == [
+        first,
+        second,
+    ]
+
+
+def test_service_proc_id_rejects_singleton_uid() -> None:
+    from monarch.actor import run_worker_loop_forever
+
+    with pytest.raises(ValueError, match="instance UID"):
+        run_worker_loop_forever(
+            address="ipc://unused",
+            service_proc_id=ProcId(Uid.from_string("service")),
+            ca="trust_all_connections",
+        )
+
+
+def test_service_proc_id_rejects_string() -> None:
+    from monarch.actor import run_worker_loop_forever
+
+    with pytest.raises(TypeError):
+        run_worker_loop_forever(
+            address="ipc://unused",
+            service_proc_id=cast(Any, "service<2>"),
+            ca="trust_all_connections",
+        )
 
 
 def _append_line(path: str, line: str) -> None:
@@ -628,7 +675,13 @@ def test_process_job_kill_reaps_worker_session():
 
         tmpdir = tempfile.mkdtemp(prefix="test_process_job_kill_")
         job = ProcessJob({"hosts": 1})
-        job._host_to_pid = {"h_0": ProcessState(worker, f"ipc://{tmpdir}/h_0")}
+        job._host_to_pid = {
+            "h_0": ProcessState(
+                worker,
+                f"ipc://{tmpdir}/h_0",
+                ProcId.from_string("service<2>"),
+            )
+        }
         job._tmpdir = tmpdir
 
         job._kill()

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -50,6 +50,7 @@ from monarch._src.actor.logging import _pending_flush_tasks
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, HyProcMesh
 from monarch._src.job.job import LoginJob, ProcessState
 from monarch._src.job.process import ProcessJob
+from monarch._src.job.service_identity import new_service_proc_id
 from monarch.actor import (
     Accumulator,
     Actor,
@@ -1766,16 +1767,21 @@ class FakeLocalLoginJob(LoginJob):
         if "FB_XAR_INVOKED_NAME" in os.environ:
             env["PYTHONPATH"] = ":".join(sys.path)
         addr = f"ipc://{self._dir}/{host}"
+        service_proc_id = new_service_proc_id()
         proc = subprocess.Popen(
             [
                 sys.executable,
                 "-c",
-                f'from monarch.actor import run_worker_loop_forever; run_worker_loop_forever(address={repr(addr)}, ca="trust_all_connections")',
+                "from monarch._rust_bindings.monarch_hyperactor.proc import ProcId; "
+                "from monarch.actor import run_worker_loop_forever; "
+                f"run_worker_loop_forever(address={addr!r}, "
+                f"service_proc_id=ProcId.from_string({str(service_proc_id)!r}), "
+                'ca="trust_all_connections")',
             ],
             env=env,
             start_new_session=True,
         )
-        return ProcessState(proc.pid, addr)
+        return ProcessState(proc.pid, addr, service_proc_id)
 
 
 @parametrize_config(actor_queue_dispatch={True, False})

--- a/python/tests/test_spmd_host_mesh.py
+++ b/python/tests/test_spmd_host_mesh.py
@@ -13,12 +13,15 @@ import subprocess
 import sys
 import time
 from typing import Callable
+from unittest.mock import patch
 
 import pytest
+from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
 from monarch._src.spmd.host_mesh import (
     _IN_PAR,
     _spawn_worker_process,
     _worker_addr_key,
+    _worker_service_proc_id_key,
     host_mesh_from_store,
 )
 
@@ -159,6 +162,45 @@ def test_host_mesh_from_store_non_local_rank_zero_is_passive(
     assert host_mesh_from_store(store, transport="ipc") is None
     # This rank did not spawn; nobody published for group 1.
     assert _worker_addr_key(1) not in store._values
+
+
+@patch("monarch._src.spmd.host_mesh.attach_to_workers")
+@patch("monarch._src.spmd.host_mesh._spawn_worker_process")
+@patch("monarch._src.spmd.host_mesh.new_service_proc_id")
+def test_host_mesh_from_store_carries_worker_service_proc_identity(
+    mock_new_service_proc_id,
+    mock_spawn_worker_process,
+    mock_attach_to_workers,
+) -> None:
+    service_proc_id = ProcId.from_string("service<2>")
+    mock_new_service_proc_id.return_value = service_proc_id
+    mock_spawn_worker_process.return_value = ("ipc://worker-0", 123)
+    expected_mesh = object()
+    mock_attach_to_workers.return_value = expected_mesh
+    store = _InMemoryStore()
+
+    mesh = host_mesh_from_store(
+        store,
+        rank=0,
+        local_rank=0,
+        world_size=1,
+        local_world_size=1,
+    )
+
+    assert mesh is expected_mesh
+    assert store.get(_worker_service_proc_id_key(0)) == b"service<2>"
+    mock_spawn_worker_process.assert_called_once_with(
+        transport="ipc",
+        monarch_port=0,
+        name="monarch_worker_0",
+        service_proc_id=service_proc_id,
+    )
+    mock_attach_to_workers.assert_called_once_with(
+        name="monarch_worker",
+        ca="trust_all_connections",
+        workers=["ipc://worker-0"],
+        service_proc_ids=[service_proc_id],
+    )
 
 
 def test_parent_death_kills_worker_via_pipe_eof() -> None:


### PR DESCRIPTION
Summary:

Preallocate one random typed service `ProcId` per host in every Monarch-owned launcher and pass the same identity to worker bootstrap and mesh attachment.

Propagate exact identities through Process, Login, SSH, Slurm, Kubernetes, MAST, job SPMD, store-based SPMD, helper, and Yardstick boundaries. Yardstick persists IDs in scheduler metadata so reconnecting to an existing named job remains correct. Externally managed bootstrap paths continue to use the legacy fallback.

Reviewed By: thedavekwon

Differential Revision: D115769976
