### PR TITLE
(cleanup)[2/5][torchx] Read AppDryRunInfo.app, not the private ._app (#4716)

### DIFF
--- a/python/tests/_src/tools/test_commands.py
+++ b/python/tests/_src/tools/test_commands.py
@@ -70,7 +70,7 @@ class TestCommands(unittest.TestCase):
             dryrun_info = commands.create(config)
             assert isinstance(dryrun_info, AppDryRunInfo)
 
-            app = dryrun_info._app
+            app = dryrun_info.app
             assert app is not None
 
             for role in app.roles:


### PR DESCRIPTION
Summary:

Fifteen `fbcode` call sites read the private `AppDryRunInfo._app`; they now read the public `app`. Behavior is unchanged -- `app` is a property returning `_app` today.

Runs ahead of D116707596, which turns `app`/`cfg` into plain attributes, so that diff has no readers left to break and stays revertible on its own.

**Deliberately not here:** call sites that *write* `_app`/`_cfg`, and `_cfg` readers that `json.dumps` the value. `app`/`cfg` are read-only properties today and `cfg` returns a `MappingProxyType`, so those cannot migrate until the attributes become plain -- they ride with D116707596.

**Stack:**

- D116708125 — `mrs_research` call sites
- D116809769 — this diff
- D116707596 — `app`/`cfg` as plain attributes
- D116718390 — mutation-contract docs
- D116720556 — `Runner.build_workspace()`

Reviewed By: thedavekwon

Differential Revision: D116809769


