### PR TITLE
Introduce the IbvCompletionQueue trait (#4695)

### DIFF
--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -12,6 +12,7 @@ use hyperactor::ActorRef;
 use hyperactor::actor::Referable;
 use typeuri::Named;
 
+mod cq_actor;
 mod cq_pool;
 pub mod device;
 pub mod device_selection;

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Consuming completions from a completion queue (CQ).
+//!
+//! [`IbvCompletionQueue`] is what a CQ offers a consumer: one call hands back a
+//! bounded batch, each completion naming the queue pair it completed on.
+
+// Nothing outside the tests below uses this module.
+#![allow(dead_code)]
+
+use super::primitives::IbvCq;
+use super::primitives::IbvWc;
+use super::queue_pair::PollCompletionError;
+use super::queue_pair::WorkRequestError;
+
+/// The number of CQEs requested in each `ibv_poll_cq` call.
+const CQES_PER_POLL: usize = 64;
+
+/// Identifies one CQ, distinct from every other live one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct CqId(usize);
+
+/// One completion a poll consumed: the queue pair it completed on, and either the
+/// work completion or the failure its work request reported.
+#[derive(Debug)]
+pub(super) struct Completion {
+    qp_num: u32,
+    result: Result<IbvWc, WorkRequestError>,
+}
+
+/// A CQ that hands back completions in bounded batches.
+pub(super) trait IbvCompletionQueue: std::fmt::Debug + Send + Sync + 'static {
+    /// This CQ's [`CqId`].
+    fn cq_id(&self) -> CqId;
+
+    /// Consumes a batch of completions, appending each to `out`. A batch is
+    /// bounded, so appending nothing means the CQ was empty, while a full batch
+    /// says nothing about what is left in it. A failure appends nothing.
+    ///
+    /// # Safety
+    ///
+    /// The CQ must be live -- a null `ibv_cq` does not qualify -- and no other
+    /// thread may poll it for the duration.
+    unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError>;
+}
+
+impl IbvCompletionQueue for IbvCq {
+    fn cq_id(&self) -> CqId {
+        CqId(self.as_ptr().addr())
+    }
+
+    unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError> {
+        let cq = self.as_ptr();
+        // SAFETY: `cq` is a live `ibv_cq` (caller contract), which holds its device
+        // context alive; we invoke that context's `poll_cq` verb through the ops
+        // table.
+        let poll_cq = unsafe {
+            (*(*cq).context)
+                .ops
+                .poll_cq
+                .expect("poll_cq verb missing from ibv_context ops")
+        };
+        let mut wcs = [rdmaxcel_sys::ibv_wc::default(); CQES_PER_POLL];
+        // SAFETY: `cq` is live and no other thread is polling it (caller
+        // contract); `wcs` holds the `CQES_PER_POLL` entries requested, of which
+        // `poll_cq` overwrites the first `consumed` entries whenever it returns a
+        // positive count.
+        let consumed = unsafe { poll_cq(cq, CQES_PER_POLL as i32, wcs.as_mut_ptr()) };
+        if consumed < 0 {
+            return Err(PollCompletionError::new(format!(
+                "CQ poll failed (ibv_poll_cq returned {consumed})"
+            )));
+        }
+        for wc in &wcs[..consumed as usize] {
+            // `error()` is `Some` exactly when the status is not `IBV_WC_SUCCESS`.
+            out.push(Completion {
+                qp_num: wc.qp_num,
+                result: match wc.error() {
+                    Some((status, vendor_err)) => Err(WorkRequestError::from_status(
+                        wc.wr_id(),
+                        status,
+                        vendor_err,
+                    )),
+                    None => Ok(IbvWc::from(*wc)),
+                },
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::ibverbs::device::IbvDevice;
+    use crate::backend::ibverbs::mlx_device::MlxDevice;
+    use crate::backend::ibverbs::primitives::IbvConfig;
+    use crate::backend::ibverbs::primitives::IbvDeviceInfo;
+
+    /// Polling a real, empty CQ consumes nothing, and distinct CQs have distinct ids.
+    #[test]
+    fn polling_an_empty_cq_consumes_nothing() {
+        let info = IbvDeviceInfo::first_available().expect("a device is available");
+        let device = IbvDevice::<MlxDevice>::try_open(info.name(), IbvConfig::default())
+            .expect("the first available device should open");
+        // SAFETY: the device holds its `ibv_context` open for its own lifetime.
+        let cq = unsafe { IbvCq::create(device.context(), 16) }.expect("creating a CQ should work");
+        // SAFETY: as above.
+        let other =
+            unsafe { IbvCq::create(device.context(), 16) }.expect("creating a CQ should work");
+        assert_ne!(cq.cq_id(), other.cq_id());
+
+        let mut consumed = Vec::new();
+        // SAFETY: `cq` is the live CQ created above, which nothing else has been
+        // handed and so nothing else polls.
+        unsafe { cq.poll(&mut consumed) }.expect("polling an empty CQ should succeed");
+        assert!(consumed.is_empty());
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -91,6 +91,23 @@ impl WorkRequestError {
         self.status == rdmaxcel_sys::ibv_wc_status::IBV_WC_WR_FLUSH_ERR
     }
 
+    /// Builds the failure a work completion reported, formatting its message from
+    /// the status fields.
+    pub(super) fn from_status(
+        wr_id: u64,
+        status: rdmaxcel_sys::ibv_wc_status::Type,
+        vendor_err: u32,
+    ) -> Self {
+        Self {
+            wr_id,
+            status,
+            vendor_err,
+            message: format!(
+                "completion failed for wr_id={wr_id}: status={status:?}, vendor_err={vendor_err}"
+            ),
+        }
+    }
+
     #[cfg(test)]
     pub(super) fn for_test(wr_id: u64, message: &str) -> Self {
         Self {
@@ -102,9 +119,9 @@ impl WorkRequestError {
     }
 }
 
-/// A CQ-level poll failure from [`IbvQueuePair::poll_completion`]:
-/// `ibv_poll_cq` itself failed and the completion queue is no longer
-/// usable. The owning QP should be treated as poisoned.
+/// A CQ-level poll failure: `ibv_poll_cq` itself failed, naming no work request.
+/// The entry that caused it, if any, has been consumed.
+/// [`IbvQueuePair::poll_completion`] treats it as poisoning its queue pair.
 #[derive(Debug)]
 pub struct PollCompletionError {
     message: String,
@@ -119,11 +136,9 @@ impl std::fmt::Display for PollCompletionError {
 impl std::error::Error for PollCompletionError {}
 
 impl PollCompletionError {
-    #[cfg(test)]
-    pub(super) fn for_test(message: &str) -> Self {
-        Self {
-            message: message.to_string(),
-        }
+    /// A poll that failed, described by `message`.
+    pub(super) fn new(message: String) -> Self {
+        Self { message }
     }
 }
 
@@ -2656,7 +2671,7 @@ mod tests {
         let items = vec![make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
         let _rx = submit_ops(&harness, &actor, items)?;
         let _ = recv_posted(&mut posted_rx).await;
-        qp.queue_poll_error(PollCompletionError::for_test("simulated CQ poison"));
+        qp.queue_poll_error(PollCompletionError::new("simulated CQ poison".to_string()));
 
         let event = harness.next_supervision_failure().await;
         assert_eq!(&event.actor_id, actor.actor_addr());


### PR DESCRIPTION
Summary:

Introduce the `IbvCompletionQueue` trait, which will wrap real hardware-backed completion queue. The upcoming `CompletionQueueActor` will be generic over `IbvCompletionQueue`, allowing the batched polling logic to be tested without real hardware.

Reviewed By: zdevito

Differential Revision: D116689368


