### PR TITLE
Record synchronous proc creation as pending (#4704)

### DIFF
--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -25,6 +25,7 @@ use std::sync::OnceLock;
 
 use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
+use futures::future::Either;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
@@ -296,16 +297,25 @@ mod completion_action {
             self.0 = State::Shutdown;
         }
     }
+
+    impl super::ProcCreationState {
+        pub(super) fn pending(
+            metadata: super::ProcMetadata,
+            expiry_time: Option<std::time::SystemTime>,
+        ) -> Self {
+            Self::Pending {
+                metadata,
+                on_completion: CompletionAction(State::Keep),
+                expiry_time,
+            }
+        }
+    }
 }
 
 pub(crate) use completion_action::CompletionAction;
 
 #[derive(Debug)]
 pub(crate) enum ProcCreationState {
-    #[expect(
-        dead_code,
-        reason = "pending proc creation is activated by a later change"
-    )]
     Pending {
         metadata: ProcMetadata,
         on_completion: CompletionAction,
@@ -1116,7 +1126,7 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         create_or_update: resource::CreateOrUpdate<ProcSpec>,
     ) -> anyhow::Result<()> {
         if self.created.contains_key(&create_or_update.id) {
-            // Already created: there is no update.
+            // Already requested or completed: there is no update.
             return Ok(());
         }
         if self.pending_shutdown.is_some() {
@@ -1137,7 +1147,7 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             return Ok(());
         }
 
-        let host = match self.host_mut() {
+        let host = match self.host() {
             Some(h) => h,
             None => {
                 tracing::warn!(
@@ -1147,42 +1157,58 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
                 return Ok(());
             }
         };
-        let created = match host {
-            HostAgentMode::Process { host, .. } => {
-                host.spawn(
-                    create_or_update.id.to_string(),
-                    BootstrapProcConfig {
-                        create_rank: create_or_update.rank.unwrap(),
-                        client_config_override: create_or_update
-                            .spec
-                            .client_config_override
-                            .clone(),
-                        proc_bind: create_or_update.spec.proc_bind.clone(),
-                        bootstrap_command: create_or_update.spec.bootstrap_command.clone(),
-                    },
-                )
-                .await
-            }
-            HostAgentMode::Local(host) => host.spawn(create_or_update.id.to_string(), ()).await,
+        let rank = create_or_update.rank.unwrap();
+        let id = create_or_update.id.clone();
+        let spawn = match host {
+            HostAgentMode::Process { host, .. } => Either::Left(host.spawn(
+                id.to_string(),
+                BootstrapProcConfig {
+                    create_rank: rank,
+                    client_config_override: create_or_update.spec.client_config_override.clone(),
+                    proc_bind: create_or_update.spec.proc_bind.clone(),
+                    bootstrap_command: create_or_update.spec.bootstrap_command.clone(),
+                },
+            )),
+            HostAgentMode::Local(host) => Either::Right(host.spawn(id.to_string(), ())),
         };
 
-        let rank = create_or_update.rank.unwrap();
-
-        if let Err(e) = &created {
-            tracing::error!("failed to spawn proc {}: {}", create_or_update.id, e);
-        }
         let was_empty = self.created.is_empty();
         self.created.insert(
-            create_or_update.id.clone(),
-            ProcCreationState::from_spawn_result(
+            id.clone(),
+            ProcCreationState::pending(
                 ProcMetadata {
                     rank,
                     host_mesh_id: create_or_update.spec.host_mesh_id.clone(),
                     proc_mesh_id: create_or_update.spec.proc_mesh_id.clone(),
                 },
                 None,
-                created,
             ),
+        );
+
+        let created = spawn.await;
+
+        if let Err(e) = &created {
+            tracing::error!("failed to spawn proc {}: {}", id, e);
+        }
+        let (metadata, expiry_time) = match self
+            .created
+            .remove(&id)
+            .expect("synchronous proc creation remains pending until spawn completes")
+        {
+            ProcCreationState::Pending {
+                metadata,
+                on_completion,
+                expiry_time,
+            } if on_completion.is_keep() => (metadata, expiry_time),
+            ProcCreationState::Pending { .. }
+            | ProcCreationState::Created { .. }
+            | ProcCreationState::Failed { .. } => {
+                unreachable!("HostAgent cannot process another request during synchronous spawn")
+            }
+        };
+        self.created.insert(
+            id.clone(),
+            ProcCreationState::from_spawn_result(metadata, expiry_time, created),
         );
 
         // Transition Detached → Attached on first proc creation.
@@ -1196,20 +1222,17 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
 
         // A WaitRankStatus stashed before this proc existed carries its own reply
         // rank (RSP-3); starting a status watch bridge for it needs the proc_id.
-        let proc_id = self
-            .created
-            .get(&create_or_update.id)
-            .and_then(|state| match state {
-                ProcCreationState::Created { proc_id, .. } => Some(proc_id.clone()),
-                ProcCreationState::Pending { .. } | ProcCreationState::Failed { .. } => None,
-            });
+        let proc_id = self.created.get(&id).and_then(|state| match state {
+            ProcCreationState::Created { proc_id, .. } => Some(proc_id.clone()),
+            ProcCreationState::Pending { .. } | ProcCreationState::Failed { .. } => None,
+        });
 
         // Bridge status changes to any pending waiters, then flush once now.
-        if self.pending_proc_waiters.contains_key(&create_or_update.id) {
+        if self.pending_proc_waiters.contains_key(&id) {
             if let Some(proc_id) = &proc_id {
-                self.start_watch_bridge(&create_or_update.id, proc_id).await;
+                self.start_watch_bridge(&id, proc_id).await;
             }
-            self.flush_proc_waiters(cx, &create_or_update.id).await;
+            self.flush_proc_waiters(cx, &id).await;
         }
 
         self.publish_introspect_properties(cx);

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -233,9 +233,9 @@ pub(crate) fn proc_slots(
 }
 
 #[derive(Debug)]
-pub(crate) struct ProcCreationState {
-    pub(crate) rank: usize,
-    pub(crate) host_mesh_id: Option<HostMeshId>,
+pub(crate) struct ProcMetadata {
+    rank: usize,
+    host_mesh_id: Option<HostMeshId>,
     /// The proc mesh this proc belongs to. Used to scope per-mesh queries like
     /// `StreamState`, since a host agent can hold procs from multiple meshes.
     /// Always set for procs spawned through a proc mesh (the cast `SpawnProcs`
@@ -243,7 +243,12 @@ pub(crate) struct ProcCreationState {
     /// path (e.g. the point-to-point `CreateOrUpdate` used by tests/admin),
     /// which belong to no queryable mesh and are intentionally excluded from
     /// per-mesh queries.
-    pub(crate) proc_mesh_id: Option<ProcMeshId>,
+    proc_mesh_id: Option<ProcMeshId>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ProcCreationState {
+    metadata: ProcMetadata,
     pub(crate) created: Result<(ProcAddr, ActorRef<ProcAgent>), HostError>,
     /// "Owner is alive" deadline communicated by the controller via
     /// `KeepaliveGetState`. The host's `SelfCheck` reaper compares against this
@@ -563,7 +568,7 @@ impl HostAgent {
         let matching_ids: Vec<ResourceId> = self
             .created
             .iter()
-            .filter(|(_, state)| state.host_mesh_id.as_ref() == filter)
+            .filter(|(_, state)| state.metadata.host_mesh_id.as_ref() == filter)
             .map(|(id, _)| id.clone())
             .collect();
 
@@ -1051,9 +1056,11 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         self.created.insert(
             create_or_update.id.clone(),
             ProcCreationState {
-                rank,
-                host_mesh_id: create_or_update.spec.host_mesh_id.clone(),
-                proc_mesh_id: create_or_update.spec.proc_mesh_id.clone(),
+                metadata: ProcMetadata {
+                    rank,
+                    host_mesh_id: create_or_update.spec.host_mesh_id.clone(),
+                    proc_mesh_id: create_or_update.spec.proc_mesh_id.clone(),
+                },
                 created,
                 expiry_time: None,
             },
@@ -1133,22 +1140,19 @@ impl HostAgent {
     /// status. `rank == usize::MAX` means the proc is unknown to this host.
     async fn proc_rank_status(&self, id: &ResourceId) -> (usize, Status) {
         match self.created.get(id) {
-            Some(ProcCreationState {
-                rank,
-                created: Ok((proc_id, _mesh_agent)),
-                ..
-            }) => {
-                let raw_status = match self.host() {
-                    Some(host) => host.proc_status(proc_id).await.0,
-                    None => resource::Status::Unknown,
-                };
-                (*rank, raw_status.clamp_min(self.min_proc_status()))
-            }
-            Some(ProcCreationState {
-                rank,
-                created: Err(e),
-                ..
-            }) => (*rank, Status::Failed(e.to_string())),
+            Some(state) => match &state.created {
+                Ok((proc_id, _mesh_agent)) => {
+                    let raw_status = match self.host() {
+                        Some(host) => host.proc_status(proc_id).await.0,
+                        None => resource::Status::Unknown,
+                    };
+                    (
+                        state.metadata.rank,
+                        raw_status.clamp_min(self.min_proc_status()),
+                    )
+                }
+                Err(e) => (state.metadata.rank, Status::Failed(e.to_string())),
+            },
             None => (usize::MAX, Status::NotExist),
         }
     }
@@ -1744,12 +1748,8 @@ impl HostAgent {
         id: &ResourceId,
         state: &ProcCreationState,
     ) -> resource::State<ProcState> {
-        match state {
-            ProcCreationState {
-                rank,
-                created: Ok((proc_id, mesh_agent)),
-                ..
-            } => {
+        match &state.created {
+            Ok((proc_id, mesh_agent)) => {
                 let (raw_status, proc_status, bootstrap_command) = match self.host() {
                     Some(host) => {
                         let (status, proc_status) = host.proc_status(proc_id).await;
@@ -1763,7 +1763,7 @@ impl HostAgent {
                     status,
                     state: Some(ProcState {
                         proc_id: proc_id.clone(),
-                        create_rank: *rank,
+                        create_rank: state.metadata.rank,
                         mesh_agent: mesh_agent.clone(),
                         bootstrap_command,
                         proc_status,
@@ -1772,9 +1772,7 @@ impl HostAgent {
                     timestamp: std::time::SystemTime::now(),
                 }
             }
-            ProcCreationState {
-                created: Err(e), ..
-            } => resource::State {
+            Err(e) => resource::State {
                 id: id.clone(),
                 status: resource::Status::Failed(e.to_string()),
                 state: None,
@@ -1840,8 +1838,8 @@ impl Handler<GetHostProcStates> for HostAgent {
         message: GetHostProcStates,
     ) -> anyhow::Result<()> {
         let selects = |state: &ProcCreationState| {
-            state.proc_mesh_id.as_ref() == Some(&message.proc_mesh_id)
-                && message.region.slice().contains(state.rank)
+            state.metadata.proc_mesh_id.as_ref() == Some(&message.proc_mesh_id)
+                && message.region.slice().contains(state.metadata.rank)
         };
 
         // Bump keepalive (if requested) in a separate mutable pass, so the read
@@ -1864,7 +1862,7 @@ impl Handler<GetHostProcStates> for HostAgent {
         let mut runs = Vec::new();
         for (id, state) in self.created.iter() {
             if selects(state) {
-                let base = message.region.slice().index(state.rank)?;
+                let base = message.region.slice().index(state.metadata.rank)?;
                 runs.push((base..(base + 1), self.proc_state_from(id, state).await));
             }
         }
@@ -1978,6 +1976,7 @@ impl Handler<resource::StreamState<ProcState>> for HostAgent {
         for (id, proc) in self.created.iter() {
             // Skip procs that don't belong to the subscribing proc mesh.
             if proc
+                .metadata
                 .proc_mesh_id
                 .as_ref()
                 .is_none_or(|mesh| mesh.resource_id() != &stream_state.id)
@@ -2000,7 +1999,7 @@ impl Handler<resource::StreamState<ProcState>> for HostAgent {
                         status,
                         state: Some(ProcState {
                             proc_id: proc_id.clone(),
-                            create_rank: proc.rank,
+                            create_rank: proc.metadata.rank,
                             mesh_agent: mesh_agent.clone(),
                             bootstrap_command,
                             proc_status,
@@ -2022,7 +2021,7 @@ impl Handler<resource::StreamState<ProcState>> for HostAgent {
                 cx,
                 headers.clone(),
                 resource::RankedState {
-                    rank: resource::Rank::new(proc.rank),
+                    rank: resource::Rank::new(proc.metadata.rank),
                     state,
                 },
             );

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -246,11 +246,69 @@ pub(crate) struct ProcMetadata {
     proc_mesh_id: Option<ProcMeshId>,
 }
 
+mod completion_action {
+    use super::Duration;
+
+    /// Deferred action for a proc that is still being created.
+    ///
+    /// Actions only strengthen from keep to stop, drain, or shutdown. Each
+    /// pending proc counted by a drain or shutdown must complete its accounting
+    /// exactly once, and the lifecycle reply must wait for that accounting.
+    #[derive(Debug)]
+    pub(crate) struct CompletionAction(State);
+
+    #[derive(Debug)]
+    #[expect(
+        dead_code,
+        reason = "pending proc creation is activated by a later change"
+    )]
+    enum State {
+        Keep,
+        Stop { timeout: Duration, reason: String },
+        Drain,
+        Shutdown,
+    }
+
+    impl CompletionAction {
+        pub(super) fn is_keep(&self) -> bool {
+            matches!(&self.0, State::Keep)
+        }
+
+        pub(super) fn request_stop(&mut self, timeout: Duration, reason: String) {
+            if self.is_keep() {
+                self.0 = State::Stop { timeout, reason };
+            }
+        }
+
+        /// Returns whether the requesting drain must account for this proc.
+        /// An existing drain action can be shared by another drain, but a
+        /// shutdown already owns the proc's completion.
+        pub(super) fn request_drain(&mut self) -> bool {
+            if matches!(&self.0, State::Shutdown) {
+                return false;
+            }
+
+            self.0 = State::Drain;
+            true
+        }
+
+        pub(super) fn request_shutdown(&mut self) {
+            self.0 = State::Shutdown;
+        }
+    }
+}
+
+pub(crate) use completion_action::CompletionAction;
+
 #[derive(Debug)]
 pub(crate) enum ProcCreationState {
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "pending proc creation is activated by a later change"
+    )]
     Pending {
         metadata: ProcMetadata,
+        on_completion: CompletionAction,
         expiry_time: Option<std::time::SystemTime>,
     },
     Created {
@@ -1168,6 +1226,17 @@ impl Handler<resource::Stop> for HostAgent {
             reason = %message.reason,
             "stopping proc"
         );
+        let timeout = hyperactor_config::global::get(hyperactor::config::PROCESS_EXIT_TIMEOUT);
+
+        if let Some(ProcCreationState::Pending { on_completion, .. }) =
+            self.created.get_mut(&message.id)
+        {
+            on_completion.request_stop(timeout, message.reason.clone());
+            self.flush_proc_waiters(cx, &message.id).await;
+            self.publish_introspect_properties(cx);
+            return Ok(());
+        }
+
         let host = match self.host() {
             Some(h) => h,
             None => {
@@ -1179,7 +1248,6 @@ impl Handler<resource::Stop> for HostAgent {
                 return Ok(());
             }
         };
-        let timeout = hyperactor_config::global::get(hyperactor::config::PROCESS_EXIT_TIMEOUT);
 
         if let Some(ProcCreationState::Created { proc_id, .. }) = self.created.get(&message.id) {
             host.request_stop(cx, proc_id, timeout, &message.reason)
@@ -1199,9 +1267,18 @@ impl HostAgent {
     /// status. `rank == usize::MAX` means the proc is unknown to this host.
     async fn proc_rank_status(&self, id: &ResourceId) -> (usize, Status) {
         match self.created.get(id) {
-            Some(ProcCreationState::Pending { metadata, .. }) => {
-                (metadata.rank, Status::Initializing)
-            }
+            Some(ProcCreationState::Pending {
+                metadata,
+                on_completion,
+                ..
+            }) => (
+                metadata.rank,
+                if on_completion.is_keep() {
+                    Status::Initializing
+                } else {
+                    Status::Stopping
+                },
+            ),
             Some(ProcCreationState::Created {
                 metadata, proc_id, ..
             }) => {
@@ -1319,7 +1396,13 @@ impl HostAgent {
         use crate::resource::Status;
 
         let status = match self.created.get(id) {
-            Some(ProcCreationState::Pending { .. }) => Status::Initializing,
+            Some(ProcCreationState::Pending { on_completion, .. }) => {
+                if on_completion.is_keep() {
+                    Status::Initializing
+                } else {
+                    Status::Stopping
+                }
+            }
             Some(ProcCreationState::Created { proc_id, .. }) => match self.host() {
                 Some(host) => host.proc_status(proc_id).await.0,
                 None => Status::Stopped,
@@ -1505,7 +1588,7 @@ impl Handler<DrainHost> for HostAgent {
 
         // CreateOrUpdate still waits for Host::spawn, so a drain cannot observe
         // an in-progress proc creation in this revision.
-        let remaining = 0;
+        let remaining = self.mark_requests_for_drain(msg.host_mesh_id.as_ref());
         let drain = PendingDrain {
             remaining,
             failures: Vec::new(),
@@ -1595,6 +1678,21 @@ impl HostAgent {
             },
         );
     }
+    fn mark_requests_for_drain(&mut self, filter: Option<&HostMeshId>) -> usize {
+        let mut remaining = 0;
+        for state in self.created.values_mut() {
+            if filter.is_some_and(|filter| state.host_mesh_id() != Some(filter)) {
+                continue;
+            }
+
+            if let ProcCreationState::Pending { on_completion, .. } = state
+                && on_completion.request_drain()
+            {
+                remaining += 1;
+            }
+        }
+        remaining
+    }
 }
 
 #[async_trait]
@@ -1644,19 +1742,21 @@ impl Handler<ShutdownHost> for HostAgent {
 
         // CreateOrUpdate still waits for Host::spawn, so shutdown cannot
         // observe an in-progress proc creation in this revision.
-        let remaining = 0;
-        let shutdown = PendingShutdown {
+        let remaining = self.mark_requests_for_shutdown();
+        self.pending_shutdown = Some(PendingShutdown {
             remaining,
             timeout: msg.timeout,
             max_in_flight: msg.max_in_flight,
             acknowledgements: vec![(rank, msg.ack)],
             drain_replies: Vec::new(),
-        };
+        });
 
         if remaining == 0 {
+            let shutdown = self
+                .pending_shutdown
+                .take()
+                .expect("pending shutdown exists");
             self.finish_shutdown(cx, shutdown).await;
-        } else {
-            self.pending_shutdown = Some(shutdown);
         }
 
         Ok(())
@@ -1762,6 +1862,17 @@ impl HostAgent {
             }
         }
     }
+
+    fn mark_requests_for_shutdown(&mut self) -> usize {
+        let mut remaining = 0;
+        for state in self.created.values_mut() {
+            if let ProcCreationState::Pending { on_completion, .. } = state {
+                on_completion.request_shutdown();
+                remaining += 1;
+            }
+        }
+        remaining
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Named, Serialize, Deserialize)]
@@ -1799,9 +1910,13 @@ impl HostAgent {
         state: &ProcCreationState,
     ) -> resource::State<ProcState> {
         match state {
-            ProcCreationState::Pending { .. } => resource::State {
+            ProcCreationState::Pending { on_completion, .. } => resource::State {
                 id: id.clone(),
-                status: resource::Status::Initializing,
+                status: if on_completion.is_keep() {
+                    resource::Status::Initializing
+                } else {
+                    resource::Status::Stopping
+                },
                 state: None,
                 generation: 0,
                 timestamp: std::time::SystemTime::now(),

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -247,13 +247,72 @@ pub(crate) struct ProcMetadata {
 }
 
 #[derive(Debug)]
-pub(crate) struct ProcCreationState {
-    metadata: ProcMetadata,
-    pub(crate) created: Result<(ProcAddr, ActorRef<ProcAgent>), HostError>,
-    /// "Owner is alive" deadline communicated by the controller via
-    /// `KeepaliveGetState`. The host's `SelfCheck` reaper compares against this
-    /// and tears down procs whose owner has stopped extending the keepalive.
-    pub(crate) expiry_time: Option<std::time::SystemTime>,
+pub(crate) enum ProcCreationState {
+    #[expect(dead_code)]
+    Pending {
+        metadata: ProcMetadata,
+        expiry_time: Option<std::time::SystemTime>,
+    },
+    Created {
+        metadata: ProcMetadata,
+        proc_id: ProcAddr,
+        mesh_agent: ActorRef<ProcAgent>,
+        /// "Owner is alive" deadline communicated by the controller via
+        /// `KeepaliveGetState`. The host's `SelfCheck` reaper compares against this
+        /// and tears down procs whose owner has stopped extending the keepalive.
+        expiry_time: Option<std::time::SystemTime>,
+    },
+    Failed {
+        metadata: ProcMetadata,
+        error: HostError,
+    },
+}
+
+impl ProcCreationState {
+    fn metadata(&self) -> &ProcMetadata {
+        match self {
+            Self::Pending { metadata, .. }
+            | Self::Created { metadata, .. }
+            | Self::Failed { metadata, .. } => metadata,
+        }
+    }
+
+    fn from_spawn_result(
+        metadata: ProcMetadata,
+        expiry_time: Option<std::time::SystemTime>,
+        result: Result<(ProcAddr, ActorRef<ProcAgent>), HostError>,
+    ) -> Self {
+        match result {
+            Ok((proc_id, mesh_agent)) => Self::Created {
+                metadata,
+                proc_id,
+                mesh_agent,
+                expiry_time,
+            },
+            Err(error) => Self::Failed { metadata, error },
+        }
+    }
+
+    fn set_expiry_time(&mut self, expires_after: std::time::SystemTime) {
+        match self {
+            Self::Pending { expiry_time, .. } | Self::Created { expiry_time, .. } => {
+                *expiry_time = Some(expires_after);
+            }
+            Self::Failed { .. } => {}
+        }
+    }
+
+    fn rank(&self) -> usize {
+        self.metadata().rank
+    }
+
+    fn host_mesh_id(&self) -> Option<&HostMeshId> {
+        self.metadata().host_mesh_id.as_ref()
+    }
+
+    fn proc_mesh_id(&self) -> Option<&ProcMeshId> {
+        self.metadata().proc_mesh_id.as_ref()
+    }
 }
 
 struct PendingDrain {
@@ -568,17 +627,19 @@ impl HostAgent {
         let matching_ids: Vec<ResourceId> = self
             .created
             .iter()
-            .filter(|(_, state)| state.metadata.host_mesh_id.as_ref() == filter)
+            .filter(|(_, state)| {
+                state.host_mesh_id() == filter
+                    && matches!(
+                        state,
+                        ProcCreationState::Created { .. } | ProcCreationState::Failed { .. }
+                    )
+            })
             .map(|(id, _)| id.clone())
             .collect();
 
         if let Some(host_mode) = self.host() {
             for id in &matching_ids {
-                if let Some(ProcCreationState {
-                    created: Ok((proc_id, _)),
-                    ..
-                }) = self.created.get(id)
-                {
+                if let Some(ProcCreationState::Created { proc_id, .. }) = self.created.get(id) {
                     match host_mode {
                         HostAgentMode::Process { host, .. } => {
                             let _ = host
@@ -635,7 +696,7 @@ impl HostAgent {
 
         // User procs.
         for state in self.created.values() {
-            if let Ok((proc_id, _agent_ref)) = &state.created {
+            if let ProcCreationState::Created { proc_id, .. } = state {
                 children.push(hyperactor::introspect::IntrospectRef::Proc(proc_id.clone()));
             }
         }
@@ -1055,15 +1116,15 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         let was_empty = self.created.is_empty();
         self.created.insert(
             create_or_update.id.clone(),
-            ProcCreationState {
-                metadata: ProcMetadata {
+            ProcCreationState::from_spawn_result(
+                ProcMetadata {
                     rank,
                     host_mesh_id: create_or_update.spec.host_mesh_id.clone(),
                     proc_mesh_id: create_or_update.spec.proc_mesh_id.clone(),
                 },
+                None,
                 created,
-                expiry_time: None,
-            },
+            ),
         );
 
         // Transition Detached → Attached on first proc creation.
@@ -1080,8 +1141,10 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         let proc_id = self
             .created
             .get(&create_or_update.id)
-            .and_then(|s| s.created.as_ref().ok())
-            .map(|(pid, _)| pid.clone());
+            .and_then(|state| match state {
+                ProcCreationState::Created { proc_id, .. } => Some(proc_id.clone()),
+                ProcCreationState::Pending { .. } | ProcCreationState::Failed { .. } => None,
+            });
 
         // Bridge status changes to any pending waiters, then flush once now.
         if self.pending_proc_waiters.contains_key(&create_or_update.id) {
@@ -1118,11 +1181,7 @@ impl Handler<resource::Stop> for HostAgent {
         };
         let timeout = hyperactor_config::global::get(hyperactor::config::PROCESS_EXIT_TIMEOUT);
 
-        if let Some(ProcCreationState {
-            created: Ok((proc_id, _)),
-            ..
-        }) = self.created.get(&message.id)
-        {
+        if let Some(ProcCreationState::Created { proc_id, .. }) = self.created.get(&message.id) {
             host.request_stop(cx, proc_id, timeout, &message.reason)
                 .await;
         }
@@ -1140,19 +1199,21 @@ impl HostAgent {
     /// status. `rank == usize::MAX` means the proc is unknown to this host.
     async fn proc_rank_status(&self, id: &ResourceId) -> (usize, Status) {
         match self.created.get(id) {
-            Some(state) => match &state.created {
-                Ok((proc_id, _mesh_agent)) => {
-                    let raw_status = match self.host() {
-                        Some(host) => host.proc_status(proc_id).await.0,
-                        None => resource::Status::Unknown,
-                    };
-                    (
-                        state.metadata.rank,
-                        raw_status.clamp_min(self.min_proc_status()),
-                    )
-                }
-                Err(e) => (state.metadata.rank, Status::Failed(e.to_string())),
-            },
+            Some(ProcCreationState::Pending { metadata, .. }) => {
+                (metadata.rank, Status::Initializing)
+            }
+            Some(ProcCreationState::Created {
+                metadata, proc_id, ..
+            }) => {
+                let raw_status = match self.host() {
+                    Some(host) => host.proc_status(proc_id).await.0,
+                    None => resource::Status::Unknown,
+                };
+                (metadata.rank, raw_status.clamp_min(self.min_proc_status()))
+            }
+            Some(ProcCreationState::Failed { metadata, error }) => {
+                (metadata.rank, Status::Failed(error.to_string()))
+            }
             None => (usize::MAX, Status::NotExist),
         }
     }
@@ -1197,10 +1258,7 @@ impl Handler<resource::WaitRankStatus> for HostAgent {
         // (RSP-3).
         let rank = msg.rank.unwrap();
         match self.created.get(&msg.id) {
-            Some(ProcCreationState {
-                created: Ok((proc_id, _)),
-                ..
-            }) => {
+            Some(ProcCreationState::Created { proc_id, .. }) => {
                 let status = match self.host() {
                     Some(host) => host.proc_status(proc_id).await.0,
                     None => Status::Stopped,
@@ -1223,21 +1281,18 @@ impl Handler<resource::WaitRankStatus> for HostAgent {
                 let proc_id = proc_id.clone();
                 self.start_watch_bridge(&msg.id, &proc_id).await;
             }
-            Some(ProcCreationState {
-                created: Err(e), ..
-            }) => {
+            Some(ProcCreationState::Failed { error, .. }) => {
                 // Creation failed — reply immediately with Failed status.
                 let overlay = StatusOverlay::try_from_runs(vec![(
                     rank..(rank + 1),
-                    Status::Failed(e.to_string()),
+                    Status::Failed(error.to_string()),
                 )])
                 .expect("valid single-run overlay");
                 let _ = msg.reply.post(cx, overlay);
             }
-            None => {
-                // Proc doesn't exist yet. Stash the waiter with the rank the
-                // request carries (RSP-3); `CreateOrUpdate` starts the watch
-                // bridge.
+            Some(ProcCreationState::Pending { .. }) | None => {
+                // Proc isn't ready yet. Stash the waiter with the rank the
+                // request carries (RSP-3); proc creation starts the watch bridge.
                 self.pending_proc_waiters
                     .entry(msg.id.clone())
                     .or_default()
@@ -1264,17 +1319,12 @@ impl HostAgent {
         use crate::resource::Status;
 
         let status = match self.created.get(id) {
-            Some(ProcCreationState {
-                created: Ok((proc_id, _)),
-                ..
-            }) => match self.host() {
+            Some(ProcCreationState::Pending { .. }) => Status::Initializing,
+            Some(ProcCreationState::Created { proc_id, .. }) => match self.host() {
                 Some(host) => host.proc_status(proc_id).await.0,
                 None => Status::Stopped,
             },
-            Some(ProcCreationState {
-                created: Err(error),
-                ..
-            }) => Status::Failed(error.to_string()),
+            Some(ProcCreationState::Failed { error, .. }) => Status::Failed(error.to_string()),
             None => {
                 // Proc not created yet, nothing to flush.
                 return;
@@ -1748,8 +1798,20 @@ impl HostAgent {
         id: &ResourceId,
         state: &ProcCreationState,
     ) -> resource::State<ProcState> {
-        match &state.created {
-            Ok((proc_id, mesh_agent)) => {
+        match state {
+            ProcCreationState::Pending { .. } => resource::State {
+                id: id.clone(),
+                status: resource::Status::Initializing,
+                state: None,
+                generation: 0,
+                timestamp: std::time::SystemTime::now(),
+            },
+            ProcCreationState::Created {
+                metadata,
+                proc_id,
+                mesh_agent,
+                ..
+            } => {
                 let (raw_status, proc_status, bootstrap_command) = match self.host() {
                     Some(host) => {
                         let (status, proc_status) = host.proc_status(proc_id).await;
@@ -1763,7 +1825,7 @@ impl HostAgent {
                     status,
                     state: Some(ProcState {
                         proc_id: proc_id.clone(),
-                        create_rank: state.metadata.rank,
+                        create_rank: metadata.rank,
                         mesh_agent: mesh_agent.clone(),
                         bootstrap_command,
                         proc_status,
@@ -1772,9 +1834,9 @@ impl HostAgent {
                     timestamp: std::time::SystemTime::now(),
                 }
             }
-            Err(e) => resource::State {
+            ProcCreationState::Failed { error, .. } => resource::State {
                 id: id.clone(),
-                status: resource::Status::Failed(e.to_string()),
+                status: resource::Status::Failed(error.to_string()),
                 state: None,
                 generation: 0,
                 timestamp: std::time::SystemTime::now(),
@@ -1838,8 +1900,8 @@ impl Handler<GetHostProcStates> for HostAgent {
         message: GetHostProcStates,
     ) -> anyhow::Result<()> {
         let selects = |state: &ProcCreationState| {
-            state.metadata.proc_mesh_id.as_ref() == Some(&message.proc_mesh_id)
-                && message.region.slice().contains(state.metadata.rank)
+            state.proc_mesh_id() == Some(&message.proc_mesh_id)
+                && message.region.slice().contains(state.rank())
         };
 
         // Bump keepalive (if requested) in a separate mutable pass, so the read
@@ -1847,7 +1909,7 @@ impl Handler<GetHostProcStates> for HostAgent {
         if let Some(expires_after) = message.keepalive {
             for state in self.created.values_mut() {
                 if selects(state) {
-                    state.expiry_time = Some(expires_after);
+                    state.set_expiry_time(expires_after);
                 }
             }
         }
@@ -1862,7 +1924,7 @@ impl Handler<GetHostProcStates> for HostAgent {
         let mut runs = Vec::new();
         for (id, state) in self.created.iter() {
             if selects(state) {
-                let base = message.region.slice().index(state.metadata.rank)?;
+                let base = message.region.slice().index(state.rank())?;
                 runs.push((base..(base + 1), self.proc_state_from(id, state).await));
             }
         }
@@ -1900,7 +1962,10 @@ impl Handler<crate::proc_agent::SelfCheck> for HostAgent {
             .created
             .iter()
             .filter_map(|(id, state)| {
-                let expiry = state.expiry_time?;
+                let ProcCreationState::Created { expiry_time, .. } = state else {
+                    return None;
+                };
+                let expiry = *expiry_time.as_ref()?;
                 if now > expiry { Some(id.clone()) } else { None }
             })
             .collect();
@@ -1913,18 +1978,16 @@ impl Handler<crate::proc_agent::SelfCheck> for HostAgent {
         }
 
         for id in expired {
-            if let Some(ProcCreationState {
-                created: Ok((proc_id, _)),
-                ..
-            }) = self.created.get(&id)
-            {
+            if let Some(ProcCreationState::Created { proc_id, .. }) = self.created.get(&id) {
                 let proc_id = proc_id.clone();
                 if let Some(host) = self.host() {
                     host.request_stop(cx, &proc_id, timeout, "orphaned").await;
                 }
                 // Don't reap repeatedly while teardown is in flight.
-                if let Some(state) = self.created.get_mut(&id) {
-                    state.expiry_time = None;
+                if let Some(ProcCreationState::Created { expiry_time, .. }) =
+                    self.created.get_mut(&id)
+                {
+                    *expiry_time = None;
                 }
             }
         }
@@ -1954,7 +2017,7 @@ impl Handler<resource::KeepaliveGetState<ProcState>> for HostAgent {
         // (e.g. its process dies abruptly), the proc will be reaped past
         // `expires_after`.
         if let Some(state) = self.created.get_mut(&message.get_state.id) {
-            state.expiry_time = Some(message.expires_after);
+            state.set_expiry_time(message.expires_after);
         }
         <Self as Handler<resource::GetState<ProcState>>>::handle(self, cx, message.get_state).await
     }
@@ -1976,52 +2039,19 @@ impl Handler<resource::StreamState<ProcState>> for HostAgent {
         for (id, proc) in self.created.iter() {
             // Skip procs that don't belong to the subscribing proc mesh.
             if proc
-                .metadata
-                .proc_mesh_id
-                .as_ref()
+                .proc_mesh_id()
                 .is_none_or(|mesh| mesh.resource_id() != &stream_state.id)
             {
                 continue;
             }
 
-            let state = match &proc.created {
-                Ok((proc_id, mesh_agent)) => {
-                    let (raw_status, proc_status, bootstrap_command) = match self.host() {
-                        Some(host) => {
-                            let (status, proc_status) = host.proc_status(proc_id).await;
-                            (status, proc_status, host.bootstrap_command())
-                        }
-                        None => (resource::Status::Unknown, None, None),
-                    };
-                    let status = raw_status.clamp_min(self.min_proc_status());
-                    resource::State {
-                        id: id.clone(),
-                        status,
-                        state: Some(ProcState {
-                            proc_id: proc_id.clone(),
-                            create_rank: proc.metadata.rank,
-                            mesh_agent: mesh_agent.clone(),
-                            bootstrap_command,
-                            proc_status,
-                        }),
-                        generation: 0,
-                        timestamp: std::time::SystemTime::now(),
-                    }
-                }
-                Err(e) => resource::State {
-                    id: id.clone(),
-                    status: resource::Status::Failed(e.to_string()),
-                    state: None,
-                    generation: 0,
-                    timestamp: std::time::SystemTime::now(),
-                },
-            };
+            let state = self.proc_state_from(id, proc).await;
 
             stream_state.subscriber.post_with_headers(
                 cx,
                 headers.clone(),
                 resource::RankedState {
-                    rank: resource::Rank::new(proc.metadata.rank),
+                    rank: resource::Rank::new(proc.rank()),
                     state,
                 },
             );

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -251,6 +251,60 @@ pub(crate) struct ProcCreationState {
     pub(crate) expiry_time: Option<std::time::SystemTime>,
 }
 
+struct PendingDrain {
+    /// Number of matching proc spawns that were pending when the drain began.
+    /// Each counted spawn decrements this exactly once. Reaching zero completes
+    /// the drain and posts every reply exactly once.
+    remaining: usize,
+    failures: Vec<String>,
+    timeout: Duration,
+    max_in_flight: usize,
+    replies: Vec<PendingDrainReply>,
+}
+
+struct PendingDrainReply {
+    rank: usize,
+    reply: PortRef<crate::StatusOverlay>,
+}
+
+#[derive(Default)]
+struct PendingDrains {
+    /// A full drain subsumes the selective drains, which remain in the map so
+    /// that every selective request still receives its reply.
+    full: Option<PendingDrain>,
+    selective: HashMap<HostMeshId, PendingDrain>,
+}
+
+impl PendingDrains {
+    fn blocks_create(&self, host_mesh_id: Option<&HostMeshId>) -> bool {
+        self.full.is_some()
+            || host_mesh_id.is_some_and(|host_mesh_id| self.selective.contains_key(host_mesh_id))
+    }
+
+    fn take_all(&mut self) -> impl Iterator<Item = PendingDrain> {
+        let full = self.full.take();
+        let selective = std::mem::take(&mut self.selective);
+        full.into_iter().chain(selective.into_values())
+    }
+}
+
+impl PendingDrain {
+    fn post_replies(self, cx: &Context<'_, HostAgent>) {
+        let status = if self.failures.is_empty() {
+            resource::Status::Stopped
+        } else {
+            resource::Status::Failed(self.failures.join("; "))
+        };
+
+        for PendingDrainReply { rank, reply } in self.replies {
+            let overlay =
+                crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
+                    .expect("valid single-run overlay");
+            reply.post(cx, overlay);
+        }
+    }
+}
+
 /// Actor name used when spawning the host mesh agent on the system proc.
 pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "host_agent";
 
@@ -280,14 +334,7 @@ struct ProcStatusChanged {
 
 /// Sent by DrainWorker back to HostAgent when draining completes.
 /// Not exported — delivered locally via PortHandle (no serialization).
-struct DrainComplete {
-    host: HostAgentMode,
-    /// This host's ordinal within the drain cast region.
-    rank: usize,
-    /// Streaming status reply the parent posts the drained overlay to,
-    /// after restoring state.
-    reply: PortRef<crate::StatusOverlay>,
-}
+struct DrainComplete(HostAgentMode);
 
 /// Child actor whose only job is to run `host.terminate_children()` in
 /// its `init()`, return the host and ack to the parent via DrainComplete,
@@ -298,8 +345,6 @@ struct DrainWorker {
     host: Option<HostAgentMode>,
     timeout: Duration,
     max_in_flight: usize,
-    rank: usize,
-    reply: Option<PortRef<crate::StatusOverlay>>,
     done_notify: PortHandle<DrainComplete>,
 }
 
@@ -324,18 +369,9 @@ impl Actor for DrainWorker {
             }
         }
 
-        // Bundle host + reply into DrainComplete so the parent reports the
-        // drained overlay AFTER restoring state (prevents race with
-        // ShutdownHost).
-        if let (Some(host), Some(reply)) = (self.host.take(), self.reply.take()) {
-            let _ = self.done_notify.post(
-                this,
-                DrainComplete {
-                    host,
-                    rank: self.rank,
-                    reply,
-                },
-            );
+        // Restore the host before the parent reports drain completion.
+        if let Some(host) = self.host.take() {
+            let _ = self.done_notify.post(this, DrainComplete(host));
         }
 
         Ok(())
@@ -377,6 +413,7 @@ impl fmt::Debug for DrainWorker {
 pub struct HostAgent {
     state: HostAgentState,
     pub(crate) created: HashMap<ResourceId, ProcCreationState>,
+    pending_drains: PendingDrains,
     /// Pending `WaitRankStatus` waiters, keyed by resource name.
     /// Each entry is `(min_status, rank, reply_port)`. Only touched
     /// from `&mut self` handlers.
@@ -410,6 +447,7 @@ impl HostAgent {
         Self {
             state: HostAgentState::Detached(host),
             created: HashMap::new(),
+            pending_drains: PendingDrains::default(),
             pending_proc_waiters: HashMap::new(),
             watching: HashSet::new(),
             proc_status_port: None,
@@ -940,6 +978,16 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             // Already created: there is no update.
             return Ok(());
         }
+        if self
+            .pending_drains
+            .blocks_create(create_or_update.spec.host_mesh_id.as_ref())
+        {
+            tracing::warn!(
+                id = %create_or_update.id,
+                "ignoring CreateOrUpdate: HostAgent is draining"
+            );
+            return Ok(());
+        }
 
         let host = match self.host_mut() {
             Some(h) => h,
@@ -1357,74 +1405,120 @@ wirevalue::register_type!(DrainHost);
 impl Handler<DrainHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainHost) -> anyhow::Result<()> {
         let rank = msg.rank.unwrap();
-        // This host's drain completion, as a single-rank `Stopped` overlay at
-        // its ordinal. The caller reduces these into a StatusMesh barrier.
-        let drained_overlay = || {
-            crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), resource::Status::Stopped)])
-                .expect("valid single-run overlay")
+        let active_drain = match msg.host_mesh_id.as_ref() {
+            Some(host_mesh_id) => self.pending_drains.selective.get_mut(host_mesh_id),
+            None => self.pending_drains.full.as_mut(),
         };
-
-        if msg.host_mesh_id.is_some() {
-            // Selective drain: stop only procs belonging to the named mesh.
-            self.drain_by_mesh_name(cx, msg.timeout, msg.host_mesh_id.as_ref())
-                .await;
-            msg.reply.post(cx, drained_overlay());
+        if let Some(drain) = active_drain {
+            drain.replies.push(PendingDrainReply {
+                rank,
+                reply: msg.reply,
+            });
             return Ok(());
         }
 
-        // Full drain: terminate all children.
+        // CreateOrUpdate still waits for Host::spawn, so a drain cannot observe
+        // an in-progress proc creation in this revision.
+        let remaining = 0;
+        let drain = PendingDrain {
+            remaining,
+            failures: Vec::new(),
+            timeout: msg.timeout,
+            max_in_flight: msg.max_in_flight,
+            replies: vec![PendingDrainReply {
+                rank,
+                reply: msg.reply,
+            }],
+        };
+
+        match msg.host_mesh_id {
+            Some(host_mesh_id) => {
+                if self.pending_drains.full.is_some() {
+                    let replaced = self.pending_drains.selective.insert(host_mesh_id, drain);
+                    debug_assert!(replaced.is_none(), "duplicate selective drain was joined");
+                    return Ok(());
+                }
+
+                self.drain_by_mesh_name(cx, msg.timeout, Some(&host_mesh_id))
+                    .await;
+
+                if remaining == 0 {
+                    drain.post_replies(cx);
+                } else {
+                    let replaced = self.pending_drains.selective.insert(host_mesh_id, drain);
+                    debug_assert!(replaced.is_none(), "duplicate selective drain was joined");
+                }
+            }
+            None => {
+                if remaining == 0 && self.pending_drains.selective.is_empty() {
+                    self.start_full_drain(cx, drain);
+                } else {
+                    debug_assert!(
+                        self.pending_drains.full.is_none(),
+                        "duplicate full drain joined"
+                    );
+                    self.pending_drains.full = Some(drain);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl HostAgent {
+    fn start_full_drain(&mut self, cx: &Context<'_, Self>, drain: PendingDrain) {
+        if drain.remaining != 0 {
+            unreachable!("full drain requires no remaining proc creations");
+        }
+        let timeout = drain.timeout;
+        let max_in_flight = drain.max_in_flight;
+
         let host = match std::mem::replace(&mut self.state, HostAgentState::Draining) {
             HostAgentState::Attached(h) => h,
             other @ (HostAgentState::Detached(_) | HostAgentState::Draining) => {
                 // Nothing to drain — report immediately.
                 self.state = other;
-                msg.reply.post(cx, drained_overlay());
-                return Ok(());
+                drain.post_replies(cx);
+                return;
             }
             HostAgentState::Shutdown => {
                 self.state = HostAgentState::Shutdown;
-                msg.reply.post(cx, drained_overlay());
-                return Ok(());
+                drain.post_replies(cx);
+                return;
             }
         };
 
-        // Do NOT clear `self.created` here: the DrainWorker
-        // terminates procs asynchronously, and concurrent GetState /
-        // GetRankStatus queries must still find the entries. With the
-        // host in Draining state (`self.host()` returns None), those
-        // handlers already report Status::Stopped for every known
-        // proc, which is the correct answer while draining is
-        // in progress.
+        debug_assert!(
+            self.pending_drains.full.is_none(),
+            "duplicate full drain was joined"
+        );
+        self.pending_drains.full = Some(drain);
 
+        // Do not clear `self.created` here. The DrainWorker terminates procs
+        // asynchronously, and status queries must still find their entries.
         let done_port = cx.port::<DrainComplete>();
 
         cx.spawn_with_label(
             "drain_worker",
             DrainWorker {
                 host: Some(host),
-                timeout: msg.timeout,
-                max_in_flight: msg.max_in_flight,
-                rank,
-                reply: Some(msg.reply),
+                timeout,
+                max_in_flight,
                 done_notify: done_port,
             },
         );
-
-        Ok(())
     }
 }
 
 #[async_trait]
 impl Handler<DrainComplete> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainComplete) -> anyhow::Result<()> {
-        self.state = HostAgentState::Detached(msg.host);
+        self.state = HostAgentState::Detached(msg.0);
         self.created.clear();
-        let overlay = crate::StatusOverlay::try_from_runs(vec![(
-            msg.rank..(msg.rank + 1),
-            resource::Status::Stopped,
-        )])
-        .expect("valid single-run overlay");
-        msg.reply.post(cx, overlay);
+        for drain in self.pending_drains.take_all() {
+            drain.post_replies(cx);
+        }
         Ok(())
     }
 }
@@ -2002,6 +2096,27 @@ mod tests {
         assert_matches!(status, resource::Status::Failed(_));
     }
 
+    async fn spawn_local_host_agent(spawn: ProcManagerSpawnFn) -> ActorHandle<HostAgent> {
+        let host = Host::new(LocalProcManager::new(spawn), ChannelTransport::Unix.any())
+            .await
+            .expect("local host should start");
+
+        let host_agent = host
+            .system_proc()
+            .clone()
+            .spawn_with_uid(
+                Uid::singleton(Label::new(HOST_MESH_AGENT_ACTOR_NAME).unwrap()),
+                HostAgent::new_local(host),
+            )
+            .expect("host agent should start");
+
+        HostAgent::wait_initialized(&host_agent)
+            .await
+            .expect("host agent should initialize");
+
+        host_agent
+    }
+
     // RSP-* coverage map for the HostAgent rank-status tests. Each deliberately
     // uses `message_rank != creation_rank`, so a handler that read the creation
     // rank would fail:
@@ -2365,18 +2480,7 @@ mod tests {
                 anyhow::anyhow!("test failure"),
             )))
         });
-        let host = Host::new(LocalProcManager::new(spawn), ChannelTransport::Unix.any())
-            .await
-            .unwrap();
-
-        let system_proc = host.system_proc().clone();
-        let host_agent = system_proc
-            .spawn_with_uid(
-                Uid::singleton(Label::new(HOST_MESH_AGENT_ACTOR_NAME).unwrap()),
-                HostAgent::new_local(host),
-            )
-            .unwrap();
-        HostAgent::wait_initialized(&host_agent).await.unwrap();
+        let host_agent = spawn_local_host_agent(spawn).await;
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let client = client_proc.client("client");
@@ -2448,6 +2552,92 @@ mod tests {
             .expect("reply timed out")
             .expect("reply channel closed");
         assert_overlay_failed_at_rank(&overlay, get_rank);
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn duplicate_selective_drains_each_receive_completion() {
+        let (spawn_started_tx, mut spawn_started_rx) = tokio::sync::watch::channel(false);
+        let (release_spawn_tx, release_spawn_rx) = tokio::sync::watch::channel(false);
+        let spawn: ProcManagerSpawnFn = Box::new(move |proc| {
+            let spawn_started_tx = spawn_started_tx.clone();
+            let mut release_spawn_rx = release_spawn_rx.clone();
+            Box::pin(async move {
+                spawn_started_tx
+                    .send(true)
+                    .expect("spawn-start receiver remains open");
+                release_spawn_rx
+                    .wait_for(|release| *release)
+                    .await
+                    .expect("spawn-release sender remains open");
+                ProcAgent::boot_v1(proc, None)
+            })
+        });
+        let host_agent = spawn_local_host_agent(spawn).await;
+
+        let client_proc =
+            Proc::direct(ChannelTransport::Unix.any(), "drain_client".to_string()).unwrap();
+        let client = client_proc.client("drain_client");
+        let host_mesh_id = HostMeshId::instance(Label::new("mesh-a").unwrap());
+        let proc_id = ResourceId::instance(Label::new("proc-a").unwrap());
+        let agent_ref: ActorRef<HostAgent> = host_agent.bind();
+
+        agent_ref.post(
+            &client,
+            resource::CreateOrUpdate {
+                id: proc_id,
+                rank: resource::Rank::new(0),
+                spec: ProcSpec {
+                    host_mesh_id: Some(host_mesh_id.clone()),
+                    ..Default::default()
+                },
+            },
+        );
+        spawn_started_rx
+            .wait_for(|started| *started)
+            .await
+            .expect("spawn-start sender remains open");
+
+        let (first_reply, mut first_reply_rx) = client.open_port::<crate::StatusOverlay>();
+        let (second_reply, mut second_reply_rx) = client.open_port::<crate::StatusOverlay>();
+        agent_ref.post(
+            &client,
+            DrainHost {
+                timeout: Duration::from_secs(5),
+                max_in_flight: 16,
+                host_mesh_id: Some(host_mesh_id.clone()),
+                rank: resource::Rank::new(3),
+                reply: first_reply.bind(),
+            },
+        );
+        agent_ref.post(
+            &client,
+            DrainHost {
+                timeout: Duration::from_secs(5),
+                max_in_flight: 16,
+                host_mesh_id: Some(host_mesh_id),
+                rank: resource::Rank::new(7),
+                reply: second_reply.bind(),
+            },
+        );
+
+        release_spawn_tx
+            .send(true)
+            .expect("spawn-release receivers remain open");
+
+        let first = first_reply_rx.recv().await.expect("first drain reply");
+        assert_overlay_at_rank(&first, 3);
+        assert_eq!(
+            first.runs().next().unwrap().1,
+            resource::Status::Stopped,
+            "first drain should complete successfully",
+        );
+        let second = second_reply_rx.recv().await.expect("second drain reply");
+        assert_overlay_at_rank(&second, 7);
+        assert_eq!(
+            second.runs().next().unwrap().1,
+            resource::Status::Stopped,
+            "second drain should complete successfully",
+        );
     }
 
     /// DrainHost with a host_mesh_id filter only stops procs

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -296,6 +296,10 @@ impl PendingDrain {
             resource::Status::Failed(self.failures.join("; "))
         };
 
+        self.post_replies_with_status(cx, status);
+    }
+
+    fn post_replies_with_status(self, cx: &Context<'_, HostAgent>, status: resource::Status) {
         for PendingDrainReply { rank, reply } in self.replies {
             let overlay =
                 crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
@@ -303,6 +307,14 @@ impl PendingDrain {
             reply.post(cx, overlay);
         }
     }
+}
+
+struct PendingShutdown {
+    remaining: usize,
+    timeout: Duration,
+    max_in_flight: usize,
+    acknowledgements: Vec<(usize, PortRef<usize>)>,
+    drain_replies: Vec<PendingDrainReply>,
 }
 
 /// Actor name used when spawning the host mesh agent on the system proc.
@@ -414,6 +426,7 @@ pub struct HostAgent {
     state: HostAgentState,
     pub(crate) created: HashMap<ResourceId, ProcCreationState>,
     pending_drains: PendingDrains,
+    pending_shutdown: Option<PendingShutdown>,
     /// Pending `WaitRankStatus` waiters, keyed by resource name.
     /// Each entry is `(min_status, rank, reply_port)`. Only touched
     /// from `&mut self` handlers.
@@ -448,6 +461,7 @@ impl HostAgent {
             state: HostAgentState::Detached(host),
             created: HashMap::new(),
             pending_drains: PendingDrains::default(),
+            pending_shutdown: None,
             pending_proc_waiters: HashMap::new(),
             watching: HashSet::new(),
             proc_status_port: None,
@@ -483,6 +497,9 @@ impl HostAgent {
     /// Minimum status floor derived from the host agent's lifecycle.
     /// Procs on this host cannot be healthier than this.
     fn min_proc_status(&self) -> resource::Status {
+        if self.pending_shutdown.is_some() {
+            return resource::Status::Stopping;
+        }
         match &self.state {
             HostAgentState::Detached(_) | HostAgentState::Attached(_) => resource::Status::Running,
             HostAgentState::Draining => resource::Status::Stopping,
@@ -978,6 +995,13 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             // Already created: there is no update.
             return Ok(());
         }
+        if self.pending_shutdown.is_some() {
+            tracing::warn!(
+                id = %create_or_update.id,
+                "ignoring CreateOrUpdate: HostAgent is shutting down"
+            );
+            return Ok(());
+        }
         if self
             .pending_drains
             .blocks_create(create_or_update.spec.host_mesh_id.as_ref())
@@ -1405,6 +1429,14 @@ wirevalue::register_type!(DrainHost);
 impl Handler<DrainHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainHost) -> anyhow::Result<()> {
         let rank = msg.rank.unwrap();
+        if let Some(shutdown) = self.pending_shutdown.as_mut() {
+            shutdown.drain_replies.push(PendingDrainReply {
+                rank,
+                reply: msg.reply,
+            });
+            return Ok(());
+        }
+
         let active_drain = match msg.host_mesh_id.as_ref() {
             Some(host_mesh_id) => self.pending_drains.selective.get_mut(host_mesh_id),
             None => self.pending_drains.full.as_mut(),
@@ -1519,6 +1551,18 @@ impl Handler<DrainComplete> for HostAgent {
         for drain in self.pending_drains.take_all() {
             drain.post_replies(cx);
         }
+
+        if self
+            .pending_shutdown
+            .as_ref()
+            .is_some_and(|shutdown| shutdown.remaining == 0)
+        {
+            let shutdown = self
+                .pending_shutdown
+                .take()
+                .expect("pending shutdown exists");
+            self.finish_shutdown(cx, shutdown).await;
+        }
         Ok(())
     }
 }
@@ -1527,6 +1571,62 @@ impl Handler<DrainComplete> for HostAgent {
 impl Handler<ShutdownHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: ShutdownHost) -> anyhow::Result<()> {
         let rank = msg.rank.unwrap();
+        if matches!(&self.state, HostAgentState::Shutdown) {
+            msg.ack.post(cx, rank);
+            return Ok(());
+        }
+
+        if let Some(shutdown) = self.pending_shutdown.as_mut() {
+            shutdown.acknowledgements.push((rank, msg.ack));
+            return Ok(());
+        }
+
+        for drain in self.pending_drains.take_all() {
+            drain.post_replies_with_status(
+                cx,
+                resource::Status::Failed("host shutdown superseded drain".to_string()),
+            );
+        }
+
+        // CreateOrUpdate still waits for Host::spawn, so shutdown cannot
+        // observe an in-progress proc creation in this revision.
+        let remaining = 0;
+        let shutdown = PendingShutdown {
+            remaining,
+            timeout: msg.timeout,
+            max_in_flight: msg.max_in_flight,
+            acknowledgements: vec![(rank, msg.ack)],
+            drain_replies: Vec::new(),
+        };
+
+        if remaining == 0 {
+            self.finish_shutdown(cx, shutdown).await;
+        } else {
+            self.pending_shutdown = Some(shutdown);
+        }
+
+        Ok(())
+    }
+}
+
+impl HostAgent {
+    async fn finish_shutdown(&mut self, cx: &Context<'_, Self>, shutdown: PendingShutdown) {
+        if matches!(&self.state, HostAgentState::Draining) {
+            self.pending_shutdown = Some(shutdown);
+            return;
+        }
+
+        let PendingShutdown {
+            remaining: 0,
+            timeout,
+            max_in_flight,
+            acknowledgements,
+            drain_replies,
+        } = shutdown
+        else {
+            unreachable!("shutdown cannot finish while proc creation is pending");
+        };
+
         // Terminate children BEFORE acking, so the caller's networking
         // stays alive while children flush their forwarders during
         // teardown. If we ack first, the caller proceeds to tear down
@@ -1534,7 +1634,16 @@ impl Handler<ShutdownHost> for HostAgent {
         // causing their forwarder flushes to hang until
         // MESSAGE_DELIVERY_TIMEOUT expires.
         if !self.created.is_empty() {
-            self.drain(cx, msg.timeout, msg.max_in_flight).await;
+            self.drain(cx, timeout, max_in_flight).await;
+        }
+
+        for PendingDrainReply { rank, reply } in drain_replies {
+            let overlay = crate::StatusOverlay::try_from_runs(vec![(
+                rank..(rank + 1),
+                resource::Status::Stopped,
+            )])
+            .expect("valid single-run overlay");
+            reply.post(cx, overlay);
         }
 
         // Drop the host and signal the bootstrap loop to drain the
@@ -1549,10 +1658,12 @@ impl Handler<ShutdownHost> for HostAgent {
                 shutdown_tx: Some(tx),
             }) => {
                 // Keep the host's outbound gateway alive until the direct
-                // shutdown acknowledgment has been flushed. The bootstrap
+                // shutdown acknowledgments have been flushed. The bootstrap
                 // task may stop the frontend as soon as it receives the
                 // handle below.
-                msg.ack.post(cx, rank);
+                for (rank, ack) in acknowledgements {
+                    ack.post(cx, rank);
+                }
                 let flush_timeout =
                     hyperactor_config::global::get(hyperactor::config::FORWARDER_FLUSH_TIMEOUT);
                 match tokio::time::timeout(flush_timeout, host.gateway().flush()).await {
@@ -1582,18 +1693,20 @@ impl Handler<ShutdownHost> for HostAgent {
                 // after that proc has stopped.
                 tokio::spawn(async move {
                     for mut proc in procs {
-                        let _ = proc
-                            .destroy_and_wait(msg.timeout, "local host shutdown")
-                            .await;
+                        let _ = proc.destroy_and_wait(timeout, "local host shutdown").await;
                     }
                     host.shutdown_servers().await;
-                    msg.ack.post(&shutdown_client, rank);
+                    for (rank, ack) in acknowledgements {
+                        ack.post(&shutdown_client, rank);
+                    }
                 });
             }
-            _ => msg.ack.post(cx, rank),
+            _ => {
+                for (rank, ack) in acknowledgements {
+                    ack.post(cx, rank);
+                }
+            }
         }
-
-        Ok(())
     }
 }
 
@@ -2060,8 +2173,11 @@ impl Handler<ConfigDump> for HostAgent {
 #[cfg(all(test, fbcode_build))]
 mod tests {
     use std::assert_matches;
+    use std::sync::Arc;
 
     use hyperactor::ActorAddr;
+    use hyperactor::Client;
+    use hyperactor::PortReceiver;
     use hyperactor::Proc;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::id::Label;
@@ -2115,6 +2231,120 @@ mod tests {
             .expect("host agent should initialize");
 
         host_agent
+    }
+
+    #[derive(Debug)]
+    struct DrainBlockingActor {
+        stop_started: Arc<tokio::sync::Notify>,
+        release_stop: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl Actor for DrainBlockingActor {
+        async fn handle_stop(
+            &mut self,
+            this: &Instance<Self>,
+            mode: hyperactor::actor::StopMode,
+            reason: &str,
+        ) -> anyhow::Result<()> {
+            let this = this.clone_for_py();
+            let release_stop = Arc::clone(&self.release_stop);
+            let reason = reason.to_string();
+            this.close();
+            self.stop_started.notify_one();
+            tokio::spawn(async move {
+                release_stop.notified().await;
+                match mode {
+                    hyperactor::actor::StopMode::Stop => this.exit(&reason).unwrap(),
+                    hyperactor::actor::StopMode::DrainAndStop => {
+                        this.exit_after_drain(&reason).unwrap()
+                    }
+                }
+            });
+            Ok(())
+        }
+    }
+
+    /// Spawn a Proc, wait for it to be running, request a drain
+    async fn start_blocked_full_drain(
+        client_name: &str,
+    ) -> (
+        ActorHandle<HostAgent>,
+        Client,
+        Arc<tokio::sync::Notify>,
+        PortReceiver<crate::StatusOverlay>,
+    ) {
+        let stop_started = Arc::new(tokio::sync::Notify::new());
+        let release_stop = Arc::new(tokio::sync::Notify::new());
+
+        let spawn: ProcManagerSpawnFn = {
+            let stop_started_for_spawn = Arc::clone(&stop_started);
+            let release_stop_for_spawn = Arc::clone(&release_stop);
+
+            Box::new(move |proc: Proc| {
+                proc.spawn(DrainBlockingActor {
+                    stop_started: Arc::clone(&stop_started_for_spawn),
+                    release_stop: Arc::clone(&release_stop_for_spawn),
+                });
+                Box::pin(std::future::ready(ProcAgent::boot_v1(proc, None)))
+            })
+        };
+        let host_agent = spawn_local_host_agent(spawn).await;
+
+        let client = Proc::direct(ChannelTransport::Unix.any(), client_name.to_string())
+            .unwrap()
+            .client("client");
+        let proc_id = ResourceId::instance(Label::new("proc").unwrap());
+        let (running_reply, mut running_rx) = client.open_port::<crate::StatusOverlay>();
+
+        host_agent
+            .wait_rank_status(
+                &client,
+                proc_id.clone(),
+                resource::Rank::new(0),
+                resource::Status::Running,
+                running_reply.bind(),
+            )
+            .await
+            .expect("running waiter should be accepted");
+
+        host_agent
+            .create_or_update(
+                &client,
+                proc_id,
+                resource::Rank::new(0),
+                ProcSpec::default(),
+            )
+            .await
+            .expect("proc should start");
+
+        let running_status = running_rx
+            .recv()
+            .await
+            .expect("proc should report running before drain");
+
+        assert_overlay_at_rank(&running_status, 0);
+        assert_eq!(
+            running_status.runs().next().unwrap().1,
+            resource::Status::Running,
+        );
+
+        let (drain_reply, drain_rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .try_post(
+                &client,
+                DrainHost {
+                    timeout: Duration::from_secs(20),
+                    max_in_flight: 1,
+                    host_mesh_id: None,
+                    rank: resource::Rank::new(0),
+                    reply: drain_reply.bind(),
+                },
+            )
+            .expect("drain request should be delivered");
+        stop_started.notified().await;
+
+        (host_agent, client, release_stop, drain_rx)
     }
 
     // RSP-* coverage map for the HostAgent rank-status tests. Each deliberately
@@ -2254,6 +2484,111 @@ mod tests {
         assert!(
             cast_actor.status().borrow().is_terminal(),
             "local CastActor must stop before acknowledging shutdown"
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn shutdown_waits_for_active_drain_worker() {
+        let (host_agent, client, release_stop, mut drain_rx) =
+            start_blocked_full_drain("shutdown_during_drain_client").await;
+
+        let (ack, mut ack_rx) = client.open_port::<usize>();
+        host_agent
+            .try_post(
+                &client,
+                ShutdownHost {
+                    timeout: Duration::from_secs(5),
+                    max_in_flight: 1,
+                    rank: resource::Rank::new(0),
+                    ack: ack.bind().unsplit(),
+                },
+            )
+            .expect("shutdown request should be delivered");
+
+        let drain_status = drain_rx
+            .recv()
+            .await
+            .expect("shutdown should supersede the active drain");
+        assert_overlay_failed_at_rank(&drain_status, 0);
+        assert_eq!(
+            ack_rx
+                .try_recv()
+                .expect("shutdown ack port should remain open"),
+            None,
+            "shutdown was acknowledged before DrainComplete",
+        );
+
+        release_stop.notify_one();
+        assert_eq!(
+            ack_rx
+                .recv()
+                .await
+                .expect("shutdown should be acknowledged"),
+            0,
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn drain_during_pending_shutdown_waits_for_completion() {
+        let (host_agent, client, release_stop, mut active_drain_rx) =
+            start_blocked_full_drain("drain_during_shutdown_client").await;
+
+        let (ack, mut ack_rx) = client.open_port::<usize>();
+        host_agent
+            .try_post(
+                &client,
+                ShutdownHost {
+                    timeout: Duration::from_secs(5),
+                    max_in_flight: 1,
+                    rank: resource::Rank::new(0),
+                    ack: ack.bind().unsplit(),
+                },
+            )
+            .expect("shutdown request should be delivered");
+
+        let active_drain_status = active_drain_rx
+            .recv()
+            .await
+            .expect("shutdown should supersede the active drain");
+        assert_overlay_failed_at_rank(&active_drain_status, 0);
+
+        let (drain_reply, mut drain_rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .try_post(
+                &client,
+                DrainHost {
+                    timeout: Duration::from_secs(20),
+                    max_in_flight: 1,
+                    host_mesh_id: None,
+                    rank: resource::Rank::new(0),
+                    reply: drain_reply.bind(),
+                },
+            )
+            .expect("drain request should be delivered during shutdown");
+        assert_eq!(
+            drain_rx
+                .try_recv()
+                .expect("drain reply port should remain open"),
+            None,
+            "drain completed before shutdown finished terminating procs",
+        );
+
+        release_stop.notify_one();
+        let drain_status = drain_rx
+            .recv()
+            .await
+            .expect("drain during shutdown should complete");
+        assert_overlay_at_rank(&drain_status, 0);
+        assert_eq!(
+            drain_status.runs().next().unwrap().1,
+            resource::Status::Stopped,
+        );
+        assert_eq!(
+            ack_rx
+                .recv()
+                .await
+                .expect("shutdown should be acknowledged"),
+            0,
         );
     }
 


### PR DESCRIPTION
Summary:

Gets us closer to the shape of async `CreateOrUpdate<ProcSpec>` by inserting a `Pending` proc state before awaiting `Host::spawn` and then replace it with `Created` or `Failed` after we await the result.

Reviewed By: shayne-fletcher

Differential Revision: D116669551


