### PR TITLE
Model PendingShutdown (#4700)

### DIFF
--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -251,6 +251,60 @@ pub(crate) struct ProcCreationState {
     pub(crate) expiry_time: Option<std::time::SystemTime>,
 }
 
+struct PendingDrain {
+    /// Number of matching proc spawns that were pending when the drain began.
+    /// Each counted spawn decrements this exactly once. Reaching zero completes
+    /// the drain and posts every reply exactly once.
+    remaining: usize,
+    failures: Vec<String>,
+    timeout: Duration,
+    max_in_flight: usize,
+    replies: Vec<PendingDrainReply>,
+}
+
+struct PendingDrainReply {
+    rank: usize,
+    reply: PortRef<crate::StatusOverlay>,
+}
+
+#[derive(Default)]
+struct PendingDrains {
+    /// A full drain subsumes the selective drains, which remain in the map so
+    /// that every selective request still receives its reply.
+    full: Option<PendingDrain>,
+    selective: HashMap<HostMeshId, PendingDrain>,
+}
+
+impl PendingDrains {
+    fn blocks_create(&self, host_mesh_id: Option<&HostMeshId>) -> bool {
+        self.full.is_some()
+            || host_mesh_id.is_some_and(|host_mesh_id| self.selective.contains_key(host_mesh_id))
+    }
+
+    fn take_all(&mut self) -> impl Iterator<Item = PendingDrain> {
+        let full = self.full.take();
+        let selective = std::mem::take(&mut self.selective);
+        full.into_iter().chain(selective.into_values())
+    }
+}
+
+impl PendingDrain {
+    fn post_replies(self, cx: &Context<'_, HostAgent>) {
+        let status = if self.failures.is_empty() {
+            resource::Status::Stopped
+        } else {
+            resource::Status::Failed(self.failures.join("; "))
+        };
+
+        for PendingDrainReply { rank, reply } in self.replies {
+            let overlay =
+                crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
+                    .expect("valid single-run overlay");
+            reply.post(cx, overlay);
+        }
+    }
+}
+
 /// Actor name used when spawning the host mesh agent on the system proc.
 pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "host_agent";
 
@@ -280,14 +334,7 @@ struct ProcStatusChanged {
 
 /// Sent by DrainWorker back to HostAgent when draining completes.
 /// Not exported — delivered locally via PortHandle (no serialization).
-struct DrainComplete {
-    host: HostAgentMode,
-    /// This host's ordinal within the drain cast region.
-    rank: usize,
-    /// Streaming status reply the parent posts the drained overlay to,
-    /// after restoring state.
-    reply: PortRef<crate::StatusOverlay>,
-}
+struct DrainComplete(HostAgentMode);
 
 /// Child actor whose only job is to run `host.terminate_children()` in
 /// its `init()`, return the host and ack to the parent via DrainComplete,
@@ -298,8 +345,6 @@ struct DrainWorker {
     host: Option<HostAgentMode>,
     timeout: Duration,
     max_in_flight: usize,
-    rank: usize,
-    reply: Option<PortRef<crate::StatusOverlay>>,
     done_notify: PortHandle<DrainComplete>,
 }
 
@@ -324,18 +369,9 @@ impl Actor for DrainWorker {
             }
         }
 
-        // Bundle host + reply into DrainComplete so the parent reports the
-        // drained overlay AFTER restoring state (prevents race with
-        // ShutdownHost).
-        if let (Some(host), Some(reply)) = (self.host.take(), self.reply.take()) {
-            let _ = self.done_notify.post(
-                this,
-                DrainComplete {
-                    host,
-                    rank: self.rank,
-                    reply,
-                },
-            );
+        // Restore the host before the parent reports drain completion.
+        if let Some(host) = self.host.take() {
+            let _ = self.done_notify.post(this, DrainComplete(host));
         }
 
         Ok(())
@@ -377,6 +413,7 @@ impl fmt::Debug for DrainWorker {
 pub struct HostAgent {
     state: HostAgentState,
     pub(crate) created: HashMap<ResourceId, ProcCreationState>,
+    pending_drains: PendingDrains,
     /// Pending `WaitRankStatus` waiters, keyed by resource name.
     /// Each entry is `(min_status, rank, reply_port)`. Only touched
     /// from `&mut self` handlers.
@@ -410,6 +447,7 @@ impl HostAgent {
         Self {
             state: HostAgentState::Detached(host),
             created: HashMap::new(),
+            pending_drains: PendingDrains::default(),
             pending_proc_waiters: HashMap::new(),
             watching: HashSet::new(),
             proc_status_port: None,
@@ -940,6 +978,16 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             // Already created: there is no update.
             return Ok(());
         }
+        if self
+            .pending_drains
+            .blocks_create(create_or_update.spec.host_mesh_id.as_ref())
+        {
+            tracing::warn!(
+                id = %create_or_update.id,
+                "ignoring CreateOrUpdate: HostAgent is draining"
+            );
+            return Ok(());
+        }
 
         let host = match self.host_mut() {
             Some(h) => h,
@@ -1357,74 +1405,120 @@ wirevalue::register_type!(DrainHost);
 impl Handler<DrainHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainHost) -> anyhow::Result<()> {
         let rank = msg.rank.unwrap();
-        // This host's drain completion, as a single-rank `Stopped` overlay at
-        // its ordinal. The caller reduces these into a StatusMesh barrier.
-        let drained_overlay = || {
-            crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), resource::Status::Stopped)])
-                .expect("valid single-run overlay")
+        let active_drain = match msg.host_mesh_id.as_ref() {
+            Some(host_mesh_id) => self.pending_drains.selective.get_mut(host_mesh_id),
+            None => self.pending_drains.full.as_mut(),
         };
-
-        if msg.host_mesh_id.is_some() {
-            // Selective drain: stop only procs belonging to the named mesh.
-            self.drain_by_mesh_name(cx, msg.timeout, msg.host_mesh_id.as_ref())
-                .await;
-            msg.reply.post(cx, drained_overlay());
+        if let Some(drain) = active_drain {
+            drain.replies.push(PendingDrainReply {
+                rank,
+                reply: msg.reply,
+            });
             return Ok(());
         }
 
-        // Full drain: terminate all children.
+        // CreateOrUpdate still waits for Host::spawn, so a drain cannot observe
+        // an in-progress proc creation in this revision.
+        let remaining = 0;
+        let drain = PendingDrain {
+            remaining,
+            failures: Vec::new(),
+            timeout: msg.timeout,
+            max_in_flight: msg.max_in_flight,
+            replies: vec![PendingDrainReply {
+                rank,
+                reply: msg.reply,
+            }],
+        };
+
+        match msg.host_mesh_id {
+            Some(host_mesh_id) => {
+                if self.pending_drains.full.is_some() {
+                    let replaced = self.pending_drains.selective.insert(host_mesh_id, drain);
+                    debug_assert!(replaced.is_none(), "duplicate selective drain was joined");
+                    return Ok(());
+                }
+
+                self.drain_by_mesh_name(cx, msg.timeout, Some(&host_mesh_id))
+                    .await;
+
+                if remaining == 0 {
+                    drain.post_replies(cx);
+                } else {
+                    let replaced = self.pending_drains.selective.insert(host_mesh_id, drain);
+                    debug_assert!(replaced.is_none(), "duplicate selective drain was joined");
+                }
+            }
+            None => {
+                if remaining == 0 && self.pending_drains.selective.is_empty() {
+                    self.start_full_drain(cx, drain);
+                } else {
+                    debug_assert!(
+                        self.pending_drains.full.is_none(),
+                        "duplicate full drain joined"
+                    );
+                    self.pending_drains.full = Some(drain);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl HostAgent {
+    fn start_full_drain(&mut self, cx: &Context<'_, Self>, drain: PendingDrain) {
+        if drain.remaining != 0 {
+            unreachable!("full drain requires no remaining proc creations");
+        }
+        let timeout = drain.timeout;
+        let max_in_flight = drain.max_in_flight;
+
         let host = match std::mem::replace(&mut self.state, HostAgentState::Draining) {
             HostAgentState::Attached(h) => h,
             other @ (HostAgentState::Detached(_) | HostAgentState::Draining) => {
                 // Nothing to drain — report immediately.
                 self.state = other;
-                msg.reply.post(cx, drained_overlay());
-                return Ok(());
+                drain.post_replies(cx);
+                return;
             }
             HostAgentState::Shutdown => {
                 self.state = HostAgentState::Shutdown;
-                msg.reply.post(cx, drained_overlay());
-                return Ok(());
+                drain.post_replies(cx);
+                return;
             }
         };
 
-        // Do NOT clear `self.created` here: the DrainWorker
-        // terminates procs asynchronously, and concurrent GetState /
-        // GetRankStatus queries must still find the entries. With the
-        // host in Draining state (`self.host()` returns None), those
-        // handlers already report Status::Stopped for every known
-        // proc, which is the correct answer while draining is
-        // in progress.
+        debug_assert!(
+            self.pending_drains.full.is_none(),
+            "duplicate full drain was joined"
+        );
+        self.pending_drains.full = Some(drain);
 
+        // Do not clear `self.created` here. The DrainWorker terminates procs
+        // asynchronously, and status queries must still find their entries.
         let done_port = cx.port::<DrainComplete>();
 
         cx.spawn_with_label(
             "drain_worker",
             DrainWorker {
                 host: Some(host),
-                timeout: msg.timeout,
-                max_in_flight: msg.max_in_flight,
-                rank,
-                reply: Some(msg.reply),
+                timeout,
+                max_in_flight,
                 done_notify: done_port,
             },
         );
-
-        Ok(())
     }
 }
 
 #[async_trait]
 impl Handler<DrainComplete> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainComplete) -> anyhow::Result<()> {
-        self.state = HostAgentState::Detached(msg.host);
+        self.state = HostAgentState::Detached(msg.0);
         self.created.clear();
-        let overlay = crate::StatusOverlay::try_from_runs(vec![(
-            msg.rank..(msg.rank + 1),
-            resource::Status::Stopped,
-        )])
-        .expect("valid single-run overlay");
-        msg.reply.post(cx, overlay);
+        for drain in self.pending_drains.take_all() {
+            drain.post_replies(cx);
+        }
         Ok(())
     }
 }
@@ -2002,6 +2096,27 @@ mod tests {
         assert_matches!(status, resource::Status::Failed(_));
     }
 
+    async fn spawn_local_host_agent(spawn: ProcManagerSpawnFn) -> ActorHandle<HostAgent> {
+        let host = Host::new(LocalProcManager::new(spawn), ChannelTransport::Unix.any())
+            .await
+            .expect("local host should start");
+
+        let host_agent = host
+            .system_proc()
+            .clone()
+            .spawn_with_uid(
+                Uid::singleton(Label::new(HOST_MESH_AGENT_ACTOR_NAME).unwrap()),
+                HostAgent::new_local(host),
+            )
+            .expect("host agent should start");
+
+        HostAgent::wait_initialized(&host_agent)
+            .await
+            .expect("host agent should initialize");
+
+        host_agent
+    }
+
     // RSP-* coverage map for the HostAgent rank-status tests. Each deliberately
     // uses `message_rank != creation_rank`, so a handler that read the creation
     // rank would fail:
@@ -2365,18 +2480,7 @@ mod tests {
                 anyhow::anyhow!("test failure"),
             )))
         });
-        let host = Host::new(LocalProcManager::new(spawn), ChannelTransport::Unix.any())
-            .await
-            .unwrap();
-
-        let system_proc = host.system_proc().clone();
-        let host_agent = system_proc
-            .spawn_with_uid(
-                Uid::singleton(Label::new(HOST_MESH_AGENT_ACTOR_NAME).unwrap()),
-                HostAgent::new_local(host),
-            )
-            .unwrap();
-        HostAgent::wait_initialized(&host_agent).await.unwrap();
+        let host_agent = spawn_local_host_agent(spawn).await;
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let client = client_proc.client("client");
@@ -2448,6 +2552,92 @@ mod tests {
             .expect("reply timed out")
             .expect("reply channel closed");
         assert_overlay_failed_at_rank(&overlay, get_rank);
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn duplicate_selective_drains_each_receive_completion() {
+        let (spawn_started_tx, mut spawn_started_rx) = tokio::sync::watch::channel(false);
+        let (release_spawn_tx, release_spawn_rx) = tokio::sync::watch::channel(false);
+        let spawn: ProcManagerSpawnFn = Box::new(move |proc| {
+            let spawn_started_tx = spawn_started_tx.clone();
+            let mut release_spawn_rx = release_spawn_rx.clone();
+            Box::pin(async move {
+                spawn_started_tx
+                    .send(true)
+                    .expect("spawn-start receiver remains open");
+                release_spawn_rx
+                    .wait_for(|release| *release)
+                    .await
+                    .expect("spawn-release sender remains open");
+                ProcAgent::boot_v1(proc, None)
+            })
+        });
+        let host_agent = spawn_local_host_agent(spawn).await;
+
+        let client_proc =
+            Proc::direct(ChannelTransport::Unix.any(), "drain_client".to_string()).unwrap();
+        let client = client_proc.client("drain_client");
+        let host_mesh_id = HostMeshId::instance(Label::new("mesh-a").unwrap());
+        let proc_id = ResourceId::instance(Label::new("proc-a").unwrap());
+        let agent_ref: ActorRef<HostAgent> = host_agent.bind();
+
+        agent_ref.post(
+            &client,
+            resource::CreateOrUpdate {
+                id: proc_id,
+                rank: resource::Rank::new(0),
+                spec: ProcSpec {
+                    host_mesh_id: Some(host_mesh_id.clone()),
+                    ..Default::default()
+                },
+            },
+        );
+        spawn_started_rx
+            .wait_for(|started| *started)
+            .await
+            .expect("spawn-start sender remains open");
+
+        let (first_reply, mut first_reply_rx) = client.open_port::<crate::StatusOverlay>();
+        let (second_reply, mut second_reply_rx) = client.open_port::<crate::StatusOverlay>();
+        agent_ref.post(
+            &client,
+            DrainHost {
+                timeout: Duration::from_secs(5),
+                max_in_flight: 16,
+                host_mesh_id: Some(host_mesh_id.clone()),
+                rank: resource::Rank::new(3),
+                reply: first_reply.bind(),
+            },
+        );
+        agent_ref.post(
+            &client,
+            DrainHost {
+                timeout: Duration::from_secs(5),
+                max_in_flight: 16,
+                host_mesh_id: Some(host_mesh_id),
+                rank: resource::Rank::new(7),
+                reply: second_reply.bind(),
+            },
+        );
+
+        release_spawn_tx
+            .send(true)
+            .expect("spawn-release receivers remain open");
+
+        let first = first_reply_rx.recv().await.expect("first drain reply");
+        assert_overlay_at_rank(&first, 3);
+        assert_eq!(
+            first.runs().next().unwrap().1,
+            resource::Status::Stopped,
+            "first drain should complete successfully",
+        );
+        let second = second_reply_rx.recv().await.expect("second drain reply");
+        assert_overlay_at_rank(&second, 7);
+        assert_eq!(
+            second.runs().next().unwrap().1,
+            resource::Status::Stopped,
+            "second drain should complete successfully",
+        );
     }
 
     /// DrainHost with a host_mesh_id filter only stops procs

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -296,6 +296,10 @@ impl PendingDrain {
             resource::Status::Failed(self.failures.join("; "))
         };
 
+        self.post_replies_with_status(cx, status);
+    }
+
+    fn post_replies_with_status(self, cx: &Context<'_, HostAgent>, status: resource::Status) {
         for PendingDrainReply { rank, reply } in self.replies {
             let overlay =
                 crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
@@ -303,6 +307,14 @@ impl PendingDrain {
             reply.post(cx, overlay);
         }
     }
+}
+
+struct PendingShutdown {
+    remaining: usize,
+    timeout: Duration,
+    max_in_flight: usize,
+    acknowledgements: Vec<(usize, PortRef<usize>)>,
+    drain_replies: Vec<PendingDrainReply>,
 }
 
 /// Actor name used when spawning the host mesh agent on the system proc.
@@ -414,6 +426,7 @@ pub struct HostAgent {
     state: HostAgentState,
     pub(crate) created: HashMap<ResourceId, ProcCreationState>,
     pending_drains: PendingDrains,
+    pending_shutdown: Option<PendingShutdown>,
     /// Pending `WaitRankStatus` waiters, keyed by resource name.
     /// Each entry is `(min_status, rank, reply_port)`. Only touched
     /// from `&mut self` handlers.
@@ -448,6 +461,7 @@ impl HostAgent {
             state: HostAgentState::Detached(host),
             created: HashMap::new(),
             pending_drains: PendingDrains::default(),
+            pending_shutdown: None,
             pending_proc_waiters: HashMap::new(),
             watching: HashSet::new(),
             proc_status_port: None,
@@ -483,6 +497,9 @@ impl HostAgent {
     /// Minimum status floor derived from the host agent's lifecycle.
     /// Procs on this host cannot be healthier than this.
     fn min_proc_status(&self) -> resource::Status {
+        if self.pending_shutdown.is_some() {
+            return resource::Status::Stopping;
+        }
         match &self.state {
             HostAgentState::Detached(_) | HostAgentState::Attached(_) => resource::Status::Running,
             HostAgentState::Draining => resource::Status::Stopping,
@@ -978,6 +995,13 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             // Already created: there is no update.
             return Ok(());
         }
+        if self.pending_shutdown.is_some() {
+            tracing::warn!(
+                id = %create_or_update.id,
+                "ignoring CreateOrUpdate: HostAgent is shutting down"
+            );
+            return Ok(());
+        }
         if self
             .pending_drains
             .blocks_create(create_or_update.spec.host_mesh_id.as_ref())
@@ -1405,6 +1429,14 @@ wirevalue::register_type!(DrainHost);
 impl Handler<DrainHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainHost) -> anyhow::Result<()> {
         let rank = msg.rank.unwrap();
+        if let Some(shutdown) = self.pending_shutdown.as_mut() {
+            shutdown.drain_replies.push(PendingDrainReply {
+                rank,
+                reply: msg.reply,
+            });
+            return Ok(());
+        }
+
         let active_drain = match msg.host_mesh_id.as_ref() {
             Some(host_mesh_id) => self.pending_drains.selective.get_mut(host_mesh_id),
             None => self.pending_drains.full.as_mut(),
@@ -1519,6 +1551,18 @@ impl Handler<DrainComplete> for HostAgent {
         for drain in self.pending_drains.take_all() {
             drain.post_replies(cx);
         }
+
+        if self
+            .pending_shutdown
+            .as_ref()
+            .is_some_and(|shutdown| shutdown.remaining == 0)
+        {
+            let shutdown = self
+                .pending_shutdown
+                .take()
+                .expect("pending shutdown exists");
+            self.finish_shutdown(cx, shutdown).await;
+        }
         Ok(())
     }
 }
@@ -1527,6 +1571,62 @@ impl Handler<DrainComplete> for HostAgent {
 impl Handler<ShutdownHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: ShutdownHost) -> anyhow::Result<()> {
         let rank = msg.rank.unwrap();
+        if matches!(&self.state, HostAgentState::Shutdown) {
+            msg.ack.post(cx, rank);
+            return Ok(());
+        }
+
+        if let Some(shutdown) = self.pending_shutdown.as_mut() {
+            shutdown.acknowledgements.push((rank, msg.ack));
+            return Ok(());
+        }
+
+        for drain in self.pending_drains.take_all() {
+            drain.post_replies_with_status(
+                cx,
+                resource::Status::Failed("host shutdown superseded drain".to_string()),
+            );
+        }
+
+        // CreateOrUpdate still waits for Host::spawn, so shutdown cannot
+        // observe an in-progress proc creation in this revision.
+        let remaining = 0;
+        let shutdown = PendingShutdown {
+            remaining,
+            timeout: msg.timeout,
+            max_in_flight: msg.max_in_flight,
+            acknowledgements: vec![(rank, msg.ack)],
+            drain_replies: Vec::new(),
+        };
+
+        if remaining == 0 {
+            self.finish_shutdown(cx, shutdown).await;
+        } else {
+            self.pending_shutdown = Some(shutdown);
+        }
+
+        Ok(())
+    }
+}
+
+impl HostAgent {
+    async fn finish_shutdown(&mut self, cx: &Context<'_, Self>, shutdown: PendingShutdown) {
+        if matches!(&self.state, HostAgentState::Draining) {
+            self.pending_shutdown = Some(shutdown);
+            return;
+        }
+
+        let PendingShutdown {
+            remaining: 0,
+            timeout,
+            max_in_flight,
+            acknowledgements,
+            drain_replies,
+        } = shutdown
+        else {
+            unreachable!("shutdown cannot finish while proc creation is pending");
+        };
+
         // Terminate children BEFORE acking, so the caller's networking
         // stays alive while children flush their forwarders during
         // teardown. If we ack first, the caller proceeds to tear down
@@ -1534,7 +1634,16 @@ impl Handler<ShutdownHost> for HostAgent {
         // causing their forwarder flushes to hang until
         // MESSAGE_DELIVERY_TIMEOUT expires.
         if !self.created.is_empty() {
-            self.drain(cx, msg.timeout, msg.max_in_flight).await;
+            self.drain(cx, timeout, max_in_flight).await;
+        }
+
+        for PendingDrainReply { rank, reply } in drain_replies {
+            let overlay = crate::StatusOverlay::try_from_runs(vec![(
+                rank..(rank + 1),
+                resource::Status::Stopped,
+            )])
+            .expect("valid single-run overlay");
+            reply.post(cx, overlay);
         }
 
         // Drop the host and signal the bootstrap loop to drain the
@@ -1549,10 +1658,12 @@ impl Handler<ShutdownHost> for HostAgent {
                 shutdown_tx: Some(tx),
             }) => {
                 // Keep the host's outbound gateway alive until the direct
-                // shutdown acknowledgment has been flushed. The bootstrap
+                // shutdown acknowledgments have been flushed. The bootstrap
                 // task may stop the frontend as soon as it receives the
                 // handle below.
-                msg.ack.post(cx, rank);
+                for (rank, ack) in acknowledgements {
+                    ack.post(cx, rank);
+                }
                 let flush_timeout =
                     hyperactor_config::global::get(hyperactor::config::FORWARDER_FLUSH_TIMEOUT);
                 match tokio::time::timeout(flush_timeout, host.gateway().flush()).await {
@@ -1582,18 +1693,20 @@ impl Handler<ShutdownHost> for HostAgent {
                 // after that proc has stopped.
                 tokio::spawn(async move {
                     for mut proc in procs {
-                        let _ = proc
-                            .destroy_and_wait(msg.timeout, "local host shutdown")
-                            .await;
+                        let _ = proc.destroy_and_wait(timeout, "local host shutdown").await;
                     }
                     host.shutdown_servers().await;
-                    msg.ack.post(&shutdown_client, rank);
+                    for (rank, ack) in acknowledgements {
+                        ack.post(&shutdown_client, rank);
+                    }
                 });
             }
-            _ => msg.ack.post(cx, rank),
+            _ => {
+                for (rank, ack) in acknowledgements {
+                    ack.post(cx, rank);
+                }
+            }
         }
-
-        Ok(())
     }
 }
 
@@ -2060,8 +2173,11 @@ impl Handler<ConfigDump> for HostAgent {
 #[cfg(all(test, fbcode_build))]
 mod tests {
     use std::assert_matches;
+    use std::sync::Arc;
 
     use hyperactor::ActorAddr;
+    use hyperactor::Client;
+    use hyperactor::PortReceiver;
     use hyperactor::Proc;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::id::Label;
@@ -2115,6 +2231,120 @@ mod tests {
             .expect("host agent should initialize");
 
         host_agent
+    }
+
+    #[derive(Debug)]
+    struct DrainBlockingActor {
+        stop_started: Arc<tokio::sync::Notify>,
+        release_stop: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl Actor for DrainBlockingActor {
+        async fn handle_stop(
+            &mut self,
+            this: &Instance<Self>,
+            mode: hyperactor::actor::StopMode,
+            reason: &str,
+        ) -> anyhow::Result<()> {
+            let this = this.clone_for_py();
+            let release_stop = Arc::clone(&self.release_stop);
+            let reason = reason.to_string();
+            this.close();
+            self.stop_started.notify_one();
+            tokio::spawn(async move {
+                release_stop.notified().await;
+                match mode {
+                    hyperactor::actor::StopMode::Stop => this.exit(&reason).unwrap(),
+                    hyperactor::actor::StopMode::DrainAndStop => {
+                        this.exit_after_drain(&reason).unwrap()
+                    }
+                }
+            });
+            Ok(())
+        }
+    }
+
+    /// Spawn a Proc, wait for it to be running, request a drain
+    async fn start_blocked_full_drain(
+        client_name: &str,
+    ) -> (
+        ActorHandle<HostAgent>,
+        Client,
+        Arc<tokio::sync::Notify>,
+        PortReceiver<crate::StatusOverlay>,
+    ) {
+        let stop_started = Arc::new(tokio::sync::Notify::new());
+        let release_stop = Arc::new(tokio::sync::Notify::new());
+
+        let spawn: ProcManagerSpawnFn = {
+            let stop_started_for_spawn = Arc::clone(&stop_started);
+            let release_stop_for_spawn = Arc::clone(&release_stop);
+
+            Box::new(move |proc: Proc| {
+                proc.spawn(DrainBlockingActor {
+                    stop_started: Arc::clone(&stop_started_for_spawn),
+                    release_stop: Arc::clone(&release_stop_for_spawn),
+                });
+                Box::pin(std::future::ready(ProcAgent::boot_v1(proc, None)))
+            })
+        };
+        let host_agent = spawn_local_host_agent(spawn).await;
+
+        let client = Proc::direct(ChannelTransport::Unix.any(), client_name.to_string())
+            .unwrap()
+            .client("client");
+        let proc_id = ResourceId::instance(Label::new("proc").unwrap());
+        let (running_reply, mut running_rx) = client.open_port::<crate::StatusOverlay>();
+
+        host_agent
+            .wait_rank_status(
+                &client,
+                proc_id.clone(),
+                resource::Rank::new(0),
+                resource::Status::Running,
+                running_reply.bind(),
+            )
+            .await
+            .expect("running waiter should be accepted");
+
+        host_agent
+            .create_or_update(
+                &client,
+                proc_id,
+                resource::Rank::new(0),
+                ProcSpec::default(),
+            )
+            .await
+            .expect("proc should start");
+
+        let running_status = running_rx
+            .recv()
+            .await
+            .expect("proc should report running before drain");
+
+        assert_overlay_at_rank(&running_status, 0);
+        assert_eq!(
+            running_status.runs().next().unwrap().1,
+            resource::Status::Running,
+        );
+
+        let (drain_reply, drain_rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .try_post(
+                &client,
+                DrainHost {
+                    timeout: Duration::from_secs(20),
+                    max_in_flight: 1,
+                    host_mesh_id: None,
+                    rank: resource::Rank::new(0),
+                    reply: drain_reply.bind(),
+                },
+            )
+            .expect("drain request should be delivered");
+        stop_started.notified().await;
+
+        (host_agent, client, release_stop, drain_rx)
     }
 
     // RSP-* coverage map for the HostAgent rank-status tests. Each deliberately
@@ -2254,6 +2484,111 @@ mod tests {
         assert!(
             cast_actor.status().borrow().is_terminal(),
             "local CastActor must stop before acknowledging shutdown"
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn shutdown_waits_for_active_drain_worker() {
+        let (host_agent, client, release_stop, mut drain_rx) =
+            start_blocked_full_drain("shutdown_during_drain_client").await;
+
+        let (ack, mut ack_rx) = client.open_port::<usize>();
+        host_agent
+            .try_post(
+                &client,
+                ShutdownHost {
+                    timeout: Duration::from_secs(5),
+                    max_in_flight: 1,
+                    rank: resource::Rank::new(0),
+                    ack: ack.bind().unsplit(),
+                },
+            )
+            .expect("shutdown request should be delivered");
+
+        let drain_status = drain_rx
+            .recv()
+            .await
+            .expect("shutdown should supersede the active drain");
+        assert_overlay_failed_at_rank(&drain_status, 0);
+        assert_eq!(
+            ack_rx
+                .try_recv()
+                .expect("shutdown ack port should remain open"),
+            None,
+            "shutdown was acknowledged before DrainComplete",
+        );
+
+        release_stop.notify_one();
+        assert_eq!(
+            ack_rx
+                .recv()
+                .await
+                .expect("shutdown should be acknowledged"),
+            0,
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn drain_during_pending_shutdown_waits_for_completion() {
+        let (host_agent, client, release_stop, mut active_drain_rx) =
+            start_blocked_full_drain("drain_during_shutdown_client").await;
+
+        let (ack, mut ack_rx) = client.open_port::<usize>();
+        host_agent
+            .try_post(
+                &client,
+                ShutdownHost {
+                    timeout: Duration::from_secs(5),
+                    max_in_flight: 1,
+                    rank: resource::Rank::new(0),
+                    ack: ack.bind().unsplit(),
+                },
+            )
+            .expect("shutdown request should be delivered");
+
+        let active_drain_status = active_drain_rx
+            .recv()
+            .await
+            .expect("shutdown should supersede the active drain");
+        assert_overlay_failed_at_rank(&active_drain_status, 0);
+
+        let (drain_reply, mut drain_rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .try_post(
+                &client,
+                DrainHost {
+                    timeout: Duration::from_secs(20),
+                    max_in_flight: 1,
+                    host_mesh_id: None,
+                    rank: resource::Rank::new(0),
+                    reply: drain_reply.bind(),
+                },
+            )
+            .expect("drain request should be delivered during shutdown");
+        assert_eq!(
+            drain_rx
+                .try_recv()
+                .expect("drain reply port should remain open"),
+            None,
+            "drain completed before shutdown finished terminating procs",
+        );
+
+        release_stop.notify_one();
+        let drain_status = drain_rx
+            .recv()
+            .await
+            .expect("drain during shutdown should complete");
+        assert_overlay_at_rank(&drain_status, 0);
+        assert_eq!(
+            drain_status.runs().next().unwrap().1,
+            resource::Status::Stopped,
+        );
+        assert_eq!(
+            ack_rx
+                .recv()
+                .await
+                .expect("shutdown should be acknowledged"),
+            0,
         );
     }
 


### PR DESCRIPTION
Summary:

Once we switch over to async `Proc` spawning, we will have a period where `Proc` spawns have been requested but not yet completed.

During this period, if we issue a `ShutdownHost`, we will need to mark the shutdown as pending and complete the shutdown when `HostAgent` is notified that the `Proc` spawn has completed.

We will also deny drains and creation of new `Proc`s during this period

There is no behavioural change yet because the pending period does not exist until the final diff where handling `CreateOrUpdate<ProcSpec>` is actually asynchronous, but we introduce the necessary infrastructure to enable this.

Reviewed By: shayne-fletcher

Differential Revision: D116642336


