### PR TITLE
refuse root-client bootstrap inside Tokio (#4713)

### DIFF
--- a/monarch_hyperactor/src/handle.rs
+++ b/monarch_hyperactor/src/handle.rs
@@ -52,9 +52,13 @@
 //!   and every acquisition goes through `monarch_with_gil{,_blocking}`. Enforced
 //!   by the crate's `#![deny(clippy::disallowed_methods)]` ban on raw
 //!   `Python::with_gil`/`attach` -- a hard compile error, not a `debug_assert`.
-//! - **HDL-6 (`WouldBlockRuntime` is `get()`'s alone).** Only `get()` raises it,
-//!   and only in a Tokio runtime context; `as_asyncio()`/`__await__` off a loop
-//!   raise the native `RuntimeError` instead.
+//! - **HDL-6 (`WouldBlockRuntime` is `get()`'s alone *among the observers*).**
+//!   Of the `Handle` observers only `get()` raises it, and only in a Tokio
+//!   runtime context; `as_asyncio()`/`__await__` off a loop raise the native
+//!   `RuntimeError` instead. The exception type itself is not private to this
+//!   module: it marks synchronous APIs that refuse to enter or block on Tokio
+//!   from an existing Tokio runtime context. The Python layer also raises it
+//!   for fresh root-client bootstrap (`monarch._src.actor.actor_mesh`).
 //! - **HDL-7 (`as_asyncio` publish).** The observer waits borrow-first (via
 //!   `wait_ready`, never `changed()`-first) and sets a result only on a
 //!   non-cancelled future, swallowing `InvalidStateError`; any `StopIteration`
@@ -139,7 +143,9 @@ pyo3::create_exception!(
     pytokio,
     WouldBlockRuntime,
     pyo3::exceptions::PyRuntimeError,
-    "raised when Handle.get() is called from a Tokio runtime context"
+    "raised when a synchronous API refuses to enter or block on Tokio from \
+     an existing Tokio runtime context -- Handle.get(), or a fresh root-client \
+     bootstrap from the Python layer"
 );
 
 /// The watch-channel mechanics behind a `Handle`.
@@ -525,10 +531,10 @@ impl PyHandle {
     /// `poll()`/`get()`/`await` still observes completion.
     #[pyo3(signature = (timeout = None))]
     fn get(slf: PyRef<'_, Self>, py: Python<'_>, timeout: Option<f64>) -> PyResult<Py<PyAny>> {
-        // HDL-6: get() is the sole WouldBlockRuntime raiser. It is the blocking
-        // API, and in a Tokio runtime context blocking would panic the runtime,
-        // so refuse unconditionally -- even a ready value -- keying the outcome
-        // to context, not producer timing.
+        // HDL-6: among the observers, get() is the sole WouldBlockRuntime
+        // raiser. It is the blocking API, and in a Tokio runtime context
+        // blocking would panic the runtime, so refuse unconditionally -- even
+        // a ready value -- keying the outcome to context, not producer timing.
         if is_tokio_thread() {
             return Err(WouldBlockRuntime::new_err(
                 "get() cannot be called from a Tokio runtime context; use poll() or as_asyncio()",

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
@@ -160,7 +160,13 @@ class Handle(Generic[T]):
 
 class WouldBlockRuntime(RuntimeError):
     """
-    Raised when Handle.get() is called from a Tokio runtime context.
+    Raised when a synchronous API refuses to enter or block on Tokio from an
+    existing Tokio runtime context.
+
+    Two raisers today: ``Handle.get()``, and a fresh root-client bootstrap
+    (``context()`` with no actor context and no initialized client, or
+    ``attach()``). Reusing an already-initialized client does not block and so
+    does not raise.
     """
 
     ...

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -69,7 +69,11 @@ from monarch._rust_bindings.monarch_hyperactor.pickle import (
     PicklingState,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._rust_bindings.monarch_hyperactor.pytokio import (
+    is_tokio_thread,
+    PythonTask,
+    WouldBlockRuntime,
+)
 from monarch._rust_bindings.monarch_hyperactor.shape import Point as HyPoint, Shape
 from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
 from monarch._src.actor import config
@@ -462,6 +466,12 @@ def _init_client_context(via: Optional[str] = None) -> Context:
     Create a client context that bootstraps an actor instance running on a real
     local proc mesh on a real local host mesh.
 
+    Fresh bootstrap ends in ``block_on()``, which panics on a Tokio runtime
+    worker. Reject it from every Tokio runtime context, including the blocking
+    pool, so this synchronous API does not depend on which Tokio-managed thread
+    invoked it. An already-initialized client bypasses this function and can
+    still be reused.
+
     When ``via`` is a non-empty ZMQ-style address, the local client's
     gateway is connected to the gateway serving that address: outbound
     traffic forwards over the duplex, and the remote gateway routes
@@ -470,6 +480,13 @@ def _init_client_context(via: Optional[str] = None) -> Context:
     procs are reached, not the host's identity. Use ``attach``
     to supply ``via`` before the client context is first used.
     """
+    if is_tokio_thread():
+        raise WouldBlockRuntime(
+            "cannot bootstrap a root client from inside the Tokio runtime; "
+            "call context(), this_host(), or attach(addr) before entering "
+            "Tokio. An already-initialized client can still be reused."
+        )
+
     import atexit
 
     from monarch._rust_bindings.monarch_hyperactor.host_mesh import bootstrap_host
@@ -527,7 +544,8 @@ def attach(addr: str) -> None:
     first client-context use. Raises ``RuntimeError`` if the client
     context has already been bootstrapped. ``this_host()`` still names
     the current machine — attach only changes how this host's procs
-    are reached.
+    are reached. Raises ``WouldBlockRuntime`` if called from inside a Tokio
+    runtime before the client has been initialized.
     """
     with _client_context._lock:
         if _client_context._val is not None:
@@ -594,7 +612,9 @@ def context() -> Context:
 
     Call this from within an endpoint to inspect the running actor and the
     current message's position in the mesh. Outside an actor (on the client) it
-    returns the root client context.
+    returns the root client context. Raises ``WouldBlockRuntime`` rather than
+    attempting fresh root-client bootstrap from inside a Tokio runtime; an
+    already-initialized client can still be reused there.
     """
     c = _context.get()
     if c is None:

--- a/python/tests/test_client_context_guard.py
+++ b/python/tests/test_client_context_guard.py
@@ -1,0 +1,170 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Fresh root-client bootstrap must not be attempted from inside Tokio.
+
+Bootstrapping a client ends in ``block_on()``, which panics on a Tokio runtime
+worker. The guard rejects fresh bootstrap from every Tokio runtime context,
+including its blocking pool, while still allowing an already-initialized client
+to be reused.
+"""
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.pytokio import (
+    is_tokio_thread,
+    PythonTask,
+    WouldBlockRuntime,
+)
+from monarch._src.actor.host_mesh import this_host
+from monarch.actor import Actor, endpoint
+
+_EXPECTED = "WouldBlockRuntime uninitialized=True"
+
+
+def _probe_fresh_bootstrap() -> str:
+    """Ask for a context on a Tokio thread with neither actor nor client."""
+    from monarch._src.actor.actor_mesh import _client_context, _context, context
+
+    if not is_tokio_thread():
+        return "precondition: not a tokio thread"
+    if _client_context.try_get() is not None:
+        return "precondition: client already initialized"
+    # spawn_blocking propagates the caller's actor context; drop it so the
+    # fresh-bootstrap branch is the one under test.
+    token = _context.set(None)
+    try:
+        context()
+    except WouldBlockRuntime:
+        return f"WouldBlockRuntime uninitialized={_client_context.try_get() is None}"
+    # BaseException, not Exception: PyO3's PanicException derives from it, and
+    # reporting that panic by name is the point of these probes. The result is
+    # transformed into the returned string, not swallowed.
+    except BaseException as err:  # noqa: B036
+        return f"{type(err).__name__}: {err}"
+    else:
+        return "no raise"
+    finally:
+        _context.reset(token)
+
+
+async def _probe_fresh_bootstrap_on_worker() -> str:
+    """The incident shape: a runtime *worker* thread, where block_on panics.
+
+    ``spawn_blocking`` threads report ``is_tokio_thread()`` but tolerate
+    ``block_on``; a worker thread does not. This is the case that motivated
+    the guard.
+    """
+    return _probe_fresh_bootstrap()
+
+
+def _probe_attach() -> str:
+    """``attach()`` bootstraps directly, bypassing ``context()``."""
+    from monarch._src.actor.actor_mesh import _client_context, attach
+
+    if not is_tokio_thread():
+        return "precondition: not a tokio thread"
+    if _client_context.try_get() is not None:
+        return "precondition: client already initialized"
+    try:
+        attach("tcp://127.0.0.1:1")
+    except WouldBlockRuntime:
+        return f"WouldBlockRuntime uninitialized={_client_context.try_get() is None}"
+    # BaseException, not Exception: PyO3's PanicException derives from it, and
+    # reporting that panic by name is the point of these probes. The result is
+    # transformed into the returned string, not swallowed.
+    except BaseException as err:  # noqa: B036
+        return f"{type(err).__name__}: {err}"
+    return "no raise"
+
+
+def _probe_reuse() -> str:
+    """An initialized client must still be handed back on a Tokio thread."""
+    from monarch._src.actor.actor_mesh import _client_context, _context, context
+
+    if not is_tokio_thread():
+        return "precondition: not a tokio thread"
+    expected = _client_context.try_get()
+    if expected is None:
+        return "precondition: client not initialized"
+    token = _context.set(None)
+    try:
+        got = context()
+    # BaseException, not Exception: PyO3's PanicException derives from it, and
+    # reporting that panic by name is the point of these probes. The result is
+    # transformed into the returned string, not swallowed.
+    except BaseException as err:  # noqa: B036
+        return f"{type(err).__name__}: {err}"
+    else:
+        return "reused" if got is expected else "different object"
+    finally:
+        _context.reset(token)
+
+
+class _Prober(Actor):
+    """Runs probes on Tokio worker and blocking threads in a worker process.
+
+    A worker process never bootstraps a client of its own, so it is the only
+    place the fresh-bootstrap branch is genuinely reachable.
+    """
+
+    @endpoint
+    def run(self, which: str) -> str:
+        if which == "fresh_worker":
+            return (
+                PythonTask.from_coroutine(_probe_fresh_bootstrap_on_worker())
+                .spawn()
+                .block_on()
+            )
+        probes = {"fresh": _probe_fresh_bootstrap, "attach": _probe_attach}
+        return PythonTask.spawn_blocking(probes[which]).block_on()
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_context_on_tokio_without_client_refuses_fresh_bootstrap() -> None:
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
+    try:
+        prober = pm.spawn("prober", _Prober)
+        assert prober.run.call_one("fresh").get() == _EXPECTED
+    finally:
+        pm.stop().get()
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_context_on_tokio_worker_refuses_fresh_bootstrap() -> None:
+    """The incident shape: fresh bootstrap from a runtime worker thread."""
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
+    try:
+        prober = pm.spawn("prober", _Prober)
+        assert prober.run.call_one("fresh_worker").get() == _EXPECTED
+    finally:
+        pm.stop().get()
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_attach_on_tokio_refuses_before_bootstrap() -> None:
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
+    try:
+        prober = pm.spawn("prober", _Prober)
+        assert prober.run.call_one("attach").get() == _EXPECTED
+    finally:
+        pm.stop().get()
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_context_on_tokio_reuses_initialized_client() -> None:
+    """The guard must not reject a contextless Tokio caller out of hand."""
+    from monarch._src.actor.actor_mesh import _client_context, context
+
+    context()
+    assert _client_context.try_get() is not None, "client should be initialized here"
+    assert PythonTask.spawn_blocking(_probe_reuse).block_on() == "reused"


### PR DESCRIPTION
Summary:

fresh root-client initialization waits synchronously for Monarch's runtime. if code tries to initialize the client from work already running on that runtime, the process can panic and the caller sees an unrelated error such as `channel closed`.

this change detects that situation before initialization begins and raises `WouldBlockRuntime` with a clear explanation. an already initialized client is still reused normally. the same check covers both `context()` and `attach()`.

Reviewed By: zdevito

Differential Revision: D116802826


