### PR TITLE
Complete proc status waiters during teardown

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -20,6 +20,7 @@ use std::fs::OpenOptions;
 use std::future;
 use std::io;
 use std::io::Write;
+use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -33,6 +34,7 @@ use std::time::SystemTime;
 use anyhow::Context;
 use async_trait::async_trait;
 use base64::prelude::*;
+use futures::FutureExt;
 use futures::StreamExt;
 use futures::stream;
 use humantime::format_duration;
@@ -1995,6 +1997,32 @@ pub struct BootstrapProcConfig {
     pub bootstrap_command: Option<BootstrapCommand>,
 }
 
+struct LaunchCleanup {
+    launcher: Arc<dyn ProcLauncher>,
+    proc_id: Option<ProcAddr>,
+}
+
+impl LaunchCleanup {
+    fn disarm(mut self) {
+        self.proc_id = None;
+    }
+}
+
+impl Drop for LaunchCleanup {
+    fn drop(&mut self) {
+        let Some(proc_id) = self.proc_id.take() else {
+            return;
+        };
+        let launcher = Arc::clone(&self.launcher);
+
+        tokio::spawn(async move {
+            if let Err(error) = launcher.kill(&proc_id).await {
+                tracing::warn!(%proc_id, %error, "failed to clean up interrupted proc launch");
+            }
+        });
+    }
+}
+
 #[async_trait]
 impl ProcManager for BootstrapProcManager {
     type Handle = BootstrapProcHandle;
@@ -2089,21 +2117,34 @@ impl ProcManager for BootstrapProcManager {
         // Launch via the configured launcher backend.
         tracing::info!(proc_id = %proc_id, "launching proc with opts={opts:?}");
         let ref_proc_id: ProcAddr = proc_id.clone();
-        let launch_result = self
-            .launcher()
-            .launch(&ref_proc_id, opts.clone())
+        let launcher = Arc::clone(self.launcher());
+        let launch_result = match AssertUnwindSafe(launcher.launch(&ref_proc_id, opts.clone()))
+            .catch_unwind()
             .await
-            .map_err(|e| {
-                let io_err = match e {
+        {
+            Ok(Ok(launch_result)) => launch_result,
+            Ok(Err(error)) => {
+                let io_err = match error {
                     ProcLauncherError::Launch(io_err) => io_err,
                     other => std::io::Error::other(other.to_string()),
                 };
-                HostError::ProcessSpawnFailure(
+                return Err(HostError::ProcessSpawnFailure(
                     proc_id.clone(),
                     format!("{:?}", opts.command),
                     io_err,
-                )
-            })?;
+                ));
+            }
+            Err(panic) => {
+                if let Err(error) = launcher.kill(&ref_proc_id).await {
+                    tracing::warn!(proc_id = %ref_proc_id, %error, "failed to clean up panicked proc launch");
+                }
+                std::panic::resume_unwind(panic);
+            }
+        };
+        let cleanup = LaunchCleanup {
+            launcher,
+            proc_id: Some(proc_id.clone()),
+        };
 
         // Wire up StreamFwders if stdio was captured.
         let (out_fwder, err_fwder) = match launch_result.stdio {
@@ -2184,6 +2225,7 @@ impl ProcManager for BootstrapProcManager {
         });
 
         // Callers do `handle.read().await` for mesh readiness.
+        cleanup.disarm();
         Ok(handle)
     }
 }
@@ -2469,6 +2511,49 @@ mod tests {
     use hyperactor_config::Flattrs;
 
     use super::*;
+
+    struct CleanupLauncher {
+        killed: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl ProcLauncher for CleanupLauncher {
+        async fn launch(
+            &self,
+            _proc_id: &ProcAddr,
+            _opts: LaunchOptions,
+        ) -> Result<crate::proc_launcher::LaunchResult, ProcLauncherError> {
+            unreachable!("cleanup guard test does not launch a proc")
+        }
+
+        async fn terminate(
+            &self,
+            _proc_id: &ProcAddr,
+            _timeout: Duration,
+        ) -> Result<(), ProcLauncherError> {
+            unreachable!("cleanup guard test does not terminate a proc")
+        }
+
+        async fn kill(&self, _proc_id: &ProcAddr) -> Result<(), ProcLauncherError> {
+            self.killed.notify_one();
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn launch_cleanup_kills_an_uncommitted_proc() {
+        let killed = Arc::new(tokio::sync::Notify::new());
+        let launcher: Arc<dyn ProcLauncher> = Arc::new(CleanupLauncher {
+            killed: Arc::clone(&killed),
+        });
+
+        drop(LaunchCleanup {
+            launcher,
+            proc_id: Some(test_proc_id("cleanup")),
+        });
+
+        killed.notified().await;
+    }
 
     struct ShutdownFlushProbe {
         gateway: Gateway,

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -59,14 +59,18 @@
 //! `HostMeshAgent::handle(GetLocalProc)` first asks for it.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::fmt;
 use std::marker::PhantomData;
+use std::panic::AssertUnwindSafe;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::Future;
+use futures::FutureExt;
 use futures::StreamExt;
 use futures::stream;
 use hyperactor::Actor;
@@ -87,6 +91,7 @@ use hyperactor::channel::ServerError;
 use hyperactor::channel::Tx;
 use hyperactor::context;
 use hyperactor::gateway::GatewayServeHandle;
+use hyperactor::gateway::PeerAttachError;
 use hyperactor::gateway::PeerAttachGuard;
 use hyperactor::mailbox::IntoBoxedMailboxSender as _;
 use hyperactor::mailbox::MailboxClient;
@@ -124,6 +129,18 @@ pub enum HostError {
     /// The named proc already exists and cannot be spawned.
     #[error("proc '{0}' already exists")]
     ProcExists(String),
+
+    /// The host's proc-name registry cannot be used safely.
+    #[error("host proc-name registry is poisoned")]
+    ProcRegistryPoisoned,
+
+    /// Attaching a spawned proc to the host gateway failed.
+    #[error("failed to attach proc '{0}' to the host gateway: {1}")]
+    PeerAttachFailure(ProcAddr, #[source] PeerAttachError),
+
+    /// The detached task spawning a proc panicked.
+    #[error("proc '{0}' spawn panicked: {1}")]
+    SpawnPanicked(String, String),
 
     /// Failures occuring while spawning a subprocess.
     #[error("proc '{0}' (command: {1}) failed to spawn process: {2}")]
@@ -195,6 +212,46 @@ impl Drop for HostShutdownHandles {
     }
 }
 
+struct ProcHandleKillGuard<H: ProcHandle> {
+    handle: Option<H>,
+}
+
+impl<H: ProcHandle> ProcHandleKillGuard<H> {
+    fn handle(&self) -> &H {
+        self.handle
+            .as_ref()
+            .expect("active spawn cleanup owns the proc handle")
+    }
+
+    fn disarm(mut self) {
+        self.handle = None;
+    }
+
+    fn maybe_kill(&mut self) -> impl Future<Output = ()> + Send + 'static {
+        let handle = self.handle.take();
+
+        async move {
+            let Some(handle) = handle else {
+                return;
+            };
+            match handle.kill().await {
+                Ok(_) | Err(TerminateError::AlreadyTerminated(_)) => {}
+                Err(error) => {
+                    tracing::warn!(proc = %handle.proc_addr(), %error, "failed to clean up proc spawn");
+                }
+            }
+        }
+    }
+}
+
+impl<H: ProcHandle> Drop for ProcHandleKillGuard<H> {
+    fn drop(&mut self) {
+        if self.handle.is_some() {
+            tokio::spawn(self.maybe_kill());
+        }
+    }
+}
+
 /// Lifecycle manager for the procs on one machine.
 ///
 /// The host delegates all connectivity to its [`Gateway`]. It creates
@@ -205,7 +262,7 @@ pub struct Host<M> {
     /// [`PeerAttachGuard`] keeps the gateway peer route for the child
     /// alive; dropping it removes the entry (used by
     /// [`Host::terminate_children`] to free slots).
-    procs: HashMap<String, PeerAttachGuard>,
+    procs: Arc<StdMutex<HashMap<String, PeerAttachGuard>>>,
     frontend_addr: ChannelAddr,
     backend_addr: ChannelAddr,
     /// Connectivity for every proc owned by this host.
@@ -220,7 +277,7 @@ pub struct Host<M> {
     /// host was bootstrapped out-of-cluster. Kept alive for the host's
     /// lifetime so the cluster route and outbound forwarder persist.
     via_handle: Option<GatewayServeHandle>,
-    manager: M,
+    manager: Arc<M>,
     service_proc: Proc,
     local_proc: Proc,
 }
@@ -355,14 +412,14 @@ impl<M: ProcManager> Host<M> {
         );
 
         Ok(Host {
-            procs: HashMap::new(),
+            procs: Arc::new(StdMutex::new(HashMap::new())),
             frontend_addr,
             backend_addr,
             gateway,
             frontend_handle: Some(frontend_handle),
             backend_handle: Some(backend_handle),
             via_handle,
-            manager,
+            manager: Arc::new(manager),
             service_proc,
             local_proc,
         })
@@ -370,7 +427,7 @@ impl<M: ProcManager> Host<M> {
 
     /// The underlying proc manager.
     pub fn manager(&self) -> &M {
-        &self.manager
+        self.manager.as_ref()
     }
 
     /// The address which accepts messages destined for this host.
@@ -398,61 +455,108 @@ impl<M: ProcManager> Host<M> {
     /// [`ProcAddr`]. The proc id is derived from `name`; its location is
     /// advertised through this host's frontend gateway using a `Via(child_uid,
     /// host_location)` source route.
-    pub async fn spawn(
-        &mut self,
+    /// The caller must ensure that no other spawn with the same `name` is in
+    /// flight. This method only rejects names that are already registered with the host.
+    pub(crate) fn spawn(
+        &self,
         name: String,
         config: M::Config,
-    ) -> Result<(ProcAddr, ActorRef<ManagerAgent<M>>), HostError> {
-        if self.procs.contains_key(&name) {
-            return Err(HostError::ProcExists(name));
-        }
+    ) -> impl Future<Output = Result<(ProcAddr, ActorRef<ManagerAgent<M>>), HostError>> + Send + 'static
+    where
+        M: Send + Sync + 'static,
+        M::Config: Send + 'static,
+    {
+        let procs = Arc::clone(&self.procs);
+        let backend_addr = self.backend_addr.clone();
+        let gateway = self.gateway.clone();
+        let manager = Arc::clone(&self.manager);
 
-        // Advertise the child with a `Via(child_uid, host_location)`
-        // location so peers source-route through this host: the outer
-        // hop matches the peer entry installed below, and gets peeled
-        // to deliver to the child's gateway. The host location comes
-        // from the gateway's active routing state, so a later
-        // `serve`/`serve_via` controls newly spawned child refs.
-        let resource_id = ResourceId::from_name(&name);
-        let proc_uid = resource_id.uid().clone();
-        let host_location = self.gateway.default_location();
-        let location = host_location.with_via(proc_uid.clone());
-        let proc_id = resource_id.proc_addr(location);
-        let handle = self
-            .manager
-            .spawn(proc_id.clone(), self.backend_addr.clone(), config)
-            .await?;
+        async move {
+            if procs
+                .lock()
+                .map_err(|_| HostError::ProcRegistryPoisoned)?
+                .contains_key(&name)
+            {
+                return Err(HostError::ProcExists(name));
+            }
 
-        // Await readiness (config-driven; 0s disables timeout).
-        let to: Duration =
-            hyperactor_config::global::get(hyperactor::config::HOST_SPAWN_READY_TIMEOUT);
-        let ready = if to == Duration::from_secs(0) {
-            ReadyProc::ensure(&handle).await
-        } else {
-            match tokio::time::timeout(to, ReadyProc::ensure(&handle)).await {
-                Ok(result) => result,
-                Err(_elapsed) => Err(ReadyProcError::Timeout),
+            // Advertise the child with a `Via(child_uid, host_location)`
+            // location so peers source-route through this host: the outer
+            // hop matches the peer entry installed below, and gets peeled
+            // to deliver to the child's gateway. The host location comes
+            // from the gateway's active routing state, so a later
+            // `serve`/`serve_via` controls newly spawned child refs.
+            let resource_id = ResourceId::from_name(&name);
+            let proc_uid = resource_id.uid().clone();
+            let proc_id =
+                resource_id.proc_addr(gateway.default_location().with_via(proc_uid.clone()));
+            let handle = manager.spawn(proc_id.clone(), backend_addr, config).await?;
+            let mut proc_handle_guard = ProcHandleKillGuard {
+                handle: Some(handle),
+            };
+
+            let created = async {
+                let timeout: Duration =
+                    hyperactor_config::global::get(hyperactor::config::HOST_SPAWN_READY_TIMEOUT);
+
+                let ready = if timeout == Duration::from_secs(0) {
+                    ReadyProc::ensure(proc_handle_guard.handle()).await
+                } else {
+                    match tokio::time::timeout(
+                        timeout,
+                        ReadyProc::ensure(proc_handle_guard.handle()),
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(_elapsed) => Err(ReadyProcError::Timeout),
+                    }
+                }
+                .map_err(|e| {
+                    HostError::ProcessConfigurationFailure(
+                        proc_id.clone(),
+                        anyhow::anyhow!("{e:?}"),
+                    )
+                })?;
+
+                let child_sender = MailboxClient::dial(ready.addr().clone()).map_err(|e| {
+                    HostError::ProcessConfigurationFailure(
+                        proc_id.clone(),
+                        anyhow::anyhow!("failed to dial spawned proc at {}: {}", ready.addr(), e),
+                    )
+                })?;
+                let agent_ref = ready.agent_ref().clone();
+                drop(ready);
+
+                let guard = gateway
+                    .attach_peer(proc_uid.clone(), child_sender.into_boxed())
+                    .map_err(|error| HostError::PeerAttachFailure(proc_id.clone(), error))?;
+                match procs
+                    .lock()
+                    .map_err(|_| HostError::ProcRegistryPoisoned)?
+                    .entry(name.clone())
+                {
+                    Entry::Vacant(entry) => {
+                        entry.insert(guard);
+                    }
+                    Entry::Occupied(_) => return Err(HostError::ProcExists(name.clone())),
+                }
+
+                Ok((proc_id.clone(), agent_ref))
+            }
+            .await;
+
+            match created {
+                Ok(created) => {
+                    proc_handle_guard.disarm();
+                    Ok(created)
+                }
+                Err(error) => {
+                    proc_handle_guard.maybe_kill().await;
+                    Err(error)
+                }
             }
         }
-        .map_err(|e| {
-            HostError::ProcessConfigurationFailure(proc_id.clone(), anyhow::anyhow!("{e:?}"))
-        })?;
-
-        let child_sender = MailboxClient::dial(ready.addr().clone()).map_err(|e| {
-            HostError::ProcessConfigurationFailure(
-                proc_id.clone(),
-                anyhow::anyhow!("failed to dial spawned proc at {}: {}", ready.addr(), e),
-            )
-        })?;
-        // The proc id derives from `name`, and we rejected a duplicate
-        // `name` above, so this peer uid is unique.
-        let guard = self
-            .gateway
-            .attach_peer(proc_uid, child_sender.into_boxed())
-            .expect("spawned proc uid is unique: duplicate name rejected above");
-        self.procs.insert(name.clone(), guard);
-
-        Ok((proc_id, ready.agent_ref().clone()))
     }
 
     /// The host's [`Gateway`]. All incoming traffic addressed to this
@@ -462,6 +566,16 @@ impl<M: ProcManager> Host<M> {
     /// [`Gateway::attach_peer`].
     pub fn gateway(&self) -> &Gateway {
         &self.gateway
+    }
+
+    /// Remove a child proc's gateway registration and release its name.
+    pub(crate) fn remove_proc(&self, name: &str) {
+        let guard = self
+            .procs
+            .lock()
+            .expect("procs mutex poisoned")
+            .remove(name);
+        drop(guard);
     }
 
     /// Take ownership of the frontend server handle.
@@ -741,9 +855,12 @@ impl<M: ProcManager + BulkTerminate> Host<M> {
             .manager
             .terminate_all(cx, timeout, max_in_flight, reason)
             .await;
-        // Detach procs from the gateway by dropping their attach
-        // guards, freeing the name slots for any future respawns.
-        self.procs.clear();
+        {
+            let _guards = {
+                let mut entries = self.procs.lock().expect("procs mutex poisoned");
+                std::mem::take(&mut *entries)
+            };
+        }
         summary
     }
 }
@@ -1001,6 +1118,15 @@ impl<S> LocalProcManager<S> {
             procs: Arc::new(Mutex::new(HashMap::new())),
             stopping: Arc::new(Mutex::new(HashMap::new())),
             spawn,
+        }
+    }
+
+    async fn discard_proc(&self, proc_id: &ProcAddr, reason: &str) {
+        let proc = self.procs.lock().await.remove(proc_id);
+        if let Some(mut proc) = proc
+            && let Err(error) = proc.destroy_and_wait(Duration::ZERO, reason).await
+        {
+            tracing::warn!(%proc_id, %error, "failed to discard local proc");
         }
     }
 
@@ -1296,9 +1422,19 @@ where
             .await
             .insert(proc_id.clone(), proc.clone());
         let _handle = proc.clone().serve(rx);
-        let agent_handle = (self.spawn)(proc)
-            .await
-            .map_err(|e| HostError::AgentSpawnFailure(proc_id.clone(), e))?;
+        let agent_handle = match AssertUnwindSafe((self.spawn)(proc)).catch_unwind().await {
+            Ok(Ok(agent_handle)) => agent_handle,
+            Ok(Err(error)) => {
+                self.discard_proc(&proc_id, "proc agent failed to spawn")
+                    .await;
+                return Err(HostError::AgentSpawnFailure(proc_id, error));
+            }
+            Err(panic) => {
+                self.discard_proc(&proc_id, "proc agent spawn panicked")
+                    .await;
+                std::panic::resume_unwind(panic);
+            }
+        };
 
         Ok(LocalHandle {
             proc_id,
@@ -1314,11 +1450,10 @@ where
 ///
 /// This implementation launches a child via `Command` and relies on
 /// `kill_on_drop(true)` so that children are SIGKILLed if the manager
-/// (or host) drops. There is **no** proc control plane (no RPC to a
-/// proc agent for shutdown) and **no** exit monitor wired here.
-/// Consequently:
-/// - `terminate()` and `kill()` return `Unsupported`.
-/// - `wait()` is trivial (no lifecycle observation).
+/// (or host) drops. There is **no** graceful proc control plane or
+/// exit monitor wired here. `terminate()` and `kill()` therefore
+/// remove and force-kill the child directly, while `wait()` remains
+/// trivial and does not report real lifecycle state.
 ///
 /// It follows a simple protocol:
 ///
@@ -1336,6 +1471,40 @@ pub struct ProcessProcManager<A> {
     program: std::path::PathBuf,
     children: Arc<Mutex<HashMap<ProcAddr, Child>>>,
     _phantom: PhantomData<A>,
+}
+
+struct ProcessChildCleanup {
+    children: Arc<Mutex<HashMap<ProcAddr, Child>>>,
+    proc_id: Option<ProcAddr>,
+}
+
+impl ProcessChildCleanup {
+    fn disarm(mut self) {
+        self.proc_id = None;
+    }
+}
+
+impl Drop for ProcessChildCleanup {
+    fn drop(&mut self) {
+        let Some(proc_id) = self.proc_id.take() else {
+            return;
+        };
+        let children = Arc::clone(&self.children);
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            tracing::error!(%proc_id, "cannot clean up interrupted process spawn without a Tokio runtime");
+            return;
+        };
+        runtime.spawn(async move {
+            if let Some(mut child) = children.lock().await.remove(&proc_id) {
+                if let Err(error) = child.kill().await {
+                    tracing::warn!(%proc_id, %error, "failed to kill interrupted process spawn");
+                }
+                if let Err(error) = child.wait().await {
+                    tracing::warn!(%proc_id, %error, "failed to reap interrupted process spawn");
+                }
+            }
+        });
+    }
 }
 
 impl<A> ProcessProcManager<A> {
@@ -1370,13 +1539,9 @@ impl<A> Drop for ProcessProcManager<A> {
 ///
 /// Unlike [`LocalHandle`], this corresponds to a real OS process
 /// launched by the manager. In this **toy** implementation the handle
-/// does not own/monitor the `Child` and there is no shutdown control
-/// plane. It is a stable, clonable surface exposing the proc's
-/// identity, address, and agent reference so host code can interact
-/// uniformly with local/external procs. `terminate()`/`kill()` are
-/// intentionally `Unsupported` here; process cleanup relies on
-/// `cmd.kill_on_drop(true)` when launching the child (the OS will
-/// SIGKILL it if the handle is dropped).
+/// has no graceful shutdown control plane or exit monitor. It retains
+/// access to the manager's child registry so `terminate()` and `kill()`
+/// can remove, kill, and reap the process when a host spawn fails.
 ///
 /// The type bound `A: Actor + Referable` comes from the
 /// [`ProcHandle::Agent`] requirement: `Actor` because the agent
@@ -1388,6 +1553,7 @@ pub struct ProcessHandle<A: Actor + Referable> {
     proc_id: ProcAddr,
     addr: ChannelAddr,
     agent_ref: ActorRef<A>,
+    children: Arc<Mutex<HashMap<ProcAddr, Child>>>,
 }
 
 // Manual `Clone` to avoid requiring `A: Clone`.
@@ -1397,6 +1563,7 @@ impl<A: Actor + Referable> Clone for ProcessHandle<A> {
             proc_id: self.proc_id.clone(),
             addr: self.addr.clone(),
             agent_ref: self.agent_ref.clone(),
+            children: Arc::clone(&self.children),
         }
     }
 }
@@ -1438,11 +1605,22 @@ impl<A: Actor + Referable> ProcHandle for ProcessHandle<A> {
         _deadline: Duration,
         _reason: &str,
     ) -> Result<(), TerminateError<Self::TerminalStatus>> {
-        Err(TerminateError::Unsupported)
+        self.kill().await
     }
 
     async fn kill(&self) -> Result<(), TerminateError<Self::TerminalStatus>> {
-        Err(TerminateError::Unsupported)
+        let Some(mut child) = self.children.lock().await.remove(&self.proc_id) else {
+            return Err(TerminateError::AlreadyTerminated(()));
+        };
+        child
+            .kill()
+            .await
+            .map_err(|error| TerminateError::Io(error.into()))?;
+        child
+            .wait()
+            .await
+            .map_err(|error| TerminateError::Io(error.into()))?;
+        Ok(())
     }
 }
 
@@ -1496,6 +1674,10 @@ where
             let mut children = self.children.lock().await;
             children.insert(proc_id.clone(), child);
         }
+        let cleanup = ProcessChildCleanup {
+            children: Arc::clone(&self.children),
+            proc_id: Some(proc_id.clone()),
+        };
 
         // Wait for the child's callback with (addr, agent_ref)
         let (proc_addr, agent_ref) = callback_rx.recv().await?;
@@ -1508,11 +1690,14 @@ where
         //   immediate `Child::kill()`.
         // - wire an exit monitor so `wait()` resolves with a real
         //   terminal status.
-        Ok(ProcessHandle {
+        let handle = ProcessHandle {
             proc_id,
             addr: proc_addr,
             agent_ref,
-        })
+            children: Arc::clone(&self.children),
+        };
+        cleanup.disarm();
+        Ok(handle)
     }
 }
 
@@ -1649,7 +1834,7 @@ mod tests {
             Ok(proc.spawn_with_label::<()>("host_agent", ()))
         });
         let procs = Arc::clone(&proc_manager.procs);
-        let mut host = Host::new(proc_manager, ChannelAddr::any(ChannelTransport::Unix))
+        let host = Host::new(proc_manager, ChannelAddr::any(ChannelTransport::Unix))
             .await
             .unwrap();
 
@@ -1720,7 +1905,7 @@ mod tests {
         let process_manager = ProcessProcManager::<EchoActor>::new(
             buck_resources::get("monarch/hyperactor_mesh/host_bootstrap").unwrap(),
         );
-        let mut host = Host::new(process_manager, ChannelAddr::any(ChannelTransport::Unix))
+        let host = Host::new(process_manager, ChannelAddr::any(ChannelTransport::Unix))
             .await
             .unwrap();
 
@@ -1834,6 +2019,8 @@ mod tests {
         mode: ReadyMode,
         omit_addr: bool,
         omit_agent: bool,
+        kill_notify: Option<Arc<tokio::sync::Notify>>,
+        kill_release: Option<Arc<tokio::sync::Notify>>,
     }
 
     #[async_trait::async_trait]
@@ -1886,7 +2073,13 @@ mod tests {
             Err(TerminateError::Unsupported)
         }
         async fn kill(&self) -> Result<Self::TerminalStatus, TerminateError<Self::TerminalStatus>> {
-            Err(TerminateError::Unsupported)
+            if let Some(notify) = &self.kill_notify {
+                notify.notify_one();
+            }
+            if let Some(release) = &self.kill_release {
+                release.notified().await;
+            }
+            Ok(())
         }
     }
 
@@ -1896,6 +2089,8 @@ mod tests {
         omit_addr: bool,
         omit_agent: bool,
         transport: ChannelTransport,
+        kill_notify: Option<Arc<tokio::sync::Notify>>,
+        kill_release: Option<Arc<tokio::sync::Notify>>,
     }
 
     impl TestManager {
@@ -1905,11 +2100,21 @@ mod tests {
                 omit_addr: false,
                 omit_agent: false,
                 transport: ChannelTransport::Local,
+                kill_notify: None,
+                kill_release: None,
             }
         }
         fn with_omissions(mut self, addr: bool, agent: bool) -> Self {
             self.omit_addr = addr;
             self.omit_agent = agent;
+            self
+        }
+        fn with_kill_notify(mut self, notify: Arc<tokio::sync::Notify>) -> Self {
+            self.kill_notify = Some(notify);
+            self
+        }
+        fn with_kill_release(mut self, release: Arc<tokio::sync::Notify>) -> Self {
+            self.kill_release = Some(release);
             self
         }
     }
@@ -1936,8 +2141,79 @@ mod tests {
                 mode: self.mode,
                 omit_addr: self.omit_addr,
                 omit_agent: self.omit_agent,
+                kill_notify: self.kill_notify.clone(),
+                kill_release: self.kill_release.clone(),
             })
         }
+    }
+
+    #[tokio::test]
+    async fn host_spawn_cleans_up_handle_after_readiness_failure() {
+        let cleanup_started = Arc::new(tokio::sync::Notify::new());
+        let cleanup_release = Arc::new(tokio::sync::Notify::new());
+        let host = Host::new(
+            TestManager::local(ReadyMode::ErrTerminal)
+                .with_kill_notify(Arc::clone(&cleanup_started))
+                .with_kill_release(Arc::clone(&cleanup_release)),
+            ChannelAddr::any(ChannelTransport::Local),
+        )
+        .await
+        .expect("host should start");
+
+        let spawn = tokio::spawn(host.spawn("failed-proc".to_string(), ()));
+        cleanup_started.notified().await;
+        assert!(
+            !spawn.is_finished(),
+            "spawn returned before failed-proc cleanup completed",
+        );
+        cleanup_release.notify_one();
+
+        let error = spawn
+            .await
+            .expect("spawn task should complete")
+            .expect_err("readiness failure should fail the spawn");
+        assert!(matches!(
+            error,
+            HostError::ProcessConfigurationFailure(_, _)
+        ));
+        assert!(
+            !host
+                .procs
+                .lock()
+                .expect("procs mutex poisoned")
+                .contains_key("failed-proc"),
+            "failed spawn should not leave a peer registration",
+        );
+    }
+
+    #[tokio::test]
+    async fn local_manager_cleans_up_proc_when_agent_spawn_panics() {
+        async fn panicking_spawn(_proc: Proc) -> anyhow::Result<ActorHandle<()>> {
+            panic!("test agent spawn panic");
+        }
+
+        let manager = LocalProcManager::new(panicking_spawn);
+        let managed_procs = Arc::clone(&manager.procs);
+        let host = Host::new(manager, ChannelAddr::any(ChannelTransport::Local))
+            .await
+            .expect("host should start");
+
+        let result = AssertUnwindSafe(host.spawn("panicking-proc".to_string(), ()))
+            .catch_unwind()
+            .await;
+        assert!(result.is_err(), "agent spawn panic should be preserved");
+        assert!(
+            managed_procs.lock().await.is_empty(),
+            "panicking agent spawn should not leave a managed proc",
+        );
+        assert!(
+            !host
+                .procs
+                .lock()
+                .expect("procs mutex poisoned")
+                .contains_key("panicking-proc"),
+            "panicking agent spawn should release its name reservation",
+        );
     }
 
     #[tokio::test]
@@ -1948,7 +2224,7 @@ mod tests {
             Duration::from_millis(10),
         );
 
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::Pending),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -1967,7 +2243,7 @@ mod tests {
             Duration::from_secs(0),
         );
 
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::OkAfter(Duration::from_millis(20))),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -1976,12 +2252,17 @@ mod tests {
 
         let (pid, agent) = host.spawn("ok".into(), ()).await.expect("must succeed");
         assert_eq!(agent.actor_addr().proc_addr(), pid);
-        assert!(host.procs.contains_key("ok"));
+        assert!(
+            host.procs
+                .lock()
+                .expect("procs mutex poisoned")
+                .contains_key("ok")
+        );
     }
 
     #[tokio::test]
     async fn host_spawn_maps_channel_closed_ready_error_to_config_failure() {
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::ErrChannelClosed),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -1994,7 +2275,7 @@ mod tests {
 
     #[tokio::test]
     async fn host_spawn_maps_terminal_ready_error_to_config_failure() {
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::ErrTerminal),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -2007,7 +2288,7 @@ mod tests {
 
     #[tokio::test]
     async fn host_spawn_fails_if_ready_but_missing_addr() {
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::OkAfter(Duration::ZERO)).with_omissions(true, false),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -2023,7 +2304,7 @@ mod tests {
 
     #[tokio::test]
     async fn host_spawn_fails_if_ready_but_missing_agent() {
-        let mut host = Host::new(
+        let host = Host::new(
             TestManager::local(ReadyMode::OkAfter(Duration::ZERO)).with_omissions(false, true),
             ChannelAddr::any(ChannelTransport::Local),
         )
@@ -2278,7 +2559,7 @@ mod tests {
         let attached_location = Location::from(attached_host_addr).with_via(attached_uid);
         gateway.set_default_location(attached_location.clone());
 
-        let mut host = Host::new_with_gateway(
+        let host = Host::new_with_gateway(
             proc_manager,
             ChannelAddr::any(ChannelTransport::Unix),
             None,
@@ -2305,7 +2586,7 @@ mod tests {
             Ok(proc.spawn_with_label::<()>("host_agent", ()))
         });
 
-        let mut host = Host::new_with_gateway(
+        let host = Host::new_with_gateway(
             proc_manager,
             ChannelAddr::any(ChannelTransport::Unix),
             None,

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1341,18 +1341,14 @@ impl HostMeshRef {
             },
         );
 
-        // Build each proc's `ProcRef` up front: the caller derives the same
-        // id/rank (`host_agent::proc_name(&proc_mesh_id, create_rank)`) that
-        // each HostAgent will, so the refs are ready before the cast lands. A single
-        // `SpawnProcs` cast (below) then has each HostAgent spawn all of its
-        // per-host slots, replying with status overlays to drive the readiness
-        // barrier.
+        // Build each proc's `ProcRef` up front from the same slot derivation used
+        // by the HostAgent spawn and wait handlers.
         let mut proc_names = Vec::new();
         let client_config_override = hyperactor_config::global::propagatable_attrs();
         for (host_rank, agent) in self.host_agent_mesh.values().enumerate() {
-            for per_host_rank in 0..per_host.num_ranks() {
-                let create_rank = per_host.num_ranks() * host_rank + per_host_rank;
-                let proc_name = host_agent::proc_name(&proc_mesh_id, create_rank);
+            for (_, create_rank, proc_name) in
+                host_agent::proc_slots(&proc_mesh_id, host_rank, per_host.num_ranks())
+            {
                 proc_names.push(proc_name.clone());
                 let proc_id = named_proc_on_host(&agent, &proc_name);
                 let proc_agent =
@@ -1395,8 +1391,8 @@ impl HostMeshRef {
             None => None,
         };
 
-        // One cast: each HostAgent spawns all `num_per_host` of its proc slots,
-        // deriving each proc's id/rank from its stamped host rank.
+        // Start each host's proc slots, then subscribe to their readiness on the
+        // same ordered sender-destination streams.
         self.host_agent_mesh.cast(
             cx,
             host_agent::SpawnProcs {
@@ -1408,7 +1404,15 @@ impl HostMeshRef {
                 default_bootstrap_command: self.bootstrap_command.clone(),
                 proc_bind,
                 bootstrap_commands,
-                status_reply: Some(reply_port),
+            },
+        )?;
+        self.host_agent_mesh.cast(
+            cx,
+            host_agent::WaitProcs {
+                rank: resource::Rank::default(),
+                proc_mesh_id: proc_mesh_id.clone(),
+                num_per_host: per_host.num_ranks(),
+                status_reply: reply_port,
             },
         )?;
 

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -25,6 +25,7 @@ use std::sync::OnceLock;
 
 use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
+use futures::future::Either;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
@@ -257,7 +258,6 @@ pub(crate) enum CompletionAction {
 
 #[derive(Debug)]
 pub(crate) enum ProcCreationState {
-    #[expect(dead_code)]
     Pending {
         metadata: ProcMetadata,
         on_completion: CompletionAction,
@@ -1063,7 +1063,7 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         create_or_update: resource::CreateOrUpdate<ProcSpec>,
     ) -> anyhow::Result<()> {
         if self.created.contains_key(&create_or_update.id) {
-            // Already created: there is no update.
+            // Already requested or completed: there is no update.
             return Ok(());
         }
         if self.pending_shutdown.is_some() {
@@ -1085,7 +1085,7 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             return Ok(());
         }
 
-        let host = match self.host_mut() {
+        let host = match self.host() {
             Some(h) => h,
             None => {
                 tracing::warn!(
@@ -1095,42 +1095,59 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
                 return Ok(());
             }
         };
-        let created = match host {
-            HostAgentMode::Process { host, .. } => {
-                host.spawn(
-                    create_or_update.id.to_string(),
-                    BootstrapProcConfig {
-                        create_rank: create_or_update.rank.unwrap(),
-                        client_config_override: create_or_update
-                            .spec
-                            .client_config_override
-                            .clone(),
-                        proc_bind: create_or_update.spec.proc_bind.clone(),
-                        bootstrap_command: create_or_update.spec.bootstrap_command.clone(),
-                    },
-                )
-                .await
-            }
-            HostAgentMode::Local(host) => host.spawn(create_or_update.id.to_string(), ()).await,
+        let rank = create_or_update.rank.unwrap();
+        let id = create_or_update.id.clone();
+        let spawn = match host {
+            HostAgentMode::Process { host, .. } => Either::Left(host.spawn(
+                id.to_string(),
+                BootstrapProcConfig {
+                    create_rank: rank,
+                    client_config_override: create_or_update.spec.client_config_override.clone(),
+                    proc_bind: create_or_update.spec.proc_bind.clone(),
+                    bootstrap_command: create_or_update.spec.bootstrap_command.clone(),
+                },
+            )),
+            HostAgentMode::Local(host) => Either::Right(host.spawn(id.to_string(), ())),
         };
 
-        let rank = create_or_update.rank.unwrap();
-
-        if let Err(e) = &created {
-            tracing::error!("failed to spawn proc {}: {}", create_or_update.id, e);
-        }
         let was_empty = self.created.is_empty();
         self.created.insert(
-            create_or_update.id.clone(),
-            ProcCreationState::from_spawn_result(
-                ProcMetadata {
+            id.clone(),
+            ProcCreationState::Pending {
+                metadata: ProcMetadata {
                     rank,
                     host_mesh_id: create_or_update.spec.host_mesh_id.clone(),
                     proc_mesh_id: create_or_update.spec.proc_mesh_id.clone(),
                 },
-                None,
-                created,
-            ),
+                on_completion: CompletionAction::Keep,
+                expiry_time: None,
+            },
+        );
+
+        let created = spawn.await;
+
+        if let Err(e) = &created {
+            tracing::error!("failed to spawn proc {}: {}", id, e);
+        }
+        let (metadata, expiry_time) = match self
+            .created
+            .remove(&id)
+            .expect("synchronous proc creation remains pending until spawn completes")
+        {
+            ProcCreationState::Pending {
+                metadata,
+                on_completion: CompletionAction::Keep,
+                expiry_time,
+            } => (metadata, expiry_time),
+            ProcCreationState::Pending { .. }
+            | ProcCreationState::Created { .. }
+            | ProcCreationState::Failed { .. } => {
+                unreachable!("HostAgent cannot process another request during synchronous spawn")
+            }
+        };
+        self.created.insert(
+            id.clone(),
+            ProcCreationState::from_spawn_result(metadata, expiry_time, created),
         );
 
         // Transition Detached → Attached on first proc creation.
@@ -1144,20 +1161,17 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
 
         // A WaitRankStatus stashed before this proc existed carries its own reply
         // rank (RSP-3); starting a status watch bridge for it needs the proc_id.
-        let proc_id = self
-            .created
-            .get(&create_or_update.id)
-            .and_then(|state| match state {
-                ProcCreationState::Created { proc_id, .. } => Some(proc_id.clone()),
-                ProcCreationState::Pending { .. } | ProcCreationState::Failed { .. } => None,
-            });
+        let proc_id = self.created.get(&id).and_then(|state| match state {
+            ProcCreationState::Created { proc_id, .. } => Some(proc_id.clone()),
+            ProcCreationState::Pending { .. } | ProcCreationState::Failed { .. } => None,
+        });
 
         // Bridge status changes to any pending waiters, then flush once now.
-        if self.pending_proc_waiters.contains_key(&create_or_update.id) {
+        if self.pending_proc_waiters.contains_key(&id) {
             if let Some(proc_id) = &proc_id {
-                self.start_watch_bridge(&create_or_update.id, proc_id).await;
+                self.start_watch_bridge(&id, proc_id).await;
             }
-            self.flush_proc_waiters(cx, &create_or_update.id).await;
+            self.flush_proc_waiters(cx, &id).await;
         }
 
         self.publish_introspect_properties(cx);

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -247,10 +247,20 @@ pub(crate) struct ProcMetadata {
 }
 
 #[derive(Debug)]
+#[expect(dead_code)]
+pub(crate) enum CompletionAction {
+    Keep,
+    Stop { timeout: Duration, reason: String },
+    Drain,
+    Shutdown,
+}
+
+#[derive(Debug)]
 pub(crate) enum ProcCreationState {
     #[expect(dead_code)]
     Pending {
         metadata: ProcMetadata,
+        on_completion: CompletionAction,
         expiry_time: Option<std::time::SystemTime>,
     },
     Created {
@@ -1164,6 +1174,22 @@ impl Handler<resource::Stop> for HostAgent {
             reason = %message.reason,
             "stopping proc"
         );
+        let timeout = hyperactor_config::global::get(hyperactor::config::PROCESS_EXIT_TIMEOUT);
+
+        if let Some(ProcCreationState::Pending { on_completion, .. }) =
+            self.created.get_mut(&message.id)
+        {
+            if matches!(&*on_completion, CompletionAction::Keep) {
+                *on_completion = CompletionAction::Stop {
+                    timeout,
+                    reason: message.reason.clone(),
+                };
+            }
+            self.flush_proc_waiters(cx, &message.id).await;
+            self.publish_introspect_properties(cx);
+            return Ok(());
+        }
+
         let host = match self.host() {
             Some(h) => h,
             None => {
@@ -1175,7 +1201,6 @@ impl Handler<resource::Stop> for HostAgent {
                 return Ok(());
             }
         };
-        let timeout = hyperactor_config::global::get(hyperactor::config::PROCESS_EXIT_TIMEOUT);
 
         if let Some(ProcCreationState::Created { proc_id, .. }) = self.created.get(&message.id) {
             host.request_stop(cx, proc_id, timeout, &message.reason)
@@ -1195,9 +1220,12 @@ impl HostAgent {
     /// status. `rank == usize::MAX` means the proc is unknown to this host.
     async fn proc_rank_status(&self, id: &ResourceId) -> (usize, Status) {
         match self.created.get(id) {
-            Some(ProcCreationState::Pending { metadata, .. }) => {
-                (metadata.rank, Status::Initializing)
-            }
+            Some(ProcCreationState::Pending {
+                metadata,
+                on_completion: CompletionAction::Keep,
+                ..
+            }) => (metadata.rank, Status::Initializing),
+            Some(ProcCreationState::Pending { metadata, .. }) => (metadata.rank, Status::Stopping),
             Some(ProcCreationState::Created {
                 metadata, proc_id, ..
             }) => {
@@ -1315,7 +1343,11 @@ impl HostAgent {
         use crate::resource::Status;
 
         let status = match self.created.get(id) {
-            Some(ProcCreationState::Pending { .. }) => Status::Initializing,
+            Some(ProcCreationState::Pending {
+                on_completion: CompletionAction::Keep,
+                ..
+            }) => Status::Initializing,
+            Some(ProcCreationState::Pending { .. }) => Status::Stopping,
             Some(ProcCreationState::Created { proc_id, .. }) => match self.host() {
                 Some(host) => host.proc_status(proc_id).await.0,
                 None => Status::Stopped,
@@ -1505,7 +1537,7 @@ impl Handler<DrainHost> for HostAgent {
         let selective = matches!(&kind, PendingDrainKind::Selective(_));
         // CreateOrUpdate still waits for Host::spawn, so a drain cannot observe
         // an in-progress proc creation in this revision.
-        let remaining = 0;
+        let remaining = self.mark_requests_for_drain(msg.host_mesh_id.as_ref());
         let drain = PendingDrain {
             kind,
             remaining,
@@ -1587,6 +1619,23 @@ impl HostAgent {
         crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), resource::Status::Stopped)])
             .expect("valid single-run overlay")
     }
+
+    fn mark_requests_for_drain(&mut self, filter: Option<&HostMeshId>) -> usize {
+        let mut remaining = 0;
+        for state in self.created.values_mut() {
+            if filter.is_some_and(|filter| state.host_mesh_id() != Some(filter)) {
+                continue;
+            }
+
+            if let ProcCreationState::Pending { on_completion, .. } = state
+                && !matches!(on_completion, CompletionAction::Shutdown)
+            {
+                *on_completion = CompletionAction::Drain;
+                remaining += 1;
+            }
+        }
+        remaining
+    }
 }
 
 #[async_trait]
@@ -1641,18 +1690,20 @@ impl Handler<ShutdownHost> for HostAgent {
 
         // CreateOrUpdate still waits for Host::spawn, so shutdown cannot
         // observe an in-progress proc creation in this revision.
-        let remaining = 0;
-        let shutdown = PendingShutdown {
+        let remaining = self.mark_requests_for_shutdown();
+        self.pending_shutdown = Some(PendingShutdown {
             remaining,
             timeout: msg.timeout,
             max_in_flight: msg.max_in_flight,
             acknowledgements: vec![(rank, msg.ack)],
-        };
+        });
 
         if remaining == 0 {
+            let shutdown = self
+                .pending_shutdown
+                .take()
+                .expect("pending shutdown exists");
             self.finish_shutdown(cx, shutdown).await;
-        } else {
-            self.pending_shutdown = Some(shutdown);
         }
 
         Ok(())
@@ -1748,6 +1799,17 @@ impl HostAgent {
             }
         }
     }
+
+    fn mark_requests_for_shutdown(&mut self) -> usize {
+        let mut remaining = 0;
+        for state in self.created.values_mut() {
+            if let ProcCreationState::Pending { on_completion, .. } = state {
+                *on_completion = CompletionAction::Shutdown;
+                remaining += 1;
+            }
+        }
+        remaining
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Named, Serialize, Deserialize)]
@@ -1785,9 +1847,19 @@ impl HostAgent {
         state: &ProcCreationState,
     ) -> resource::State<ProcState> {
         match state {
-            ProcCreationState::Pending { .. } => resource::State {
+            ProcCreationState::Pending {
+                on_completion: CompletionAction::Keep,
+                ..
+            } => resource::State {
                 id: id.clone(),
                 status: resource::Status::Initializing,
+                state: None,
+                generation: 0,
+                timestamp: std::time::SystemTime::now(),
+            },
+            ProcCreationState::Pending { .. } => resource::State {
+                id: id.clone(),
+                status: resource::Status::Stopping,
                 state: None,
                 generation: 0,
                 timestamp: std::time::SystemTime::now(),

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -154,6 +154,36 @@ impl HostAgentMode {
         }
     }
 
+    async fn terminate_proc(
+        &self,
+        cx: &impl context::Actor,
+        id: &ResourceId,
+        proc: &ProcAddr,
+        timeout: Duration,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        let result = match self {
+            HostAgentMode::Process { host, .. } => {
+                host.terminate_proc(cx, proc, timeout, reason).await
+            }
+            HostAgentMode::Local(host) => host.terminate_proc(cx, proc, timeout, reason).await,
+        };
+
+        match result {
+            Ok(_) => {
+                match self {
+                    HostAgentMode::Process { host, .. } => host.remove_proc(&id.to_string()),
+                    HostAgentMode::Local(host) => host.remove_proc(&id.to_string()),
+                }
+                Ok(())
+            }
+            Err(error) => {
+                tracing::warn!(%id, %error, "failed to terminate proc");
+                Err(error)
+            }
+        }
+    }
+
     /// Query a proc's lifecycle state, returning both the coarse
     /// `resource::Status` used by the resource protocol and the
     /// detailed `bootstrap::ProcStatus` (when available) for callers
@@ -350,6 +380,10 @@ struct PendingDrain {
 }
 
 impl PendingDrain {
+    fn record_failure(&mut self, error: String) {
+        self.failures.push(error);
+    }
+
     fn overlay(&self) -> crate::StatusOverlay {
         let status = if self.failures.is_empty() {
             resource::Status::Stopped
@@ -628,7 +662,7 @@ impl HostAgent {
         cx: &Context<'_, Self>,
         timeout: std::time::Duration,
         filter: Option<&HostMeshId>,
-    ) {
+    ) -> Option<String> {
         let matching_ids: Vec<ResourceId> = self
             .created
             .iter()
@@ -642,38 +676,53 @@ impl HostAgent {
             .map(|(id, _)| id.clone())
             .collect();
 
-        if let Some(host_mode) = self.host() {
-            for id in &matching_ids {
-                if let Some(ProcCreationState::Created { proc_id, .. }) = self.created.get(id) {
-                    match host_mode {
-                        HostAgentMode::Process { host, .. } => {
-                            let _ = host
-                                .terminate_proc(cx, proc_id, timeout, "selective drain")
-                                .await;
-                        }
-                        HostAgentMode::Local(host) => {
-                            let _ = host
-                                .terminate_proc(cx, proc_id, timeout, "selective drain")
-                                .await;
-                        }
-                    }
+        let mut drained_ids = Vec::new();
+        let mut failures = Vec::new();
+
+        for id in &matching_ids {
+            let proc_id = match self.created.get(id) {
+                Some(ProcCreationState::Created { proc_id, .. }) => proc_id.clone(),
+                Some(ProcCreationState::Failed { .. }) => {
+                    drained_ids.push(id.clone());
+                    continue;
                 }
+                _ => continue,
+            };
+
+            let Some(host_mode) = self.host() else {
+                failures.push(format!("host unavailable while terminating {id}"));
+                continue;
+            };
+
+            match host_mode
+                .terminate_proc(cx, id, &proc_id, timeout, "selective drain")
+                .await
+            {
+                Ok(()) => drained_ids.push(id.clone()),
+                Err(error) => failures.push(format!("{id}: {error}")),
             }
         }
 
         // Remove drained entries and associated state so that
         // future spawns with the same proc names get fresh watch bridges.
-        for id in &matching_ids {
+        for id in &drained_ids {
             self.created.remove(id);
             self.watching.remove(id);
             self.pending_proc_waiters.remove(id);
         }
 
         tracing::info!(
-            count = matching_ids.len(),
+            count = drained_ids.len(),
+            failed = failures.len(),
             filter = ?filter,
             "selectively drained procs",
         );
+
+        if failures.is_empty() {
+            None
+        } else {
+            Some(failures.join("; "))
+        }
     }
 
     /// Publish the current host properties and child list for
@@ -1552,7 +1601,7 @@ impl Handler<DrainHost> for HostAgent {
         // CreateOrUpdate still waits for Host::spawn, so a drain cannot observe
         // an in-progress proc creation in this revision.
         let remaining = self.mark_requests_for_drain(msg.host_mesh_id.as_ref());
-        let drain = PendingDrain {
+        let mut drain = PendingDrain {
             kind,
             remaining,
             failures: Vec::new(),
@@ -1563,8 +1612,12 @@ impl Handler<DrainHost> for HostAgent {
         };
 
         if selective {
-            self.drain_by_mesh_name(cx, msg.timeout, msg.host_mesh_id.as_ref())
-                .await;
+            if let Some(error) = self
+                .drain_by_mesh_name(cx, msg.timeout, msg.host_mesh_id.as_ref())
+                .await
+            {
+                drain.record_failure(error);
+            }
             if remaining == 0 {
                 let overlay = drain.overlay();
                 drain.reply.post(cx, overlay);

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -247,13 +247,72 @@ pub(crate) struct ProcMetadata {
 }
 
 #[derive(Debug)]
-pub(crate) struct ProcCreationState {
-    metadata: ProcMetadata,
-    pub(crate) created: Result<(ProcAddr, ActorRef<ProcAgent>), HostError>,
-    /// "Owner is alive" deadline communicated by the controller via
-    /// `KeepaliveGetState`. The host's `SelfCheck` reaper compares against this
-    /// and tears down procs whose owner has stopped extending the keepalive.
-    pub(crate) expiry_time: Option<std::time::SystemTime>,
+pub(crate) enum ProcCreationState {
+    #[expect(dead_code)]
+    Pending {
+        metadata: ProcMetadata,
+        expiry_time: Option<std::time::SystemTime>,
+    },
+    Created {
+        metadata: ProcMetadata,
+        proc_id: ProcAddr,
+        mesh_agent: ActorRef<ProcAgent>,
+        /// "Owner is alive" deadline communicated by the controller via
+        /// `KeepaliveGetState`. The host's `SelfCheck` reaper compares against this
+        /// and tears down procs whose owner has stopped extending the keepalive.
+        expiry_time: Option<std::time::SystemTime>,
+    },
+    Failed {
+        metadata: ProcMetadata,
+        error: HostError,
+    },
+}
+
+impl ProcCreationState {
+    fn metadata(&self) -> &ProcMetadata {
+        match self {
+            Self::Pending { metadata, .. }
+            | Self::Created { metadata, .. }
+            | Self::Failed { metadata, .. } => metadata,
+        }
+    }
+
+    fn from_spawn_result(
+        metadata: ProcMetadata,
+        expiry_time: Option<std::time::SystemTime>,
+        result: Result<(ProcAddr, ActorRef<ProcAgent>), HostError>,
+    ) -> Self {
+        match result {
+            Ok((proc_id, mesh_agent)) => Self::Created {
+                metadata,
+                proc_id,
+                mesh_agent,
+                expiry_time,
+            },
+            Err(error) => Self::Failed { metadata, error },
+        }
+    }
+
+    fn set_expiry_time(&mut self, expires_after: std::time::SystemTime) {
+        match self {
+            Self::Pending { expiry_time, .. } | Self::Created { expiry_time, .. } => {
+                *expiry_time = Some(expires_after);
+            }
+            Self::Failed { .. } => {}
+        }
+    }
+
+    fn rank(&self) -> usize {
+        self.metadata().rank
+    }
+
+    fn host_mesh_id(&self) -> Option<&HostMeshId> {
+        self.metadata().host_mesh_id.as_ref()
+    }
+
+    fn proc_mesh_id(&self) -> Option<&ProcMeshId> {
+        self.metadata().proc_mesh_id.as_ref()
+    }
 }
 
 enum PendingDrainKind {
@@ -563,17 +622,19 @@ impl HostAgent {
         let matching_ids: Vec<ResourceId> = self
             .created
             .iter()
-            .filter(|(_, state)| state.metadata.host_mesh_id.as_ref() == filter)
+            .filter(|(_, state)| {
+                state.host_mesh_id() == filter
+                    && matches!(
+                        state,
+                        ProcCreationState::Created { .. } | ProcCreationState::Failed { .. }
+                    )
+            })
             .map(|(id, _)| id.clone())
             .collect();
 
         if let Some(host_mode) = self.host() {
             for id in &matching_ids {
-                if let Some(ProcCreationState {
-                    created: Ok((proc_id, _)),
-                    ..
-                }) = self.created.get(id)
-                {
+                if let Some(ProcCreationState::Created { proc_id, .. }) = self.created.get(id) {
                     match host_mode {
                         HostAgentMode::Process { host, .. } => {
                             let _ = host
@@ -630,7 +691,7 @@ impl HostAgent {
 
         // User procs.
         for state in self.created.values() {
-            if let Ok((proc_id, _agent_ref)) = &state.created {
+            if let ProcCreationState::Created { proc_id, .. } = state {
                 children.push(hyperactor::introspect::IntrospectRef::Proc(proc_id.clone()));
             }
         }
@@ -1051,15 +1112,15 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         let was_empty = self.created.is_empty();
         self.created.insert(
             create_or_update.id.clone(),
-            ProcCreationState {
-                metadata: ProcMetadata {
+            ProcCreationState::from_spawn_result(
+                ProcMetadata {
                     rank,
                     host_mesh_id: create_or_update.spec.host_mesh_id.clone(),
                     proc_mesh_id: create_or_update.spec.proc_mesh_id.clone(),
                 },
+                None,
                 created,
-                expiry_time: None,
-            },
+            ),
         );
 
         // Transition Detached → Attached on first proc creation.
@@ -1076,8 +1137,10 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         let proc_id = self
             .created
             .get(&create_or_update.id)
-            .and_then(|s| s.created.as_ref().ok())
-            .map(|(pid, _)| pid.clone());
+            .and_then(|state| match state {
+                ProcCreationState::Created { proc_id, .. } => Some(proc_id.clone()),
+                ProcCreationState::Pending { .. } | ProcCreationState::Failed { .. } => None,
+            });
 
         // Bridge status changes to any pending waiters, then flush once now.
         if self.pending_proc_waiters.contains_key(&create_or_update.id) {
@@ -1114,11 +1177,7 @@ impl Handler<resource::Stop> for HostAgent {
         };
         let timeout = hyperactor_config::global::get(hyperactor::config::PROCESS_EXIT_TIMEOUT);
 
-        if let Some(ProcCreationState {
-            created: Ok((proc_id, _)),
-            ..
-        }) = self.created.get(&message.id)
-        {
+        if let Some(ProcCreationState::Created { proc_id, .. }) = self.created.get(&message.id) {
             host.request_stop(cx, proc_id, timeout, &message.reason)
                 .await;
         }
@@ -1136,19 +1195,21 @@ impl HostAgent {
     /// status. `rank == usize::MAX` means the proc is unknown to this host.
     async fn proc_rank_status(&self, id: &ResourceId) -> (usize, Status) {
         match self.created.get(id) {
-            Some(state) => match &state.created {
-                Ok((proc_id, _mesh_agent)) => {
-                    let raw_status = match self.host() {
-                        Some(host) => host.proc_status(proc_id).await.0,
-                        None => resource::Status::Unknown,
-                    };
-                    (
-                        state.metadata.rank,
-                        raw_status.clamp_min(self.min_proc_status()),
-                    )
-                }
-                Err(e) => (state.metadata.rank, Status::Failed(e.to_string())),
-            },
+            Some(ProcCreationState::Pending { metadata, .. }) => {
+                (metadata.rank, Status::Initializing)
+            }
+            Some(ProcCreationState::Created {
+                metadata, proc_id, ..
+            }) => {
+                let raw_status = match self.host() {
+                    Some(host) => host.proc_status(proc_id).await.0,
+                    None => resource::Status::Unknown,
+                };
+                (metadata.rank, raw_status.clamp_min(self.min_proc_status()))
+            }
+            Some(ProcCreationState::Failed { metadata, error }) => {
+                (metadata.rank, Status::Failed(error.to_string()))
+            }
             None => (usize::MAX, Status::NotExist),
         }
     }
@@ -1193,10 +1254,7 @@ impl Handler<resource::WaitRankStatus> for HostAgent {
         // (RSP-3).
         let rank = msg.rank.unwrap();
         match self.created.get(&msg.id) {
-            Some(ProcCreationState {
-                created: Ok((proc_id, _)),
-                ..
-            }) => {
+            Some(ProcCreationState::Created { proc_id, .. }) => {
                 let status = match self.host() {
                     Some(host) => host.proc_status(proc_id).await.0,
                     None => Status::Stopped,
@@ -1219,21 +1277,18 @@ impl Handler<resource::WaitRankStatus> for HostAgent {
                 let proc_id = proc_id.clone();
                 self.start_watch_bridge(&msg.id, &proc_id).await;
             }
-            Some(ProcCreationState {
-                created: Err(e), ..
-            }) => {
+            Some(ProcCreationState::Failed { error, .. }) => {
                 // Creation failed — reply immediately with Failed status.
                 let overlay = StatusOverlay::try_from_runs(vec![(
                     rank..(rank + 1),
-                    Status::Failed(e.to_string()),
+                    Status::Failed(error.to_string()),
                 )])
                 .expect("valid single-run overlay");
                 let _ = msg.reply.post(cx, overlay);
             }
-            None => {
-                // Proc doesn't exist yet. Stash the waiter with the rank the
-                // request carries (RSP-3); `CreateOrUpdate` starts the watch
-                // bridge.
+            Some(ProcCreationState::Pending { .. }) | None => {
+                // Proc isn't ready yet. Stash the waiter with the rank the
+                // request carries (RSP-3); proc creation starts the watch bridge.
                 self.pending_proc_waiters
                     .entry(msg.id.clone())
                     .or_default()
@@ -1260,17 +1315,12 @@ impl HostAgent {
         use crate::resource::Status;
 
         let status = match self.created.get(id) {
-            Some(ProcCreationState {
-                created: Ok((proc_id, _)),
-                ..
-            }) => match self.host() {
+            Some(ProcCreationState::Pending { .. }) => Status::Initializing,
+            Some(ProcCreationState::Created { proc_id, .. }) => match self.host() {
                 Some(host) => host.proc_status(proc_id).await.0,
                 None => Status::Stopped,
             },
-            Some(ProcCreationState {
-                created: Err(error),
-                ..
-            }) => Status::Failed(error.to_string()),
+            Some(ProcCreationState::Failed { error, .. }) => Status::Failed(error.to_string()),
             None => {
                 // Proc not created yet, nothing to flush.
                 return;
@@ -1734,8 +1784,20 @@ impl HostAgent {
         id: &ResourceId,
         state: &ProcCreationState,
     ) -> resource::State<ProcState> {
-        match &state.created {
-            Ok((proc_id, mesh_agent)) => {
+        match state {
+            ProcCreationState::Pending { .. } => resource::State {
+                id: id.clone(),
+                status: resource::Status::Initializing,
+                state: None,
+                generation: 0,
+                timestamp: std::time::SystemTime::now(),
+            },
+            ProcCreationState::Created {
+                metadata,
+                proc_id,
+                mesh_agent,
+                ..
+            } => {
                 let (raw_status, proc_status, bootstrap_command) = match self.host() {
                     Some(host) => {
                         let (status, proc_status) = host.proc_status(proc_id).await;
@@ -1749,7 +1811,7 @@ impl HostAgent {
                     status,
                     state: Some(ProcState {
                         proc_id: proc_id.clone(),
-                        create_rank: state.metadata.rank,
+                        create_rank: metadata.rank,
                         mesh_agent: mesh_agent.clone(),
                         bootstrap_command,
                         proc_status,
@@ -1758,9 +1820,9 @@ impl HostAgent {
                     timestamp: std::time::SystemTime::now(),
                 }
             }
-            Err(e) => resource::State {
+            ProcCreationState::Failed { error, .. } => resource::State {
                 id: id.clone(),
-                status: resource::Status::Failed(e.to_string()),
+                status: resource::Status::Failed(error.to_string()),
                 state: None,
                 generation: 0,
                 timestamp: std::time::SystemTime::now(),
@@ -1824,8 +1886,8 @@ impl Handler<GetHostProcStates> for HostAgent {
         message: GetHostProcStates,
     ) -> anyhow::Result<()> {
         let selects = |state: &ProcCreationState| {
-            state.metadata.proc_mesh_id.as_ref() == Some(&message.proc_mesh_id)
-                && message.region.slice().contains(state.metadata.rank)
+            state.proc_mesh_id() == Some(&message.proc_mesh_id)
+                && message.region.slice().contains(state.rank())
         };
 
         // Bump keepalive (if requested) in a separate mutable pass, so the read
@@ -1833,7 +1895,7 @@ impl Handler<GetHostProcStates> for HostAgent {
         if let Some(expires_after) = message.keepalive {
             for state in self.created.values_mut() {
                 if selects(state) {
-                    state.expiry_time = Some(expires_after);
+                    state.set_expiry_time(expires_after);
                 }
             }
         }
@@ -1848,7 +1910,7 @@ impl Handler<GetHostProcStates> for HostAgent {
         let mut runs = Vec::new();
         for (id, state) in self.created.iter() {
             if selects(state) {
-                let base = message.region.slice().index(state.metadata.rank)?;
+                let base = message.region.slice().index(state.rank())?;
                 runs.push((base..(base + 1), self.proc_state_from(id, state).await));
             }
         }
@@ -1886,7 +1948,10 @@ impl Handler<crate::proc_agent::SelfCheck> for HostAgent {
             .created
             .iter()
             .filter_map(|(id, state)| {
-                let expiry = state.expiry_time?;
+                let ProcCreationState::Created { expiry_time, .. } = state else {
+                    return None;
+                };
+                let expiry = *expiry_time.as_ref()?;
                 if now > expiry { Some(id.clone()) } else { None }
             })
             .collect();
@@ -1899,18 +1964,16 @@ impl Handler<crate::proc_agent::SelfCheck> for HostAgent {
         }
 
         for id in expired {
-            if let Some(ProcCreationState {
-                created: Ok((proc_id, _)),
-                ..
-            }) = self.created.get(&id)
-            {
+            if let Some(ProcCreationState::Created { proc_id, .. }) = self.created.get(&id) {
                 let proc_id = proc_id.clone();
                 if let Some(host) = self.host() {
                     host.request_stop(cx, &proc_id, timeout, "orphaned").await;
                 }
                 // Don't reap repeatedly while teardown is in flight.
-                if let Some(state) = self.created.get_mut(&id) {
-                    state.expiry_time = None;
+                if let Some(ProcCreationState::Created { expiry_time, .. }) =
+                    self.created.get_mut(&id)
+                {
+                    *expiry_time = None;
                 }
             }
         }
@@ -1940,7 +2003,7 @@ impl Handler<resource::KeepaliveGetState<ProcState>> for HostAgent {
         // (e.g. its process dies abruptly), the proc will be reaped past
         // `expires_after`.
         if let Some(state) = self.created.get_mut(&message.get_state.id) {
-            state.expiry_time = Some(message.expires_after);
+            state.set_expiry_time(message.expires_after);
         }
         <Self as Handler<resource::GetState<ProcState>>>::handle(self, cx, message.get_state).await
     }
@@ -1962,52 +2025,19 @@ impl Handler<resource::StreamState<ProcState>> for HostAgent {
         for (id, proc) in self.created.iter() {
             // Skip procs that don't belong to the subscribing proc mesh.
             if proc
-                .metadata
-                .proc_mesh_id
-                .as_ref()
+                .proc_mesh_id()
                 .is_none_or(|mesh| mesh.resource_id() != &stream_state.id)
             {
                 continue;
             }
 
-            let state = match &proc.created {
-                Ok((proc_id, mesh_agent)) => {
-                    let (raw_status, proc_status, bootstrap_command) = match self.host() {
-                        Some(host) => {
-                            let (status, proc_status) = host.proc_status(proc_id).await;
-                            (status, proc_status, host.bootstrap_command())
-                        }
-                        None => (resource::Status::Unknown, None, None),
-                    };
-                    let status = raw_status.clamp_min(self.min_proc_status());
-                    resource::State {
-                        id: id.clone(),
-                        status,
-                        state: Some(ProcState {
-                            proc_id: proc_id.clone(),
-                            create_rank: proc.metadata.rank,
-                            mesh_agent: mesh_agent.clone(),
-                            bootstrap_command,
-                            proc_status,
-                        }),
-                        generation: 0,
-                        timestamp: std::time::SystemTime::now(),
-                    }
-                }
-                Err(e) => resource::State {
-                    id: id.clone(),
-                    status: resource::Status::Failed(e.to_string()),
-                    state: None,
-                    generation: 0,
-                    timestamp: std::time::SystemTime::now(),
-                },
-            };
+            let state = self.proc_state_from(id, proc).await;
 
             stream_state.subscriber.post_with_headers(
                 cx,
                 headers.clone(),
                 resource::RankedState {
-                    rank: resource::Rank::new(proc.metadata.rank),
+                    rank: resource::Rank::new(proc.rank()),
                     state,
                 },
             );

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -635,6 +635,23 @@ impl HostAgent {
         timeout: std::time::Duration,
         max_in_flight: usize,
     ) {
+        let terminal_statuses =
+            self.created
+                .iter()
+                .map(|(id, state)| {
+                    (
+                        id.clone(),
+                        match state {
+                            ProcCreationState::Failed { error, .. } => {
+                                Status::Failed(error.to_string())
+                            }
+                            ProcCreationState::Pending { .. }
+                            | ProcCreationState::Created { .. } => Status::Stopped,
+                        },
+                    )
+                })
+                .collect::<Vec<_>>();
+
         if let Some(host_mode) = self.host_mut() {
             match host_mode {
                 HostAgentMode::Process { host, .. } => {
@@ -650,6 +667,9 @@ impl HostAgent {
                     tracing::info!(?summary, "terminated children on local host");
                 }
             }
+        }
+        for (id, status) in terminal_statuses {
+            self.flush_proc_waiters_with_status(cx, &id, status);
         }
         self.created.clear();
     }
@@ -1349,7 +1369,8 @@ impl Handler<resource::WaitRankStatus> for HostAgent {
                 let status = match self.host() {
                     Some(host) => host.proc_status(proc_id).await.0,
                     None => Status::Stopped,
-                };
+                }
+                .clamp_min(self.min_proc_status());
 
                 // If already at or past the requested threshold, reply immediately.
                 if status >= msg.min_status {
@@ -1377,6 +1398,22 @@ impl Handler<resource::WaitRankStatus> for HostAgent {
                 .expect("valid single-run overlay");
                 let _ = msg.reply.post(cx, overlay);
             }
+            Some(ProcCreationState::Pending { on_completion, .. })
+                if !matches!(on_completion, CompletionAction::Keep) =>
+            {
+                if Status::Stopping >= msg.min_status {
+                    let _ = msg.reply.post(
+                        cx,
+                        StatusOverlay::try_from_runs(vec![(rank..(rank + 1), Status::Stopping)])
+                            .expect("valid single-run overlay"),
+                    );
+                } else {
+                    self.pending_proc_waiters
+                        .entry(msg.id.clone())
+                        .or_default()
+                        .push((msg.min_status, rank, msg.reply));
+                }
+            }
             Some(ProcCreationState::Pending { .. }) | None => {
                 // Proc isn't ready yet. Stash the waiter with the rank the
                 // request carries (RSP-3); proc creation starts the watch bridge.
@@ -1402,26 +1439,33 @@ impl Handler<ProcStatusChanged> for HostAgent {
 impl HostAgent {
     /// Flush pending `WaitRankStatus` waiters whose threshold is now satisfied.
     async fn flush_proc_waiters(&mut self, cx: &Context<'_, Self>, id: &ResourceId) {
-        use crate::StatusOverlay;
-        use crate::resource::Status;
-
         let status = match self.created.get(id) {
-            Some(ProcCreationState::Pending {
-                on_completion: CompletionAction::Keep,
-                ..
-            }) => Status::Initializing,
-            Some(ProcCreationState::Pending { .. }) => Status::Stopping,
             Some(ProcCreationState::Created { proc_id, .. }) => match self.host() {
                 Some(host) => host.proc_status(proc_id).await.0,
                 None => Status::Stopped,
             },
             Some(ProcCreationState::Failed { error, .. }) => Status::Failed(error.to_string()),
-            None => {
+            Some(ProcCreationState::Pending { on_completion, .. })
+                if !matches!(on_completion, CompletionAction::Keep) =>
+            {
+                Status::Stopping
+            }
+            Some(ProcCreationState::Pending { .. }) | None => {
                 // Proc not created yet, nothing to flush.
                 return;
             }
-        };
+        }
+        .clamp_min(self.min_proc_status());
 
+        self.flush_proc_waiters_with_status(cx, id, status);
+    }
+
+    fn flush_proc_waiters_with_status(
+        &mut self,
+        cx: &Context<'_, Self>,
+        id: &ResourceId,
+        status: Status,
+    ) {
         let Some(waiters) = self.pending_proc_waiters.get_mut(id) else {
             return;
         };

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -251,6 +251,42 @@ pub(crate) struct ProcCreationState {
     pub(crate) expiry_time: Option<std::time::SystemTime>,
 }
 
+enum PendingDrainKind {
+    Full,
+    Selective(HostMeshId),
+}
+
+impl PendingDrainKind {
+    fn blocks_create(&self, host_mesh_id: Option<&HostMeshId>) -> bool {
+        match self {
+            Self::Full => true,
+            Self::Selective(draining_host_mesh_id) => host_mesh_id == Some(draining_host_mesh_id),
+        }
+    }
+}
+
+struct PendingDrain {
+    kind: PendingDrainKind,
+    remaining: usize,
+    failures: Vec<String>,
+    timeout: Duration,
+    max_in_flight: usize,
+    rank: usize,
+    reply: PortRef<crate::StatusOverlay>,
+}
+
+impl PendingDrain {
+    fn overlay(&self) -> crate::StatusOverlay {
+        let status = if self.failures.is_empty() {
+            resource::Status::Stopped
+        } else {
+            resource::Status::Failed(self.failures.join("; "))
+        };
+        crate::StatusOverlay::try_from_runs(vec![(self.rank..(self.rank + 1), status)])
+            .expect("valid single-run overlay")
+    }
+}
+
 /// Actor name used when spawning the host mesh agent on the system proc.
 pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "host_agent";
 
@@ -377,6 +413,7 @@ impl fmt::Debug for DrainWorker {
 pub struct HostAgent {
     state: HostAgentState,
     pub(crate) created: HashMap<ResourceId, ProcCreationState>,
+    pending_drain: Option<PendingDrain>,
     /// Pending `WaitRankStatus` waiters, keyed by resource name.
     /// Each entry is `(min_status, rank, reply_port)`. Only touched
     /// from `&mut self` handlers.
@@ -410,6 +447,7 @@ impl HostAgent {
         Self {
             state: HostAgentState::Detached(host),
             created: HashMap::new(),
+            pending_drain: None,
             pending_proc_waiters: HashMap::new(),
             watching: HashSet::new(),
             proc_status_port: None,
@@ -940,6 +978,17 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             // Already created: there is no update.
             return Ok(());
         }
+        if self.pending_drain.as_ref().is_some_and(|drain| {
+            drain
+                .kind
+                .blocks_create(create_or_update.spec.host_mesh_id.as_ref())
+        }) {
+            tracing::warn!(
+                id = %create_or_update.id,
+                "ignoring CreateOrUpdate: HostAgent is draining"
+            );
+            return Ok(());
+        }
 
         let host = match self.host_mut() {
             Some(h) => h,
@@ -1357,60 +1406,104 @@ wirevalue::register_type!(DrainHost);
 impl Handler<DrainHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainHost) -> anyhow::Result<()> {
         let rank = msg.rank.unwrap();
-        // This host's drain completion, as a single-rank `Stopped` overlay at
-        // its ordinal. The caller reduces these into a StatusMesh barrier.
-        let drained_overlay = || {
-            crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), resource::Status::Stopped)])
-                .expect("valid single-run overlay")
-        };
-
-        if msg.host_mesh_id.is_some() {
-            // Selective drain: stop only procs belonging to the named mesh.
-            self.drain_by_mesh_name(cx, msg.timeout, msg.host_mesh_id.as_ref())
-                .await;
-            msg.reply.post(cx, drained_overlay());
+        if self.pending_drain.is_some() {
+            let overlay = crate::StatusOverlay::try_from_runs(vec![(
+                rank..(rank + 1),
+                resource::Status::Failed("another drain is already pending".to_string()),
+            )])
+            .expect("valid single-run overlay");
+            msg.reply.post(cx, overlay);
             return Ok(());
         }
 
-        // Full drain: terminate all children.
+        let kind = match &msg.host_mesh_id {
+            Some(host_mesh_id) => PendingDrainKind::Selective(host_mesh_id.clone()),
+            None => PendingDrainKind::Full,
+        };
+        let selective = matches!(&kind, PendingDrainKind::Selective(_));
+        // CreateOrUpdate still waits for Host::spawn, so a drain cannot observe
+        // an in-progress proc creation in this revision.
+        let remaining = 0;
+        let drain = PendingDrain {
+            kind,
+            remaining,
+            failures: Vec::new(),
+            timeout: msg.timeout,
+            max_in_flight: msg.max_in_flight,
+            rank,
+            reply: msg.reply,
+        };
+
+        if selective {
+            self.drain_by_mesh_name(cx, msg.timeout, msg.host_mesh_id.as_ref())
+                .await;
+            if remaining == 0 {
+                let overlay = drain.overlay();
+                drain.reply.post(cx, overlay);
+            } else {
+                self.pending_drain = Some(drain);
+            }
+            return Ok(());
+        }
+
+        if remaining == 0 {
+            self.start_full_drain(cx, drain);
+        } else {
+            self.pending_drain = Some(drain);
+        }
+
+        Ok(())
+    }
+}
+
+impl HostAgent {
+    fn start_full_drain(&mut self, cx: &Context<'_, Self>, drain: PendingDrain) {
+        let PendingDrain {
+            kind: PendingDrainKind::Full,
+            remaining: 0,
+            failures: _,
+            timeout,
+            max_in_flight,
+            rank,
+            reply,
+        } = drain
+        else {
+            unreachable!("full drain requires no remaining proc creations");
+        };
+
         let host = match std::mem::replace(&mut self.state, HostAgentState::Draining) {
-            HostAgentState::Attached(h) => h,
+            HostAgentState::Attached(host) => host,
             other @ (HostAgentState::Detached(_) | HostAgentState::Draining) => {
-                // Nothing to drain — report immediately.
                 self.state = other;
-                msg.reply.post(cx, drained_overlay());
-                return Ok(());
+                reply.post(cx, Self::drained_overlay(rank));
+                return;
             }
             HostAgentState::Shutdown => {
                 self.state = HostAgentState::Shutdown;
-                msg.reply.post(cx, drained_overlay());
-                return Ok(());
+                reply.post(cx, Self::drained_overlay(rank));
+                return;
             }
         };
 
-        // Do NOT clear `self.created` here: the DrainWorker
-        // terminates procs asynchronously, and concurrent GetState /
-        // GetRankStatus queries must still find the entries. With the
-        // host in Draining state (`self.host()` returns None), those
-        // handlers already report Status::Stopped for every known
-        // proc, which is the correct answer while draining is
-        // in progress.
-
+        // Do not clear `self.created` here. The DrainWorker terminates procs
+        // asynchronously, and status queries must still find their entries.
         let done_port = cx.port::<DrainComplete>();
-
         cx.spawn_with_label(
             "drain_worker",
             DrainWorker {
                 host: Some(host),
-                timeout: msg.timeout,
-                max_in_flight: msg.max_in_flight,
+                timeout,
+                max_in_flight,
                 rank,
-                reply: Some(msg.reply),
+                reply: Some(reply),
                 done_notify: done_port,
             },
         );
+    }
 
-        Ok(())
+    fn drained_overlay(rank: usize) -> crate::StatusOverlay {
+        crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), resource::Status::Stopped)])
+            .expect("valid single-run overlay")
     }
 }
 

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -233,9 +233,9 @@ pub(crate) fn proc_slots(
 }
 
 #[derive(Debug)]
-pub(crate) struct ProcCreationState {
-    pub(crate) rank: usize,
-    pub(crate) host_mesh_id: Option<HostMeshId>,
+pub(crate) struct ProcMetadata {
+    rank: usize,
+    host_mesh_id: Option<HostMeshId>,
     /// The proc mesh this proc belongs to. Used to scope per-mesh queries like
     /// `StreamState`, since a host agent can hold procs from multiple meshes.
     /// Always set for procs spawned through a proc mesh (the cast `SpawnProcs`
@@ -243,7 +243,12 @@ pub(crate) struct ProcCreationState {
     /// path (e.g. the point-to-point `CreateOrUpdate` used by tests/admin),
     /// which belong to no queryable mesh and are intentionally excluded from
     /// per-mesh queries.
-    pub(crate) proc_mesh_id: Option<ProcMeshId>,
+    proc_mesh_id: Option<ProcMeshId>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ProcCreationState {
+    metadata: ProcMetadata,
     pub(crate) created: Result<(ProcAddr, ActorRef<ProcAgent>), HostError>,
     /// "Owner is alive" deadline communicated by the controller via
     /// `KeepaliveGetState`. The host's `SelfCheck` reaper compares against this
@@ -558,7 +563,7 @@ impl HostAgent {
         let matching_ids: Vec<ResourceId> = self
             .created
             .iter()
-            .filter(|(_, state)| state.host_mesh_id.as_ref() == filter)
+            .filter(|(_, state)| state.metadata.host_mesh_id.as_ref() == filter)
             .map(|(id, _)| id.clone())
             .collect();
 
@@ -1047,9 +1052,11 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         self.created.insert(
             create_or_update.id.clone(),
             ProcCreationState {
-                rank,
-                host_mesh_id: create_or_update.spec.host_mesh_id.clone(),
-                proc_mesh_id: create_or_update.spec.proc_mesh_id.clone(),
+                metadata: ProcMetadata {
+                    rank,
+                    host_mesh_id: create_or_update.spec.host_mesh_id.clone(),
+                    proc_mesh_id: create_or_update.spec.proc_mesh_id.clone(),
+                },
                 created,
                 expiry_time: None,
             },
@@ -1129,22 +1136,19 @@ impl HostAgent {
     /// status. `rank == usize::MAX` means the proc is unknown to this host.
     async fn proc_rank_status(&self, id: &ResourceId) -> (usize, Status) {
         match self.created.get(id) {
-            Some(ProcCreationState {
-                rank,
-                created: Ok((proc_id, _mesh_agent)),
-                ..
-            }) => {
-                let raw_status = match self.host() {
-                    Some(host) => host.proc_status(proc_id).await.0,
-                    None => resource::Status::Unknown,
-                };
-                (*rank, raw_status.clamp_min(self.min_proc_status()))
-            }
-            Some(ProcCreationState {
-                rank,
-                created: Err(e),
-                ..
-            }) => (*rank, Status::Failed(e.to_string())),
+            Some(state) => match &state.created {
+                Ok((proc_id, _mesh_agent)) => {
+                    let raw_status = match self.host() {
+                        Some(host) => host.proc_status(proc_id).await.0,
+                        None => resource::Status::Unknown,
+                    };
+                    (
+                        state.metadata.rank,
+                        raw_status.clamp_min(self.min_proc_status()),
+                    )
+                }
+                Err(e) => (state.metadata.rank, Status::Failed(e.to_string())),
+            },
             None => (usize::MAX, Status::NotExist),
         }
     }
@@ -1730,12 +1734,8 @@ impl HostAgent {
         id: &ResourceId,
         state: &ProcCreationState,
     ) -> resource::State<ProcState> {
-        match state {
-            ProcCreationState {
-                rank,
-                created: Ok((proc_id, mesh_agent)),
-                ..
-            } => {
+        match &state.created {
+            Ok((proc_id, mesh_agent)) => {
                 let (raw_status, proc_status, bootstrap_command) = match self.host() {
                     Some(host) => {
                         let (status, proc_status) = host.proc_status(proc_id).await;
@@ -1749,7 +1749,7 @@ impl HostAgent {
                     status,
                     state: Some(ProcState {
                         proc_id: proc_id.clone(),
-                        create_rank: *rank,
+                        create_rank: state.metadata.rank,
                         mesh_agent: mesh_agent.clone(),
                         bootstrap_command,
                         proc_status,
@@ -1758,9 +1758,7 @@ impl HostAgent {
                     timestamp: std::time::SystemTime::now(),
                 }
             }
-            ProcCreationState {
-                created: Err(e), ..
-            } => resource::State {
+            Err(e) => resource::State {
                 id: id.clone(),
                 status: resource::Status::Failed(e.to_string()),
                 state: None,
@@ -1826,8 +1824,8 @@ impl Handler<GetHostProcStates> for HostAgent {
         message: GetHostProcStates,
     ) -> anyhow::Result<()> {
         let selects = |state: &ProcCreationState| {
-            state.proc_mesh_id.as_ref() == Some(&message.proc_mesh_id)
-                && message.region.slice().contains(state.rank)
+            state.metadata.proc_mesh_id.as_ref() == Some(&message.proc_mesh_id)
+                && message.region.slice().contains(state.metadata.rank)
         };
 
         // Bump keepalive (if requested) in a separate mutable pass, so the read
@@ -1850,7 +1848,7 @@ impl Handler<GetHostProcStates> for HostAgent {
         let mut runs = Vec::new();
         for (id, state) in self.created.iter() {
             if selects(state) {
-                let base = message.region.slice().index(state.rank)?;
+                let base = message.region.slice().index(state.metadata.rank)?;
                 runs.push((base..(base + 1), self.proc_state_from(id, state).await));
             }
         }
@@ -1964,6 +1962,7 @@ impl Handler<resource::StreamState<ProcState>> for HostAgent {
         for (id, proc) in self.created.iter() {
             // Skip procs that don't belong to the subscribing proc mesh.
             if proc
+                .metadata
                 .proc_mesh_id
                 .as_ref()
                 .is_none_or(|mesh| mesh.resource_id() != &stream_state.id)
@@ -1986,7 +1985,7 @@ impl Handler<resource::StreamState<ProcState>> for HostAgent {
                         status,
                         state: Some(ProcState {
                             proc_id: proc_id.clone(),
-                            create_rank: proc.rank,
+                            create_rank: proc.metadata.rank,
                             mesh_agent: mesh_agent.clone(),
                             bootstrap_command,
                             proc_status,
@@ -2008,7 +2007,7 @@ impl Handler<resource::StreamState<ProcState>> for HostAgent {
                 cx,
                 headers.clone(),
                 resource::RankedState {
-                    rank: resource::Rank::new(proc.rank),
+                    rank: resource::Rank::new(proc.metadata.rank),
                     state,
                 },
             );

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -221,6 +221,17 @@ pub(crate) fn proc_name(proc_mesh_id: &ProcMeshId, rank: usize) -> ResourceId {
     }
 }
 
+pub(crate) fn proc_slots(
+    proc_mesh_id: &ProcMeshId,
+    host_rank: usize,
+    num_per_host: usize,
+) -> impl Iterator<Item = (usize, usize, ResourceId)> + '_ {
+    (0..num_per_host).map(move |per_host_rank| {
+        let rank = num_per_host * host_rank + per_host_rank;
+        (per_host_rank, rank, proc_name(proc_mesh_id, rank))
+    })
+}
+
 #[derive(Debug)]
 pub(crate) struct ProcCreationState {
     pub(crate) rank: usize,
@@ -344,6 +355,7 @@ impl fmt::Debug for DrainWorker {
     handlers=[
         resource::CreateOrUpdate<ProcSpec>,
         SpawnProcs,
+        WaitProcs,
         resource::Stop,
         resource::GetState<ProcState>,
         resource::KeepaliveGetState<ProcState>,
@@ -788,11 +800,6 @@ pub struct SpawnProcs {
     /// Optional per-rank bootstrap overrides, indexed by absolute proc rank
     /// (`num_per_host * host_rank + per_host_rank`).
     pub bootstrap_commands: Option<Vec<Option<BootstrapCommand>>>,
-    /// Spawn ack: the host posts one multi-rank overlay covering all of its
-    /// procs; the caller reduces these per-host overlays into a `StatusMesh`
-    /// barrier.
-    #[serde(default)]
-    pub status_reply: Option<PortRef<crate::StatusOverlay>>,
 }
 wirevalue::register_type!(SpawnProcs);
 
@@ -807,13 +814,9 @@ impl Handler<SpawnProcs> for HostAgent {
 
         tracing::Span::current().record("host_rank", host_rank);
 
-        let mut spawn_result = Ok(());
-
-        for per_host_rank in 0..spawn.num_per_host {
-            let rank = spawn.num_per_host * host_rank + per_host_rank;
-
-            let id = proc_name(&spawn.proc_mesh_id, rank);
-
+        for (per_host_rank, rank, id) in
+            proc_slots(&spawn.proc_mesh_id, host_rank, spawn.num_per_host)
+        {
             let bootstrap_command = spawn
                 .bootstrap_commands
                 .as_ref()
@@ -825,7 +828,7 @@ impl Handler<SpawnProcs> for HostAgent {
                 .as_ref()
                 .and_then(|binds| binds.get(per_host_rank).cloned());
 
-            if let Err(e) = <Self as Handler<resource::CreateOrUpdate<ProcSpec>>>::handle(
+            if let Err(error) = <Self as Handler<resource::CreateOrUpdate<ProcSpec>>>::handle(
                 self,
                 cx,
                 resource::CreateOrUpdate {
@@ -842,43 +845,83 @@ impl Handler<SpawnProcs> for HostAgent {
             )
             .await
             {
-                // Stop spawning, but fall through to report the result below.
-                spawn_result = Err(e);
+                tracing::error!(%error, "failed to request proc creation");
                 break;
             }
         }
 
-        // Report this host's full rank range in a single multi-rank overlay. The
-        // caller's readiness barrier only completes once *every* rank has moved
-        // off NotExist, so on the error path the ranks we never created are
-        // reported as Failed too — otherwise the caller would wait out its whole
-        // idle timeout instead of failing fast on the error we return below.
-        if let Some(reply) = &spawn.status_reply {
-            let mut runs = Vec::with_capacity(spawn.num_per_host);
+        Ok(())
+    }
+}
 
-            for per_host_rank in 0..spawn.num_per_host {
-                let rank = spawn.num_per_host * host_rank + per_host_rank;
+/// Cast after [`SpawnProcs`] to report when each derived proc reaches
+/// [`Status::Running`]. Hyperactor delivers the two casts in order for each
+/// sender-destination stream, so an absent proc means its create was rejected.
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    Debug,
+    Named,
+    Handler,
+    RefClient,
+    HandleClient
+)]
+pub struct WaitProcs {
+    /// This host's ordinal within the cast region, stamped by the cast layer.
+    pub rank: resource::Rank,
+    /// Proc mesh id used to derive the same proc ids as [`SpawnProcs`].
+    pub proc_mesh_id: ProcMeshId,
+    /// Number of procs spawned on this host.
+    pub num_per_host: usize,
+    /// Sparse readiness updates for the caller's status barrier.
+    pub status_reply: PortRef<crate::StatusOverlay>,
+}
+wirevalue::register_type!(WaitProcs);
 
-                let id = proc_name(&spawn.proc_mesh_id, rank);
+#[async_trait]
+impl Handler<WaitProcs> for HostAgent {
+    async fn handle(&mut self, cx: &Context<Self>, wait: WaitProcs) -> anyhow::Result<()> {
+        let host_rank = wait
+            .rank
+            .0
+            .expect("cast layer stamps the rank before delivery");
+        let mut failed = Vec::new();
 
-                let status = match self.proc_rank_status(&id).await {
-                    (resolved, status) if resolved != usize::MAX => status,
-                    // Unknown to this host: not yet attempted, or its creation
-                    // errored before being recorded. Mark Failed on the error
-                    // path; on success every rank is created so this is moot.
-                    _ => match &spawn_result {
-                        Err(e) => Status::Failed(e.to_string()),
-                        Ok(()) => continue,
+        for (_, rank, id) in proc_slots(&wait.proc_mesh_id, host_rank, wait.num_per_host) {
+            if self.created.contains_key(&id) {
+                if let Err(error) = <Self as Handler<resource::WaitRankStatus>>::handle(
+                    self,
+                    cx,
+                    resource::WaitRankStatus {
+                        id,
+                        rank: resource::Rank::new(rank),
+                        min_status: Status::Running,
+                        reply: wait.status_reply.clone(),
                     },
-                };
-
-                runs.push((rank..(rank + 1), status));
+                )
+                .await
+                {
+                    failed.push((
+                        rank..(rank + 1),
+                        Status::Failed(format!("failed to wait for proc status: {error}")),
+                    ));
+                }
+            } else {
+                failed.push((
+                    rank..(rank + 1),
+                    Status::Failed("proc creation was not accepted".to_string()),
+                ));
             }
-
-            reply.post(cx, crate::StatusOverlay::try_from_runs(runs)?);
         }
 
-        spawn_result
+        if !failed.is_empty() {
+            let overlay = crate::StatusOverlay::try_from_runs(failed)
+                .expect("proc slots produce ordered non-overlapping ranks");
+            wait.status_reply.post(cx, overlay);
+        }
+
+        Ok(())
     }
 }
 
@@ -1929,6 +1972,7 @@ mod tests {
     use hyperactor::channel::ChannelTransport;
     use hyperactor::id::Label;
     use hyperactor::id::Uid;
+    use timed_test::async_timed_test;
 
     use super::*;
     use crate::bootstrap::ProcStatus;
@@ -2697,7 +2741,7 @@ mod tests {
     /// A single `SpawnProcs` message at host rank 0 fans out into
     /// `num_per_host` procs, each created under the id derived from
     /// `proc_name(&proc_mesh_id, rank)`. All of them should come up Running.
-    #[tokio::test]
+    #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_procs_many_per_host() {
         let host = Host::new(
             BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
@@ -2722,9 +2766,10 @@ mod tests {
 
         let proc_mesh_id = ProcMeshId::singleton(Label::new("spawn-many").unwrap());
         let num_per_host = 4;
+        let (spawn_status_reply, mut spawn_status_rx) = client.open_port::<crate::StatusOverlay>();
 
-        // Send a single point-to-point SpawnProcs (not a cast) to the host
-        // agent at host rank 0.
+        // Send the command and wait messages in the same order used by
+        // HostMesh::spawn.
         let agent_ref: ActorRef<HostAgent> = host_agent.bind();
         agent_ref.post(
             &client,
@@ -2737,40 +2782,30 @@ mod tests {
                 default_bootstrap_command: None,
                 proc_bind: None,
                 bootstrap_commands: None,
-                status_reply: None,
+            },
+        );
+        agent_ref.post(
+            &client,
+            WaitProcs {
+                rank: resource::Rank::new(0),
+                proc_mesh_id: proc_mesh_id.clone(),
+                num_per_host,
+                status_reply: spawn_status_reply.bind(),
             },
         );
 
-        // Each of the num_per_host procs should reach Running. Query each at a
-        // message rank distinct from its creation rank to prove positioning
-        // follows the message.
-        for rank in 0..num_per_host {
-            let id = proc_name(&proc_mesh_id, rank);
-            let message_rank = rank + 100;
-            let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
-            host_agent
-                .wait_rank_status(
-                    &client,
-                    id.clone(),
-                    resource::Rank::new(message_rank),
-                    resource::Status::Running,
-                    port.bind(),
-                )
+        let mut reported = vec![false; num_per_host];
+        for _ in 0..num_per_host {
+            let overlay = spawn_status_rx
+                .recv()
                 .await
-                .unwrap();
-            let overlay = tokio::time::timeout(Duration::from_secs(30), rx.recv())
-                .await
-                .unwrap_or_else(|_| panic!("proc {rank} did not reach Running"))
-                .expect("reply channel closed");
-            assert_overlay_at_rank(&overlay, message_rank);
-
-            assert_matches!(
-                host_agent.get_state(&client, id).await.unwrap(),
-                resource::State {
-                    status: resource::Status::Running,
-                    ..
-                }
-            );
+                .expect("WaitProcs status reply channel closed");
+            assert_eq!(overlay.len(), 1, "expected one proc status per reply");
+            let (range, status) = overlay.runs().next().expect("status overlay has a run");
+            assert_eq!(range.end, range.start + 1);
+            assert_eq!(status, &resource::Status::Running);
+            reported[range.start] = true;
         }
+        assert!(reported.into_iter().all(|reported| reported));
     }
 }

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -287,6 +287,13 @@ impl PendingDrain {
     }
 }
 
+struct PendingShutdown {
+    remaining: usize,
+    timeout: Duration,
+    max_in_flight: usize,
+    acknowledgements: Vec<(usize, PortRef<usize>)>,
+}
+
 /// Actor name used when spawning the host mesh agent on the system proc.
 pub const HOST_MESH_AGENT_ACTOR_NAME: &str = "host_agent";
 
@@ -414,6 +421,7 @@ pub struct HostAgent {
     state: HostAgentState,
     pub(crate) created: HashMap<ResourceId, ProcCreationState>,
     pending_drain: Option<PendingDrain>,
+    pending_shutdown: Option<PendingShutdown>,
     /// Pending `WaitRankStatus` waiters, keyed by resource name.
     /// Each entry is `(min_status, rank, reply_port)`. Only touched
     /// from `&mut self` handlers.
@@ -448,6 +456,7 @@ impl HostAgent {
             state: HostAgentState::Detached(host),
             created: HashMap::new(),
             pending_drain: None,
+            pending_shutdown: None,
             pending_proc_waiters: HashMap::new(),
             watching: HashSet::new(),
             proc_status_port: None,
@@ -483,6 +492,9 @@ impl HostAgent {
     /// Minimum status floor derived from the host agent's lifecycle.
     /// Procs on this host cannot be healthier than this.
     fn min_proc_status(&self) -> resource::Status {
+        if self.pending_shutdown.is_some() {
+            return resource::Status::Stopping;
+        }
         match &self.state {
             HostAgentState::Detached(_) | HostAgentState::Attached(_) => resource::Status::Running,
             HostAgentState::Draining => resource::Status::Stopping,
@@ -978,6 +990,13 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             // Already created: there is no update.
             return Ok(());
         }
+        if self.pending_shutdown.is_some() {
+            tracing::warn!(
+                id = %create_or_update.id,
+                "ignoring CreateOrUpdate: HostAgent is shutting down"
+            );
+            return Ok(());
+        }
         if self.pending_drain.as_ref().is_some_and(|drain| {
             drain
                 .kind
@@ -1406,6 +1425,15 @@ wirevalue::register_type!(DrainHost);
 impl Handler<DrainHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainHost) -> anyhow::Result<()> {
         let rank = msg.rank.unwrap();
+        if self.pending_shutdown.is_some() {
+            let overlay = crate::StatusOverlay::try_from_runs(vec![(
+                rank..(rank + 1),
+                resource::Status::Failed("host shutdown is pending".to_string()),
+            )])
+            .expect("valid single-run overlay");
+            msg.reply.post(cx, overlay);
+            return Ok(());
+        }
         if self.pending_drain.is_some() {
             let overlay = crate::StatusOverlay::try_from_runs(vec![(
                 rank..(rank + 1),
@@ -1518,6 +1546,18 @@ impl Handler<DrainComplete> for HostAgent {
         )])
         .expect("valid single-run overlay");
         msg.reply.post(cx, overlay);
+
+        if self
+            .pending_shutdown
+            .as_ref()
+            .is_some_and(|shutdown| shutdown.remaining == 0)
+        {
+            let shutdown = self
+                .pending_shutdown
+                .take()
+                .expect("pending shutdown exists");
+            self.finish_shutdown(cx, shutdown).await;
+        }
         Ok(())
     }
 }
@@ -1526,6 +1566,62 @@ impl Handler<DrainComplete> for HostAgent {
 impl Handler<ShutdownHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: ShutdownHost) -> anyhow::Result<()> {
         let rank = msg.rank.unwrap();
+        if matches!(&self.state, HostAgentState::Shutdown) {
+            msg.ack.post(cx, rank);
+            return Ok(());
+        }
+
+        if let Some(shutdown) = self.pending_shutdown.as_mut() {
+            shutdown.acknowledgements.push((rank, msg.ack));
+            return Ok(());
+        }
+
+        if let Some(drain) = self.pending_drain.take() {
+            let overlay = crate::StatusOverlay::try_from_runs(vec![(
+                drain.rank..(drain.rank + 1),
+                resource::Status::Failed("host shutdown superseded drain".to_string()),
+            )])
+            .expect("valid single-run overlay");
+            drain.reply.post(cx, overlay);
+        }
+
+        // CreateOrUpdate still waits for Host::spawn, so shutdown cannot
+        // observe an in-progress proc creation in this revision.
+        let remaining = 0;
+        let shutdown = PendingShutdown {
+            remaining,
+            timeout: msg.timeout,
+            max_in_flight: msg.max_in_flight,
+            acknowledgements: vec![(rank, msg.ack)],
+        };
+
+        if remaining == 0 {
+            self.finish_shutdown(cx, shutdown).await;
+        } else {
+            self.pending_shutdown = Some(shutdown);
+        }
+
+        Ok(())
+    }
+}
+
+impl HostAgent {
+    async fn finish_shutdown(&mut self, cx: &Context<'_, Self>, shutdown: PendingShutdown) {
+        if matches!(&self.state, HostAgentState::Draining) {
+            self.pending_shutdown = Some(shutdown);
+            return;
+        }
+
+        let PendingShutdown {
+            remaining: 0,
+            timeout,
+            max_in_flight,
+            acknowledgements,
+        } = shutdown
+        else {
+            unreachable!("shutdown cannot finish while proc creation is pending");
+        };
+
         // Terminate children BEFORE acking, so the caller's networking
         // stays alive while children flush their forwarders during
         // teardown. If we ack first, the caller proceeds to tear down
@@ -1533,7 +1629,7 @@ impl Handler<ShutdownHost> for HostAgent {
         // causing their forwarder flushes to hang until
         // MESSAGE_DELIVERY_TIMEOUT expires.
         if !self.created.is_empty() {
-            self.drain(cx, msg.timeout, msg.max_in_flight).await;
+            self.drain(cx, timeout, max_in_flight).await;
         }
 
         // Drop the host and signal the bootstrap loop to drain the
@@ -1548,10 +1644,12 @@ impl Handler<ShutdownHost> for HostAgent {
                 shutdown_tx: Some(tx),
             }) => {
                 // Keep the host's outbound gateway alive until the direct
-                // shutdown acknowledgment has been flushed. The bootstrap
+                // shutdown acknowledgments have been flushed. The bootstrap
                 // task may stop the frontend as soon as it receives the
                 // handle below.
-                msg.ack.post(cx, rank);
+                for (rank, ack) in acknowledgements {
+                    ack.post(cx, rank);
+                }
                 let flush_timeout =
                     hyperactor_config::global::get(hyperactor::config::FORWARDER_FLUSH_TIMEOUT);
                 match tokio::time::timeout(flush_timeout, host.gateway().flush()).await {
@@ -1581,18 +1679,20 @@ impl Handler<ShutdownHost> for HostAgent {
                 // after that proc has stopped.
                 tokio::spawn(async move {
                     for mut proc in procs {
-                        let _ = proc
-                            .destroy_and_wait(msg.timeout, "local host shutdown")
-                            .await;
+                        let _ = proc.destroy_and_wait(timeout, "local host shutdown").await;
                     }
                     host.shutdown_servers().await;
-                    msg.ack.post(&shutdown_client, rank);
+                    for (rank, ack) in acknowledgements {
+                        ack.post(&shutdown_client, rank);
+                    }
                 });
             }
-            _ => msg.ack.post(cx, rank),
+            _ => {
+                for (rank, ack) in acknowledgements {
+                    ack.post(cx, rank);
+                }
+            }
         }
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Summary: When we drain, before clearing `HostAgent` state, we make sure to respond the terminal states of all `Proc`s to all callers who have requested its status

Differential Revision: D116711917


