### PR TITLE
preserve actor identity when returning Ports (#4711)

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -172,14 +172,22 @@ impl PythonResponseMessage {
     /// Decode this response's payload, reuniting its out-of-band `refs` table
     /// so mesh references reconstruct. Mirrors [`PythonMessage::decode`] for the
     /// accumulated (valuemesh / `.call()`) path.
-    pub(crate) fn decode(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+    /// `instance` is the receiving actor, required so a `Port` in the payload
+    /// reconstructs against it rather than falling back to `context()` on a
+    /// Tokio worker. Mandatory rather than optional: this is only ever called
+    /// from an eager collector, all of which hold the caller instance.
+    pub(crate) fn decode(
+        &self,
+        py: Python<'_>,
+        instance: &Instance<PythonActor>,
+    ) -> PyResult<Py<PyAny>> {
         let (part, refs) = match self {
             PythonResponseMessage::Result { part, refs }
             | PythonResponseMessage::Exception { part, refs } => (part, refs),
         };
         let mesh_references = refs.iter().cloned().map(Some).collect();
         let mut state = PicklingState::from_parts(part.clone(), VecDeque::new(), mesh_references);
-        state.unpickle(py)
+        state.unpickle_with_receiver(py, instance)
     }
 }
 

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -322,7 +322,9 @@ async fn collect_value(
                             refs.into_iter().map(Some).collect();
                         let mut state =
                             PicklingState::from_parts(message, VecDeque::new(), mesh_references);
-                        Err(PyErr::from_value(state.unpickle(py)?.into_bound(py)))
+                        Err(PyErr::from_value(
+                            state.unpickle_with_receiver(py, instance)?.into_bound(py),
+                        ))
                     })
                 }
                 other => Err(pyo3::exceptions::PyValueError::new_err(format!(
@@ -428,7 +430,9 @@ async fn collect_valuemesh(
                             }
                             PythonResponseMessage::Exception { .. } => {
                                 record_guard.mark_error();
-                                return Err(PyErr::from_value(payload.decode(py)?.into_bound(py)));
+                                return Err(PyErr::from_value(
+                                    payload.decode(py, instance)?.into_bound(py),
+                                ));
                             }
                         }
                     }
@@ -442,12 +446,14 @@ async fn collect_valuemesh(
                 for (range, payload) in overlay.runs() {
                     match payload {
                         PythonResponseMessage::Result { .. } => {
-                            let obj = payload.decode(py)?;
+                            let obj = payload.decode(py, instance)?;
                             objects.extend(range.clone().map(|_| obj.clone_ref(py)));
                         }
                         PythonResponseMessage::Exception { .. } => {
                             record_guard.mark_error();
-                            return Err(PyErr::from_value(payload.decode(py)?.into_bound(py)));
+                            return Err(PyErr::from_value(
+                                payload.decode(py, instance)?.into_bound(py),
+                            ));
                         }
                     }
                 }
@@ -499,7 +505,7 @@ fn value_collector(
                     refs.into_iter().map(Some).collect();
                 let mut state =
                     PicklingState::from_parts(message, VecDeque::new(), mesh_references);
-                state.unpickle(py)
+                state.unpickle_with_receiver(py, &instance)
             }),
             Err(e) => {
                 record_guard.mark_error();
@@ -568,7 +574,7 @@ impl PyValueStream {
                         refs.into_iter().map(Some).collect();
                     let mut state =
                         PicklingState::from_parts(message, VecDeque::new(), mesh_references);
-                    state.unpickle(py)
+                    state.unpickle_with_receiver(py, &instance)
                 }),
                 Err(e) => {
                     record_guard.mark_error();

--- a/monarch_hyperactor/src/pickle.rs
+++ b/monarch_hyperactor/src/pickle.rs
@@ -51,6 +51,7 @@ use std::collections::VecDeque;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
+use hyperactor::Instance;
 use monarch_types::py_global;
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
@@ -60,9 +61,11 @@ use serde_multipart::Part;
 
 use crate::actor::MeshRef;
 use crate::actor::PyMeshRef;
+use crate::actor::PythonActor;
 use crate::actor::PythonMessage;
 use crate::actor::PythonMessageKind;
 use crate::buffers::Buffer;
+use crate::context::PyInstance;
 use crate::pytokio::PyPythonTask;
 use crate::pytokio::PyShared;
 use crate::runtime::GilSite;
@@ -149,6 +152,71 @@ impl Drop for ActivePicklingGuard {
             *cell.borrow_mut() = self.previous.take();
         });
     }
+}
+
+thread_local! {
+    /// The actor that is *receiving* the payload currently being decoded.
+    ///
+    /// A reply is decoded on a Tokio worker with no Monarch context, so
+    /// `Port._reconstruct_port` cannot recover the receiver from `context()`
+    /// without bootstrapping a client in a worker process. The eager decoders
+    /// install the caller instance they already hold here for the duration of
+    /// the decode.
+    ///
+    /// Deliberately a sibling of `ACTIVE_PICKLING_STATE` rather than a field
+    /// on it: the receiver is decode context, not pickling payload state, and
+    /// must never reach `PicklingStateInner` or the serialized bytes.
+    static RECEIVER_INSTANCE: RefCell<Option<Instance<PythonActor>>> =
+        const { RefCell::new(None) };
+}
+
+/// RAII guard installing the receiver for the current decode, restoring the
+/// previous value on drop -- on success, on error, and on panic.
+///
+/// Private: the only way to install a receiver is
+/// [`PicklingState::unpickle_with_receiver`], which cannot span an `await`.
+struct ReceiverInstanceGuard {
+    previous: Option<Instance<PythonActor>>,
+}
+
+impl ReceiverInstanceGuard {
+    /// Install `instance` as the receiver, saving any existing one.
+    ///
+    /// Takes a reference and clones internally so callers keep ownership of
+    /// the instance they are already holding across the collector.
+    fn enter(instance: &Instance<PythonActor>) -> Self {
+        let previous =
+            RECEIVER_INSTANCE.with(|cell| cell.borrow_mut().replace(instance.clone_for_py()));
+        Self { previous }
+    }
+}
+
+impl Drop for ReceiverInstanceGuard {
+    fn drop(&mut self) {
+        RECEIVER_INSTANCE.with(|cell| {
+            *cell.borrow_mut() = self.previous.take();
+        });
+    }
+}
+
+/// Clone of the receiver installed for the current decode, if any.
+///
+/// Clones rather than consumes: one payload may carry several `Port`s and each
+/// must reconstruct against the same receiver.
+fn current_receiver_instance_raw() -> Option<Instance<PythonActor>> {
+    RECEIVER_INSTANCE.with(|cell| cell.borrow().as_ref().map(|i| i.clone_for_py()))
+}
+
+/// The receiver for the decode in progress, or `None` outside one.
+///
+/// `Port._reconstruct_port` prefers this and falls back to `context()`, which
+/// keeps reconstruction outside an endpoint reply decode unchanged.
+#[pyfunction]
+fn _current_receiver_instance() -> Option<PyInstance> {
+    // Clone out of the `RefCell` before building the Python wrapper: the
+    // conversion allocates a Python object, and holding the borrow across that
+    // risks a re-entrant borrow.
+    current_receiver_instance_raw().map(PyInstance::from)
 }
 
 /// State maintained during active pickling/unpickling operations.
@@ -361,6 +429,21 @@ impl PicklingState {
 }
 
 impl PicklingState {
+    /// [`unpickle`](Self::unpickle) with `instance` installed as the receiver.
+    ///
+    /// Rust-only and deliberately unexposed to Python: the guard must not
+    /// outlive the synchronous decode. Every caller is the body of a
+    /// `monarch_with_gil_blocking` closure, so the guard never spans an
+    /// `await` and the thread-local cannot leak to another task.
+    pub(crate) fn unpickle_with_receiver(
+        &mut self,
+        py: Python<'_>,
+        instance: &Instance<PythonActor>,
+    ) -> PyResult<Py<PyAny>> {
+        let _guard = ReceiverInstanceGuard::enter(instance);
+        self.unpickle(py)
+    }
+
     /// Fill the reserved mesh slots from their pending handles, producing a
     /// PicklingState whose out-of-band `refs` table is fully populated.
     ///
@@ -797,6 +880,7 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     )?)?;
     module.add_function(wrap_pyfunction!(pop_tensor_engine_reference, module)?)?;
     module.add_function(wrap_pyfunction!(pop_mesh_reference, module)?)?;
+    module.add_function(wrap_pyfunction!(_current_receiver_instance, module)?)?;
     module.add_function(wrap_pyfunction!(reserve_mesh_reference, module)?)?;
     module.add_function(wrap_pyfunction!(_get_pending_reserve_count, module)?)?;
     module.add_function(wrap_pyfunction!(_reset_pending_reserve_count, module)?)?;
@@ -871,6 +955,74 @@ mod tests {
                 "payload_len should be the length of the pickled buffer"
             );
         }
+    }
+
+    /// The receiver guard's three contracts: a lookup clones rather than
+    /// consumes, a nested guard overrides and then restores, and a guard
+    /// dropped by an unwinding error restores too.
+    // `#[tokio::test]` because `Proc::direct` needs a runtime. The body has no
+    // await, so it stays on one thread and the thread-local is observed there.
+    #[tokio::test]
+    async fn receiver_instance_guard_clones_nests_and_restores() {
+        use std::panic::AssertUnwindSafe;
+
+        use hyperactor::Proc;
+        use hyperactor::channel::ChannelTransport;
+
+        fn instance(name: &str) -> Instance<PythonActor> {
+            Proc::direct(ChannelTransport::Unix.any(), format!("{name}_proc"))
+                .unwrap()
+                .actor_instance::<PythonActor>(name)
+                .unwrap()
+                .instance
+        }
+
+        let outer = instance("outer");
+        let inner = instance("inner");
+        let outer_id = outer.self_addr().clone();
+        let inner_id = inner.self_addr().clone();
+
+        assert!(current_receiver_instance_raw().is_none(), "clean to start");
+
+        {
+            let _g = ReceiverInstanceGuard::enter(&outer);
+
+            // Non-consuming: a payload with several Ports looks up repeatedly.
+            for _ in 0..3 {
+                let got = current_receiver_instance_raw().expect("receiver installed");
+                assert_eq!(got.self_addr(), &outer_id);
+            }
+
+            {
+                let _nested = ReceiverInstanceGuard::enter(&inner);
+                assert_eq!(
+                    current_receiver_instance_raw().unwrap().self_addr(),
+                    &inner_id,
+                );
+            }
+            assert_eq!(
+                current_receiver_instance_raw().unwrap().self_addr(),
+                &outer_id,
+                "nested guard must restore its parent",
+            );
+
+            // Drop on unwind restores the parent, not `None`.
+            let unwound = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                let _failing = ReceiverInstanceGuard::enter(&inner);
+                panic!("decode blew up");
+            }));
+            assert!(unwound.is_err());
+            assert_eq!(
+                current_receiver_instance_raw().unwrap().self_addr(),
+                &outer_id,
+                "a guard dropped while unwinding must restore",
+            );
+        }
+
+        assert!(
+            current_receiver_instance_raw().is_none(),
+            "outermost guard must clear the receiver",
+        );
     }
 
     #[tokio::test]

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
@@ -13,6 +13,7 @@ from monarch._rust_bindings.monarch_hyperactor.actor import (
     PythonMessageKind,
 )
 from monarch._rust_bindings.monarch_hyperactor.buffers import FrozenBuffer
+from monarch._rust_bindings.monarch_hyperactor.context import Instance
 from monarch._rust_bindings.monarch_hyperactor.pytokio import Shared
 
 class PicklingState:
@@ -183,4 +184,19 @@ def _get_mesh_pop_count() -> int:
 
 def _reset_mesh_pop_count() -> None:
     """Test helper: reset the mesh-pop counter to zero."""
+    ...
+
+def _current_receiver_instance() -> Instance | None:
+    """
+    The actor receiving the payload currently being decoded, or ``None``
+    outside an eager reply decode.
+
+    Set by the endpoint response collectors for the duration of a decode, so a
+    ``Port`` in a reply reconstructs against the caller actor rather than
+    falling back to ``context()`` on a Tokio worker, which would bootstrap a
+    client inside a worker process.
+
+    Non-consuming: repeated calls within one decode all return the same
+    receiver, so a payload carrying several ``Port`` values works.
+    """
     ...

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -63,6 +63,7 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     UndeliverableMessageEnvelope,
 )
 from monarch._rust_bindings.monarch_hyperactor.pickle import (
+    _current_receiver_instance,
     PendingMessage,
     pickle,
     PicklingState,
@@ -1106,8 +1107,15 @@ class Port(Generic[R]):
         def _reconstruct_port(
             port_ref: PortRef | OncePortRef, rank: Optional[int]
         ) -> "Port[R]":
-            instance = context().actor_instance._as_rust()
-            return Port(port_ref, instance, rank)
+            # Prefer the receiver the decoder installed. An eager reply decode
+            # runs on a Tokio worker with no Monarch context, where `context()`
+            # would bootstrap a client inside the receiving actor's process.
+            # Outside such a decode -- ordinary client-side reconstruction --
+            # there is no receiver and the context path is unchanged.
+            receiver = _current_receiver_instance()
+            if receiver is not None:
+                return Port(port_ref, receiver, rank)
+            return Port(port_ref, context().actor_instance._as_rust(), rank)
 
         return (
             _reconstruct_port,

--- a/python/tests/test_port_reconstruction.py
+++ b/python/tests/test_port_reconstruction.py
@@ -7,13 +7,17 @@
 # pyre-unsafe
 
 import time
-from typing import Callable, List, Tuple, TypeVar
+from typing import List, Tuple, TypeVar
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     PortId,
     PortRef,
     UndeliverableMessageEnvelope,
+)
+from monarch._rust_bindings.monarch_hyperactor.pickle import (
+    _get_mesh_pop_count,
+    _reset_mesh_pop_count,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._src.actor.actor_mesh import (
@@ -25,19 +29,32 @@ from monarch._src.actor.actor_mesh import (
 )
 from monarch._src.actor.host_mesh import this_host
 from monarch._src.actor.proc_mesh import ProcMesh
-from monarch.actor import Actor, ActorError, endpoint
+from monarch.actor import Actor, endpoint
 
 
 class PortOwner(Actor):
     """Owns channels and hands their sending ``Port`` to another actor."""
 
-    def __init__(self) -> None:
+    def __init__(self, extra: "PortOwner | None" = None) -> None:
         self._recv: PortReceiver[int]
+        self._extra = extra
 
     @endpoint
     async def make_port(self) -> Port[int]:
         send, self._recv = Channel[int].open()
         return send
+
+    @endpoint
+    async def make_port_and_mesh(self) -> Tuple[Port[int], "PortOwner"]:
+        """A reply carrying both a ``Port`` and a mesh reference.
+
+        The mesh drives ``collect_valuemesh`` down its *eager* ref-reuniting
+        branch, a different decode site from ``value_collector``.
+        """
+        send, self._recv = Channel[int].open()
+        extra = self._extra
+        assert extra is not None
+        return send, extra
 
     @endpoint
     async def received(self) -> int:
@@ -120,34 +137,6 @@ class SyncCaller(_CallerMixin, Actor):
         return observed, str(context().actor_instance.actor_id)
 
 
-class PortReconstructionBug(Exception):
-    """The meta-pytorch/monarch#4658 failure, translated from ``ActorError``.
-
-    Expecting a bare ``ActorError`` would also swallow an unrelated setup or
-    cleanup failure and report it as the known bug. Only the target call, and
-    only when it carries the signature below, becomes this exception; anything
-    else propagates and fails the test.
-    """
-
-
-T = TypeVar("T")
-
-
-def _expect_4658(call: Callable[[], T]) -> T:
-    """Run a Port-returning call, translating only the #4658 failure.
-
-    The reply decode has no Monarch context, so ``_reconstruct_port`` ->
-    ``context()`` bootstraps a client, whose ``block_on`` panics inside the
-    Tokio runtime; the remote error reaches the caller as a closed channel.
-    """
-    try:
-        return call()
-    except ActorError as e:
-        if "channel closed" not in str(e):
-            raise
-        raise PortReconstructionBug(str(e)) from e
-
-
 CallerT = TypeVar("CallerT", AsyncCaller, SyncCaller)
 
 
@@ -181,25 +170,18 @@ def _await_observed_sender(caller: AsyncCaller | SyncCaller) -> Tuple[str, str]:
 
 
 @pytest.mark.timeout(120)
-@pytest.mark.xfail(
-    strict=True,
-    raises=PortReconstructionBug,
-    reason=(
-        "meta-pytorch/monarch#4658: a Port returned by call_one is decoded on a Tokio worker with no Monarch context, so _reconstruct_port -> context() bootstraps a client inside the caller actor process. Remove this mark with the fix."
-    ),
-)
 def test_port_returned_to_async_actor_does_not_bootstrap_client() -> None:
     """A Port returned by one remote actor to another must be reconstructed
     with the *caller actor's* instance, not by bootstrapping a client.
 
-    Currently red: the reply is decoded by a ``PythonTask::new`` collector on a
-    Tokio worker with no Monarch context, so ``Port._reconstruct_port`` ->
-    ``context()`` takes the client-bootstrap branch inside a worker process and
-    ``_init_client_context`` calls ``block_on`` from inside the runtime.
+    The reply is decoded by a ``PythonTask::new`` collector on a Tokio worker
+    with no Monarch context, so the collector installs the caller instance as
+    the decode receiver and ``_reconstruct_port`` never reaches the
+    client-bootstrap branch of ``context()``.
     """
     pm, owner, caller = _spawn_owner_and_caller(AsyncCaller)
     try:
-        bootstrapped = _expect_4658(lambda: caller.use.call_one(42).get())
+        bootstrapped = caller.use.call_one(42).get()
         assert 42 == owner.received.call_one().get()
         assert not bootstrapped, (
             "a client context was bootstrapped inside the caller actor process"
@@ -249,22 +231,92 @@ def test_port_reconstruction_binds_exact_sync_caller_instance() -> None:
 
 
 @pytest.mark.timeout(120)
-@pytest.mark.xfail(
-    strict=True,
-    raises=PortReconstructionBug,
-    reason=(
-        "meta-pytorch/monarch#4658: a Port returned by call_one is decoded on a Tokio worker with no Monarch context, so _reconstruct_port -> context() bootstraps a client inside the caller actor process. Remove this mark with the fix."
-    ),
-)
 def test_port_reconstruction_binds_exact_async_caller_instance() -> None:
-    """The async counterpart of the exact-identity proof. Currently red."""
+    """The async counterpart of the exact-identity proof."""
     pm, _owner, caller = _spawn_owner_and_caller(AsyncCaller)
     try:
-        _expect_4658(lambda: caller.send_doomed.call_one().get())
+        caller.send_doomed.call_one().get()
         observed, caller_actor_id = _await_observed_sender(caller)
         assert observed, "no undeliverable envelope returned to the caller"
         assert observed == caller_actor_id, (
             f"Port bound to {observed}, expected the caller {caller_actor_id}"
         )
+    finally:
+        pm.stop().get()
+
+
+class StreamCaller(_CallerMixin, Actor):
+    """Obtains a ``Port`` through ``.stream()``, a different eager collector."""
+
+    def __init__(self, owner: PortOwner) -> None:
+        self._owner = owner
+        self._undeliverable: List[str] = []
+
+    @endpoint
+    async def send_doomed_via_stream(self) -> None:
+        for fut in self._owner.make_doomed_port.stream():
+            port = await fut
+            port.send(1)
+
+    @endpoint
+    async def collect_identity(self) -> Tuple[str, str]:
+        observed = self._undeliverable[0] if self._undeliverable else ""
+        return observed, str(context().actor_instance.actor_id)
+
+
+class RefBearingCaller(_CallerMixin, Actor):
+    """Receives a reply carrying a mesh reference alongside the ``Port``."""
+
+    def __init__(self, owner: PortOwner) -> None:
+        self._owner = owner
+        self._undeliverable: List[str] = []
+
+    @endpoint
+    async def use_call_with_refs(self, value: int) -> Tuple[bool, int]:
+        _reset_mesh_pop_count()
+        vm = await self._owner.make_port_and_mesh.call()
+        port, mesh = vm.item()
+        assert mesh is not None
+        port.send(value)
+        return _client_context._val is not None, _get_mesh_pop_count()
+
+
+@pytest.mark.timeout(120)
+def test_port_reconstruction_through_stream_binds_caller_instance() -> None:
+    """``.stream()`` has its own collector, which must install the receiver too."""
+    pm = this_host().spawn_procs(per_host={"gpus": 2})
+    try:
+        owner = pm.slice(gpus=0).spawn("owner", PortOwner)
+        caller = pm.slice(gpus=1).spawn("caller", StreamCaller, owner)
+        caller.send_doomed_via_stream.call_one().get()
+        observed, caller_actor_id = _await_observed_sender(caller)
+        assert observed, "no undeliverable envelope returned to the caller"
+        assert observed == caller_actor_id, (
+            f"Port bound to {observed}, expected the caller {caller_actor_id}"
+        )
+    finally:
+        pm.stop().get()
+
+
+@pytest.mark.timeout(120)
+def test_ref_bearing_call_decodes_port_and_mesh_eagerly() -> None:
+    """A reply carrying a ``Port`` *and* a mesh takes the eager valuemesh branch.
+
+    A nonzero mesh-pop count in the caller's process proves the out-of-band
+    reference was reunited during that eager decode, so this exercises the
+    ref-bearing path rather than the lazy one.
+    """
+    pm = this_host().spawn_procs(per_host={"gpus": 2})
+    try:
+        extra = pm.slice(gpus=0).spawn("extra", PortOwner)
+        owner = pm.slice(gpus=0).spawn("owner", PortOwner, extra)
+        caller = pm.slice(gpus=1).spawn("caller", RefBearingCaller, owner)
+
+        bootstrapped, mesh_pops = caller.use_call_with_refs.call_one(44).get()
+        assert 44 == owner.received.call_one().get()
+        assert not bootstrapped, (
+            "a client context was bootstrapped inside the caller actor process"
+        )
+        assert mesh_pops > 0, "the eager mesh-reference decode path did not run"
     finally:
         pm.stop().get()

--- a/python/tests/test_port_reconstruction.py
+++ b/python/tests/test_port_reconstruction.py
@@ -1,0 +1,270 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import time
+from typing import Callable, List, Tuple, TypeVar
+
+import pytest
+from monarch._rust_bindings.monarch_hyperactor.mailbox import (
+    PortId,
+    PortRef,
+    UndeliverableMessageEnvelope,
+)
+from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
+from monarch._src.actor.actor_mesh import (
+    _client_context,
+    Channel,
+    context,
+    Port,
+    PortReceiver,
+)
+from monarch._src.actor.host_mesh import this_host
+from monarch._src.actor.proc_mesh import ProcMesh
+from monarch.actor import Actor, ActorError, endpoint
+
+
+class PortOwner(Actor):
+    """Owns channels and hands their sending ``Port`` to another actor."""
+
+    def __init__(self) -> None:
+        self._recv: PortReceiver[int]
+
+    @endpoint
+    async def make_port(self) -> Port[int]:
+        send, self._recv = Channel[int].open()
+        return send
+
+    @endpoint
+    async def received(self) -> int:
+        return await self._recv.recv()
+
+    @endpoint
+    async def make_doomed_port(self) -> Port[int]:
+        """A ``Port`` addressed at a proc that does not exist.
+
+        Sending through it cannot be delivered, so the envelope is returned to
+        whichever instance posted it. That is what makes the *sender* -- and
+        therefore the instance the ``Port`` was reconstructed with -- directly
+        observable, without a getter on ``Port``.
+        """
+        port_id = PortId(
+            actor_id=ActorAddr(addr="local:0", proc_name="bogus", actor_name="bogus"),
+            port=1234,
+        )
+        return Port(PortRef(port_id), context().actor_instance._as_rust(), None)
+
+
+class _CallerMixin:
+    """Captures the sender of any message this actor failed to deliver."""
+
+    def _handle_undeliverable_message(
+        self, message: UndeliverableMessageEnvelope
+    ) -> bool:
+        # pyrefly: ignore [missing-attribute]
+        self._undeliverable.append(str(message.sender()))
+        return True
+
+
+class AsyncCaller(_CallerMixin, Actor):
+    """Obtains a ``Port`` as a ``call_one`` return value from an async endpoint.
+
+    Sync and async endpoints cannot be mixed on one actor -- actor-mesh
+    construction rejects it -- so the sync half lives in :class:`SyncCaller`.
+    """
+
+    def __init__(self, owner: PortOwner) -> None:
+        self._owner = owner
+        self._undeliverable: List[str] = []
+
+    @endpoint
+    async def use(self, value: int) -> bool:
+        port = await self._owner.make_port.call_one()
+        port.send(value)
+        return _client_context._val is not None
+
+    @endpoint
+    async def send_doomed(self) -> None:
+        port = await self._owner.make_doomed_port.call_one()
+        port.send(1)
+
+    @endpoint
+    async def collect_identity(self) -> Tuple[str, str]:
+        observed = self._undeliverable[0] if self._undeliverable else ""
+        return observed, str(context().actor_instance.actor_id)
+
+
+class SyncCaller(_CallerMixin, Actor):
+    def __init__(self, owner: PortOwner) -> None:
+        self._owner = owner
+        self._undeliverable: List[str] = []
+
+    @endpoint
+    def use(self, value: int) -> bool:
+        port = self._owner.make_port.call_one().get()
+        port.send(value)
+        return _client_context._val is not None
+
+    @endpoint
+    def send_doomed(self) -> None:
+        port = self._owner.make_doomed_port.call_one().get()
+        port.send(1)
+
+    @endpoint
+    def collect_identity(self) -> Tuple[str, str]:
+        observed = self._undeliverable[0] if self._undeliverable else ""
+        return observed, str(context().actor_instance.actor_id)
+
+
+class PortReconstructionBug(Exception):
+    """The meta-pytorch/monarch#4658 failure, translated from ``ActorError``.
+
+    Expecting a bare ``ActorError`` would also swallow an unrelated setup or
+    cleanup failure and report it as the known bug. Only the target call, and
+    only when it carries the signature below, becomes this exception; anything
+    else propagates and fails the test.
+    """
+
+
+T = TypeVar("T")
+
+
+def _expect_4658(call: Callable[[], T]) -> T:
+    """Run a Port-returning call, translating only the #4658 failure.
+
+    The reply decode has no Monarch context, so ``_reconstruct_port`` ->
+    ``context()`` bootstraps a client, whose ``block_on`` panics inside the
+    Tokio runtime; the remote error reaches the caller as a closed channel.
+    """
+    try:
+        return call()
+    except ActorError as e:
+        if "channel closed" not in str(e):
+            raise
+        raise PortReconstructionBug(str(e)) from e
+
+
+CallerT = TypeVar("CallerT", AsyncCaller, SyncCaller)
+
+
+def _spawn_owner_and_caller(
+    caller_class: type[CallerT],
+) -> Tuple[ProcMesh, PortOwner, CallerT]:
+    """One two-proc mesh; owner on rank 0, caller on rank 1.
+
+    The ProcMesh is sliced *before* spawning. Spawning first and slicing the
+    resulting ActorMesh would place both actor classes on both ranks and then
+    merely address one of each.
+    """
+    pm = this_host().spawn_procs(per_host={"gpus": 2})
+    owner = pm.slice(gpus=0).spawn("owner", PortOwner)
+    caller = pm.slice(gpus=1).spawn("caller", caller_class, owner)
+    return pm, owner, caller
+
+
+def _await_observed_sender(caller: AsyncCaller | SyncCaller) -> Tuple[str, str]:
+    """Poll for the bounced envelope.
+
+    Collected through a second endpoint rather than inside ``send_doomed`` so a
+    *sync* caller does not block its own actor loop waiting for the return.
+    """
+    for _ in range(200):
+        observed, actor_id = caller.collect_identity.call_one().get()
+        if observed:
+            return observed, actor_id
+        time.sleep(0.05)
+    return "", ""
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.xfail(
+    strict=True,
+    raises=PortReconstructionBug,
+    reason=(
+        "meta-pytorch/monarch#4658: a Port returned by call_one is decoded on a Tokio worker with no Monarch context, so _reconstruct_port -> context() bootstraps a client inside the caller actor process. Remove this mark with the fix."
+    ),
+)
+def test_port_returned_to_async_actor_does_not_bootstrap_client() -> None:
+    """A Port returned by one remote actor to another must be reconstructed
+    with the *caller actor's* instance, not by bootstrapping a client.
+
+    Currently red: the reply is decoded by a ``PythonTask::new`` collector on a
+    Tokio worker with no Monarch context, so ``Port._reconstruct_port`` ->
+    ``context()`` takes the client-bootstrap branch inside a worker process and
+    ``_init_client_context`` calls ``block_on`` from inside the runtime.
+    """
+    pm, owner, caller = _spawn_owner_and_caller(AsyncCaller)
+    try:
+        bootstrapped = _expect_4658(lambda: caller.use.call_one(42).get())
+        assert 42 == owner.received.call_one().get()
+        assert not bootstrapped, (
+            "a client context was bootstrapped inside the caller actor process"
+        )
+    finally:
+        pm.stop().get()
+
+
+@pytest.mark.timeout(120)
+def test_port_returned_to_sync_actor_does_not_bootstrap_client() -> None:
+    """The sync-caller control.
+
+    ``Future.get()`` drives the collector via ``block_on`` on the calling
+    thread, where the actor context *is* set. If this ever fails too, the
+    defect is not reply-decode context propagation and the analysis is wrong.
+    """
+    pm, owner, caller = _spawn_owner_and_caller(SyncCaller)
+    try:
+        bootstrapped = caller.use.call_one(43).get()
+        assert 43 == owner.received.call_one().get()
+        assert not bootstrapped, (
+            "a client context was bootstrapped inside the caller actor process"
+        )
+    finally:
+        pm.stop().get()
+
+
+@pytest.mark.timeout(120)
+def test_port_reconstruction_binds_exact_sync_caller_instance() -> None:
+    """Reconstruction must use the caller's *own* ``Instance``.
+
+    Asserting only that the Port can carry a sentinel is too weak: any instance
+    able to post would satisfy it. The bounced envelope names the actor that
+    actually posted, so comparing it against the caller's own actor id pins the
+    exact instance.
+    """
+    pm, _owner, caller = _spawn_owner_and_caller(SyncCaller)
+    try:
+        caller.send_doomed.call_one().get()
+        observed, caller_actor_id = _await_observed_sender(caller)
+        assert observed, "no undeliverable envelope returned to the caller"
+        assert observed == caller_actor_id, (
+            f"Port bound to {observed}, expected the caller {caller_actor_id}"
+        )
+    finally:
+        pm.stop().get()
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.xfail(
+    strict=True,
+    raises=PortReconstructionBug,
+    reason=(
+        "meta-pytorch/monarch#4658: a Port returned by call_one is decoded on a Tokio worker with no Monarch context, so _reconstruct_port -> context() bootstraps a client inside the caller actor process. Remove this mark with the fix."
+    ),
+)
+def test_port_reconstruction_binds_exact_async_caller_instance() -> None:
+    """The async counterpart of the exact-identity proof. Currently red."""
+    pm, _owner, caller = _spawn_owner_and_caller(AsyncCaller)
+    try:
+        _expect_4658(lambda: caller.send_doomed.call_one().get())
+        observed, caller_actor_id = _await_observed_sender(caller)
+        assert observed, "no undeliverable envelope returned to the caller"
+        assert observed == caller_actor_id, (
+            f"Port bound to {observed}, expected the caller {caller_actor_id}"
+        )
+    finally:
+        pm.stop().get()


### PR DESCRIPTION
Summary:

D91755421 moved `call_one()` response handling from Python into Rust. async replies are decoded on a worker thread, where the actor that made the call is not available through the Python context.

a returned `Port` gets its destination from the remote actor, but uses the receiving actor as its sender. this change carries the receiving actor's identity through reply decoding and uses it when reconstructing the `Port`. decoding outside endpoint replies is unchanged.

the same path handles `call_one()`, `choose()`, `stream()`, and replies from `.call()` that must be decoded immediately. replies from `.call()` without out-of-band references remain lazy. the characterization tests from D116779210 are now green, with additional coverage for streaming replies, ref-bearing replies, and nested receiver-state restoration.

Reviewed By: thomasywang

Differential Revision: D116782372


