### PR TITLE
Attach out-of-cluster job sidecars through scheduler gateways (#4691)

### DIFF
--- a/docs/source/examples/grpo/kubernetes_grpo.py
+++ b/docs/source/examples/grpo/kubernetes_grpo.py
@@ -188,6 +188,7 @@ from monarch.actor import (
     current_size,
     endpoint,
 )
+from monarch.job import TelemetryConfig
 from monarch.job.kubernetes import KubeConfig, KubernetesJob
 from monarch.rdma import RDMABuffer
 
@@ -1078,6 +1079,7 @@ async def main(
         timeout=600,
         kubeconfig=KubeConfig.from_path(kubeconfig) if out_of_cluster else None,
     )
+    k8s_job.enable_telemetry(TelemetryConfig(include_dashboard=True, dashboard_port=0))
     # Learner pod requests 2 GPUs; ``device_map="auto"`` inside the actor
     # spreads the trainable policy across both. ``spawn_procs({"gpus": 1})``
     # below still spawns a single learner proc that sees both GPUs in its

--- a/python/monarch/_src/job/_job_sidecar_worker.py
+++ b/python/monarch/_src/job/_job_sidecar_worker.py
@@ -15,30 +15,29 @@ refresh/shutdown requests.
 
 Usage::
 
-    python -m monarch._src.job._job_sidecar_worker [--runtime-transport TRANSPORT] <socket_path> <lock_fd>
+    python -m monarch._src.job._job_sidecar_worker \
+        [--runtime-transport TRANSPORT] [--attach-to ADDRESS] \
+        <socket_path> <lock_fd>
 """
 
-import sys
+import argparse
 
 
 def main() -> None:
-    args = sys.argv[1:]
-    if len(args) < 2:
-        raise RuntimeError("job sidecar worker requires socket path and lock fd")
-
-    runtime_transport = None
-    startup_args = args[:-2]
-    if startup_args:
-        if len(startup_args) != 2 or startup_args[0] != "--runtime-transport":
-            raise RuntimeError(f"unexpected job sidecar worker args: {startup_args!r}")
-        runtime_transport = startup_args[1]
-
-    socket_path = args[-2]
-    int(args[-1])  # keep fd open to hold the flock for the process lifetime
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runtime-transport")
+    parser.add_argument("--attach-to")
+    parser.add_argument("socket_path")
+    parser.add_argument("lock_fd", type=int)
+    args = parser.parse_args()
 
     from monarch._src.job.job_sidecar import _run_job_sidecar
 
-    _run_job_sidecar(socket_path, runtime_transport=runtime_transport)
+    _run_job_sidecar(
+        args.socket_path,
+        runtime_transport=args.runtime_transport,
+        attach_to=args.attach_to,
+    )
 
 
 if __name__ == "__main__":

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -32,6 +32,7 @@ from monarch._src.job.telemetry_config import TelemetryConfig
 # only be importing _public_ monarch API functions.
 from monarch.actor import (
     Actor,
+    attach,
     current_rank,
     enable_transport,
     endpoint,
@@ -393,6 +394,7 @@ class JobTrait(ABC):
         self._status: Literal["running", "not_running"] | CachedRunning = "not_running"
         self._components: JobComponents = JobComponents()
         self._apply_id: Optional[str] = None
+        self._client_attached_to: str | None = None
 
     def _should_spawn_telemetry_worker_collector_actors(self) -> bool:
         """Whether sidecar telemetry should spawn per-host worker collectors.
@@ -402,6 +404,28 @@ class JobTrait(ABC):
         local fan-out.
         """
         return True
+
+    def _attach_client(self, attach_to: str | None) -> None:
+        """Attach the process-global client context; detaching requires exit."""
+        if attach_to is None:
+            return
+        if self._client_attached_to is not None:
+            if self._client_attached_to != attach_to:
+                raise RuntimeError(
+                    "client is already attached through "
+                    f"{self._client_attached_to}, not {attach_to}; detaching is "
+                    "not supported, so use a new process to attach through a "
+                    "different address"
+                )
+            logger.debug(
+                "Client gateway is already attached via duplex address: %s",
+                attach_to,
+            )
+            return
+
+        logger.info("Attaching client gateway via duplex address: %s", attach_to)
+        attach(attach_to)
+        self._client_attached_to = attach_to
 
     def _connect_host_meshes(self, running_job: "JobTrait") -> Dict[str, HostMesh]:
         """Run the connect phases and return the final host meshes.

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -25,7 +25,7 @@ from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job, MONARCH_BATCH_JOB_ENV
 from monarch._src.job._telemetry_query_client import QueryEngineClient
 from monarch._src.job.job_components import JobComponents, MeshAdminConfig
-from monarch._src.job.job_sidecar import stop_job_sidecar
+from monarch._src.job.job_sidecar import create_job_sidecar, stop_job_sidecar
 from monarch._src.job.telemetry_config import TelemetryConfig
 
 # note: the jobs api is intended as a library so it should
@@ -405,6 +405,24 @@ class JobTrait(ABC):
         """
         return True
 
+    def _sidecar_attach_to(self) -> str | None:
+        """Duplex gateway address the job sidecar should attach through."""
+        return self._client_attached_to
+
+    def _requires_sidecar_gateway(self) -> bool:
+        """Whether a sidecar must join the client's scheduler gateway.
+
+        Scheduler jobs override this when their workers advertise addresses
+        that the independently running sidecar cannot reach directly. The
+        gateway must then be resolved before the sidecar starts its actor
+        context.
+        """
+        return False
+
+    def _prepare_client_gateway(self) -> None:
+        """Resolve and attach through a scheduler-provided client gateway."""
+        return None
+
     def _attach_client(self, attach_to: str | None) -> None:
         """Attach the process-global client context; detaching requires exit."""
         if attach_to is None:
@@ -439,6 +457,18 @@ class JobTrait(ABC):
         the raw host meshes (``self``, a cached job, or the wrapped
         CachedRunning job).
         """
+        if running_job._requires_sidecar_gateway() and self._components.needs_sidecar():
+            # The sidecar runs in a separate process, so attaching the client
+            # does not make cluster-only worker addresses routable from the
+            # sidecar. Start it through the same scheduler gateway before any
+            # component initializes the sidecar's actor context.
+            running_job._prepare_client_gateway()
+            attach_to = running_job._sidecar_attach_to()
+            if self.apply_id is not None and attach_to is not None:
+                create_job_sidecar(
+                    self.apply_id,
+                    attach_to=attach_to,
+                )
         self._components.before_connect(self)
         host_meshes = dict(running_job._state()._hosts)
         return self._components.connect(self, host_meshes)
@@ -1070,10 +1100,14 @@ class BatchJob(JobTrait):
     def _should_spawn_telemetry_worker_collector_actors(self) -> bool:
         return self._job._should_spawn_telemetry_worker_collector_actors()
 
-    def _connect_host_meshes(self, running_job: "JobTrait") -> Dict[str, HostMesh]:
-        self._components.before_connect(self)
-        host_meshes = dict(running_job._state()._hosts)
-        return self._components.connect(self, host_meshes)
+    def _prepare_client_gateway(self) -> None:
+        self._job._prepare_client_gateway()
+
+    def _sidecar_attach_to(self) -> str | None:
+        return self._job._sidecar_attach_to()
+
+    def _requires_sidecar_gateway(self) -> bool:
+        return self._job._requires_sidecar_gateway()
 
     def state(
         self, cached_path: Optional[str] = ".monarch/job_state.pkl"

--- a/python/monarch/_src/job/job_components.py
+++ b/python/monarch/_src/job/job_components.py
@@ -117,6 +117,10 @@ class MountComponent(JobComponent):
             result[mesh_name] = mesh
         return result
 
+    def needs_sidecar(self) -> bool:
+        """Whether configured mounts require the shared job sidecar."""
+        return bool(self._mounts._remote_entries or self._mounts._gather_entries)
+
     def python_executable_for_mesh(self, mesh_name: str) -> Optional[str]:
         return self._python_executables.get(mesh_name, self._default_python_exe)
 
@@ -400,6 +404,10 @@ class JobComponents:
     telemetry: Optional[TelemetryComponent] = None
     admin: Optional[AdminComponent] = None
     snapshot: Optional[SnapshotComponent] = None
+
+    def needs_sidecar(self) -> bool:
+        """Whether telemetry or mounts require the shared job sidecar."""
+        return self.mounts.needs_sidecar() or self.telemetry is not None
 
     def _ordered(self) -> List[JobComponent]:
         components: List[JobComponent] = [self.mounts]

--- a/python/monarch/_src/job/job_sidecar.py
+++ b/python/monarch/_src/job/job_sidecar.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from monarch._rust_bindings.monarch_hyperactor.channel import BindSpec
 from monarch._src.job.process_guard import find_process, ProcessGuard
-from monarch.actor import enable_transport, HostMesh
+from monarch.actor import attach, enable_transport, HostMesh
 from monarch.config import get_runtime_config
 
 _JOB_SIDECAR_WORKER_MODULE = "monarch._src.job._job_sidecar_worker"
@@ -46,6 +46,7 @@ def spawn_module(
     config_key: object,
     module_name: str,
     runtime_transport: str | None = None,
+    attach_to: str | None = None,
 ) -> ProcessGuard:
     """Launch a Python module as a ``ProcessGuard``-managed background process."""
     if _IN_PAR:
@@ -58,10 +59,15 @@ def spawn_module(
         env = None
     if runtime_transport is not None:
         command.extend(["--runtime-transport", runtime_transport])
+    if attach_to is not None:
+        command.extend(["--attach-to", attach_to])
     return ProcessGuard.create(lock_path, config_key, command, env=env)
 
 
-def create_job_sidecar(apply_id: str) -> ProcessGuard:
+def create_job_sidecar(
+    apply_id: str,
+    attach_to: str | None = None,
+) -> ProcessGuard:
     """Ensure the per-job sidecar process is running and return its guard."""
     runtime_transport = sidecar_transport_from_runtime()
     return spawn_module(
@@ -69,6 +75,7 @@ def create_job_sidecar(apply_id: str) -> ProcessGuard:
         apply_id,
         _JOB_SIDECAR_WORKER_MODULE,
         runtime_transport=runtime_transport,
+        attach_to=attach_to,
     )
 
 
@@ -211,7 +218,11 @@ def _dbg(msg: str) -> None:
     print(f"[job_sidecar pid={os.getpid()}] {msg}", file=sys.stderr, flush=True)
 
 
-def _run_job_sidecar(socket_path: str, runtime_transport: str | None = None) -> None:
+def _run_job_sidecar(
+    socket_path: str,
+    runtime_transport: str | None = None,
+    attach_to: str | None = None,
+) -> None:
     """Run in the child process: bind socket then serve refresh/shutdown requests."""
     import signal as _signal
 
@@ -221,6 +232,8 @@ def _run_job_sidecar(socket_path: str, runtime_transport: str | None = None) -> 
         _signal.signal(_signal.SIGTERM, _signal.SIG_DFL)
 
     configure_sidecar_transport(runtime_transport)
+    if attach_to is not None:
+        attach(attach_to)
 
     from monarch._src.job.process_guard import _Shutdown
 

--- a/python/monarch/_src/job/kubernetes.py
+++ b/python/monarch/_src/job/kubernetes.py
@@ -233,8 +233,47 @@ class KubernetesJob(JobTrait):
         self._kubeconfig: KubeConfig = kubeconfig or KubeConfig()
         self._attach_to = attach_to
         self._meshes: dict[str, _MeshConfig] = {}
+        self._prepared_mesh_pods: dict[str, list[_MonarchMeshPod]] | None = None
         self._port_forward_processes: list[subprocess.Popen[str]] = []
         super().__init__()
+
+    def _requires_sidecar_gateway(self) -> bool:
+        # Out-of-cluster mode resolves an automatic port-forward when no
+        # address is supplied; an explicit address requires the same ordering.
+        return self._kubeconfig.out_of_cluster or self._attach_to is not None
+
+    def _prepare_client_gateway(self) -> None:
+        if self._prepared_mesh_pods is not None:
+            return
+
+        all_mesh_pods: dict[str, list[_MonarchMeshPod]] = {}
+        for mesh_name, mesh_config in self._meshes.items():
+            all_mesh_pods[mesh_name] = self._wait_for_ready_pods(
+                mesh_config["label_selector"],
+                mesh_config["num_replicas"],
+                mesh_config["pod_rank_label"],
+                timeout=self._timeout,
+            )
+
+        attach_to = self._attach_to
+        try:
+            if self._kubeconfig.out_of_cluster and attach_to is None:
+                for pods in all_mesh_pods.values():
+                    if pods:
+                        attach_to = self._port_forward_to_pod(pods[0])
+                        break
+                if attach_to is None:
+                    raise RuntimeError(
+                        "out-of-cluster mode requires at least one ready pod "
+                        "and no attach_to was provided"
+                    )
+
+            self._attach_client(attach_to)
+        except Exception:
+            self._terminate_port_forwards()
+            raise
+
+        self._prepared_mesh_pods = all_mesh_pods
 
     # TODO: Consider adding monarch-rank label instead of relying on StatefulSet index by default if using MonarchMesh CRD.
     def add_mesh(
@@ -736,42 +775,14 @@ class KubernetesJob(JobTrait):
         Returns:
             JobState containing HostMesh objects for each configured mesh
         """
+        self._prepare_client_gateway()
+        all_mesh_pods = self._prepared_mesh_pods
+        if all_mesh_pods is None:
+            raise RuntimeError("Kubernetes connection was not prepared")
+        self._prepared_mesh_pods = None
+
         host_meshes = {}
-        attach_to = self._attach_to
-
-        # Discover all mesh pods first so we can set up port-forwarding
-        # before attaching to any workers.
-        all_mesh_pods: dict[str, list[_MonarchMeshPod]] = {}
-        for mesh_name, mesh_config in self._meshes.items():
-            # Wait for pods to be ready and discover their ports
-            pods = self._wait_for_ready_pods(
-                mesh_config["label_selector"],
-                mesh_config["num_replicas"],
-                mesh_config["pod_rank_label"],
-                timeout=self._timeout,
-            )
-            all_mesh_pods[mesh_name] = pods
-
-        # Set up out-of-cluster client attachment before connecting to workers.
-        # If anything below fails after a port-forward subprocess is started,
-        # terminate it so we do not leak kubectl processes and bound ports.
         try:
-            if self._kubeconfig.out_of_cluster and attach_to is None:
-                # No explicit attach_to — auto-forward to the first pod's
-                # monarch port (which doubles as the duplex attach address).
-                for pods in all_mesh_pods.values():
-                    if pods:
-                        attach_to = self._port_forward_to_pod(pods[0])
-                        break
-                if attach_to is None:
-                    raise RuntimeError(
-                        "out-of-cluster mode requires at least one ready pod "
-                        "and no attach_to was provided"
-                    )
-
-            if attach_to is not None:
-                self._attach_client(attach_to)
-
             for mesh_name, pods in all_mesh_pods.items():
                 # Create worker addresses using discovered IPs and ports
                 workers = [f"tcp://{pod.ip}:{pod.port}" for pod in pods]
@@ -833,6 +844,7 @@ class KubernetesJob(JobTrait):
         # Close local forwarding even when attach-only meshes make remote
         # teardown unsupported.
         self._terminate_port_forwards()
+        self._prepared_mesh_pods = None
 
         provisioned = [
             name for name, cfg in self._meshes.items() if cfg.get("provisioned")

--- a/python/monarch/_src/job/kubernetes.py
+++ b/python/monarch/_src/job/kubernetes.py
@@ -30,7 +30,6 @@ from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job.job import JobState, JobTrait
-from monarch.actor import attach
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -771,10 +770,7 @@ class KubernetesJob(JobTrait):
                     )
 
             if attach_to is not None:
-                logger.info(
-                    "Attaching client gateway via duplex address: %s", attach_to
-                )
-                attach(attach_to)
+                self._attach_client(attach_to)
 
             for mesh_name, pods in all_mesh_pods.items():
                 # Create worker addresses using discovered IPs and ports
@@ -834,6 +830,8 @@ class KubernetesJob(JobTrait):
             NotImplementedError: If no provisioned meshes exist (all
                 meshes are attach-only).
         """
+        # Close local forwarding even when attach-only meshes make remote
+        # teardown unsupported.
         self._terminate_port_forwards()
 
         provisioned = [

--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -20,7 +20,6 @@ from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job
 from monarch._src.job._slurm_batch import _WORKER_BOOTSTRAP
 from monarch._src.job.job import BatchJob, JobState, JobTrait
-from monarch.actor import attach
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -116,7 +115,6 @@ class SlurmJob(JobTrait):
         self._qos = qos
         self._out_of_cluster = out_of_cluster
         self._attach_to = attach_to
-        self._client_attached = False
         # Track the single SLURM job ID and all allocated hostnames
         self._slurm_job_id: Optional[str] = None
         self._all_hostnames: List[str] = []
@@ -131,8 +129,15 @@ class SlurmJob(JobTrait):
         self.__dict__.update(state)
         # Attachment belongs to this process's global client context, not the
         # serialized job state.
-        self._client_attached = False
+        self._client_attached_to = None
         configure(default_transport=ChannelTransport.TcpWithHostname)
+
+    def _resolve_attach_to(self) -> str | None:
+        if self._attach_to is not None:
+            return self._attach_to
+        if self._out_of_cluster:
+            return f"tcp://{self._all_hostnames[0]}:{self._port}"
+        return None
 
     def add_mesh(self, name: str, num_nodes: int) -> None:
         self._meshes[name] = num_nodes
@@ -367,13 +372,7 @@ class SlurmJob(JobTrait):
                 job_id, total_nodes, timeout=self._job_start_timeout
             )
 
-        attach_to = self._attach_to
-        if self._out_of_cluster and attach_to is None:
-            attach_to = f"tcp://{self._all_hostnames[0]}:{self._port}"
-        if attach_to is not None and not self._client_attached:
-            logger.info("Attaching client gateway via duplex address: %s", attach_to)
-            attach(attach_to)
-            self._client_attached = True
+        self._attach_client(self._resolve_attach_to())
 
         # Distribute the allocated hostnames among meshes
         host_meshes = {}
@@ -470,7 +469,7 @@ class SlurmJob(JobTrait):
 
         No-op in batch mode: ``BatchJob`` registers this as an ``atexit`` hook on
         the in-allocation client, but the sbatch runner owns teardown there, so
-        the client must not scancel its own allocation. The external-controller
+        the client must not scancel its own allocation. The external-client
         path scancels as before.
         """
         if in_batch_job():

--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -139,6 +139,24 @@ class SlurmJob(JobTrait):
             return f"tcp://{self._all_hostnames[0]}:{self._port}"
         return None
 
+    def _requires_sidecar_gateway(self) -> bool:
+        return self._out_of_cluster or self._attach_to is not None
+
+    def _prepare_client_gateway(self) -> None:
+        if not self._jobs_active():
+            raise RuntimeError("SLURM job is no longer active")
+
+        if not self._all_hostnames:
+            job_id = self._resolved_job_id()
+            if job_id is None:
+                raise RuntimeError("SLURM job ID is not set")
+            total_nodes = sum(self._meshes.values())
+            self._all_hostnames = self._wait_for_job_start(
+                job_id, total_nodes, timeout=self._job_start_timeout
+            )
+
+        self._attach_client(self._resolve_attach_to())
+
     def add_mesh(self, name: str, num_nodes: int) -> None:
         self._meshes[name] = num_nodes
 
@@ -359,20 +377,7 @@ class SlurmJob(JobTrait):
             raise
 
     def _state(self) -> JobState:
-        if not self._jobs_active():
-            raise RuntimeError("SLURM job is no longer active")
-
-        # Wait for job to start and get hostnames if not already done
-        if not self._all_hostnames:
-            job_id = self._resolved_job_id()
-            if job_id is None:
-                raise RuntimeError("SLURM job ID is not set")
-            total_nodes = sum(self._meshes.values())
-            self._all_hostnames = self._wait_for_job_start(
-                job_id, total_nodes, timeout=self._job_start_timeout
-            )
-
-        self._attach_client(self._resolve_attach_to())
+        self._prepare_client_gateway()
 
         # Distribute the allocated hostnames among meshes
         host_meshes = {}

--- a/python/tests/_src/job/test_kubernetes.py
+++ b/python/tests/_src/job/test_kubernetes.py
@@ -1369,6 +1369,53 @@ class TestStateOutOfCluster(unittest.TestCase):
         mock_port_forward.assert_not_called()
         mock_attach.assert_called_once_with("tcp://127.0.0.1:34000")
 
+    def test_components_bootstrap_before_host_mesh_materialization(self) -> None:
+        job = self._make_job()
+        job._status = "running"
+        job._apply_id = "apply"
+        raw_host = MagicMock()
+        raw_state = MagicMock()
+        raw_state._hosts = {"mesh1": raw_host}
+        events = []
+
+        def prepare_client_gateway() -> None:
+            events.append("prepare")
+            job._client_attached_to = "tcp://127.0.0.1:45678"
+
+        def materialize_state() -> MagicMock:
+            events.append("state")
+            return raw_state
+
+        job._components = MagicMock()
+        job._components.needs_sidecar.return_value = True
+        job._components.before_connect.side_effect = lambda _job: events.append(
+            "before_connect"
+        )
+        job._components.connect.side_effect = (
+            lambda _job, host_meshes: events.append("connect") or host_meshes
+        )
+
+        with (
+            patch.object(
+                job,
+                "_prepare_client_gateway",
+                side_effect=prepare_client_gateway,
+            ),
+            patch.object(job, "_state", side_effect=materialize_state),
+            patch(
+                "monarch._src.job.job.create_job_sidecar",
+                side_effect=lambda *_args, **_kwargs: events.append("sidecar"),
+            ),
+        ):
+            host_meshes = job._connect_host_meshes(job)
+
+        self.assertEqual(
+            events,
+            ["prepare", "sidecar", "before_connect", "state", "connect"],
+        )
+        self.assertEqual(host_meshes, {"mesh1": raw_host})
+        self.assertEqual(job._sidecar_attach_to(), "tcp://127.0.0.1:45678")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/_src/job/test_kubernetes.py
+++ b/python/tests/_src/job/test_kubernetes.py
@@ -977,8 +977,13 @@ class TestKill(unittest.TestCase):
     def test_kill_attach_only_raises_not_implemented(self) -> None:
         job = self._make_job()
         job.add_mesh("workers", num_replicas=1)
+        job._client_attached_to = "tcp://127.0.0.1:45678"
         with self.assertRaises(NotImplementedError):
             job._kill()
+        self.assertEqual(
+            job._client_attached_to,
+            "tcp://127.0.0.1:45678",
+        )
 
     @patch("monarch._src.job.kubernetes.client.CustomObjectsApi")
     @patch("monarch._src.job.kubernetes.config.load_incluster_config")
@@ -1252,7 +1257,7 @@ class TestStateOutOfCluster(unittest.TestCase):
         ]
 
     @patch("monarch._src.job.kubernetes.attach_to_workers")
-    @patch("monarch._src.job.kubernetes.attach")
+    @patch("monarch._src.job.job.attach")
     @patch("monarch._src.job.kubernetes.KubernetesJob._port_forward_to_pod")
     @patch("monarch._src.job.kubernetes.watch.Watch")
     @patch("monarch._src.job.kubernetes.client.CoreV1Api")
@@ -1292,7 +1297,7 @@ class TestStateOutOfCluster(unittest.TestCase):
         mock_attach.assert_called_once_with("tcp://127.0.0.1:45678")
 
     @patch("monarch._src.job.kubernetes.attach_to_workers")
-    @patch("monarch._src.job.kubernetes.attach")
+    @patch("monarch._src.job.job.attach")
     @patch("monarch._src.job.kubernetes.KubernetesJob._port_forward_to_pod")
     @patch("monarch._src.job.kubernetes.watch.Watch")
     @patch("monarch._src.job.kubernetes.client.CoreV1Api")
@@ -1333,7 +1338,7 @@ class TestStateOutOfCluster(unittest.TestCase):
         mock_attach.assert_called_once_with("tcp://127.0.0.1:55555")
 
     @patch("monarch._src.job.kubernetes.attach_to_workers")
-    @patch("monarch._src.job.kubernetes.attach")
+    @patch("monarch._src.job.job.attach")
     @patch("monarch._src.job.kubernetes.KubernetesJob._port_forward_to_pod")
     @patch("monarch._src.job.kubernetes.watch.Watch")
     @patch("monarch._src.job.kubernetes.client.CoreV1Api")

--- a/python/tests/_src/job/test_slurm.py
+++ b/python/tests/_src/job/test_slurm.py
@@ -10,7 +10,7 @@ import json
 import pickle
 import shlex
 import subprocess
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from monarch._src.job import _slurm_batch
@@ -130,6 +130,8 @@ def test_external_controller_mode_has_no_client(tmp_path, monkeypatch):
 
 def test_out_of_cluster_attaches_through_first_worker_before_meshes():
     events = []
+    job = _make_job(out_of_cluster=True)
+    job._components.telemetry = MagicMock()
 
     def _record_attach(address):
         events.append(("attach", address))
@@ -145,11 +147,18 @@ def test_out_of_cluster_attaches_through_first_worker_before_meshes():
         ),
         patch("monarch._src.job.job.attach", side_effect=_record_attach),
         patch("monarch._src.job.slurm.attach_to_workers", side_effect=_record_mesh),
+        patch(
+            "monarch._src.job.job.create_job_sidecar",
+            side_effect=lambda _apply_id, attach_to: events.append(
+                ("sidecar", attach_to)
+            ),
+        ),
     ):
-        _make_job(out_of_cluster=True).state(cached_path=None)
+        job.state(cached_path=None)
 
     assert events == [
         ("attach", "tcp://trainer-host:22222"),
+        ("sidecar", "tcp://trainer-host:22222"),
         ("mesh", "trainer"),
         ("mesh", "generator"),
     ]

--- a/python/tests/_src/job/test_slurm.py
+++ b/python/tests/_src/job/test_slurm.py
@@ -143,7 +143,7 @@ def test_out_of_cluster_attaches_through_first_worker_before_meshes():
             "monarch._src.job.slurm.subprocess.run",
             side_effect=_fake_running_slurm,
         ),
-        patch("monarch._src.job.slurm.attach", side_effect=_record_attach),
+        patch("monarch._src.job.job.attach", side_effect=_record_attach),
         patch("monarch._src.job.slurm.attach_to_workers", side_effect=_record_mesh),
     ):
         _make_job(out_of_cluster=True).state(cached_path=None)
@@ -161,7 +161,7 @@ def test_explicit_attach_to_overrides_automatic_worker_gateway():
             "monarch._src.job.slurm.subprocess.run",
             side_effect=_fake_running_slurm,
         ),
-        patch("monarch._src.job.slurm.attach") as attach,
+        patch("monarch._src.job.job.attach") as attach,
         patch("monarch._src.job.slurm.attach_to_workers", return_value=object()),
     ):
         _make_job(
@@ -172,13 +172,25 @@ def test_explicit_attach_to_overrides_automatic_worker_gateway():
     attach.assert_called_once_with("tcp://127.0.0.1:45678")
 
 
+def test_client_cannot_reattach_through_different_gateway():
+    job = _make_job()
+
+    with patch("monarch._src.job.job.attach") as attach:
+        job._attach_client("tcp://trainer-host:22222")
+        job._attach_client("tcp://trainer-host:22222")
+        with pytest.raises(RuntimeError, match="use a new process"):
+            job._attach_client("tcp://other-host:22222")
+
+    attach.assert_called_once_with("tcp://trainer-host:22222")
+
+
 def test_out_of_cluster_attaches_once_per_loaded_job():
     with (
         patch(
             "monarch._src.job.slurm.subprocess.run",
             side_effect=_fake_running_slurm,
         ),
-        patch("monarch._src.job.slurm.attach") as attach,
+        patch("monarch._src.job.job.attach") as attach,
         patch("monarch._src.job.slurm.attach_to_workers", return_value=object()),
     ):
         job = _make_job(out_of_cluster=True)
@@ -200,7 +212,7 @@ def test_in_cluster_state_does_not_attach_client_gateway():
             "monarch._src.job.slurm.subprocess.run",
             side_effect=_fake_running_slurm,
         ),
-        patch("monarch._src.job.slurm.attach") as attach,
+        patch("monarch._src.job.job.attach") as attach,
         patch("monarch._src.job.slurm.attach_to_workers", return_value=object()),
     ):
         _make_job().state(cached_path=None)
@@ -285,10 +297,11 @@ def test_kill_is_noop_inside_batch_allocation(monkeypatch):
     run.assert_not_called()
 
 
-def test_kill_scancels_for_external_controller(monkeypatch):
+def test_kill_scancels_for_external_client(monkeypatch):
     monkeypatch.delenv("MONARCH_BATCH_JOB", raising=False)
     job = _make_job()
     job._slurm_job_id = "777"
+    job._client_attached_to = "tcp://trainer-host:22222"
     seen = []
 
     def _record(*args, **kwargs):
@@ -298,6 +311,7 @@ def test_kill_scancels_for_external_controller(monkeypatch):
     with patch("monarch._src.job.slurm.subprocess.run", side_effect=_record):
         job._kill()
     assert ["scancel", "777"] in seen
+    assert job._client_attached_to == "tcp://trainer-host:22222"
 
 
 def test_jobs_active_for_reloaded_batch_job(monkeypatch):

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -219,17 +219,28 @@ def test_spawn_module_reenters_parent_binary_inside_par():
 
 def test_create_job_sidecar_spawns_job_sidecar_worker_module():
     with (
+        patch.object(js, "_IN_PAR", False),
         patch.object(js, "sidecar_transport_from_runtime", return_value="metatls"),
-        patch.object(js, "spawn_module") as spawn_module,
+        patch("monarch._src.job.process_guard.ProcessGuard.create") as create,
     ):
-        js.create_job_sidecar("apply_id")
+        js.create_job_sidecar(
+            "apply_id",
+            attach_to="tcp://127.0.0.1:45678",
+        )
 
-    spawn_module.assert_called_once_with(
-        js.job_sidecar_lock_path("apply_id"),
-        "apply_id",
+    lock_path, config_key, command = create.call_args.args
+    assert lock_path == js.job_sidecar_lock_path("apply_id")
+    assert config_key == "apply_id"
+    assert command == [
+        sys.executable,
+        "-m",
         "monarch._src.job._job_sidecar_worker",
-        runtime_transport="metatls",
-    )
+        "--runtime-transport",
+        "metatls",
+        "--attach-to",
+        "tcp://127.0.0.1:45678",
+    ]
+    assert create.call_args.kwargs == {"env": None}
 
 
 def test_mounts_ensure_open_clears_existing_sidecar_when_empty():
@@ -277,7 +288,7 @@ def test_mounts_ensure_open_sends_mounts_request():
     guard.send.return_value.get.assert_called_once_with()
 
 
-def test_job_sidecar_worker_passes_transport_arg_to_server():
+def test_job_sidecar_worker_passes_startup_args_to_server():
     with (
         patch.object(
             sys,
@@ -286,6 +297,8 @@ def test_job_sidecar_worker_passes_transport_arg_to_server():
                 "worker",
                 "--runtime-transport",
                 "metatls",
+                "--attach-to",
+                "tcp://127.0.0.1:45678",
                 "/tmp/socket",
                 "123",
             ],
@@ -294,7 +307,28 @@ def test_job_sidecar_worker_passes_transport_arg_to_server():
     ):
         js_worker.main()
 
-    run_sidecar.assert_called_once_with("/tmp/socket", runtime_transport="metatls")
+    run_sidecar.assert_called_once_with(
+        "/tmp/socket",
+        runtime_transport="metatls",
+        attach_to="tcp://127.0.0.1:45678",
+    )
+
+
+def test_run_job_sidecar_attaches_gateway_once_before_serving():
+    server = MagicMock()
+    server.accept.side_effect = OSError
+    with (
+        patch("signal.signal"),
+        patch.object(js, "attach") as attach,
+        patch.object(js.socket, "socket", return_value=server),
+    ):
+        js._run_job_sidecar(
+            "/tmp/socket",
+            attach_to="tcp://127.0.0.1:45678",
+        )
+
+    attach.assert_called_once_with("tcp://127.0.0.1:45678")
+    server.bind.assert_called_once_with("/tmp/socket")
 
 
 def test_run_job_sidecar_manages_mount_lifecycle():


### PR DESCRIPTION
Summary:

- Resolve Kubernetes and Slurm gateways before sidecar-backed components start.
- Pass the gateway through the explicit `--attach-to` sidecar startup argument.
- Enable and validate out-of-cluster telemetry in `kubernetes_grpo.py`.

Reviewed By: dulinriley

Differential Revision: D116542842


