### PR TITLE
Clean up interrupted bootstrap launches (#4705)

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -20,6 +20,7 @@ use std::fs::OpenOptions;
 use std::future;
 use std::io;
 use std::io::Write;
+use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -33,6 +34,7 @@ use std::time::SystemTime;
 use anyhow::Context;
 use async_trait::async_trait;
 use base64::prelude::*;
+use futures::FutureExt;
 use futures::StreamExt;
 use futures::stream;
 use humantime::format_duration;
@@ -1998,6 +2000,32 @@ pub struct BootstrapProcConfig {
     pub bootstrap_command: Option<BootstrapCommand>,
 }
 
+struct LaunchCleanup {
+    launcher: Arc<dyn ProcLauncher>,
+    proc_id: Option<ProcAddr>,
+}
+
+impl LaunchCleanup {
+    fn disarm(mut self) {
+        self.proc_id = None;
+    }
+}
+
+impl Drop for LaunchCleanup {
+    fn drop(&mut self) {
+        let Some(proc_id) = self.proc_id.take() else {
+            return;
+        };
+        let launcher = Arc::clone(&self.launcher);
+
+        tokio::spawn(async move {
+            if let Err(error) = launcher.kill(&proc_id).await {
+                tracing::warn!(%proc_id, %error, "failed to clean up interrupted proc launch");
+            }
+        });
+    }
+}
+
 #[async_trait]
 impl ProcManager for BootstrapProcManager {
     type Handle = BootstrapProcHandle;
@@ -2092,21 +2120,34 @@ impl ProcManager for BootstrapProcManager {
         // Launch via the configured launcher backend.
         tracing::info!(proc_id = %proc_id, "launching proc with opts={opts:?}");
         let ref_proc_id: ProcAddr = proc_id.clone();
-        let launch_result = self
-            .launcher()
-            .launch(&ref_proc_id, opts.clone())
+        let launcher = Arc::clone(self.launcher());
+        let launch_result = match AssertUnwindSafe(launcher.launch(&ref_proc_id, opts.clone()))
+            .catch_unwind()
             .await
-            .map_err(|e| {
-                let io_err = match e {
+        {
+            Ok(Ok(launch_result)) => launch_result,
+            Ok(Err(error)) => {
+                let io_err = match error {
                     ProcLauncherError::Launch(io_err) => io_err,
                     other => std::io::Error::other(other.to_string()),
                 };
-                HostError::ProcessSpawnFailure(
+                return Err(HostError::ProcessSpawnFailure(
                     proc_id.clone(),
                     format!("{:?}", opts.command),
                     io_err,
-                )
-            })?;
+                ));
+            }
+            Err(panic) => {
+                if let Err(error) = launcher.kill(&ref_proc_id).await {
+                    tracing::warn!(proc_id = %ref_proc_id, %error, "failed to clean up panicked proc launch");
+                }
+                std::panic::resume_unwind(panic);
+            }
+        };
+        let cleanup = LaunchCleanup {
+            launcher,
+            proc_id: Some(proc_id.clone()),
+        };
 
         // Wire up StreamFwders if stdio was captured.
         let (out_fwder, err_fwder) = match launch_result.stdio {
@@ -2187,6 +2228,7 @@ impl ProcManager for BootstrapProcManager {
         });
 
         // Callers do `handle.read().await` for mesh readiness.
+        cleanup.disarm();
         Ok(handle)
     }
 }
@@ -2457,6 +2499,7 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use async_trait::async_trait;
+    use futures::FutureExt;
     use hyperactor::ActorEnvironment;
     use hyperactor::Location;
     use hyperactor::PortHandle;
@@ -2470,8 +2513,136 @@ mod tests {
     use hyperactor::mailbox::Undeliverable;
     use hyperactor::testing::ids::test_proc_id;
     use hyperactor::testing::ids::test_proc_id_with_addr;
+    use timed_test::async_timed_test;
 
     use super::*;
+
+    #[derive(Clone, Copy)]
+    enum CleanupLaunchBehavior {
+        Succeed,
+        Panic,
+    }
+
+    struct CleanupLauncher {
+        behavior: CleanupLaunchBehavior,
+        killed: tokio::sync::mpsc::UnboundedSender<ProcAddr>,
+    }
+
+    #[async_trait]
+    impl ProcLauncher for CleanupLauncher {
+        async fn launch(
+            &self,
+            _proc_id: &ProcAddr,
+            _opts: LaunchOptions,
+        ) -> Result<crate::proc_launcher::LaunchResult, ProcLauncherError> {
+            match self.behavior {
+                CleanupLaunchBehavior::Succeed => {
+                    let (_exit_tx, exit_rx) = tokio::sync::oneshot::channel();
+                    Ok(LaunchResult {
+                        pid: None,
+                        started_at: std::time::SystemTime::now(),
+                        stdio: StdioHandling::ManagedByLauncher,
+                        exit_rx,
+                    })
+                }
+                CleanupLaunchBehavior::Panic => panic!("test launcher panic"),
+            }
+        }
+
+        async fn terminate(
+            &self,
+            _proc_id: &ProcAddr,
+            _timeout: Duration,
+        ) -> Result<(), ProcLauncherError> {
+            unreachable!("cleanup guard test does not terminate a proc")
+        }
+
+        async fn kill(&self, proc_id: &ProcAddr) -> Result<(), ProcLauncherError> {
+            let _ = self.killed.send(proc_id.clone());
+            Ok(())
+        }
+    }
+
+    fn manager_with_cleanup_launcher(
+        behavior: CleanupLaunchBehavior,
+    ) -> (
+        BootstrapProcManager,
+        tokio::sync::mpsc::UnboundedReceiver<ProcAddr>,
+    ) {
+        let (killed, killed_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let manager = BootstrapProcManager::new(BootstrapCommand::default())
+            .expect("bootstrap proc manager should be created");
+
+        manager
+            .set_launcher(Arc::new(CleanupLauncher { behavior, killed }))
+            .expect("test launcher should be installed");
+
+        (manager, killed_rx)
+    }
+
+    fn cleanup_test_config() -> BootstrapProcConfig {
+        BootstrapProcConfig {
+            create_rank: 0,
+            client_config_override: Attrs::new(),
+            proc_bind: None,
+            bootstrap_command: None,
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn cancelled_bootstrap_spawn_kills_launched_proc_before_registration() {
+        let (manager, mut killed_rx) =
+            manager_with_cleanup_launcher(CleanupLaunchBehavior::Succeed);
+
+        let proc_id = test_proc_id("cancelled-bootstrap-spawn");
+        // Hold the registry lock at the ownership handoff. The spawn can launch
+        // the proc and arm LaunchCleanup, but it cannot register the handle.
+        // Cancelling here must kill the proc and leave no registry entry.
+        let _children_guard = manager.children.lock().await;
+        let mut spawn = Box::pin(manager.spawn(
+            proc_id.clone(),
+            ChannelAddr::any(ChannelTransport::Unix),
+            cleanup_test_config(),
+        ));
+
+        assert!(
+            futures::poll!(&mut spawn).is_pending(),
+            "spawn should wait to register the launched proc",
+        );
+        drop(spawn);
+
+        assert_eq!(
+            killed_rx
+                .recv()
+                .await
+                .expect("cancelled spawn should kill the launched proc"),
+            proc_id,
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn panicked_bootstrap_spawn_kills_proc_and_resumes_unwind() {
+        let (manager, mut killed_rx) = manager_with_cleanup_launcher(CleanupLaunchBehavior::Panic);
+        let proc_id = test_proc_id("panicked-bootstrap-spawn");
+
+        let result = AssertUnwindSafe(manager.spawn(
+            proc_id.clone(),
+            ChannelAddr::any(ChannelTransport::Unix),
+            cleanup_test_config(),
+        ))
+        .catch_unwind()
+        .await;
+
+        assert!(result.is_err(), "launcher panic should resume unwinding");
+        assert_eq!(
+            killed_rx
+                .recv()
+                .await
+                .expect("panicked spawn should kill the launched proc"),
+            proc_id,
+        );
+    }
 
     struct ShutdownFlushProbe {
         gateway: Gateway,

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -25,6 +25,7 @@ use std::sync::OnceLock;
 
 use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
+use futures::future::Either;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
@@ -296,16 +297,25 @@ mod completion_action {
             self.0 = State::Shutdown;
         }
     }
+
+    impl super::ProcCreationState {
+        pub(super) fn pending(
+            metadata: super::ProcMetadata,
+            expiry_time: Option<std::time::SystemTime>,
+        ) -> Self {
+            Self::Pending {
+                metadata,
+                on_completion: CompletionAction(State::Keep),
+                expiry_time,
+            }
+        }
+    }
 }
 
 pub(crate) use completion_action::CompletionAction;
 
 #[derive(Debug)]
 pub(crate) enum ProcCreationState {
-    #[expect(
-        dead_code,
-        reason = "pending proc creation is activated by a later change"
-    )]
     Pending {
         metadata: ProcMetadata,
         on_completion: CompletionAction,
@@ -1116,7 +1126,7 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         create_or_update: resource::CreateOrUpdate<ProcSpec>,
     ) -> anyhow::Result<()> {
         if self.created.contains_key(&create_or_update.id) {
-            // Already created: there is no update.
+            // Already requested or completed: there is no update.
             return Ok(());
         }
         if self.pending_shutdown.is_some() {
@@ -1137,7 +1147,7 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             return Ok(());
         }
 
-        let host = match self.host_mut() {
+        let host = match self.host() {
             Some(h) => h,
             None => {
                 tracing::warn!(
@@ -1147,42 +1157,58 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
                 return Ok(());
             }
         };
-        let created = match host {
-            HostAgentMode::Process { host, .. } => {
-                host.spawn(
-                    create_or_update.id.to_string(),
-                    BootstrapProcConfig {
-                        create_rank: create_or_update.rank.unwrap(),
-                        client_config_override: create_or_update
-                            .spec
-                            .client_config_override
-                            .clone(),
-                        proc_bind: create_or_update.spec.proc_bind.clone(),
-                        bootstrap_command: create_or_update.spec.bootstrap_command.clone(),
-                    },
-                )
-                .await
-            }
-            HostAgentMode::Local(host) => host.spawn(create_or_update.id.to_string(), ()).await,
+        let rank = create_or_update.rank.unwrap();
+        let id = create_or_update.id.clone();
+        let spawn = match host {
+            HostAgentMode::Process { host, .. } => Either::Left(host.spawn(
+                id.to_string(),
+                BootstrapProcConfig {
+                    create_rank: rank,
+                    client_config_override: create_or_update.spec.client_config_override.clone(),
+                    proc_bind: create_or_update.spec.proc_bind.clone(),
+                    bootstrap_command: create_or_update.spec.bootstrap_command.clone(),
+                },
+            )),
+            HostAgentMode::Local(host) => Either::Right(host.spawn(id.to_string(), ())),
         };
 
-        let rank = create_or_update.rank.unwrap();
-
-        if let Err(e) = &created {
-            tracing::error!("failed to spawn proc {}: {}", create_or_update.id, e);
-        }
         let was_empty = self.created.is_empty();
         self.created.insert(
-            create_or_update.id.clone(),
-            ProcCreationState::from_spawn_result(
+            id.clone(),
+            ProcCreationState::pending(
                 ProcMetadata {
                     rank,
                     host_mesh_id: create_or_update.spec.host_mesh_id.clone(),
                     proc_mesh_id: create_or_update.spec.proc_mesh_id.clone(),
                 },
                 None,
-                created,
             ),
+        );
+
+        let created = spawn.await;
+
+        if let Err(e) = &created {
+            tracing::error!("failed to spawn proc {}: {}", id, e);
+        }
+        let (metadata, expiry_time) = match self
+            .created
+            .remove(&id)
+            .expect("synchronous proc creation remains pending until spawn completes")
+        {
+            ProcCreationState::Pending {
+                metadata,
+                on_completion,
+                expiry_time,
+            } if on_completion.is_keep() => (metadata, expiry_time),
+            ProcCreationState::Pending { .. }
+            | ProcCreationState::Created { .. }
+            | ProcCreationState::Failed { .. } => {
+                unreachable!("HostAgent cannot process another request during synchronous spawn")
+            }
+        };
+        self.created.insert(
+            id.clone(),
+            ProcCreationState::from_spawn_result(metadata, expiry_time, created),
         );
 
         // Transition Detached → Attached on first proc creation.
@@ -1196,20 +1222,17 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
 
         // A WaitRankStatus stashed before this proc existed carries its own reply
         // rank (RSP-3); starting a status watch bridge for it needs the proc_id.
-        let proc_id = self
-            .created
-            .get(&create_or_update.id)
-            .and_then(|state| match state {
-                ProcCreationState::Created { proc_id, .. } => Some(proc_id.clone()),
-                ProcCreationState::Pending { .. } | ProcCreationState::Failed { .. } => None,
-            });
+        let proc_id = self.created.get(&id).and_then(|state| match state {
+            ProcCreationState::Created { proc_id, .. } => Some(proc_id.clone()),
+            ProcCreationState::Pending { .. } | ProcCreationState::Failed { .. } => None,
+        });
 
         // Bridge status changes to any pending waiters, then flush once now.
-        if self.pending_proc_waiters.contains_key(&create_or_update.id) {
+        if self.pending_proc_waiters.contains_key(&id) {
             if let Some(proc_id) = &proc_id {
-                self.start_watch_bridge(&create_or_update.id, proc_id).await;
+                self.start_watch_bridge(&id, proc_id).await;
             }
-            self.flush_proc_waiters(cx, &create_or_update.id).await;
+            self.flush_proc_waiters(cx, &id).await;
         }
 
         self.publish_introspect_properties(cx);


### PR DESCRIPTION
Summary:

We we create a `LaunchCleanup` that will kill the launched OS process when dropped unless disarmed.

We can only disarm after `BootstrapProcManager` has registered the handle so it is able to monitor the process

Reviewed By: shayne-fletcher

Differential Revision: D116711916


