### PR TITLE
(cleanup)[3/5][torchx][specs] AppDryRunInfo.app/cfg as plain attributes

### DIFF
--- a/python/monarch/_src/tools/commands.py
+++ b/python/monarch/_src/tools/commands.py
@@ -95,7 +95,7 @@ def create(
     from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
         defaults,
     )
-    from torchx.specs import AppDef, AppDryRunInfo, CfgVal
+    from torchx.specs import AppDef, CfgVal
 
     if name is None:
         name = _default_name()
@@ -120,16 +120,9 @@ def create(
 
                 info = runner.dryrun(appdef, scheduler, cfg, str(workspace_out))
 
-        info_json_fmt = AppDryRunInfo(
-            info.request,
-            fmt=defaults.dryrun_info_formatter(info),
-        )
-        info_json_fmt._app = info._app
-        info_json_fmt._cfg = info._cfg
-        info_json_fmt._scheduler = info._scheduler
-
         if config.dryrun:
-            return info_json_fmt
+            info._fmt = defaults.dryrun_info_formatter(info)
+            return info
         else:
             server_handle = runner.schedule(info)
             return server_handle


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/torchx/pull/1400

`AppDryRunInfo` declares `request` as a plain attribute but `app` and `cfg` as read-only properties over `_app`/`_cfg`, so the scheduler filling them in reaches through the underscore names:

**Before**

```lang=python
dryrun_info._app = app
dryrun_info._cfg = resolved_cfg  # .app / .cfg are read-only properties
```

**After**

```lang=python
dryrun_info.app = app
dryrun_info.cfg = resolved_cfg
```

Trade-off: `cfg` hands back the plain mapping, so mutation is rejected by the `Mapping[str, CfgVal]` annotation but not at runtime. A guard on one of three sibling attributes costs more in surface inconsistency than it buys.

Carries only the call sites that cannot migrate ahead of it: every `_app`/`_cfg` **writer** (assigning to a setter-less property raises) and the two `_cfg` readers that `json.dumps` the value (`MappingProxyType` is not JSON-serializable).

One writer is deleted, not migrated: `monarch/_src/tools/commands.py` exports to `meta-pytorch/monarch`, which resolves `torchx` from unpinned `torchx-nightly`, so a public-attribute write raises there until that nightly publishes. `create()` now swaps the formatter on the dryrun info in place instead of copy-constructing one and re-attaching `app`/`cfg`/`_scheduler`.

Differential Revision: D116707596
