### PR TITLE
Update choose docstring (#4689)

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -329,7 +329,47 @@ sequenceDiagram
     Mesh-->>Client: Future[List[Result]]
 ```
 
-#### 3. `broadcast()` - Fire and Forget
+#### 3. `choose()` - Random Single Actor
+
+Send to one randomly selected actor and get its response.
+
+```python
+workers = procs.spawn("workers", Worker)
+
+result = workers.compute.choose(data).get()
+```
+
+Each call independently selects an actor uniformly at random. Selection does not
+account for actor load, so calls are balanced only across many calls, and
+consecutive calls may hit the same actor.
+
+**Use When:**
+- Any one actor can serve the request
+- Actors are interchangeable and hold no per-rank state
+- Approximate spreading over many calls is good enough
+
+**Avoid When:**
+- The workload is sensitive to how evenly work is distributed
+- You need a specific rank — slice the mesh and use `call_one` instead
+
+**Flow Diagram:**
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Mesh
+    participant A1 as Actor 1
+    participant A2 as Actor 2
+    participant An as Actor N
+
+    Client->>Mesh: choose(args)
+    Note over Mesh: Pick one rank at random
+    Mesh->>A2: message
+    A2-->>Mesh: result
+    Mesh-->>Client: Future[Result]
+```
+
+#### 4. `broadcast()` - Fire and Forget
 
 Send to all actors without waiting for responses.
 
@@ -362,7 +402,7 @@ sequenceDiagram
     Note over Actors: Process async
 ```
 
-#### 4. `rref()` - Distributed Tensor Reference
+#### 5. `rref()` - Distributed Tensor Reference
 
 Return distributed tensor from actor endpoint.
 
@@ -389,7 +429,7 @@ with procs.activate():
 - Need tensor operations across actors
 - Building neural network layers
 
-#### 5. `stream()` - Streaming Responses
+#### 6. `stream()` - Streaming Responses
 
 Stream responses as they arrive.
 

--- a/docs/source/api/monarch.actor.rst
+++ b/docs/source/api/monarch.actor.rst
@@ -67,7 +67,7 @@ Messaging is done through the "adverbs" defined for each endpoint
    :undoc-members:
    :inherited-members:
    :show-inheritance:
-   :exclude-members: __init__, choose
+   :exclude-members: __init__
 
 .. autoclass:: Future
    :members:

--- a/docs/source/examples/grpo_yield.py
+++ b/docs/source/examples/grpo_yield.py
@@ -37,9 +37,10 @@ parallel, all writing into the same rollouts port. A single ``Scorer``,
 The only hop that is *not* a port send is the weight update. The
 ``Trainer`` uses ``send(gen_mesh.update_weights, ..., selection="choose")``
 to dispatch each fresh ``state_dict`` to exactly one of the four
-generators, fire-and-forget. This pattern load-balances weight transfer
-across the pool and mirrors how real asynchronous RL systems drift
-generator and trainer replicas in and out of lock-step.
+generators, fire-and-forget. The generator is selected uniformly at
+random on each call, spreading weight transfer across the pool over many
+steps, and mirrors how real asynchronous RL systems drift generator and
+trainer replicas in and out of lock-step.
 
 Coroutine analogy
 -----------------
@@ -96,9 +97,9 @@ Contrast with ``grpo_actor.py``
 ``grpo_actor.py`` funnels data through dedicated queue actors
 (``TrajectoryQueue``, ``ReplayBuffer``) and copies weights via
 ``RDMABuffer``. Here we use neither — only ``Channel.open()``,
-``Port.send(...)``, and one ``send(..., selection="choose")`` call for
-load-balanced weight dispatch. The code is shorter, and the data-flow
-graph is visible at a glance in ``main``.
+``Port.send(...)``, and one ``send(..., selection="choose")`` call to
+dispatch weights to a randomly selected generator. The code is shorter,
+and the data-flow graph is visible at a glance in ``main``.
 
 Ports and RDMA are compatible
 -----------------------------
@@ -395,7 +396,7 @@ class RefModel(Actor):
 # -------------
 # Runs GRPO: PPO-clip on group-normalised advantages plus a KL penalty
 # against the reference model. On each step it dispatches a fresh
-# ``state_dict`` to one of the generators via
+# ``state_dict`` to a randomly selected generator via
 # ``send(..., selection="choose")`` — fire-and-forget. After
 # ``MAX_STEPS`` updates it broadcasts ``stop`` to the generator pool and
 # fires the one-shot done port.
@@ -462,9 +463,9 @@ class Trainer(Actor):
                 f"kl={kl.item():+.3f}"
             )
 
-            # Fire-and-forget weight dispatch. ``selection="choose"``
-            # load-balances across the generator pool; ``port=None``
-            # means no response is collected.
+            # Fire-and-forget weight dispatch. ``selection="choose"`` picks
+            # one generator uniformly at random; ``port=None`` means no
+            # response is collected.
             new_sd = copy.deepcopy(self.model.state_dict())
             send(
                 gen_mesh.update_weights,

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -745,7 +745,11 @@ pub(crate) trait Endpoint {
         wrap_in_future(py, task)
     }
 
-    /// Load balanced sends a message to one chosen actor and awaits a result.
+    /// Sends a message to a randomly selected actor and waits for its result.
+    ///
+    /// Each call independently selects an actor uniformly at random. Selection does
+    /// not account for actor load, so calls are balanced only across many calls. Use
+    /// `call_one` on a slice of the mesh when placement must be deterministic.
     fn choose<'py>(
         &self,
         py: Python<'py>,
@@ -1145,7 +1149,11 @@ impl ActorEndpoint {
         self.call(py, args, kwargs)
     }
 
-    /// Load balanced sends a message to one chosen actor and awaits a result.
+    /// Sends a message to a randomly selected actor and waits for its result.
+    ///
+    /// Each call independently selects an actor uniformly at random. Selection does
+    /// not account for actor load, so calls are balanced only across many calls. Use
+    /// `call_one` on a slice of the mesh when placement must be deterministic.
     #[pyo3(signature = (*args, **kwargs), name = "choose")]
     fn py_choose<'py>(
         &self,
@@ -1299,7 +1307,11 @@ impl Remote {
         self.call(py, args, kwargs)
     }
 
-    /// Load balanced sends a message to one chosen actor and awaits a result.
+    /// Sends a message to a randomly selected actor and waits for its result.
+    ///
+    /// Each call independently selects an actor uniformly at random. Selection does
+    /// not account for actor load, so calls are balanced only across many calls. Use
+    /// `call_one` on a slice of the mesh when placement must be deterministic.
     #[pyo3(signature = (*args, **kwargs), name = "choose")]
     fn py_choose<'py>(
         &self,

--- a/python/monarch/_rust_bindings/monarch_hyperactor/endpoint.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/endpoint.pyi
@@ -83,9 +83,12 @@ class ActorEndpoint(Generic[P, R]):
     def call(self, *args: P.args, **kwargs: P.kwargs) -> "Future[ValueMesh[R]]": ...
     def choose(self, *args: P.args, **kwargs: P.kwargs) -> Future[R]:
         """
-        Load balanced sends a message to one chosen actor and awaits a result.
+        Sends a message to a randomly selected actor and waits for its result.
 
-        Load balanced RPC-style entrypoint for request/response messaging.
+        Each call independently selects an actor uniformly at random. Selection
+        does not account for actor load, so calls are balanced only across many
+        calls. Use ``call_one`` on a slice of the mesh when placement must be
+        deterministic.
         """
         ...
     def call_one(self, *args: P.args, **kwargs: P.kwargs) -> Future[R]: ...
@@ -164,9 +167,12 @@ class Remote(Generic[P, R]):
     def call(self, *args: P.args, **kwargs: P.kwargs) -> "Future[ValueMesh[R]]": ...
     def choose(self, *args: P.args, **kwargs: P.kwargs) -> Future[R]:
         """
-        Load balanced sends a message to one chosen actor and awaits a result.
+        Sends a message to a randomly selected actor and waits for its result.
 
-        Load balanced RPC-style entrypoint for request/response messaging.
+        Each call independently selects an actor uniformly at random. Selection
+        does not account for actor load, so calls are balanced only across many
+        calls. Use ``call_one`` on a slice of the mesh when placement must be
+        deterministic.
         """
         ...
     def call_one(self, *args: P.args, **kwargs: P.kwargs) -> Future[R]: ...

--- a/python/monarch/_src/actor/endpoint.py
+++ b/python/monarch/_src/actor/endpoint.py
@@ -86,9 +86,12 @@ class Endpoint(Protocol[P, R]):
 
     def choose(self, *args: P.args, **kwargs: P.kwargs) -> Future[R]:
         """
-        Load balanced sends a message to one chosen actor and awaits a result.
+        Sends a message to a randomly selected actor and waits for its result.
 
-        Load balanced RPC-style entrypoint for request/response messaging.
+        Each call independently selects an actor uniformly at random. Selection
+        does not account for actor load, so calls are balanced only across many
+        calls. Use ``call_one`` on a slice of the mesh when placement must be
+        deterministic.
         """
         ...
 


### PR DESCRIPTION
Summary:

Currently the docstring for `choose` is:

```
Load balanced sends a message to one chosen actor and awaits a result.
```

Which is not always correct in terms of load balancing. For example, the mesh size might be 4, and the user only did 4 `choose`. Random selection cannot guarantee the requests will be placed on 4 actors. In this use case, a round-robin would be better. *However*, the docstring could leave the user the impression that it is fine.

Instead of vaguely saying "load balanced", we should be explicit on what `choose` actually does. This diff is making that change.

Reviewed By: shayne-fletcher

Differential Revision: D116461789


