### PR TITLE
Make actor mesh spawn mode configurable (#4715)

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1637,6 +1637,7 @@ mod tests {
     use crate::proc_agent::ActorState;
     use crate::proc_mesh::ACTOR_SPAWN_MAX_IDLE;
     use crate::proc_mesh::GET_ACTOR_STATE_MAX_IDLE;
+    use crate::proc_mesh::USE_DIRECT_SPAWN;
     use crate::resource;
     use crate::supervision::MeshFailure;
     use crate::test_utils::local_host_mesh;
@@ -1770,6 +1771,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_actor_mesh_ref_lazy_materialization() {
+        let config = hyperactor_config::global::lock();
+        let _mode = config.override_key(USE_DIRECT_SPAWN, false);
         // 1) Bring up procs and spawn actors.
         let instance = testing::instance();
         // Small mesh so the test runs fast, but > page_size so we
@@ -2007,6 +2010,7 @@ mod tests {
 
         let instance = testing::instance();
         let config = hyperactor_config::global::lock();
+        let _mode = config.override_key(USE_DIRECT_SPAWN, false);
         let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(120));
         let _actor_spawn = config.override_key(ACTOR_SPAWN_MAX_IDLE, Duration::from_secs(120));
         let _host_spawn = config.override_key(
@@ -2109,6 +2113,7 @@ mod tests {
         hyperactor_telemetry::initialize_logging_for_test();
 
         let config = hyperactor_config::global::lock();
+        let _mode = config.override_key(USE_DIRECT_SPAWN, false);
         let _poll = config.override_key(SUPERVISION_POLL_FREQUENCY, Duration::from_secs(1));
         let _guard = config.override_key(GET_ACTOR_STATE_MAX_IDLE, Duration::from_secs(1));
         let _proc_guard = config.override_key(GET_PROC_STATE_MAX_IDLE, Duration::from_secs(1));
@@ -2219,6 +2224,7 @@ mod tests {
         let supervisor = supervision_port.bind();
         let (mut hm, _actor_mesh, sliced, sliced_replicas, child_name) = {
             let config = hyperactor_config::global::lock();
+            let _mode = config.override_key(USE_DIRECT_SPAWN, false);
             let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(120));
             let _actor_spawn = config.override_key(ACTOR_SPAWN_MAX_IDLE, Duration::from_secs(120));
             let _host_spawn = config.override_key(
@@ -2764,6 +2770,7 @@ mod tests {
         // handler waits for ProcAgents to report `Stopped`. Shorten it
         // from 30s to 1s so the test finishes quickly.
         let config = hyperactor_config::global::lock();
+        let _mode = config.override_key(USE_DIRECT_SPAWN, false);
         let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(60));
         let _host_spawn = config.override_key(
             hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
@@ -2856,6 +2863,7 @@ mod tests {
         hyperactor_telemetry::initialize_logging_for_test();
 
         let config = hyperactor_config::global::lock();
+        let _mode = config.override_key(USE_DIRECT_SPAWN, false);
         let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(60));
         let _host_spawn = config.override_key(
             hyperactor::config::HOST_SPAWN_READY_TIMEOUT,

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1692,6 +1692,7 @@ mod tests {
     use crate::mesh_id::ResourceId;
     use crate::proc_agent::ActorState;
     use crate::proc_agent::MESH_ORPHAN_TIMEOUT;
+    use crate::proc_mesh::USE_DIRECT_SPAWN;
     use crate::resource;
     use crate::supervision::MeshFailure;
     use crate::test_utils::local_host_mesh;
@@ -1943,6 +1944,7 @@ mod tests {
     #[tokio::test]
     async fn test_orphaned_actors_are_cleaned_up() {
         let config = hyperactor_config::global::lock();
+        let _mode = config.override_key(USE_DIRECT_SPAWN, false);
         // Short orphan timeout so SelfCheck fires frequently.
         let _orphan = config.override_key(MESH_ORPHAN_TIMEOUT, Some(Duration::from_secs(1)));
 
@@ -2068,6 +2070,7 @@ mod tests {
     #[cfg(fbcode_build)]
     async fn test_orphaned_actors_cleaned_up_on_controller_crash() {
         let config = hyperactor_config::global::lock();
+        let _mode = config.override_key(USE_DIRECT_SPAWN, false);
         let _orphan = config.override_key(MESH_ORPHAN_TIMEOUT, Some(Duration::from_secs(2)));
         let _poll = config.override_key(SUPERVISION_POLL_FREQUENCY, Duration::from_secs(1));
         let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(60));

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -71,6 +71,13 @@ use crate::resource::Status;
 use crate::supervision::MeshFailure;
 
 declare_attrs! {
+    /// Whether ordinary actor mesh spawns use the direct spawn path.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_MESH_USE_DIRECT_SPAWN".to_string()),
+        Some("use_direct_spawn".to_string()),
+    ))
+    pub attr USE_DIRECT_SPAWN: bool = false;
+
     /// The maximum idle time between updates while spawning actor
     /// meshes.
     @meta(CONFIG = ConfigAttr::new(
@@ -134,6 +141,14 @@ pub struct ProcMesh {
     id: ProcMeshId,
     current_ref: ProcMeshRef,
     controller: Option<ActorRef<crate::mesh_controller::ProcMeshController>>,
+}
+
+enum SpawnedActorMesh<A: RemoteSpawn> {
+    Managed {
+        mesh: ActorMesh<A>,
+        statuses: crate::StatusMesh,
+    },
+    Data(ActorMesh<A>),
 }
 
 impl ProcMesh {
@@ -770,7 +785,7 @@ impl ProcMeshRef {
         tracing::info!(name = "ActorMeshStatus", status = "Spawn::Attempt");
         let id = ActorMeshId::singleton(Label::strip(name));
         let result = self
-            .spawn_mesh_inner(cx, id, params, None)
+            .spawn_managed_mesh_inner(cx, id, params, None)
             .await
             .map(|(mesh, _statuses)| mesh);
         match &result {
@@ -793,9 +808,9 @@ impl ProcMeshRef {
     ///
     /// This initiates an actor spawn on each proc and constructs a stoppable
     /// data mesh from the actor refs and local supervisor handles without
-    /// waiting for the remote supervision sessions to link. If a later spawn
-    /// fails, all previously created local supervisors receive a best-effort
-    /// stop request.
+    /// waiting for the remote supervision sessions to link. If a request cannot
+    /// be initiated, all previously created local supervisors receive a
+    /// best-effort stop request.
     ///
     /// Bounds:
     /// - `A: Actor` - the actor actually runs inside each proc.
@@ -807,13 +822,25 @@ impl ProcMeshRef {
         params: &A::Params,
     ) -> crate::Result<ActorMesh<A>>
     where
-        A::Params: RemoteMessage + Clone,
+        A::Params: RemoteMessage,
     {
-        // Data meshes are nameless: they are identified by their members, not an id.
+        self.spawn_data_mesh_inner(cx, params, None)
+    }
+
+    fn spawn_data_mesh_inner<A: RemoteSpawn, C: context::Actor>(
+        &self,
+        cx: &C,
+        params: &A::Params,
+        actor_mesh_id: Option<&ActorMeshId>,
+    ) -> crate::Result<ActorMesh<A>>
+    where
+        A::Params: RemoteMessage,
+    {
         let region = self.region().clone();
-        let actor_uid = Uid::anonymous();
+        let actor_uid = actor_mesh_id.map_or_else(Uid::anonymous, |id| id.uid().clone());
         let mut members = Vec::with_capacity(self.ranks.len());
         let mut stop_handles = Vec::with_capacity(self.ranks.len());
+        let serialized_params = bincode::serde::encode_to_vec(params, bincode::config::legacy())?;
 
         let stop_spawned = |handles: &[ActorMeshStopHandle], reason: &str| {
             for handle in handles {
@@ -821,15 +848,24 @@ impl ProcMeshRef {
             }
         };
 
-        // Serially spawn an actor on each proc using the proc's actor spawner endpoint.
-        // The actor spawner is a well-known singleton actor running on each proc with
-        // the name "spawner".
+        // Each call only schedules a local supervisor that sends a one-way spawn
+        // request. No rank waits for another rank's remote actor initialization.
         for proc_ref in self.ranks.iter() {
+            let params = match bincode::serde::decode_from_slice(
+                &serialized_params,
+                bincode::config::legacy(),
+            ) {
+                Ok((params, _)) => params,
+                Err(error) => {
+                    stop_spawned(&stop_handles, "data mesh spawn failed");
+                    return Err(error.into());
+                }
+            };
             let actor_spawner = proc_ref.spawner();
             let (actor_ref, stop_handle) = match actor_spawner.spawn_uid_with_link_and_ready(
                 cx,
                 actor_uid.clone(),
-                params.clone(),
+                params,
                 KeepaliveLink::default(),
                 None,
             ) {
@@ -915,41 +951,75 @@ impl ProcMeshRef {
     where
         C::A: Handler<MeshFailure>,
     {
-        let (mut mesh, statuses) = self
-            .spawn_mesh_inner(cx, actor_mesh_id, params, supervision_display_name.clone())
+        let spawned = self
+            .spawn_mesh_inner(
+                cx,
+                actor_mesh_id,
+                params,
+                supervision_display_name.clone(),
+                is_system_actor,
+            )
             .await?;
-        // System actors are managed by their owning runtime, not an
-        // ActorMeshController.
-        if !is_system_actor {
-            // Spawn a unique mesh manager for each actor mesh, so the type of the
-            // mesh can be preserved.
-            let controller: ActorMeshController<A> = ActorMeshController::new(
-                ActorMeshControlPlane::new(mesh.deref().clone(), self.clone()),
-                supervision_display_name,
-                Some(cx.instance().port().bind()),
-                statuses,
-            );
-            // hyperactor::proc AI-3: controller name must include mesh
-            // identity for proc-wide ActorAddr uniqueness. A fixed base name alone
-            // collides across parents because pid allocation is
-            // parent-scoped.
-            let controller_name = format!(
-                "{}_{}",
-                crate::mesh_controller::ACTOR_MESH_CONTROLLER_NAME,
-                mesh.id().expect("managed actor mesh should have an id")
-            );
-            let controller = cx.spawn_with_label(&controller_name, controller);
-            // Controller and ActorMesh both depend on references from each other, break
-            // the cycle by setting the controller after the fact.
-            mesh.set_controller(Some(controller.bind()));
+        match spawned {
+            SpawnedActorMesh::Data(mesh) => Ok(mesh),
+            SpawnedActorMesh::Managed { mut mesh, statuses } => {
+                // System actors are managed by their owning runtime, not an
+                // ActorMeshController.
+                if !is_system_actor {
+                    // Spawn a unique mesh manager for each actor mesh, so the type of the
+                    // mesh can be preserved.
+                    let controller: ActorMeshController<A> = ActorMeshController::new(
+                        ActorMeshControlPlane::new(mesh.deref().clone(), self.clone()),
+                        supervision_display_name,
+                        Some(cx.instance().port().bind()),
+                        statuses,
+                    );
+                    // hyperactor::proc AI-3: controller name must include mesh
+                    // identity for proc-wide ActorAddr uniqueness. A fixed base name alone
+                    // collides across parents because pid allocation is
+                    // parent-scoped.
+                    let controller_name = format!(
+                        "{}_{}",
+                        crate::mesh_controller::ACTOR_MESH_CONTROLLER_NAME,
+                        mesh.id()
+                            .expect("managed spawn result must carry a mesh id")
+                    );
+                    let controller = cx.spawn_with_label(&controller_name, controller);
+                    // Controller and ActorMesh both depend on references from each other, break
+                    // the cycle by setting the controller after the fact.
+                    mesh.set_controller(Some(controller.bind()));
+                }
+                Ok(mesh)
+            }
         }
-        Ok(mesh)
     }
 
-    /// The common spawn path shared by
-    /// [`spawn_with_name_inner`](Self::spawn_with_name_inner) and
-    /// [`spawn_controllerless_service`](Self::spawn_controllerless_service): the
-    /// create/update cast, the accumulator port, the bounded
+    async fn spawn_mesh_inner<A: RemoteSpawn, C: context::Actor>(
+        &self,
+        cx: &C,
+        actor_mesh_id: ActorMeshId,
+        params: &A::Params,
+        supervision_display_name: Option<String>,
+        is_system_actor: bool,
+    ) -> crate::Result<SpawnedActorMesh<A>> {
+        if hyperactor_config::global::get(USE_DIRECT_SPAWN)
+            && !is_system_actor
+            && actor_mesh_id.uid().is_instance()
+        {
+            return self
+                .spawn_data_mesh_inner(cx, params, Some(&actor_mesh_id))
+                .map(SpawnedActorMesh::Data);
+        }
+
+        let (mesh, statuses) = self
+            .spawn_managed_mesh_inner(cx, actor_mesh_id, params, supervision_display_name)
+            .await?;
+        Ok(SpawnedActorMesh::Managed { mesh, statuses })
+    }
+
+    /// The managed spawn path used by singleton services and by ordinary
+    /// spawns when [`USE_DIRECT_SPAWN`] is disabled: the create/update cast,
+    /// the accumulator port, the bounded
     /// `GetRankStatus::wait` with terminal / timeout mapping, mesh
     /// materialization, and telemetry. It carries **no**
     /// `C::A: Handler<MeshFailure>` bound — that is required only by the
@@ -957,7 +1027,7 @@ impl ProcMeshRef {
     /// bounded caller layers on afterward. Returns the mesh together with the
     /// final `StatusMesh` (moved into the controller for non-system actors;
     /// discarded otherwise — system actors and the controllerless path).
-    async fn spawn_mesh_inner<A: RemoteSpawn, C: context::Actor>(
+    async fn spawn_managed_mesh_inner<A: RemoteSpawn, C: context::Actor>(
         &self,
         cx: &C,
         actor_mesh_id: ActorMeshId,
@@ -1338,6 +1408,8 @@ mod tests {
     #[cfg(fbcode_build)]
     use hyperactor::context::Mailbox;
     #[cfg(fbcode_build)]
+    use hyperactor::id::Label;
+    #[cfg(fbcode_build)]
     use ndslice::ViewExt as _;
     #[cfg(fbcode_build)]
     use ndslice::extent;
@@ -1353,11 +1425,15 @@ mod tests {
     #[cfg(fbcode_build)]
     use super::ACTOR_SPAWN_MAX_IDLE;
     #[cfg(fbcode_build)]
+    use super::USE_DIRECT_SPAWN;
+    #[cfg(fbcode_build)]
     use crate::ActorMesh;
     #[cfg(fbcode_build)]
     use crate::casting::CAST_POINT;
     #[cfg(fbcode_build)]
     use crate::host_mesh::PROC_SPAWN_MAX_IDLE;
+    #[cfg(fbcode_build)]
+    use crate::mesh_id::ActorMeshId;
     #[cfg(fbcode_build)]
     use crate::resource::RankedValues;
     #[cfg(fbcode_build)]
@@ -1418,6 +1494,78 @@ mod tests {
             .await
             .expect("stopping a data actor mesh clone should be idempotent");
 
+        hm.shutdown(instance)
+            .await
+            .expect("host mesh shutdown should complete");
+    }
+
+    #[async_timed_test(timeout_secs = 300)]
+    #[cfg(fbcode_build)]
+    async fn spawn_uses_direct_path_when_configured_but_services_remain_managed() {
+        let config = hyperactor_config::global::lock();
+        let _mode = config.override_key(USE_DIRECT_SPAWN, true);
+        let instance = testing::instance();
+        let mut hm = testing::host_mesh(1).await;
+        let proc_mesh = hm
+            .spawn(
+                instance,
+                "configured_data_spawn",
+                extent!(gpus = 2),
+                None,
+                None,
+            )
+            .await
+            .expect("spawn proc mesh");
+
+        let mut actor_mesh: ActorMesh<testactor::TestActor> = proc_mesh
+            .spawn(instance, "configured_data_actor", &())
+            .await
+            .expect("initiate configured data actor mesh spawn");
+        assert!(
+            actor_mesh.as_managed().is_none(),
+            "configured instance spawn should return a data mesh"
+        );
+        assert_eq!(
+            actor_mesh.region().num_ranks(),
+            2,
+            "direct spawn should cover all proc mesh ranks"
+        );
+        assert!(
+            actor_mesh.values().all(|actor| {
+                actor.actor_addr().label().map(|label| label.as_str())
+                    == Some("configured_data_actor")
+            }),
+            "direct spawn should preserve the requested actor label"
+        );
+
+        let service: ActorMesh<testactor::TestActor> = proc_mesh
+            .spawn_service(instance, "configured_managed_service", &())
+            .await
+            .expect("spawn managed service");
+        assert!(
+            service.as_managed().is_some(),
+            "service spawn should ignore the data mesh flag"
+        );
+
+        let system_actor: ActorMesh<testactor::TestActor> = proc_mesh
+            .spawn_with_name(
+                instance,
+                ActorMeshId::instance(Label::strip("configured_managed_system_actor")),
+                &(),
+                None,
+                true,
+            )
+            .await
+            .expect("spawn managed system actor");
+        assert!(
+            system_actor.as_managed().is_some(),
+            "system actor spawn should ignore the direct spawn flag"
+        );
+
+        actor_mesh
+            .stop(instance, "test complete".to_string())
+            .await
+            .expect("stop configured data actor mesh");
         hm.shutdown(instance)
             .await
             .expect("host mesh shutdown should complete");
@@ -1952,6 +2100,7 @@ mod tests {
         hyperactor_telemetry::initialize_logging(hyperactor_telemetry::DefaultTelemetryClock {});
 
         let config = hyperactor_config::global::lock();
+        let _mode = config.override_key(USE_DIRECT_SPAWN, false);
         let _guard = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(60));
         let _guard2 = config.override_key(
             hyperactor::config::HOST_SPAWN_READY_TIMEOUT,


### PR DESCRIPTION
Summary:

Add `HYPERACTOR_MESH_USE_DIRECT_SPAWN` as a default-off end-to-end verification switch. When enabled, ordinary `ProcMesh::spawn` calls construct `DataActorMesh` values through independent supervisor-backed, nonblocking spawns. `spawn_service`, controllerless service, and system actor paths remain managed.

Tests that depend on managed mesh controllers explicitly force the flag off. The configured-mode test verifies ordinary spawns return a data mesh while services and system actors remain managed.

Two correctness gaps remain before data mode can become the default: messages sent immediately after a nonblocking spawn can race mailbox creation, and Python data spawns omit the managed path `spawn_point` field from `init_message`.

Reviewed By: mariusae

Differential Revision: D116078442


