### PR TITLE
Make Host proc spawning independently owned (#4698)

### DIFF
--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -59,14 +59,18 @@
 //! `HostMeshAgent::handle(GetLocalProc)` first asks for it.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::fmt;
 use std::marker::PhantomData;
+use std::panic::AssertUnwindSafe;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::Future;
+use futures::FutureExt;
 use futures::StreamExt;
 use futures::stream;
 use hyperactor::Actor;
@@ -89,6 +93,7 @@ use hyperactor::channel::ServerError;
 use hyperactor::channel::Tx;
 use hyperactor::context;
 use hyperactor::gateway::GatewayServeHandle;
+use hyperactor::gateway::PeerAttachError;
 use hyperactor::gateway::PeerAttachGuard;
 use hyperactor::id::Label;
 use hyperactor::mailbox::IntoBoxedMailboxSender as _;
@@ -133,6 +138,18 @@ pub enum HostError {
     /// The named proc already exists and cannot be spawned.
     #[error("proc '{0}' already exists")]
     ProcExists(String),
+
+    /// The host's proc-name registry cannot be used safely.
+    #[error("host proc-name registry is poisoned")]
+    ProcRegistryPoisoned,
+
+    /// Attaching a spawned proc to the host gateway failed.
+    #[error("failed to attach proc '{0}' to the host gateway: {1}")]
+    PeerAttachFailure(ProcAddr, #[source] PeerAttachError),
+
+    /// The detached task spawning a proc panicked.
+    #[error("proc '{0}' spawn panicked: {1}")]
+    SpawnPanicked(String, String),
 
     /// Failures occuring while spawning a subprocess.
     #[error("proc '{0}' (command: {1}) failed to spawn process: {2}")]
@@ -212,6 +229,46 @@ impl Drop for HostShutdownHandles {
     }
 }
 
+struct ProcHandleKillGuard<H: ProcHandle> {
+    handle: Option<H>,
+}
+
+impl<H: ProcHandle> ProcHandleKillGuard<H> {
+    fn handle(&self) -> &H {
+        self.handle
+            .as_ref()
+            .expect("active spawn cleanup owns the proc handle")
+    }
+
+    fn disarm(mut self) {
+        self.handle = None;
+    }
+
+    fn maybe_kill(&mut self) -> impl Future<Output = ()> + Send + 'static {
+        let handle = self.handle.take();
+
+        async move {
+            let Some(handle) = handle else {
+                return;
+            };
+            match handle.kill().await {
+                Ok(_) | Err(TerminateError::AlreadyTerminated(_)) => {}
+                Err(error) => {
+                    tracing::warn!(proc = %handle.proc_addr(), %error, "failed to clean up proc spawn");
+                }
+            }
+        }
+    }
+}
+
+impl<H: ProcHandle> Drop for ProcHandleKillGuard<H> {
+    fn drop(&mut self) {
+        if self.handle.is_some() {
+            tokio::spawn(self.maybe_kill());
+        }
+    }
+}
+
 /// Lifecycle manager for the procs on one machine.
 ///
 /// The host delegates all connectivity to its [`Gateway`]. It creates
@@ -222,7 +279,7 @@ pub struct Host<M> {
     /// [`PeerAttachGuard`] keeps the gateway peer route for the child
     /// alive; dropping it removes the entry (used by
     /// [`Host::terminate_children`] to free slots).
-    procs: HashMap<String, PeerAttachGuard>,
+    procs: Arc<StdMutex<HashMap<String, PeerAttachGuard>>>,
     frontend_addr: ChannelAddr,
     backend_addr: ChannelAddr,
     /// Connectivity for every proc owned by this host.
@@ -237,7 +294,7 @@ pub struct Host<M> {
     /// host was bootstrapped out-of-cluster. Kept alive for the host's
     /// lifetime so the cluster route and outbound forwarder persist.
     via_handle: Option<GatewayServeHandle>,
-    manager: M,
+    manager: Arc<M>,
     service_proc: Proc,
     local_proc: Proc,
 }
@@ -403,14 +460,14 @@ impl<M: ProcManager> Host<M> {
         );
 
         Ok(Host {
-            procs: HashMap::new(),
+            procs: Arc::new(StdMutex::new(HashMap::new())),
             frontend_addr,
             backend_addr,
             gateway,
             frontend_handle: Some(frontend_handle),
             backend_handle: Some(backend_handle),
             via_handle,
-            manager,
+            manager: Arc::new(manager),
             service_proc,
             local_proc,
         })
@@ -418,7 +475,7 @@ impl<M: ProcManager> Host<M> {
 
     /// The underlying proc manager.
     pub fn manager(&self) -> &M {
-        &self.manager
+        self.manager.as_ref()
     }
 
     /// The address which accepts messages destined for this host.
@@ -446,61 +503,108 @@ impl<M: ProcManager> Host<M> {
     /// [`ProcAddr`]. The proc id is derived from `name`; its location is
     /// advertised through this host's frontend gateway using a `Via(child_uid,
     /// host_location)` source route.
-    pub async fn spawn(
-        &mut self,
+    /// The caller must ensure that no other spawn with the same `name` is in
+    /// flight. This method only rejects names that are already registered with the host.
+    pub(crate) fn spawn(
+        &self,
         name: String,
         config: M::Config,
-    ) -> Result<(ProcAddr, ActorRef<ManagerAgent<M>>), HostError> {
-        if self.procs.contains_key(&name) {
-            return Err(HostError::ProcExists(name));
-        }
+    ) -> impl Future<Output = Result<(ProcAddr, ActorRef<ManagerAgent<M>>), HostError>> + Send + 'static
+    where
+        M: Send + Sync + 'static,
+        M::Config: Send + 'static,
+    {
+        let procs = Arc::clone(&self.procs);
+        let backend_addr = self.backend_addr.clone();
+        let gateway = self.gateway.clone();
+        let manager = Arc::clone(&self.manager);
 
-        // Advertise the child with a `Via(child_uid, host_location)`
-        // location so peers source-route through this host: the outer
-        // hop matches the peer entry installed below, and gets peeled
-        // to deliver to the child's gateway. The host location comes
-        // from the gateway's active routing state, so a later
-        // `serve`/`serve_via` controls newly spawned child refs.
-        let resource_id = ResourceId::from_name(&name);
-        let proc_uid = resource_id.uid().clone();
-        let host_location = self.gateway.default_location();
-        let location = host_location.with_via(proc_uid.clone());
-        let proc_id = resource_id.proc_addr(location);
-        let handle = self
-            .manager
-            .spawn(proc_id.clone(), self.backend_addr.clone(), config)
-            .await?;
+        async move {
+            if procs
+                .lock()
+                .map_err(|_| HostError::ProcRegistryPoisoned)?
+                .contains_key(&name)
+            {
+                return Err(HostError::ProcExists(name));
+            }
 
-        // Await readiness (config-driven; 0s disables timeout).
-        let to: Duration =
-            hyperactor_config::global::get(hyperactor::config::HOST_SPAWN_READY_TIMEOUT);
-        let ready = if to == Duration::from_secs(0) {
-            ReadyProc::ensure(&handle).await
-        } else {
-            match tokio::time::timeout(to, ReadyProc::ensure(&handle)).await {
-                Ok(result) => result,
-                Err(_elapsed) => Err(ReadyProcError::Timeout),
+            // Advertise the child with a `Via(child_uid, host_location)`
+            // location so peers source-route through this host: the outer
+            // hop matches the peer entry installed below, and gets peeled
+            // to deliver to the child's gateway. The host location comes
+            // from the gateway's active routing state, so a later
+            // `serve`/`serve_via` controls newly spawned child refs.
+            let resource_id = ResourceId::from_name(&name);
+            let proc_uid = resource_id.uid().clone();
+            let proc_id =
+                resource_id.proc_addr(gateway.default_location().with_via(proc_uid.clone()));
+            let handle = manager.spawn(proc_id.clone(), backend_addr, config).await?;
+            let mut proc_handle_guard = ProcHandleKillGuard {
+                handle: Some(handle),
+            };
+
+            let created = async {
+                let timeout: Duration =
+                    hyperactor_config::global::get(hyperactor::config::HOST_SPAWN_READY_TIMEOUT);
+
+                let ready = if timeout == Duration::from_secs(0) {
+                    ReadyProc::ensure(proc_handle_guard.handle()).await
+                } else {
+                    match tokio::time::timeout(
+                        timeout,
+                        ReadyProc::ensure(proc_handle_guard.handle()),
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(_elapsed) => Err(ReadyProcError::Timeout),
+                    }
+                }
+                .map_err(|e| {
+                    HostError::ProcessConfigurationFailure(
+                        proc_id.clone(),
+                        anyhow::anyhow!("{e:?}"),
+                    )
+                })?;
+
+                let child_sender = MailboxClient::dial(ready.addr().clone()).map_err(|e| {
+                    HostError::ProcessConfigurationFailure(
+                        proc_id.clone(),
+                        anyhow::anyhow!("failed to dial spawned proc at {}: {}", ready.addr(), e),
+                    )
+                })?;
+                let agent_ref = ready.agent_ref().clone();
+                drop(ready);
+
+                let guard = gateway
+                    .attach_peer(proc_uid.clone(), child_sender.into_boxed())
+                    .map_err(|error| HostError::PeerAttachFailure(proc_id.clone(), error))?;
+                match procs
+                    .lock()
+                    .map_err(|_| HostError::ProcRegistryPoisoned)?
+                    .entry(name.clone())
+                {
+                    Entry::Vacant(entry) => {
+                        entry.insert(guard);
+                    }
+                    Entry::Occupied(_) => return Err(HostError::ProcExists(name.clone())),
+                }
+
+                Ok((proc_id.clone(), agent_ref))
+            }
+            .await;
+
+            match created {
+                Ok(created) => {
+                    proc_handle_guard.disarm();
+                    Ok(created)
+                }
+                Err(error) => {
+                    proc_handle_guard.maybe_kill().await;
+                    Err(error)
+                }
             }
         }
-        .map_err(|e| {
-            HostError::ProcessConfigurationFailure(proc_id.clone(), anyhow::anyhow!("{e:?}"))
-        })?;
-
-        let child_sender = MailboxClient::dial(ready.addr().clone()).map_err(|e| {
-            HostError::ProcessConfigurationFailure(
-                proc_id.clone(),
-                anyhow::anyhow!("failed to dial spawned proc at {}: {}", ready.addr(), e),
-            )
-        })?;
-        // The proc id derives from `name`, and we rejected a duplicate
-        // `name` above, so this peer uid is unique.
-        let guard = self
-            .gateway
-            .attach_peer(proc_uid, child_sender.into_boxed())
-            .expect("spawned proc uid is unique: duplicate name rejected above");
-        self.procs.insert(name.clone(), guard);
-
-        Ok((proc_id, ready.agent_ref().clone()))
     }
 
     /// The host's [`Gateway`]. All incoming traffic addressed to this
@@ -510,6 +614,16 @@ impl<M: ProcManager> Host<M> {
     /// [`Gateway::attach_peer`].
     pub fn gateway(&self) -> &Gateway {
         &self.gateway
+    }
+
+    /// Remove a child proc's gateway registration and release its name.
+    pub(crate) fn remove_proc(&self, name: &str) {
+        let guard = self
+            .procs
+            .lock()
+            .expect("procs mutex poisoned")
+            .remove(name);
+        drop(guard);
     }
 
     /// Take ownership of the frontend server handle.
@@ -789,9 +903,12 @@ impl<M: ProcManager + BulkTerminate> Host<M> {
             .manager
             .terminate_all(cx, timeout, max_in_flight, reason)
             .await;
-        // Detach procs from the gateway by dropping their attach
-        // guards, freeing the name slots for any future respawns.
-        self.procs.clear();
+        {
+            let _guards = {
+                let mut entries = self.procs.lock().expect("procs mutex poisoned");
+                std::mem::take(&mut *entries)
+            };
+        }
         summary
     }
 }
@@ -1049,6 +1166,15 @@ impl<S> LocalProcManager<S> {
             procs: Arc::new(Mutex::new(HashMap::new())),
             stopping: Arc::new(Mutex::new(HashMap::new())),
             spawn,
+        }
+    }
+
+    async fn discard_proc(&self, proc_id: &ProcAddr, reason: &str) {
+        let proc = self.procs.lock().await.remove(proc_id);
+        if let Some(mut proc) = proc
+            && let Err(error) = proc.destroy_and_wait(Duration::ZERO, reason).await
+        {
+            tracing::warn!(%proc_id, %error, "failed to discard local proc");
         }
     }
 
@@ -1344,9 +1470,19 @@ where
             .await
             .insert(proc_id.clone(), proc.clone());
         let _handle = proc.clone().serve(rx);
-        let agent_handle = (self.spawn)(proc)
-            .await
-            .map_err(|e| HostError::AgentSpawnFailure(proc_id.clone(), e))?;
+        let agent_handle = match AssertUnwindSafe((self.spawn)(proc)).catch_unwind().await {
+            Ok(Ok(agent_handle)) => agent_handle,
+            Ok(Err(error)) => {
+                self.discard_proc(&proc_id, "proc agent failed to spawn")
+                    .await;
+                return Err(HostError::AgentSpawnFailure(proc_id, error));
+            }
+            Err(panic) => {
+                self.discard_proc(&proc_id, "proc agent spawn panicked")
+                    .await;
+                std::panic::resume_unwind(panic);
+            }
+        };
 
         Ok(LocalHandle {
             proc_id,
@@ -1362,11 +1498,10 @@ where
 ///
 /// This implementation launches a child via `Command` and relies on
 /// `kill_on_drop(true)` so that children are SIGKILLed if the manager
-/// (or host) drops. There is **no** proc control plane (no RPC to a
-/// proc agent for shutdown) and **no** exit monitor wired here.
-/// Consequently:
-/// - `terminate()` and `kill()` return `Unsupported`.
-/// - `wait()` is trivial (no lifecycle observation).
+/// (or host) drops. There is **no** graceful proc control plane or
+/// exit monitor wired here. `terminate()` and `kill()` therefore
+/// remove and force-kill the child directly, while `wait()` remains
+/// trivial and does not report real lifecycle state.
 ///
 /// It follows a simple protocol:
 ///
@@ -1384,6 +1519,38 @@ pub struct ProcessProcManager<A> {
     program: std::path::PathBuf,
     children: Arc<Mutex<HashMap<ProcAddr, Child>>>,
     _phantom: PhantomData<A>,
+}
+
+struct ProcessChildCleanup {
+    children: Arc<Mutex<HashMap<ProcAddr, Child>>>,
+    proc_id: Option<ProcAddr>,
+}
+
+impl ProcessChildCleanup {
+    fn disarm(mut self) {
+        self.proc_id = None;
+    }
+}
+
+impl Drop for ProcessChildCleanup {
+    fn drop(&mut self) {
+        let Some(proc_id) = self.proc_id.take() else {
+            return;
+        };
+        let children = Arc::clone(&self.children);
+
+        tokio::spawn(async move {
+            if let Some(mut child) = children.lock().await.remove(&proc_id) {
+                if let Err(error) = child.kill().await {
+                    tracing::warn!(%proc_id, %error, "failed to kill interrupted process spawn");
+                }
+
+                if let Err(error) = child.wait().await {
+                    tracing::warn!(%proc_id, %error, "failed to reap interrupted process spawn");
+                }
+            }
+        });
+    }
 }
 
 impl<A> ProcessProcManager<A> {
@@ -1418,13 +1585,9 @@ impl<A> Drop for ProcessProcManager<A> {
 ///
 /// Unlike [`LocalHandle`], this corresponds to a real OS process
 /// launched by the manager. In this **toy** implementation the handle
-/// does not own/monitor the `Child` and there is no shutdown control
-/// plane. It is a stable, clonable surface exposing the proc's
-/// identity, address, and agent reference so host code can interact
-/// uniformly with local/external procs. `terminate()`/`kill()` are
-/// intentionally `Unsupported` here; process cleanup relies on
-/// `cmd.kill_on_drop(true)` when launching the child (the OS will
-/// SIGKILL it if the handle is dropped).
+/// has no graceful shutdown control plane or exit monitor. It retains
+/// access to the manager's child registry so `terminate()` and `kill()`
+/// can remove, kill, and reap the process when a host spawn fails.
 ///
 /// The type bound `A: Actor + Referable` comes from the
 /// [`ProcHandle::Agent`] requirement: `Actor` because the agent
@@ -1436,6 +1599,7 @@ pub struct ProcessHandle<A: Actor + Referable> {
     proc_id: ProcAddr,
     addr: ChannelAddr,
     agent_ref: ActorRef<A>,
+    children: Arc<Mutex<HashMap<ProcAddr, Child>>>,
 }
 
 // Manual `Clone` to avoid requiring `A: Clone`.
@@ -1445,6 +1609,7 @@ impl<A: Actor + Referable> Clone for ProcessHandle<A> {
             proc_id: self.proc_id.clone(),
             addr: self.addr.clone(),
             agent_ref: self.agent_ref.clone(),
+            children: Arc::clone(&self.children),
         }
     }
 }
@@ -1486,11 +1651,22 @@ impl<A: Actor + Referable> ProcHandle for ProcessHandle<A> {
         _deadline: Duration,
         _reason: &str,
     ) -> Result<(), TerminateError<Self::TerminalStatus>> {
-        Err(TerminateError::Unsupported)
+        self.kill().await
     }
 
     async fn kill(&self) -> Result<(), TerminateError<Self::TerminalStatus>> {
-        Err(TerminateError::Unsupported)
+        let Some(mut child) = self.children.lock().await.remove(&self.proc_id) else {
+            return Err(TerminateError::AlreadyTerminated(()));
+        };
+        child
+            .kill()
+            .await
+            .map_err(|error| TerminateError::Io(error.into()))?;
+        child
+            .wait()
+            .await
+            .map_err(|error| TerminateError::Io(error.into()))?;
+        Ok(())
     }
 }
 
@@ -1544,6 +1720,10 @@ where
             let mut children = self.children.lock().await;
             children.insert(proc_id.clone(), child);
         }
+        let cleanup = ProcessChildCleanup {
+            children: Arc::clone(&self.children),
+            proc_id: Some(proc_id.clone()),
+        };
 
         // Wait for the child's callback with (addr, agent_ref)
         let (proc_addr, agent_ref) = callback_rx.recv().await?;
@@ -1556,11 +1736,14 @@ where
         //   immediate `Child::kill()`.
         // - wire an exit monitor so `wait()` resolves with a real
         //   terminal status.
-        Ok(ProcessHandle {
+        let handle = ProcessHandle {
             proc_id,
             addr: proc_addr,
             agent_ref,
-        })
+            children: Arc::clone(&self.children),
+        };
+        cleanup.disarm();
+        Ok(handle)
     }
 }
 
@@ -1671,6 +1854,7 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -1689,6 +1873,7 @@ mod tests {
     use hyperactor::port::Port;
     #[cfg(fbcode_build)]
     use hyperactor_config::attrs::Attrs;
+    use timed_test::async_timed_test;
 
     use super::testing::EchoActor;
     use super::*;
@@ -1709,7 +1894,7 @@ mod tests {
             Ok(proc.spawn_with_label::<()>("host_agent", ()))
         });
         let procs = Arc::clone(&proc_manager.procs);
-        let mut host = Host::new(proc_manager, ChannelAddr::any(ChannelTransport::Unix))
+        let host = Host::new(proc_manager, ChannelAddr::any(ChannelTransport::Unix))
             .await
             .unwrap();
 
@@ -1853,7 +2038,7 @@ mod tests {
         let process_manager = ProcessProcManager::<EchoActor>::new(
             buck_resources::get("monarch/hyperactor_mesh/host_bootstrap").unwrap(),
         );
-        let mut host = Host::new(process_manager, ChannelAddr::any(ChannelTransport::Unix))
+        let host = Host::new(process_manager, ChannelAddr::any(ChannelTransport::Unix))
             .await
             .unwrap();
 
@@ -1923,6 +2108,91 @@ mod tests {
         assert_eq!(id3, *echo1.actor_addr());
     }
 
+    #[async_timed_test(timeout_secs = 30)]
+    async fn cancelled_process_startup_kills_reaps_and_unregisters_child() {
+        fn process_exists(pid: u32) -> bool {
+            (
+                // SAFETY: signal 0 only checks the PID
+                unsafe { libc::kill(pid as libc::pid_t, 0) }
+            ) == 0
+        }
+
+        let program_dir = tempfile::tempdir().expect("test directory should be created");
+        let program = {
+            let program = program_dir.path().join("pending_process.sh");
+
+            tokio::fs::write(&program, "#!/bin/sh\nexec /bin/sleep 600\n")
+                .await
+                .expect("test program should be written");
+
+            let mut permissions = tokio::fs::metadata(&program)
+                .await
+                .expect("test program metadata should be available")
+                .permissions();
+
+            permissions.set_mode(0o700);
+
+            tokio::fs::set_permissions(&program, permissions)
+                .await
+                .expect("test program should be executable");
+
+            program
+        };
+
+        let manager = Arc::new(ProcessProcManager::<EchoActor>::new(program));
+        let proc_id = ResourceId::proc_addr_from_name(
+            ChannelAddr::any(ChannelTransport::Unix),
+            "cancelled-process",
+        );
+        let startup = tokio::spawn({
+            let manager = Arc::clone(&manager);
+            let proc_id = proc_id.clone();
+
+            async move {
+                manager
+                    .spawn(proc_id, ChannelAddr::any(ChannelTransport::Unix), ())
+                    .await
+            }
+        });
+
+        let pid = loop {
+            {
+                let children = manager.children.lock().await;
+
+                if let Some(child) = children.get(&proc_id) {
+                    break child.id().expect("test child should have a process ID");
+                }
+            }
+            tokio::task::yield_now().await;
+        };
+        assert!(process_exists(pid));
+
+        startup.abort();
+
+        assert!(
+            startup
+                .await
+                .expect_err("startup task should be cancelled")
+                .is_cancelled(),
+        );
+
+        loop {
+            if !process_exists(pid) {
+                assert_eq!(
+                    std::io::Error::last_os_error().raw_os_error(),
+                    Some(libc::ESRCH),
+                    "cancelled child should be killed and reaped",
+                );
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !manager.children.lock().await.contains_key(&proc_id),
+            "cancelled child should be removed from the child registry",
+        );
+    }
+
     #[tokio::test]
     async fn local_ready_and_wait_are_immediate() {
         // Build a LocalHandle directly.
@@ -1967,6 +2237,8 @@ mod tests {
         mode: ReadyMode,
         omit_addr: bool,
         omit_agent: bool,
+        kill_notify: Option<Arc<tokio::sync::Notify>>,
+        kill_release: Option<Arc<tokio::sync::Notify>>,
     }
 
     #[async_trait::async_trait]
@@ -2019,7 +2291,13 @@ mod tests {
             Err(TerminateError::Unsupported)
         }
         async fn kill(&self) -> Result<Self::TerminalStatus, TerminateError<Self::TerminalStatus>> {
-            Err(TerminateError::Unsupported)
+            if let Some(notify) = &self.kill_notify {
+                notify.notify_one();
+            }
+            if let Some(release) = &self.kill_release {
+                release.notified().await;
+            }
+            Ok(())
         }
     }
 
@@ -2029,6 +2307,8 @@ mod tests {
         omit_addr: bool,
         omit_agent: bool,
         transport: ChannelTransport,
+        kill_notify: Option<Arc<tokio::sync::Notify>>,
+        kill_release: Option<Arc<tokio::sync::Notify>>,
     }
 
     impl TestManager {
@@ -2038,11 +2318,21 @@ mod tests {
                 omit_addr: false,
                 omit_agent: false,
                 transport: ChannelTransport::Local,
+                kill_notify: None,
+                kill_release: None,
             }
         }
         fn with_omissions(mut self, addr: bool, agent: bool) -> Self {
             self.omit_addr = addr;
             self.omit_agent = agent;
+            self
+        }
+        fn with_kill_notify(mut self, notify: Arc<tokio::sync::Notify>) -> Self {
+            self.kill_notify = Some(notify);
+            self
+        }
+        fn with_kill_release(mut self, release: Arc<tokio::sync::Notify>) -> Self {
+            self.kill_release = Some(release);
             self
         }
     }
@@ -2069,8 +2359,79 @@ mod tests {
                 mode: self.mode,
                 omit_addr: self.omit_addr,
                 omit_agent: self.omit_agent,
+                kill_notify: self.kill_notify.clone(),
+                kill_release: self.kill_release.clone(),
             })
         }
+    }
+
+    #[tokio::test]
+    async fn host_spawn_cleans_up_handle_after_readiness_failure() {
+        let cleanup_started = Arc::new(tokio::sync::Notify::new());
+        let cleanup_release = Arc::new(tokio::sync::Notify::new());
+        let host = Host::new(
+            TestManager::local(ReadyMode::ErrTerminal)
+                .with_kill_notify(Arc::clone(&cleanup_started))
+                .with_kill_release(Arc::clone(&cleanup_release)),
+            ChannelAddr::any(ChannelTransport::Local),
+        )
+        .await
+        .expect("host should start");
+
+        let spawn = tokio::spawn(host.spawn("failed-proc".to_string(), ()));
+        cleanup_started.notified().await;
+        assert!(
+            !spawn.is_finished(),
+            "spawn returned before failed-proc cleanup completed",
+        );
+        cleanup_release.notify_one();
+
+        let error = spawn
+            .await
+            .expect("spawn task should complete")
+            .expect_err("readiness failure should fail the spawn");
+        assert!(matches!(
+            error,
+            HostError::ProcessConfigurationFailure(_, _)
+        ));
+        assert!(
+            !host
+                .procs
+                .lock()
+                .expect("procs mutex poisoned")
+                .contains_key("failed-proc"),
+            "failed spawn should not leave a peer registration",
+        );
+    }
+
+    #[tokio::test]
+    async fn local_manager_cleans_up_proc_when_agent_spawn_panics() {
+        async fn panicking_spawn(_proc: Proc) -> anyhow::Result<ActorHandle<()>> {
+            panic!("test agent spawn panic");
+        }
+
+        let manager = LocalProcManager::new(panicking_spawn);
+        let managed_procs = Arc::clone(&manager.procs);
+        let host = Host::new(manager, ChannelAddr::any(ChannelTransport::Local))
+            .await
+            .expect("host should start");
+
+        let result = AssertUnwindSafe(host.spawn("panicking-proc".to_string(), ()))
+            .catch_unwind()
+            .await;
+        assert!(result.is_err(), "agent spawn panic should be preserved");
+        assert!(
+            managed_procs.lock().await.is_empty(),
+            "panicking agent spawn should not leave a managed proc",
+        );
+        assert!(
+            !host
+                .procs
+                .lock()
+                .expect("procs mutex poisoned")
+                .contains_key("panicking-proc"),
+            "panicking agent spawn should release its name reservation",
+        );
     }
 
     #[tokio::test]
@@ -2081,7 +2442,7 @@ mod tests {
             Duration::from_millis(10),
         );
 
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::Pending),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -2100,7 +2461,7 @@ mod tests {
             Duration::from_secs(0),
         );
 
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::OkAfter(Duration::from_millis(20))),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -2109,12 +2470,17 @@ mod tests {
 
         let (pid, agent) = host.spawn("ok".into(), ()).await.expect("must succeed");
         assert_eq!(agent.actor_addr().proc_addr(), pid);
-        assert!(host.procs.contains_key("ok"));
+        assert!(
+            host.procs
+                .lock()
+                .expect("procs mutex poisoned")
+                .contains_key("ok")
+        );
     }
 
     #[tokio::test]
     async fn host_spawn_maps_channel_closed_ready_error_to_config_failure() {
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::ErrChannelClosed),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -2127,7 +2493,7 @@ mod tests {
 
     #[tokio::test]
     async fn host_spawn_maps_terminal_ready_error_to_config_failure() {
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::ErrTerminal),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -2140,7 +2506,7 @@ mod tests {
 
     #[tokio::test]
     async fn host_spawn_fails_if_ready_but_missing_addr() {
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::OkAfter(Duration::ZERO)).with_omissions(true, false),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -2156,7 +2522,7 @@ mod tests {
 
     #[tokio::test]
     async fn host_spawn_fails_if_ready_but_missing_agent() {
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::OkAfter(Duration::ZERO)).with_omissions(false, true),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -2494,7 +2860,7 @@ mod tests {
         let attached_location = Location::from(attached_host_addr).with_via(attached_uid);
         gateway.set_default_location(attached_location.clone());
 
-        let mut host = Host::new_with_gateway(
+        let host = Host::new_with_gateway(
             proc_manager,
             ProcAddr::new(
                 legacy_service_proc_id(),
@@ -2524,7 +2890,7 @@ mod tests {
             Ok(proc.spawn_with_label::<()>("host_agent", ()))
         });
 
-        let mut host = Host::new_with_gateway(
+        let host = Host::new_with_gateway(
             proc_manager,
             ProcAddr::new(
                 legacy_service_proc_id(),

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1389,18 +1389,14 @@ impl HostMeshRef {
             },
         );
 
-        // Build each proc's `ProcRef` up front: the caller derives the same
-        // id/rank (`host_agent::proc_name(&proc_mesh_id, create_rank)`) that
-        // each HostAgent will, so the refs are ready before the cast lands. A single
-        // `SpawnProcs` cast (below) then has each HostAgent spawn all of its
-        // per-host slots, replying with status overlays to drive the readiness
-        // barrier.
+        // Build each proc's `ProcRef` up front from the same slot derivation used
+        // by the HostAgent spawn and wait handlers.
         let mut proc_names = Vec::new();
         let client_config_override = hyperactor_config::global::propagatable_attrs();
         for (host_rank, agent) in self.host_agent_mesh.values().enumerate() {
-            for per_host_rank in 0..per_host.num_ranks() {
-                let create_rank = per_host.num_ranks() * host_rank + per_host_rank;
-                let proc_name = host_agent::proc_name(&proc_mesh_id, create_rank);
+            for (_, create_rank, proc_name) in
+                host_agent::proc_slots(&proc_mesh_id, host_rank, per_host.num_ranks())
+            {
                 proc_names.push(proc_name.clone());
                 let proc_id = named_proc_on_host(&agent, &proc_name);
                 let proc_agent =
@@ -1443,8 +1439,8 @@ impl HostMeshRef {
             None => None,
         };
 
-        // One cast: each HostAgent spawns all `num_per_host` of its proc slots,
-        // deriving each proc's id/rank from its stamped host rank.
+        // Start each host's proc slots, then subscribe to their readiness on the
+        // same ordered sender-destination streams.
         self.host_agent_mesh.cast(
             cx,
             host_agent::SpawnProcs {
@@ -1456,7 +1452,15 @@ impl HostMeshRef {
                 default_bootstrap_command: self.bootstrap_command.clone(),
                 proc_bind,
                 bootstrap_commands,
-                status_reply: Some(reply_port),
+            },
+        )?;
+        self.host_agent_mesh.cast(
+            cx,
+            host_agent::WaitProcs {
+                rank: resource::Rank::default(),
+                proc_mesh_id: proc_mesh_id.clone(),
+                num_per_host: per_host.num_ranks(),
+                status_reply: reply_port,
             },
         )?;
 

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -221,6 +221,17 @@ pub(crate) fn proc_name(proc_mesh_id: &ProcMeshId, rank: usize) -> ResourceId {
     }
 }
 
+pub(crate) fn proc_slots(
+    proc_mesh_id: &ProcMeshId,
+    host_rank: usize,
+    num_per_host: usize,
+) -> impl Iterator<Item = (usize, usize, ResourceId)> + '_ {
+    (0..num_per_host).map(move |per_host_rank| {
+        let rank = num_per_host * host_rank + per_host_rank;
+        (per_host_rank, rank, proc_name(proc_mesh_id, rank))
+    })
+}
+
 #[derive(Debug)]
 pub(crate) struct ProcCreationState {
     pub(crate) rank: usize,
@@ -344,6 +355,7 @@ impl fmt::Debug for DrainWorker {
     handlers=[
         resource::CreateOrUpdate<ProcSpec>,
         SpawnProcs,
+        WaitProcs,
         resource::Stop,
         resource::GetState<ProcState>,
         resource::KeepaliveGetState<ProcState>,
@@ -788,11 +800,6 @@ pub struct SpawnProcs {
     /// Optional per-rank bootstrap overrides, indexed by absolute proc rank
     /// (`num_per_host * host_rank + per_host_rank`).
     pub bootstrap_commands: Option<Vec<Option<BootstrapCommand>>>,
-    /// Spawn ack: the host posts one multi-rank overlay covering all of its
-    /// procs; the caller reduces these per-host overlays into a `StatusMesh`
-    /// barrier.
-    #[serde(default)]
-    pub status_reply: Option<PortRef<crate::StatusOverlay>>,
 }
 wirevalue::register_type!(SpawnProcs);
 
@@ -807,13 +814,9 @@ impl Handler<SpawnProcs> for HostAgent {
 
         tracing::Span::current().record("host_rank", host_rank);
 
-        let mut spawn_result = Ok(());
-
-        for per_host_rank in 0..spawn.num_per_host {
-            let rank = spawn.num_per_host * host_rank + per_host_rank;
-
-            let id = proc_name(&spawn.proc_mesh_id, rank);
-
+        for (per_host_rank, rank, id) in
+            proc_slots(&spawn.proc_mesh_id, host_rank, spawn.num_per_host)
+        {
             let bootstrap_command = spawn
                 .bootstrap_commands
                 .as_ref()
@@ -825,7 +828,7 @@ impl Handler<SpawnProcs> for HostAgent {
                 .as_ref()
                 .and_then(|binds| binds.get(per_host_rank).cloned());
 
-            if let Err(e) = <Self as Handler<resource::CreateOrUpdate<ProcSpec>>>::handle(
+            if let Err(error) = <Self as Handler<resource::CreateOrUpdate<ProcSpec>>>::handle(
                 self,
                 cx,
                 resource::CreateOrUpdate {
@@ -842,43 +845,83 @@ impl Handler<SpawnProcs> for HostAgent {
             )
             .await
             {
-                // Stop spawning, but fall through to report the result below.
-                spawn_result = Err(e);
+                tracing::error!(%error, "failed to request proc creation");
                 break;
             }
         }
 
-        // Report this host's full rank range in a single multi-rank overlay. The
-        // caller's readiness barrier only completes once *every* rank has moved
-        // off NotExist, so on the error path the ranks we never created are
-        // reported as Failed too — otherwise the caller would wait out its whole
-        // idle timeout instead of failing fast on the error we return below.
-        if let Some(reply) = &spawn.status_reply {
-            let mut runs = Vec::with_capacity(spawn.num_per_host);
+        Ok(())
+    }
+}
 
-            for per_host_rank in 0..spawn.num_per_host {
-                let rank = spawn.num_per_host * host_rank + per_host_rank;
+/// Cast after [`SpawnProcs`] to report when each derived proc reaches
+/// [`Status::Running`]. Hyperactor delivers the two casts in order for each
+/// sender-destination stream, so an absent proc means its create was rejected.
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    Debug,
+    Named,
+    Handler,
+    RefClient,
+    HandleClient
+)]
+pub struct WaitProcs {
+    /// This host's ordinal within the cast region, stamped by the cast layer.
+    pub rank: resource::Rank,
+    /// Proc mesh id used to derive the same proc ids as [`SpawnProcs`].
+    pub proc_mesh_id: ProcMeshId,
+    /// Number of procs spawned on this host.
+    pub num_per_host: usize,
+    /// Sparse readiness updates for the caller's status barrier.
+    pub status_reply: PortRef<crate::StatusOverlay>,
+}
+wirevalue::register_type!(WaitProcs);
 
-                let id = proc_name(&spawn.proc_mesh_id, rank);
+#[async_trait]
+impl Handler<WaitProcs> for HostAgent {
+    async fn handle(&mut self, cx: &Context<Self>, wait: WaitProcs) -> anyhow::Result<()> {
+        let host_rank = wait
+            .rank
+            .0
+            .expect("cast layer stamps the rank before delivery");
+        let mut failed = Vec::new();
 
-                let status = match self.proc_rank_status(&id).await {
-                    (resolved, status) if resolved != usize::MAX => status,
-                    // Unknown to this host: not yet attempted, or its creation
-                    // errored before being recorded. Mark Failed on the error
-                    // path; on success every rank is created so this is moot.
-                    _ => match &spawn_result {
-                        Err(e) => Status::Failed(e.to_string()),
-                        Ok(()) => continue,
+        for (_, rank, id) in proc_slots(&wait.proc_mesh_id, host_rank, wait.num_per_host) {
+            if self.created.contains_key(&id) {
+                if let Err(error) = <Self as Handler<resource::WaitRankStatus>>::handle(
+                    self,
+                    cx,
+                    resource::WaitRankStatus {
+                        id,
+                        rank: resource::Rank::new(rank),
+                        min_status: Status::Running,
+                        reply: wait.status_reply.clone(),
                     },
-                };
-
-                runs.push((rank..(rank + 1), status));
+                )
+                .await
+                {
+                    failed.push((
+                        rank..(rank + 1),
+                        Status::Failed(format!("failed to wait for proc status: {error}")),
+                    ));
+                }
+            } else {
+                failed.push((
+                    rank..(rank + 1),
+                    Status::Failed("proc creation was not accepted".to_string()),
+                ));
             }
-
-            reply.post(cx, crate::StatusOverlay::try_from_runs(runs)?);
         }
 
-        spawn_result
+        if !failed.is_empty() {
+            let overlay = crate::StatusOverlay::try_from_runs(failed)
+                .expect("proc slots produce ordered non-overlapping ranks");
+            wait.status_reply.post(cx, overlay);
+        }
+
+        Ok(())
     }
 }
 
@@ -1929,6 +1972,7 @@ mod tests {
     use hyperactor::channel::ChannelTransport;
     use hyperactor::id::Label;
     use hyperactor::id::Uid;
+    use timed_test::async_timed_test;
 
     use super::*;
     use crate::bootstrap::ProcStatus;
@@ -2697,7 +2741,7 @@ mod tests {
     /// A single `SpawnProcs` message at host rank 0 fans out into
     /// `num_per_host` procs, each created under the id derived from
     /// `proc_name(&proc_mesh_id, rank)`. All of them should come up Running.
-    #[tokio::test]
+    #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_procs_many_per_host() {
         let host = Host::new(
             BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
@@ -2722,9 +2766,10 @@ mod tests {
 
         let proc_mesh_id = ProcMeshId::singleton(Label::new("spawn-many").unwrap());
         let num_per_host = 4;
+        let (spawn_status_reply, mut spawn_status_rx) = client.open_port::<crate::StatusOverlay>();
 
-        // Send a single point-to-point SpawnProcs (not a cast) to the host
-        // agent at host rank 0.
+        // Send the command and wait messages in the same order used by
+        // HostMesh::spawn.
         let agent_ref: ActorRef<HostAgent> = host_agent.bind();
         agent_ref.post(
             &client,
@@ -2737,40 +2782,30 @@ mod tests {
                 default_bootstrap_command: None,
                 proc_bind: None,
                 bootstrap_commands: None,
-                status_reply: None,
+            },
+        );
+        agent_ref.post(
+            &client,
+            WaitProcs {
+                rank: resource::Rank::new(0),
+                proc_mesh_id: proc_mesh_id.clone(),
+                num_per_host,
+                status_reply: spawn_status_reply.bind(),
             },
         );
 
-        // Each of the num_per_host procs should reach Running. Query each at a
-        // message rank distinct from its creation rank to prove positioning
-        // follows the message.
-        for rank in 0..num_per_host {
-            let id = proc_name(&proc_mesh_id, rank);
-            let message_rank = rank + 100;
-            let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
-            host_agent
-                .wait_rank_status(
-                    &client,
-                    id.clone(),
-                    resource::Rank::new(message_rank),
-                    resource::Status::Running,
-                    port.bind(),
-                )
+        let mut reported = vec![false; num_per_host];
+        for _ in 0..num_per_host {
+            let overlay = spawn_status_rx
+                .recv()
                 .await
-                .unwrap();
-            let overlay = tokio::time::timeout(Duration::from_secs(30), rx.recv())
-                .await
-                .unwrap_or_else(|_| panic!("proc {rank} did not reach Running"))
-                .expect("reply channel closed");
-            assert_overlay_at_rank(&overlay, message_rank);
-
-            assert_matches!(
-                host_agent.get_state(&client, id).await.unwrap(),
-                resource::State {
-                    status: resource::Status::Running,
-                    ..
-                }
-            );
+                .expect("WaitProcs status reply channel closed");
+            assert_eq!(overlay.len(), 1, "expected one proc status per reply");
+            let (range, status) = overlay.runs().next().expect("status overlay has a run");
+            assert_eq!(range.end, range.start + 1);
+            assert_eq!(status, &resource::Status::Running);
+            reported[range.start] = true;
         }
+        assert!(reported.into_iter().all(|reported| reported));
     }
 }


### PR DESCRIPTION
Summary:

`Host::spawn` now returns a function that performs the logic for spawning a `Proc` instead of doing it inline.

This is to enable async `CreateOrUpdate<ProcSpec>` by making it so that the handler for `CreateOrUpdate<ProcSpec>` can just `tokio::spawn` the `Proc` spawning and immediately return.

This diff does not change the behaviour of `HostAgent` has `HostAgent` still just awaits the async function and processes the result instead of `tokio::spawn`ing it

Reviewed By: shayne-fletcher

Differential Revision: D116641199


