### PR TITLE
Rename ProcSpawner behavior to SpawnProc

### DIFF
--- a/hyperactor_remote/example/remote_spawner.rs
+++ b/hyperactor_remote/example/remote_spawner.rs
@@ -10,7 +10,7 @@
 //!
 //! Run `spawner` in one process and `driver` in another. The spawner process
 //! starts a [`UnixProcSpawner`], publishes a rendezvous token for its
-//! [`ProcSpawner`] interface, and waits. The driver joins that token, asks the
+//! [`SpawnProc`] interface, and waits. The driver joins that token, asks the
 //! spawner to spawn a Unix child proc, receives the proc's `SpawnActor`
 //! interface, spawns a remote [`Calculator`] actor through that proc-local spawner, issues one
 //! calculation, and exits through [`Instance::exit`]. The spawned child process
@@ -41,10 +41,10 @@ use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use hyperactor_remote::ActorSpawnerEndpoint;
 use hyperactor_remote::JoinResult;
-use hyperactor_remote::ProcSpawner;
 use hyperactor_remote::ProcSpawnerEndpoint;
 use hyperactor_remote::Token;
 use hyperactor_remote::TokenOptions;
+use hyperactor_remote::proc_spawner::SpawnProc;
 use hyperactor_remote::proc_spawner::unix::UnixProc;
 use hyperactor_remote::proc_spawner::unix::UnixProcCommand;
 use hyperactor_remote::proc_spawner::unix::UnixProcSpawner;
@@ -53,7 +53,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-type DemoToken = Token<ActorRef<ProcSpawner>, ActorAddr>;
+type DemoToken = Token<ActorRef<SpawnProc>, ActorAddr>;
 
 #[derive(Debug)]
 struct SpawnerArgs {
@@ -196,7 +196,7 @@ impl Actor for SpawnerBootstrap {
         let proc_spawner = this.spawn(UnixProcSpawner::new_with_command(command));
         let token = token::create(
             this,
-            proc_spawner.bind::<ProcSpawner>(),
+            proc_spawner.bind::<SpawnProc>(),
             this.port::<token::Joined<ActorAddr>>().bind(),
             TokenOptions::default(),
         )?;
@@ -254,7 +254,7 @@ impl Actor for Driver {
         self.token.join(
             this,
             this.self_addr().clone(),
-            this.port::<JoinResult<ActorRef<ProcSpawner>>>().bind(),
+            this.port::<JoinResult<ActorRef<SpawnProc>>>().bind(),
         )?;
         Ok(())
     }
@@ -270,11 +270,11 @@ impl Actor for Driver {
 }
 
 #[async_trait]
-impl Handler<JoinResult<ActorRef<ProcSpawner>>> for Driver {
+impl Handler<JoinResult<ActorRef<SpawnProc>>> for Driver {
     async fn handle(
         &mut self,
         cx: &Context<Self>,
-        message: JoinResult<ActorRef<ProcSpawner>>,
+        message: JoinResult<ActorRef<SpawnProc>>,
     ) -> anyhow::Result<()> {
         let proc_spawner = match message {
             JoinResult::Joined { peer } => peer,

--- a/hyperactor_remote/src/lib.rs
+++ b/hyperactor_remote/src/lib.rs
@@ -30,7 +30,6 @@ pub use keepalive::KeepaliveSupervisorParams;
 pub use keepalive::KeepaliveWorker;
 pub use keepalive::KeepaliveWorkerParams;
 pub use link::LinkSpec;
-pub use proc_spawner::ProcSpawner;
 pub use proc_spawner::ProcSpawnerEndpoint;
 pub use proto::Gspawn;
 pub use proto::OrphanPolicy;

--- a/hyperactor_remote/src/proc_spawner.rs
+++ b/hyperactor_remote/src/proc_spawner.rs
@@ -25,7 +25,7 @@ use hyperactor::Uid;
 use hyperactor::context;
 
 use crate::KeepaliveLink;
-use crate::SpawnProc;
+use crate::SpawnProc as SpawnProcMessage;
 use crate::SupervisionOptions;
 use crate::Supervisor;
 use crate::actor_spawner::SpawnActor;
@@ -33,7 +33,7 @@ use crate::actor_spawner::SpawnActor;
 pub mod unix;
 
 // Behavior implemented by actors that expose proc spawning.
-hyperactor::behavior!(ProcSpawner, SpawnProc);
+hyperactor::behavior!(SpawnProc, SpawnProcMessage);
 
 /// Convenience methods for endpoints that accept [`SpawnProc`] requests.
 pub trait ProcSpawnerEndpoint {
@@ -41,7 +41,7 @@ pub trait ProcSpawnerEndpoint {
     fn spawn_proc(&self, cx: &impl context::Actor) -> anyhow::Result<ActorRef<SpawnActor>>
     where
         Self: Clone + Send + 'static,
-        for<'a> &'a Self: Endpoint<SpawnProc>,
+        for<'a> &'a Self: Endpoint<SpawnProcMessage>,
     {
         self.spawn_proc_uid(cx, Uid::anonymous())
     }
@@ -54,7 +54,7 @@ pub trait ProcSpawnerEndpoint {
     ) -> anyhow::Result<ActorRef<SpawnActor>>
     where
         Self: Clone + Send + 'static,
-        for<'a> &'a Self: Endpoint<SpawnProc>,
+        for<'a> &'a Self: Endpoint<SpawnProcMessage>,
     {
         self.spawn_proc_uid_with_link(cx, uid, KeepaliveLink::default())
     }
@@ -76,7 +76,7 @@ pub trait ProcSpawnerEndpoint {
     ) -> anyhow::Result<ActorRef<SpawnActor>>
     where
         Self: Clone + Send + 'static,
-        for<'a> &'a Self: Endpoint<SpawnProc>,
+        for<'a> &'a Self: Endpoint<SpawnProcMessage>,
     {
         self.spawn_proc_uid_with_link_and_ready(cx, uid, KeepaliveLink::default(), Some(ready))
     }
@@ -90,7 +90,7 @@ pub trait ProcSpawnerEndpoint {
     ) -> anyhow::Result<ActorRef<SpawnActor>>
     where
         Self: Clone + Send + 'static,
-        for<'a> &'a Self: Endpoint<SpawnProc>,
+        for<'a> &'a Self: Endpoint<SpawnProcMessage>,
     {
         self.spawn_proc_uid_with_link_and_ready(cx, uid, liveness, None)
     }
@@ -108,7 +108,7 @@ pub trait ProcSpawnerEndpoint {
     ) -> anyhow::Result<ActorRef<SpawnActor>>
     where
         Self: Clone + Send + 'static,
-        for<'a> &'a Self: Endpoint<SpawnProc>,
+        for<'a> &'a Self: Endpoint<SpawnProcMessage>,
     {
         anyhow::ensure!(uid.is_instance(), "spawned procs cannot be singletons");
 
@@ -121,7 +121,7 @@ pub trait ProcSpawnerEndpoint {
             actor_spawner.actor_addr().clone(),
             ready,
             move |cx, supervise| {
-                proc_spawner.post(cx, SpawnProc { uid, supervise });
+                proc_spawner.post(cx, SpawnProcMessage { uid, supervise });
                 Ok(())
             },
         ));
@@ -129,7 +129,7 @@ pub trait ProcSpawnerEndpoint {
     }
 }
 
-impl<T> ProcSpawnerEndpoint for T where for<'a> &'a T: Endpoint<SpawnProc> {}
+impl<T> ProcSpawnerEndpoint for T where for<'a> &'a T: Endpoint<SpawnProcMessage> {}
 
 /// Well-known singleton name of a proc's actor-spawn endpoint.
 pub(crate) const ACTOR_SPAWNER_NAME: &str = "spawner";
@@ -145,7 +145,7 @@ pub(crate) fn actor_spawner_ref(proc_addr: &ProcAddr) -> ActorRef<SpawnActor> {
     ActorRef::attest(proc_addr.actor_addr_uid(actor_spawner_uid()))
 }
 
-fn spawned_proc_addr(spawner: impl Endpoint<SpawnProc>, uid: &Uid) -> ProcAddr {
+fn spawned_proc_addr(spawner: impl Endpoint<SpawnProcMessage>, uid: &Uid) -> ProcAddr {
     let spawner_addr = spawner.endpoint_location().actor_addr().proc_addr();
     spawned_proc_addr_for_spawner_addr(&spawner_addr, uid)
 }
@@ -155,7 +155,10 @@ pub(crate) fn spawned_proc_addr_for_spawner_addr(spawner: &ProcAddr, uid: &Uid) 
     ProcAddr::new(ProcId::new(uid.clone(), None), location)
 }
 
-fn spawned_actor_spawner(spawner: impl Endpoint<SpawnProc>, uid: &Uid) -> ActorRef<SpawnActor> {
+fn spawned_actor_spawner(
+    spawner: impl Endpoint<SpawnProcMessage>,
+    uid: &Uid,
+) -> ActorRef<SpawnActor> {
     actor_spawner_ref(&spawned_proc_addr(spawner, uid))
 }
 

--- a/hyperactor_remote/src/proc_spawner/unix.rs
+++ b/hyperactor_remote/src/proc_spawner/unix.rs
@@ -97,14 +97,13 @@ use tokio::process::Command;
 use tokio::sync::oneshot;
 use typeuri::Named;
 
-use super::ProcSpawner;
+use super::SpawnProc;
 use super::actor_spawner_ref;
 use super::actor_spawner_uid;
 use super::spawned_proc_addr_for_spawner_addr;
 use crate::ActorSpawner;
 use crate::OrphanPolicy;
 use crate::RemoteActorDisposition;
-use crate::SpawnProc;
 use crate::Supervise;
 use crate::SupervisionOptions;
 use crate::SupervisorEvent;
@@ -112,6 +111,7 @@ use crate::TokenOptions;
 use crate::TokenPolicy;
 use crate::WorkerCommand;
 use crate::actor_spawner::SpawnActor;
+use crate::proto::SpawnProc as SpawnProcMessage;
 use crate::token;
 
 /// Environment variable containing the one-shot token a child proc uses to boot and join its spawner.
@@ -267,7 +267,7 @@ impl UnixProcCommand {
     }
 }
 
-/// Unix process backed implementation of [`ProcSpawner`].
+/// Unix process backed implementation of [`SpawnProc`].
 ///
 /// `UnixProcSpawner` starts one OS child process per spawned proc. The child
 /// process calls [`UnixProc::boot_from_env`], starts a proc-local [`SpawnActor`]
@@ -275,7 +275,7 @@ impl UnixProcCommand {
 /// token supplied by the spawner. The spawner links the proc only after that
 /// join, and the child process exits when the actor-spawn endpoint exits.
 #[derive(Debug)]
-#[hyperactor::export(SpawnProc)]
+#[hyperactor::export(SpawnProcMessage)]
 pub struct UnixProcSpawner {
     command: UnixProcCommand,
     procs: HashMap<Uid, ActorHandle<UnixProcWorker>>,
@@ -337,8 +337,12 @@ impl Actor for UnixProcSpawner {
 }
 
 #[async_trait]
-impl Handler<SpawnProc> for UnixProcSpawner {
-    async fn handle(&mut self, cx: &Context<Self>, message: SpawnProc) -> anyhow::Result<()> {
+impl Handler<SpawnProcMessage> for UnixProcSpawner {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: SpawnProcMessage,
+    ) -> anyhow::Result<()> {
         if !message.uid.is_instance() {
             reject_supervise(cx, &message.supervise, "spawned procs cannot be singletons");
             return Ok(());
@@ -372,7 +376,7 @@ impl Handler<SpawnProc> for UnixProcSpawner {
     }
 }
 
-hyperactor::assert_behaves!(UnixProcSpawner as ProcSpawner);
+hyperactor::assert_behaves!(UnixProcSpawner as SpawnProc);
 
 /// Helper for Unix child processes launched by [`UnixProcSpawner`].
 pub struct UnixProc;


### PR DESCRIPTION
Summary: The Actor variant of this is already called SpawnActor, and I think behaviors are meant to be verbs. Change ProcSpawner (which is newer) to be consistent with SpawnActor.

Reviewed By: shayne-fletcher

Differential Revision: D116645798


