### PR TITLE
Unify scheduler gateway attachment for job clients (#4690)

### DIFF
--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -32,6 +32,7 @@ from monarch._src.job.telemetry_config import TelemetryConfig
 # only be importing _public_ monarch API functions.
 from monarch.actor import (
     Actor,
+    attach,
     current_rank,
     enable_transport,
     endpoint,
@@ -393,6 +394,7 @@ class JobTrait(ABC):
         self._status: Literal["running", "not_running"] | CachedRunning = "not_running"
         self._components: JobComponents = JobComponents()
         self._apply_id: Optional[str] = None
+        self._client_attached_to: str | None = None
 
     def _should_spawn_telemetry_worker_collector_actors(self) -> bool:
         """Whether sidecar telemetry should spawn per-host worker collectors.
@@ -402,6 +404,28 @@ class JobTrait(ABC):
         local fan-out.
         """
         return True
+
+    def _attach_client(self, attach_to: str | None) -> None:
+        """Attach the process-global client context; detaching requires exit."""
+        if attach_to is None:
+            return
+        if self._client_attached_to is not None:
+            if self._client_attached_to != attach_to:
+                raise RuntimeError(
+                    "client is already attached through "
+                    f"{self._client_attached_to}, not {attach_to}; detaching is "
+                    "not supported, so use a new process to attach through a "
+                    "different address"
+                )
+            logger.debug(
+                "Client gateway is already attached via duplex address: %s",
+                attach_to,
+            )
+            return
+
+        logger.info("Attaching client gateway via duplex address: %s", attach_to)
+        attach(attach_to)
+        self._client_attached_to = attach_to
 
     def _connect_host_meshes(self, running_job: "JobTrait") -> Dict[str, HostMesh]:
         """Run the connect phases and return the final host meshes.

--- a/python/monarch/_src/job/kubernetes.py
+++ b/python/monarch/_src/job/kubernetes.py
@@ -30,7 +30,6 @@ from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job.job import JobState, JobTrait
-from monarch.actor import attach
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -771,10 +770,7 @@ class KubernetesJob(JobTrait):
                     )
 
             if attach_to is not None:
-                logger.info(
-                    "Attaching client gateway via duplex address: %s", attach_to
-                )
-                attach(attach_to)
+                self._attach_client(attach_to)
 
             for mesh_name, pods in all_mesh_pods.items():
                 # Create worker addresses using discovered IPs and ports
@@ -834,6 +830,8 @@ class KubernetesJob(JobTrait):
             NotImplementedError: If no provisioned meshes exist (all
                 meshes are attach-only).
         """
+        # Close local forwarding even when attach-only meshes make remote
+        # teardown unsupported.
         self._terminate_port_forwards()
 
         provisioned = [

--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -20,7 +20,6 @@ from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job
 from monarch._src.job._slurm_batch import _WORKER_BOOTSTRAP
 from monarch._src.job.job import BatchJob, JobState, JobTrait
-from monarch.actor import attach
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -116,7 +115,6 @@ class SlurmJob(JobTrait):
         self._qos = qos
         self._out_of_cluster = out_of_cluster
         self._attach_to = attach_to
-        self._client_attached = False
         # Track the single SLURM job ID and all allocated hostnames
         self._slurm_job_id: Optional[str] = None
         self._all_hostnames: List[str] = []
@@ -131,8 +129,15 @@ class SlurmJob(JobTrait):
         self.__dict__.update(state)
         # Attachment belongs to this process's global client context, not the
         # serialized job state.
-        self._client_attached = False
+        self._client_attached_to = None
         configure(default_transport=ChannelTransport.TcpWithHostname)
+
+    def _resolve_attach_to(self) -> str | None:
+        if self._attach_to is not None:
+            return self._attach_to
+        if self._out_of_cluster:
+            return f"tcp://{self._all_hostnames[0]}:{self._port}"
+        return None
 
     def add_mesh(self, name: str, num_nodes: int) -> None:
         self._meshes[name] = num_nodes
@@ -367,13 +372,7 @@ class SlurmJob(JobTrait):
                 job_id, total_nodes, timeout=self._job_start_timeout
             )
 
-        attach_to = self._attach_to
-        if self._out_of_cluster and attach_to is None:
-            attach_to = f"tcp://{self._all_hostnames[0]}:{self._port}"
-        if attach_to is not None and not self._client_attached:
-            logger.info("Attaching client gateway via duplex address: %s", attach_to)
-            attach(attach_to)
-            self._client_attached = True
+        self._attach_client(self._resolve_attach_to())
 
         # Distribute the allocated hostnames among meshes
         host_meshes = {}
@@ -470,7 +469,7 @@ class SlurmJob(JobTrait):
 
         No-op in batch mode: ``BatchJob`` registers this as an ``atexit`` hook on
         the in-allocation client, but the sbatch runner owns teardown there, so
-        the client must not scancel its own allocation. The external-controller
+        the client must not scancel its own allocation. The external-client
         path scancels as before.
         """
         if in_batch_job():

--- a/python/tests/_src/job/test_kubernetes.py
+++ b/python/tests/_src/job/test_kubernetes.py
@@ -977,8 +977,13 @@ class TestKill(unittest.TestCase):
     def test_kill_attach_only_raises_not_implemented(self) -> None:
         job = self._make_job()
         job.add_mesh("workers", num_replicas=1)
+        job._client_attached_to = "tcp://127.0.0.1:45678"
         with self.assertRaises(NotImplementedError):
             job._kill()
+        self.assertEqual(
+            job._client_attached_to,
+            "tcp://127.0.0.1:45678",
+        )
 
     @patch("monarch._src.job.kubernetes.client.CustomObjectsApi")
     @patch("monarch._src.job.kubernetes.config.load_incluster_config")
@@ -1252,7 +1257,7 @@ class TestStateOutOfCluster(unittest.TestCase):
         ]
 
     @patch("monarch._src.job.kubernetes.attach_to_workers")
-    @patch("monarch._src.job.kubernetes.attach")
+    @patch("monarch._src.job.job.attach")
     @patch("monarch._src.job.kubernetes.KubernetesJob._port_forward_to_pod")
     @patch("monarch._src.job.kubernetes.watch.Watch")
     @patch("monarch._src.job.kubernetes.client.CoreV1Api")
@@ -1292,7 +1297,7 @@ class TestStateOutOfCluster(unittest.TestCase):
         mock_attach.assert_called_once_with("tcp://127.0.0.1:45678")
 
     @patch("monarch._src.job.kubernetes.attach_to_workers")
-    @patch("monarch._src.job.kubernetes.attach")
+    @patch("monarch._src.job.job.attach")
     @patch("monarch._src.job.kubernetes.KubernetesJob._port_forward_to_pod")
     @patch("monarch._src.job.kubernetes.watch.Watch")
     @patch("monarch._src.job.kubernetes.client.CoreV1Api")
@@ -1333,7 +1338,7 @@ class TestStateOutOfCluster(unittest.TestCase):
         mock_attach.assert_called_once_with("tcp://127.0.0.1:55555")
 
     @patch("monarch._src.job.kubernetes.attach_to_workers")
-    @patch("monarch._src.job.kubernetes.attach")
+    @patch("monarch._src.job.job.attach")
     @patch("monarch._src.job.kubernetes.KubernetesJob._port_forward_to_pod")
     @patch("monarch._src.job.kubernetes.watch.Watch")
     @patch("monarch._src.job.kubernetes.client.CoreV1Api")

--- a/python/tests/_src/job/test_slurm.py
+++ b/python/tests/_src/job/test_slurm.py
@@ -143,7 +143,7 @@ def test_out_of_cluster_attaches_through_first_worker_before_meshes():
             "monarch._src.job.slurm.subprocess.run",
             side_effect=_fake_running_slurm,
         ),
-        patch("monarch._src.job.slurm.attach", side_effect=_record_attach),
+        patch("monarch._src.job.job.attach", side_effect=_record_attach),
         patch("monarch._src.job.slurm.attach_to_workers", side_effect=_record_mesh),
     ):
         _make_job(out_of_cluster=True).state(cached_path=None)
@@ -161,7 +161,7 @@ def test_explicit_attach_to_overrides_automatic_worker_gateway():
             "monarch._src.job.slurm.subprocess.run",
             side_effect=_fake_running_slurm,
         ),
-        patch("monarch._src.job.slurm.attach") as attach,
+        patch("monarch._src.job.job.attach") as attach,
         patch("monarch._src.job.slurm.attach_to_workers", return_value=object()),
     ):
         _make_job(
@@ -172,13 +172,25 @@ def test_explicit_attach_to_overrides_automatic_worker_gateway():
     attach.assert_called_once_with("tcp://127.0.0.1:45678")
 
 
+def test_client_cannot_reattach_through_different_gateway():
+    job = _make_job()
+
+    with patch("monarch._src.job.job.attach") as attach:
+        job._attach_client("tcp://trainer-host:22222")
+        job._attach_client("tcp://trainer-host:22222")
+        with pytest.raises(RuntimeError, match="use a new process"):
+            job._attach_client("tcp://other-host:22222")
+
+    attach.assert_called_once_with("tcp://trainer-host:22222")
+
+
 def test_out_of_cluster_attaches_once_per_loaded_job():
     with (
         patch(
             "monarch._src.job.slurm.subprocess.run",
             side_effect=_fake_running_slurm,
         ),
-        patch("monarch._src.job.slurm.attach") as attach,
+        patch("monarch._src.job.job.attach") as attach,
         patch("monarch._src.job.slurm.attach_to_workers", return_value=object()),
     ):
         job = _make_job(out_of_cluster=True)
@@ -200,7 +212,7 @@ def test_in_cluster_state_does_not_attach_client_gateway():
             "monarch._src.job.slurm.subprocess.run",
             side_effect=_fake_running_slurm,
         ),
-        patch("monarch._src.job.slurm.attach") as attach,
+        patch("monarch._src.job.job.attach") as attach,
         patch("monarch._src.job.slurm.attach_to_workers", return_value=object()),
     ):
         _make_job().state(cached_path=None)
@@ -285,10 +297,11 @@ def test_kill_is_noop_inside_batch_allocation(monkeypatch):
     run.assert_not_called()
 
 
-def test_kill_scancels_for_external_controller(monkeypatch):
+def test_kill_scancels_for_external_client(monkeypatch):
     monkeypatch.delenv("MONARCH_BATCH_JOB", raising=False)
     job = _make_job()
     job._slurm_job_id = "777"
+    job._client_attached_to = "tcp://trainer-host:22222"
     seen = []
 
     def _record(*args, **kwargs):
@@ -298,6 +311,7 @@ def test_kill_scancels_for_external_controller(monkeypatch):
     with patch("monarch._src.job.slurm.subprocess.run", side_effect=_record):
         job._kill()
     assert ["scancel", "777"] in seen
+    assert job._client_attached_to == "tcp://trainer-host:22222"
 
 
 def test_jobs_active_for_reloaded_batch_job(monkeypatch):


### PR DESCRIPTION
Summary:

- Move one-time controller `attach()` bookkeeping into `JobTrait`.
- Route Kubernetes and Slurm controller attachment through the shared helper.
- Clear allocation-scoped gateway state during scheduler cleanup and reset process-local state after Slurm deserialization.

Reviewed By: dulinriley

Differential Revision: D116542840


