### PR TITLE
Stop tracking local range overlap in RdmaAction (#4693)

### DIFF
--- a/monarch_rdma/src/action.rs
+++ b/monarch_rdma/src/action.rs
@@ -9,11 +9,10 @@
 //! Batched RDMA action layer.
 //!
 //! [`RdmaAction`] accumulates [`crate::RdmaOp`]s through `add_read_into_local`
-//! / `add_write_from_local`, validates the per-op sizes and the local
-//! memory ranges as ops are added, and then dispatches the queued ops
-//! across the available backends in parallel on [`RdmaAction::submit`].
+//! / `add_write_from_local`, validates the per-op sizes as ops are added,
+//! and then dispatches the queued ops across the available backends in
+//! parallel on [`RdmaAction::submit`].
 
-use std::collections::HashMap;
 use std::time::Duration;
 
 use hyperactor::context;
@@ -29,20 +28,15 @@ use crate::rdma_components::RdmaRemoteBuffer;
 /// A batch of RDMA operations submitted as a single unit.
 ///
 /// `RdmaAction` is a builder that accumulates read-into-local and
-/// write-from-local ops, performs eager validation (size check + local
-/// memory range race detection), and then runs them concurrently across
-/// the available backends on [`Self::submit`].
+/// write-from-local ops, checking each op's sizes as it is added, and then
+/// runs them concurrently across the available backends on
+/// [`Self::submit`].
 ///
-/// Local-memory race detection treats an `add_read_into_local` claim as a
-/// write to the local range and an `add_write_from_local` claim as a
-/// read; two reads of the same range merge into one claim, anything else
-/// errors. Remote-side ranges are deliberately not tracked.
+/// Overlap between the queued ops' memory ranges is not tracked, on either
+/// the local or the remote side. Two ops in one action that write the same
+/// range race, and it is the caller's job not to queue them.
 pub struct RdmaAction {
     entries: Vec<RdmaOp>,
-    // Claimed local address ranges keyed by `[start, end)`. The stored
-    // [`RdmaOpType`] doubles as the op-kind tag: `ReadIntoLocal` is a
-    // local write, `WriteFromLocal` is a local read.
-    local_claims: HashMap<(usize, usize), RdmaOpType>,
 }
 
 impl Default for RdmaAction {
@@ -55,18 +49,10 @@ impl RdmaAction {
     pub fn new() -> Self {
         Self {
             entries: Vec::new(),
-            local_claims: HashMap::new(),
         }
     }
 
-    /// True if this op writes to the local address range
-    /// (`ReadIntoLocal` reads remote data *into* local memory).
-    fn is_local_write(op_type: RdmaOpType) -> bool {
-        matches!(op_type, RdmaOpType::ReadIntoLocal)
-    }
-
-    /// Queue a read from `remote` into `local`. Records a local *write*
-    /// claim over the local memory range.
+    /// Queue a read from `remote` into `local`.
     pub fn add_read_into_local(
         &mut self,
         remote: RdmaRemoteBuffer,
@@ -79,7 +65,6 @@ impl RdmaAction {
                 remote.size,
             );
         }
-        self.record_claim(local.addr(), local.size(), RdmaOpType::ReadIntoLocal)?;
         self.entries.push(RdmaOp {
             op_type: RdmaOpType::ReadIntoLocal,
             local,
@@ -88,8 +73,7 @@ impl RdmaAction {
         Ok(self)
     }
 
-    /// Queue a write from `local` into `remote`. Records a local *read*
-    /// claim over the local memory range.
+    /// Queue a write from `local` into `remote`.
     pub fn add_write_from_local(
         &mut self,
         remote: RdmaRemoteBuffer,
@@ -102,7 +86,6 @@ impl RdmaAction {
                 remote.size,
             );
         }
-        self.record_claim(local.addr(), local.size(), RdmaOpType::WriteFromLocal)?;
         self.entries.push(RdmaOp {
             op_type: RdmaOpType::WriteFromLocal,
             local,
@@ -111,54 +94,13 @@ impl RdmaAction {
         Ok(self)
     }
 
-    fn record_claim(
-        &mut self,
-        addr: usize,
-        size: usize,
-        op_type: RdmaOpType,
-    ) -> Result<(), anyhow::Error> {
-        let mut start = addr;
-        let mut end = addr.saturating_add(size);
-        let new_is_write = Self::is_local_write(op_type);
-
-        // In one pass, we merge all entries that overlap with the new claim into a single entry.
-        // We then remove all the merged entries.
-        let mut to_remove: Vec<(usize, usize)> = Vec::new();
-        for (&(s, e), &existing) in self.local_claims.iter() {
-            if end <= s || e <= start {
-                continue;
-            }
-            if new_is_write || Self::is_local_write(existing) {
-                anyhow::bail!(
-                    "RdmaAction data race: existing {:?} claim at [{:#x}, {:#x}) overlaps new {:?} claim at [{:#x}, {:#x})",
-                    existing,
-                    s,
-                    e,
-                    op_type,
-                    start,
-                    end,
-                );
-            }
-            start = start.min(s);
-            end = end.max(e);
-            to_remove.push((s, e));
-        }
-
-        for k in &to_remove {
-            self.local_claims.remove(k);
-        }
-        self.local_claims.insert((start, end), op_type);
-        Ok(())
-    }
-
     /// Submit all queued ops. Ops are grouped by backend and each group
     /// is submitted in parallel. Safe to call more than once on the same
-    /// action — the queued ops and overlap claims are left intact.
+    /// action — the queued ops are left intact.
     ///
-    /// Takes `&mut self` so the borrow checker prevents two submit
-    /// futures from being alive on the same action simultaneously;
-    /// otherwise the local-range overlap detection would be meaningless
-    /// (two in-flight dispatches over the same claimed local memory).
+    /// Takes `&mut self` so the borrow checker prevents two submit futures
+    /// from being alive on the same action at once, which would put two
+    /// in-flight dispatches over the same local memory.
     pub async fn submit(
         &mut self,
         client: &(impl context::Actor + Send + Sync),
@@ -217,88 +159,5 @@ impl RdmaAction {
                 errors.join("\n")
             )
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Convenience: WRITE-kind claim (i.e. simulates `add_read_into_local`).
-    fn write_claim(action: &mut RdmaAction, addr: usize, size: usize) -> Result<(), anyhow::Error> {
-        action.record_claim(addr, size, RdmaOpType::ReadIntoLocal)
-    }
-
-    /// Convenience: READ-kind claim (i.e. simulates `add_write_from_local`).
-    fn read_claim(action: &mut RdmaAction, addr: usize, size: usize) -> Result<(), anyhow::Error> {
-        action.record_claim(addr, size, RdmaOpType::WriteFromLocal)
-    }
-
-    #[test]
-    fn disjoint_writes_ok() {
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        write_claim(&mut a, 0x2000, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 2);
-    }
-
-    #[test]
-    fn overlapping_writes_error() {
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        let err = write_claim(&mut a, 0x1080, 0x100).unwrap_err();
-        assert!(err.to_string().contains("data race"));
-    }
-
-    #[test]
-    fn overlapping_reads_merge() {
-        let mut a = RdmaAction::new();
-        read_claim(&mut a, 0x1000, 0x100).unwrap();
-        read_claim(&mut a, 0x1080, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 1);
-        let (&(start, end), kind) = a.local_claims.iter().next().unwrap();
-        assert_eq!(start, 0x1000);
-        assert_eq!(end, 0x1180);
-        assert_eq!(*kind, RdmaOpType::WriteFromLocal);
-    }
-
-    #[test]
-    fn cascading_reads_merge() {
-        // Two disjoint reads, then a third that bridges them — the cascade
-        // must absorb both pre-existing entries, not just the first.
-        let mut a = RdmaAction::new();
-        read_claim(&mut a, 0x1000, 0x100).unwrap();
-        read_claim(&mut a, 0x1200, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 2);
-        read_claim(&mut a, 0x1080, 0x200).unwrap();
-        assert_eq!(a.local_claims.len(), 1);
-        let (&(start, end), _) = a.local_claims.iter().next().unwrap();
-        assert_eq!(start, 0x1000);
-        assert_eq!(end, 0x1300);
-    }
-
-    #[test]
-    fn write_vs_read_errors() {
-        let mut a = RdmaAction::new();
-        read_claim(&mut a, 0x1000, 0x100).unwrap();
-        let err = write_claim(&mut a, 0x1080, 0x100).unwrap_err();
-        assert!(err.to_string().contains("data race"));
-    }
-
-    #[test]
-    fn read_vs_write_errors() {
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        let err = read_claim(&mut a, 0x1080, 0x100).unwrap_err();
-        assert!(err.to_string().contains("data race"));
-    }
-
-    #[test]
-    fn touching_ranges_do_not_overlap() {
-        // `[0,100)` and `[100,200)` are adjacent, not overlapping.
-        let mut a = RdmaAction::new();
-        write_claim(&mut a, 0x1000, 0x100).unwrap();
-        write_claim(&mut a, 0x1100, 0x100).unwrap();
-        assert_eq!(a.local_claims.len(), 2);
     }
 }

--- a/python/tests/test_rdma.py
+++ b/python/tests/test_rdma.py
@@ -714,43 +714,6 @@ class ClientActor(Actor):
         await self.action.submit()
 
     @endpoint
-    async def perform_data_race(
-        self, buffer_a: RDMABuffer, buffer_b: RDMABuffer, buffer_c: RDMABuffer
-    ) -> None:
-        """Perform batched operations using RDMAAction across multiple remote actors"""
-
-        # Create RDMAAction instance
-        action = RDMAAction()
-
-        # Chain multiple operations across different remote actors
-        # Read from buffer A into local data_a
-        action.read_remote(self.data_a.view(torch.uint8).flatten(), buffer_a)
-
-        # # Write data_a to buffer B (modified data goes from A -> B) - Data race!
-        action.write_remote(buffer_b, self.data_a.view(torch.uint8).flatten())
-
-    @endpoint
-    async def perform_data_race_w_slices(
-        self, buffer_a: RDMABuffer, buffer_b: RDMABuffer, buffer_c: RDMABuffer
-    ) -> None:
-        """Perform batched operations using RDMAAction across multiple remote actors"""
-        assert self.size == 250, "Size must be 100 for this test"
-        # Create RDMAAction instance
-        action = RDMAAction()
-
-        # Chain multiple operations across different remote actors
-        # Read from buffer A into local data_a
-        action.read_remote(
-            self.data_a.view(torch.uint8)[0 : 100 * 4].flatten(), buffer_a
-        )
-        action.write_remote(
-            buffer_a, self.data_a.view(torch.uint8)[150 * 4 :].flatten()
-        )
-        action.read_remote(
-            self.data_a.view(torch.uint8)[75 * 4 : 175 * 4].flatten(), buffer_a
-        )
-
-    @endpoint
     async def get_local_data_sums(self) -> dict:
         """Get sums of local data for verification"""
         return {
@@ -940,41 +903,6 @@ async def test_rdma_action_second_call():
     # Verify that server B, C same as before
     assert 0.0 == await server_b.get_sum.call_one()
     assert sum_c_after == await server_c.get_sum.call_one()
-
-
-@rdma_backends
-async def test_rdma_action_data_races():
-    """Test RDMAAction with concurrent execution across multiple remote actors (2 remote + 1 local)"""
-
-    # Setup: Create 3 separate processes (2 remote + 1 local)
-    server_proc_1 = this_host().spawn_procs(per_host={"processes": 1})
-    server_proc_2 = this_host().spawn_procs(per_host={"processes": 1})
-    client_proc = this_host().spawn_procs(per_host={"processes": 1})
-
-    # Create actors on different processes
-    server_a = server_proc_1.spawn(
-        "server_a",
-        DataServerActor,
-        "A",
-    )  # Data filled with 65.0 (ASCII 'A')
-    server_b = server_proc_2.spawn(
-        "server_b", DataServerActor, "B"
-    )  # Data filled with 66.0 (ASCII 'B')
-    server_c = server_proc_1.spawn(
-        "server_c", DataServerActor, "C"
-    )  # Data filled with 67.0 (ASCII 'C')
-    client = client_proc.spawn("client", ClientActor, 250)
-
-    # Create RDMA buffers on each server
-    buffer_a = await server_a.create_buffer.call_one()
-    buffer_b = await server_b.create_buffer.call_one()
-    buffer_c = await server_c.create_buffer.call_one()
-
-    with pytest.raises(Exception):
-        await client.perform_data_race.call_one(buffer_a, buffer_b, buffer_c)
-
-    with pytest.raises(Exception):
-        await client.perform_data_race_w_slices.call_one(buffer_a, buffer_b, buffer_c)
 
 
 @rdma_backends

--- a/python/tests/test_rdma_action.py
+++ b/python/tests/test_rdma_action.py
@@ -133,27 +133,11 @@ class ActionClient(Actor):
         return False
 
     @endpoint
-    async def overlapping_writes_into_local_error(self, buffer: RDMABuffer) -> bool:
-        # Two `read_remote`s onto overlapping local destinations both write
-        # the same local memory: the new local-side claim algorithm must
-        # flag this as a race.
-        size = buffer.size()
-        slot = torch.zeros(size, dtype=torch.uint8, device=self.device)
-        action = RDMAAction()
-        action.read_remote(slot, buffer)
-        try:
-            action.read_remote(slot, buffer)
-        except ValueError:
-            return True
-        return False
-
-    @endpoint
     async def overlapping_reads_from_local_ok(
         self, buffer_a: RDMABuffer, buffer_b: RDMABuffer
     ) -> None:
-        # Two `write_remote`s using the same local memory range both *read*
-        # local memory — that is safe, and the new algorithm must let it
-        # through (the old python helper would have errored).
+        # Two `write_remote`s sharing one local source range, which is what a
+        # fan-out does: one buffer's contents sent to several peers.
         size = min(buffer_a.size(), buffer_b.size())
         slot = torch.zeros(size, dtype=torch.uint8, device=self.device)
         action = RDMAAction()
@@ -399,27 +383,9 @@ async def test_submit_validation_errors_surface(host_device, client_device) -> N
 @pytest.mark.parametrize(
     ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
 )
-async def test_overlapping_local_writes_are_a_race(host_device, client_device) -> None:
-    # Two `read_remote`s onto the same local destination are concurrent writes —
-    # the bug-fixed claim algorithm must flag this as a race.
-    size = 32
-    host, client = await _spawn_host_and_client(
-        num_buffers=1, size=size, host_device=host_device, client_device=client_device
-    )
-    (buffer,) = await host.create_buffers.call_one()
-    caught = await client.overlapping_writes_into_local_error.call_one(buffer)
-    assert caught, "Expected ValueError from two overlapping read_remote claims"
-
-
-@rdma_backends
-@pytest.mark.parametrize(
-    ("host_device", "client_device"), DEVICE_VARIANTS, ids=DEVICE_IDS
-)
 async def test_overlapping_local_reads_are_ok(host_device, client_device) -> None:
-    # Two `write_remote`s from the same local source both *read* local memory —
-    # safe; today's python helper would have errored, the new one merges.
-    # Uses two distinct remote buffers so the test exercises the local-side
-    # read-merge without two writes landing on the same remote target.
+    # One local source range feeding two ops in a single action. The two remote
+    # buffers are distinct, so nothing writes the same range on either side.
     size = 32
     host, client = await _spawn_host_and_client(
         num_buffers=2, size=size, host_device=host_device, client_device=client_device


### PR DESCRIPTION
Summary:

Every time a new op is added to an `RDMAAction`, we compare the local memory range that it covers against all of the local memory ranges already in that action. This allows us to detect concurrent writes to the same local memory, but means that building an action is quadratic in the number of operations; for ~60k ops, this takes almost 4 seconds.

In theory, we could use a smarter overlap detection algorithm that's only `O(n log n)`, but the overhead for 60k ops was still about 1 second.

This just doesn't seem worth it -- the range check doesn't *really* buy us any safety because (a) we aren't checking remote ranges at all, and (b) we don't check against other independent in-flight actions. We're protecting against the case that users are least likely to mess up (reading to overlapping local ranges in the same action) while leaving the much more likely hazards unguarded.

So just remove the overlapping range check.

Reviewed By: zdevito

Differential Revision: D116666704


