### PR TITLE
add Future and Handle behavior tests (#4718)

### DIFF
--- a/monarch_hyperactor/src/handle.rs
+++ b/monarch_hyperactor/src/handle.rs
@@ -986,6 +986,62 @@ def run_two(h):
         });
     }
 
+    // __await__ in a Tokio runtime context finds no asyncio loop to bridge to,
+    // so it surfaces asyncio's native "no running event loop" RuntimeError --
+    // NOT WouldBlockRuntime, which among the observers stays specific to get()
+    // (HDL-6). The refusal consumes nothing: the same handle still observes its
+    // value afterwards. Lives here rather than in the Python suite so the Handle
+    // contract does not depend on a PythonTask-driven test helper.
+    // Attests HDL-6, HDL-7.
+    #[test]
+    fn await_in_tokio_raises_native_and_leaves_handle_observable() {
+        ensure_python();
+        let handle = monarch_with_gil_blocking(GilSite::Test, |py| {
+            let value = 11i64.into_py_any(py).unwrap();
+            Py::new(py, PyHandle::from_value(value).unwrap()).unwrap()
+        });
+        let in_tokio = monarch_with_gil_blocking(GilSite::Test, |py| handle.clone_ref(py));
+
+        // `block_on` would poll the root future on *this* thread under an
+        // entered runtime -- `is_tokio_thread()` is true there, but it is not a
+        // worker and nested blocking is tolerated. Spawn instead, so the
+        // assertion genuinely runs on a runtime worker, and join from here.
+        let joined = get_tokio_runtime().spawn(async move {
+            assert!(
+                is_tokio_thread(),
+                "the oracle must observe from a runtime worker"
+            );
+            monarch_with_gil(GilSite::Test, |py| {
+                let err = PyHandle::__await__(in_tokio.borrow(py), py).unwrap_err();
+                assert!(
+                    !err.is_instance_of::<WouldBlockRuntime>(py),
+                    "__await__ must not raise WouldBlockRuntime; among the observers that is get()'s alone"
+                );
+                assert!(
+                    err.is_instance_of::<PyRuntimeError>(py),
+                    "__await__ off an asyncio loop should raise the native RuntimeError"
+                );
+                assert!(
+                    err.to_string().contains("no running event loop"),
+                    "expected asyncio's native message, got {err}"
+                );
+            })
+            .await
+        });
+        get_tokio_runtime()
+            .block_on(joined)
+            .expect("the spawned oracle panicked");
+
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let value = PyHandle::get(handle.borrow(py), py, None).unwrap();
+            assert_eq!(
+                value.extract::<i64>(py).unwrap(),
+                11,
+                "a refused __await__ must not consume the handle"
+            );
+        });
+    }
+
     // get(timeout) raises TimeoutError and leaves the handle pending, so a later
     // observation still sees completion.
     // Attests HDL-12.

--- a/monarch_hyperactor/src/handle.rs
+++ b/monarch_hyperactor/src/handle.rs
@@ -52,9 +52,13 @@
 //!   and every acquisition goes through `monarch_with_gil{,_blocking}`. Enforced
 //!   by the crate's `#![deny(clippy::disallowed_methods)]` ban on raw
 //!   `Python::with_gil`/`attach` -- a hard compile error, not a `debug_assert`.
-//! - **HDL-6 (`WouldBlockRuntime` is `get()`'s alone).** Only `get()` raises it,
-//!   and only in a Tokio runtime context; `as_asyncio()`/`__await__` off a loop
-//!   raise the native `RuntimeError` instead.
+//! - **HDL-6 (`WouldBlockRuntime` is `get()`'s alone *among the observers*).**
+//!   Of the `Handle` observers only `get()` raises it, and only in a Tokio
+//!   runtime context; `as_asyncio()`/`__await__` off a loop raise the native
+//!   `RuntimeError` instead. The exception type itself is not private to this
+//!   module: it marks synchronous APIs that refuse to enter or block on Tokio
+//!   from an existing Tokio runtime context. The Python layer also raises it
+//!   for fresh root-client bootstrap (`monarch._src.actor.actor_mesh`).
 //! - **HDL-7 (`as_asyncio` publish).** The observer waits borrow-first (via
 //!   `wait_ready`, never `changed()`-first) and sets a result only on a
 //!   non-cancelled future, swallowing `InvalidStateError`; any `StopIteration`
@@ -139,7 +143,9 @@ pyo3::create_exception!(
     pytokio,
     WouldBlockRuntime,
     pyo3::exceptions::PyRuntimeError,
-    "raised when Handle.get() is called from a Tokio runtime context"
+    "raised when a synchronous API refuses to enter or block on Tokio from \
+     an existing Tokio runtime context -- Handle.get(), or a fresh root-client \
+     bootstrap from the Python layer"
 );
 
 /// The watch-channel mechanics behind a `Handle`.
@@ -525,10 +531,10 @@ impl PyHandle {
     /// `poll()`/`get()`/`await` still observes completion.
     #[pyo3(signature = (timeout = None))]
     fn get(slf: PyRef<'_, Self>, py: Python<'_>, timeout: Option<f64>) -> PyResult<Py<PyAny>> {
-        // HDL-6: get() is the sole WouldBlockRuntime raiser. It is the blocking
-        // API, and in a Tokio runtime context blocking would panic the runtime,
-        // so refuse unconditionally -- even a ready value -- keying the outcome
-        // to context, not producer timing.
+        // HDL-6: among the observers, get() is the sole WouldBlockRuntime
+        // raiser. It is the blocking API, and in a Tokio runtime context
+        // blocking would panic the runtime, so refuse unconditionally -- even
+        // a ready value -- keying the outcome to context, not producer timing.
         if is_tokio_thread() {
             return Err(WouldBlockRuntime::new_err(
                 "get() cannot be called from a Tokio runtime context; use poll() or as_asyncio()",

--- a/monarch_hyperactor/src/testing.rs
+++ b/monarch_hyperactor/src/testing.rs
@@ -6,12 +6,181 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Minimal PyO3 struct for testing `@rust_struct` mixin patching.
+//! Private test-support bindings.
 //!
-//! The `#[pyclass]` module is set to the Python file that defines
-//! the `@rust_struct`-decorated class so the name-validation check passes.
+//! Two unrelated pieces live here:
+//!
+//! 1. `TestStruct`, a minimal PyO3 struct for testing `@rust_struct` mixin
+//!    patching. The `#[pyclass]` module is set to the Python file that defines
+//!    the `@rust_struct`-decorated class so the name-validation check passes.
+//! 2. `_HandleProbe`, a closed probe that mints a real Rust-produced `Handle`
+//!    for the `Future`/`Handle` contract suite.
+//!
+//! Everything here is private support: nothing is re-exported from `monarch`
+//! and no production Python imports it.
 
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+
+use pyo3::exceptions::PyKeyboardInterrupt;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use tokio::sync::oneshot;
+
+use crate::handle::PyHandle;
+use crate::runtime::signal_safe_block_on;
+
+/// The value a successful probe publishes. Fixed, because the probe accepts no
+/// caller-supplied producer or value.
+pub(crate) const PROBE_SUCCESS_VALUE: i64 = 4242;
+
+/// The closed set of terminal outcomes the probe can produce.
+///
+/// Deliberately not a caller-supplied coroutine, awaitable, callable, future or
+/// producer function: the probe exists to put a real `PyHandle` into one of
+/// three reviewed terminal states, not to drive arbitrary work.
+#[derive(Clone, Copy)]
+enum ProbeOutcome {
+    Success,
+    Exception,
+    BaseException,
+}
+
+impl ProbeOutcome {
+    fn parse(name: &str) -> PyResult<Self> {
+        match name {
+            "success" => Ok(Self::Success),
+            "exception" => Ok(Self::Exception),
+            "base_exception" => Ok(Self::BaseException),
+            other => Err(PyValueError::new_err(format!(
+                "unknown probe outcome {other:?}; expected one of \
+                 'success', 'exception', 'base_exception'"
+            ))),
+        }
+    }
+
+    fn into_result(self) -> PyResult<i64> {
+        match self {
+            Self::Success => Ok(PROBE_SUCCESS_VALUE),
+            Self::Exception => Err(PyValueError::new_err("probe failure")),
+            Self::BaseException => Err(PyKeyboardInterrupt::new_err("probe base failure")),
+        }
+    }
+}
+
+/// A closed control object over one Rust-produced `Handle`.
+///
+/// The handle comes from the real [`PyHandle::spawn`] path (HDL-13), never from
+/// `PythonTask.spawn_handle()`, so the contract suite observes a genuine direct
+/// Rust producer. The producer parks on a release gate, so a test decides
+/// exactly when the terminal state becomes observable without sleeping.
+///
+/// Two limits are load-bearing, not stylistic:
+///
+/// * It must never accept arbitrary Python work -- no coroutine, awaitable,
+///   callable, future or producer function. Widening it to take one turns a
+///   contract fixture into a general async escape hatch, and every caller then
+///   depends on this module staying compiled into production.
+/// * It must never be cited as a real producer's oracle. Its timing is a
+///   release gate and its outcomes are three fixed cases, so it says nothing
+///   about when a real producer starts work or whether that work is abandoned
+///   when nobody observes it. Those belong to the producer's own tests.
+#[pyclass(
+    name = "_HandleProbe",
+    module = "monarch._rust_bindings.monarch_hyperactor.testing"
+)]
+pub struct PyHandleProbe {
+    handle: Py<PyHandle>,
+    release: Mutex<Option<oneshot::Sender<()>>>,
+    started: Arc<AtomicBool>,
+    completed: Arc<AtomicBool>,
+}
+
+#[pymethods]
+impl PyHandleProbe {
+    /// The observe-only `Handle` under test. Cloning the reference does not
+    /// consume it, so repeated lookups and observations are safe.
+    #[getter]
+    fn _handle(&self, py: Python<'_>) -> Py<PyHandle> {
+        self.handle.clone_ref(py)
+    }
+
+    /// Whether the producer body has begun.
+    ///
+    /// This can be true immediately after construction: the producer is eager,
+    /// so it enters its body and sets this *before* waiting on `_release`. Only
+    /// completion is gated, so `_completed` is the witness a test can assert a
+    /// negative on.
+    #[getter]
+    fn _started(&self) -> bool {
+        self.started.load(Ordering::SeqCst)
+    }
+
+    /// Whether the producer body has finished.
+    ///
+    /// Set just before the terminal value is published, so it is a witness for
+    /// assertions, not a synchronization primitive; use `_wait_completed` to
+    /// wait for the value to be observable.
+    #[getter]
+    fn _completed(&self) -> bool {
+        self.completed.load(Ordering::SeqCst)
+    }
+
+    /// Open the release gate so the producer can run to its terminal state.
+    ///
+    /// Idempotent: a second call is a no-op, so a test may release
+    /// unconditionally in a fixture teardown.
+    fn _release(&self) {
+        if let Some(tx) = self.release.lock().expect("probe mutex poisoned").take() {
+            let _ = tx.send(());
+        }
+    }
+
+    /// Block until the terminal state is published, discarding it.
+    ///
+    /// This is how a test reaches a genuinely *ready* `Handle` deterministically
+    /// -- the alternative is sleeping, which the contract suite forbids. The
+    /// terminal value is dropped here; the test observes it through the handle.
+    /// Must be called off a Tokio thread, like any other blocking observation.
+    fn _wait_completed(&self, py: Python<'_>) -> PyResult<()> {
+        let waiter = self.handle.bind(py).borrow().wait_completion();
+        // The probe waits for publication; whether the outcome was success or
+        // error is the test's business, observed through the handle.
+        signal_safe_block_on(py, async move {
+            let _ = waiter.await;
+        })
+    }
+}
+
+/// Build a probe whose handle will reach `outcome` once released.
+#[pyfunction]
+fn _make_handle_probe(py: Python<'_>, outcome: &str) -> PyResult<PyHandleProbe> {
+    let outcome = ProbeOutcome::parse(outcome)?;
+    let (tx, rx) = oneshot::channel::<()>();
+    let started = Arc::new(AtomicBool::new(false));
+    let completed = Arc::new(AtomicBool::new(false));
+    let started_producer = Arc::clone(&started);
+    let completed_producer = Arc::clone(&completed);
+
+    let handle = PyHandle::spawn(async move {
+        started_producer.store(true, Ordering::SeqCst);
+        // A dropped sender releases the gate too, so the producer cannot wedge
+        // if the probe is garbage collected mid-test.
+        let _ = rx.await;
+        let result = outcome.into_result();
+        completed_producer.store(true, Ordering::SeqCst);
+        result
+    });
+
+    Ok(PyHandleProbe {
+        handle: Py::new(py, handle)?,
+        release: Mutex::new(Some(tx)),
+        started,
+        completed,
+    })
+}
 
 #[pyclass(name = "TestStruct", module = "monarch._src.actor.testing")]
 pub struct PyTestStruct {
@@ -42,5 +211,8 @@ fn _make_test_struct(value: i64) -> PyTestStruct {
 pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyTestStruct>()?;
     module.add_function(wrap_pyfunction!(_make_test_struct, module)?)?;
+    module.add_class::<PyHandleProbe>()?;
+    module.add_function(wrap_pyfunction!(_make_handle_probe, module)?)?;
+    module.add("_PROBE_SUCCESS_VALUE", PROBE_SUCCESS_VALUE)?;
     Ok(())
 }

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
@@ -160,7 +160,13 @@ class Handle(Generic[T]):
 
 class WouldBlockRuntime(RuntimeError):
     """
-    Raised when Handle.get() is called from a Tokio runtime context.
+    Raised when a synchronous API refuses to enter or block on Tokio from an
+    existing Tokio runtime context.
+
+    Two raisers today: ``Handle.get()``, and a fresh root-client bootstrap
+    (``context()`` with no actor context and no initialized client, or
+    ``attach()``). Reusing an already-initialized client does not block and so
+    does not raise.
     """
 
     ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/testing.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/testing.pyi
@@ -17,3 +17,37 @@ class TestStruct:
     def shared_method(self) -> str: ...
 
 def _make_test_struct(value: int) -> Any: ...
+
+# The value a successful probe publishes.
+_PROBE_SUCCESS_VALUE: int
+
+@final
+class _HandleProbe:
+    """Closed control object over one Rust-produced ``Handle``.
+
+    Private contract-test support. The handle comes from the real
+    ``PyHandle::spawn`` path, not from ``PythonTask.spawn_handle()``. The probe
+    accepts no coroutine, awaitable, callable, future or producer function: it
+    only puts a genuine ``Handle`` into one of three reviewed terminal states.
+
+    ``_handle`` is typed ``Any`` rather than ``Handle[Any]`` so this stub does
+    not import the legacy ``pytokio`` module solely for typing; the
+    characterization suite casts it privately.
+    """
+
+    @property
+    def _handle(self) -> Any: ...
+    @property
+    def _started(self) -> bool: ...
+    @property
+    def _completed(self) -> bool: ...
+    def _release(self) -> None: ...
+    def _wait_completed(self) -> None: ...
+
+def _make_handle_probe(outcome: str) -> _HandleProbe:
+    """Build a probe whose handle reaches ``outcome`` once released.
+
+    ``outcome`` is one of ``"success"``, ``"exception"`` (an ordinary
+    ``Exception``) or ``"base_exception"``.
+    """
+    ...

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -69,7 +69,11 @@ from monarch._rust_bindings.monarch_hyperactor.pickle import (
     PicklingState,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._rust_bindings.monarch_hyperactor.pytokio import (
+    is_tokio_thread,
+    PythonTask,
+    WouldBlockRuntime,
+)
 from monarch._rust_bindings.monarch_hyperactor.shape import Point as HyPoint, Shape
 from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
 from monarch._src.actor import config
@@ -462,6 +466,12 @@ def _init_client_context(via: Optional[str] = None) -> Context:
     Create a client context that bootstraps an actor instance running on a real
     local proc mesh on a real local host mesh.
 
+    Fresh bootstrap ends in ``block_on()``, which panics on a Tokio runtime
+    worker. Reject it from every Tokio runtime context, including the blocking
+    pool, so this synchronous API does not depend on which Tokio-managed thread
+    invoked it. An already-initialized client bypasses this function and can
+    still be reused.
+
     When ``via`` is a non-empty ZMQ-style address, the local client's
     gateway is connected to the gateway serving that address: outbound
     traffic forwards over the duplex, and the remote gateway routes
@@ -470,6 +480,13 @@ def _init_client_context(via: Optional[str] = None) -> Context:
     procs are reached, not the host's identity. Use ``attach``
     to supply ``via`` before the client context is first used.
     """
+    if is_tokio_thread():
+        raise WouldBlockRuntime(
+            "cannot bootstrap a root client from inside the Tokio runtime; "
+            "call context(), this_host(), or attach(addr) before entering "
+            "Tokio. An already-initialized client can still be reused."
+        )
+
     import atexit
 
     from monarch._rust_bindings.monarch_hyperactor.host_mesh import bootstrap_host
@@ -527,7 +544,8 @@ def attach(addr: str) -> None:
     first client-context use. Raises ``RuntimeError`` if the client
     context has already been bootstrapped. ``this_host()`` still names
     the current machine — attach only changes how this host's procs
-    are reached.
+    are reached. Raises ``WouldBlockRuntime`` if called from inside a Tokio
+    runtime before the client has been initialized.
     """
     with _client_context._lock:
         if _client_context._val is not None:
@@ -594,7 +612,9 @@ def context() -> Context:
 
     Call this from within an endpoint to inspect the running actor and the
     current message's position in the mesh. Outside an actor (on the client) it
-    returns the root client context.
+    returns the root client context. Raises ``WouldBlockRuntime`` rather than
+    attempting fresh root-client bootstrap from inside a Tokio runtime; an
+    already-initialized client can still be reused there.
     """
     c = _context.get()
     if c is None:

--- a/python/tests/test_client_context_guard.py
+++ b/python/tests/test_client_context_guard.py
@@ -1,0 +1,170 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Fresh root-client bootstrap must not be attempted from inside Tokio.
+
+Bootstrapping a client ends in ``block_on()``, which panics on a Tokio runtime
+worker. The guard rejects fresh bootstrap from every Tokio runtime context,
+including its blocking pool, while still allowing an already-initialized client
+to be reused.
+"""
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.pytokio import (
+    is_tokio_thread,
+    PythonTask,
+    WouldBlockRuntime,
+)
+from monarch._src.actor.host_mesh import this_host
+from monarch.actor import Actor, endpoint
+
+_EXPECTED = "WouldBlockRuntime uninitialized=True"
+
+
+def _probe_fresh_bootstrap() -> str:
+    """Ask for a context on a Tokio thread with neither actor nor client."""
+    from monarch._src.actor.actor_mesh import _client_context, _context, context
+
+    if not is_tokio_thread():
+        return "precondition: not a tokio thread"
+    if _client_context.try_get() is not None:
+        return "precondition: client already initialized"
+    # spawn_blocking propagates the caller's actor context; drop it so the
+    # fresh-bootstrap branch is the one under test.
+    token = _context.set(None)
+    try:
+        context()
+    except WouldBlockRuntime:
+        return f"WouldBlockRuntime uninitialized={_client_context.try_get() is None}"
+    # BaseException, not Exception: PyO3's PanicException derives from it, and
+    # reporting that panic by name is the point of these probes. The result is
+    # transformed into the returned string, not swallowed.
+    except BaseException as err:  # noqa: B036
+        return f"{type(err).__name__}: {err}"
+    else:
+        return "no raise"
+    finally:
+        _context.reset(token)
+
+
+async def _probe_fresh_bootstrap_on_worker() -> str:
+    """The incident shape: a runtime *worker* thread, where block_on panics.
+
+    ``spawn_blocking`` threads report ``is_tokio_thread()`` but tolerate
+    ``block_on``; a worker thread does not. This is the case that motivated
+    the guard.
+    """
+    return _probe_fresh_bootstrap()
+
+
+def _probe_attach() -> str:
+    """``attach()`` bootstraps directly, bypassing ``context()``."""
+    from monarch._src.actor.actor_mesh import _client_context, attach
+
+    if not is_tokio_thread():
+        return "precondition: not a tokio thread"
+    if _client_context.try_get() is not None:
+        return "precondition: client already initialized"
+    try:
+        attach("tcp://127.0.0.1:1")
+    except WouldBlockRuntime:
+        return f"WouldBlockRuntime uninitialized={_client_context.try_get() is None}"
+    # BaseException, not Exception: PyO3's PanicException derives from it, and
+    # reporting that panic by name is the point of these probes. The result is
+    # transformed into the returned string, not swallowed.
+    except BaseException as err:  # noqa: B036
+        return f"{type(err).__name__}: {err}"
+    return "no raise"
+
+
+def _probe_reuse() -> str:
+    """An initialized client must still be handed back on a Tokio thread."""
+    from monarch._src.actor.actor_mesh import _client_context, _context, context
+
+    if not is_tokio_thread():
+        return "precondition: not a tokio thread"
+    expected = _client_context.try_get()
+    if expected is None:
+        return "precondition: client not initialized"
+    token = _context.set(None)
+    try:
+        got = context()
+    # BaseException, not Exception: PyO3's PanicException derives from it, and
+    # reporting that panic by name is the point of these probes. The result is
+    # transformed into the returned string, not swallowed.
+    except BaseException as err:  # noqa: B036
+        return f"{type(err).__name__}: {err}"
+    else:
+        return "reused" if got is expected else "different object"
+    finally:
+        _context.reset(token)
+
+
+class _Prober(Actor):
+    """Runs probes on Tokio worker and blocking threads in a worker process.
+
+    A worker process never bootstraps a client of its own, so it is the only
+    place the fresh-bootstrap branch is genuinely reachable.
+    """
+
+    @endpoint
+    def run(self, which: str) -> str:
+        if which == "fresh_worker":
+            return (
+                PythonTask.from_coroutine(_probe_fresh_bootstrap_on_worker())
+                .spawn()
+                .block_on()
+            )
+        probes = {"fresh": _probe_fresh_bootstrap, "attach": _probe_attach}
+        return PythonTask.spawn_blocking(probes[which]).block_on()
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_context_on_tokio_without_client_refuses_fresh_bootstrap() -> None:
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
+    try:
+        prober = pm.spawn("prober", _Prober)
+        assert prober.run.call_one("fresh").get() == _EXPECTED
+    finally:
+        pm.stop().get()
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_context_on_tokio_worker_refuses_fresh_bootstrap() -> None:
+    """The incident shape: fresh bootstrap from a runtime worker thread."""
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
+    try:
+        prober = pm.spawn("prober", _Prober)
+        assert prober.run.call_one("fresh_worker").get() == _EXPECTED
+    finally:
+        pm.stop().get()
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_attach_on_tokio_refuses_before_bootstrap() -> None:
+    pm = this_host().spawn_procs(per_host={"gpus": 1})
+    try:
+        prober = pm.spawn("prober", _Prober)
+        assert prober.run.call_one("attach").get() == _EXPECTED
+    finally:
+        pm.stop().get()
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_context_on_tokio_reuses_initialized_client() -> None:
+    """The guard must not reject a contextless Tokio caller out of hand."""
+    from monarch._src.actor.actor_mesh import _client_context, context
+
+    context()
+    assert _client_context.try_get() is not None, "client should be initialized here"
+    assert PythonTask.spawn_blocking(_probe_reuse).block_on() == "reused"

--- a/python/tests/test_future_characterization.py
+++ b/python/tests/test_future_characterization.py
@@ -17,6 +17,7 @@ warning, and the ``_take_inner()`` accessor with its ``_Taken`` terminal state
 
 import asyncio
 import warnings
+from typing import Any, Callable, cast, NamedTuple
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.pytokio import (
@@ -24,6 +25,10 @@ from monarch._rust_bindings.monarch_hyperactor.pytokio import (
     is_tokio_thread,
     PythonTask,
     WouldBlockRuntime,
+)
+from monarch._rust_bindings.monarch_hyperactor.testing import (
+    _make_handle_probe,
+    _PROBE_SUCCESS_VALUE,
 )
 from monarch._src.actor import future as future_mod
 from monarch._src.actor.future import Future
@@ -46,11 +51,43 @@ async def _await_once(fut: Future):
     return await fut
 
 
+def _future_pending() -> "tuple[Any, Callable[[], None]]":
+    """A facade observable that stays pending until it is drained.
+
+    Deliberately not a long timed sleep. A ``PythonTask.sleep(3600)`` cannot
+    race a short-timeout assertion, but it outlives the test: the runtime still
+    owns it at interpreter exit, and outstanding tasks are a documented source
+    of SIGABRT there. A gate the test controls has neither problem -- the task
+    cannot finish early, so the timeout assertion is race-free, and ``drain``
+    ends it before the test returns.
+    """
+    gate = {"released": False}
+
+    async def hold():
+        while not gate["released"]:
+            await PythonTask.sleep(0.005)
+        return _PROBE_SUCCESS_VALUE
+
+    fut: Future[int] = Future._from_coro(hold())
+
+    def drain() -> None:
+        gate["released"] = True
+        fut.get()  # block until the task has actually finished
+
+    return fut, drain
+
+
 def _run_in_tokio(coro):
     # Drive ``coro`` to completion on the Tokio runtime. Code inside ``coro``
     # runs on a Tokio worker thread, where ``is_tokio_thread()`` is True and a
     # ``Future`` takes its ``__await__`` tokio branch. ``block_on`` itself runs
     # on the (non-worker) calling thread, so it is allowed to block.
+    #
+    # ``PythonTask.spawn_blocking`` is NOT an equivalent driver, even though
+    # ``is_tokio_thread()`` is also True there: a blocking-pool thread tolerates
+    # nested blocking, while a runtime worker panics on it. Any Tokio case that
+    # turns on refusing to block must use this worker path, or it silently
+    # proves nothing.
     return PythonTask.from_coroutine(coro).block_on()
 
 
@@ -106,9 +143,12 @@ def test_get_timeout_raises_timeout_error():
     deadline, so an unfinished task surfaces a TimeoutError rather than hanging.
     The timeout is non-cancelling (state becomes _Handle); the sibling
     test_get_timeout_is_non_poisoning_and_reobservable pins re-observation."""
-    fut: Future[None] = Future._from_coro(PythonTask.sleep(3600))
-    with pytest.raises(TimeoutError):
-        fut.get(timeout=0.1)
+    fut, drain = _future_pending()
+    try:
+        with pytest.raises(TimeoutError):
+            fut.get(timeout=0.1)
+    finally:
+        drain()
 
 
 def test_get_timeout_is_non_poisoning_and_reobservable():
@@ -292,12 +332,15 @@ def test_await_tokio_after_get_exception_raises_synchronous_future():
         _run_in_tokio(attempt())
 
 
-def test_await_with_no_event_loop_raises():
+def test_await_with_no_event_loop_raises_and_is_non_consuming():
     """await with neither an asyncio loop nor a tokio runtime active: there is no
-    driver, so __await__ refuses outright."""
+    driver, so __await__ refuses outright -- and refusing consumes nothing, so
+    the Future stays _Unawaited and a later get() still drives it."""
     fut: Future[int] = Future._from_coro(_value(1))
     with pytest.raises(ValueError, match="no active event loop"):
         fut.__await__()
+    assert isinstance(fut._status, future_mod._Unawaited)
+    assert fut.get() == 1
 
 
 # ---------------------------------------------------------------------------
@@ -605,3 +648,624 @@ async def test_as_asyncio_on_cached_stop_iteration_wraps_in_runtime_error():
     settled = fut.as_asyncio()
     with pytest.raises(RuntimeError, match="StopIteration"):
         await settled
+
+
+# ---------------------------------------------------------------------------
+# Future/Handle contract matrix
+#
+# Three proof layers, kept structurally apart on purpose:
+#
+#   * incumbent Future oracle -- what the public facade does today;
+#   * direct Handle oracle    -- what the underlying Handle does, observed
+#                                through a real Rust-produced Handle rather
+#                                than through the facade;
+#   * Handle-backed facade    -- how a Future built directly on a Handle
+#                                behaves. Not executable yet: Future has no
+#                                Handle-backed constructor.
+#
+# The third layer is a seam, not a promise. Every target assertion lives in an
+# ``_assert_*`` helper that takes a *factory*, never a hard-coded constructor,
+# and each row is driven by one of four registries below. Adding a
+# Handle-backed Future factory to a registry runs that row's assertions against
+# the facade with no edit to the assertion body.
+#
+# Assertions that pin an incumbent divergence are deliberately NOT
+# factory-driven: they describe behavior that is going away, and there is
+# nothing to activate.
+#
+# Registry per row (every one of the 15 has a seam):
+#
+#   PRESERVED_BY_BOTH  -- target already satisfied by both representations
+#     fm.repeated_observation, fm.exception_identity, fm.off_loop_as_asyncio
+#   TARGET_ONLY        -- ready observable; only the Handle satisfies it today
+#     fm.ready_get_on_loop_warns, fm.ready_get_on_tokio_refuses,
+#     fm.invalid_timeout_on_ready, fm.ready_as_asyncio_settlement,
+#     fm.terminal_baseexception_reobservable, fm.off_loop_await, fm.tokio_await
+#   GATED_TARGETS      -- (control, observable) pairs, producer held mid-flight
+#     fm.timeout_then_success, fm.cancelled_observer
+#   FACADE_FACTORIES   -- facade-only surfaces, no Handle primitive
+#     fm.get_tracing_event, fm.result_alias, fm.exception_accessor
+#
+# Incumbent-divergence companions (not factory-driven, no activation):
+#   fm.ready_get_on_tokio_refuses, fm.invalid_timeout_on_ready,
+#   fm.ready_as_asyncio_settlement, fm.terminal_baseexception_reobservable
+#
+# fm.cancelled_observer also has an unparametrized current-side test, but it is
+# a *preserve* row: both representations behave identically, so that test is a
+# second oracle for the same behavior, not a divergence.
+#
+# The permanent Handle-side oracle for fm.tokio_await lives in handle.rs, so
+# that contract does not depend on a PythonTask-driven helper.
+# ---------------------------------------------------------------------------
+
+
+def _probe(outcome: str):
+    """A gated probe: the producer has spawned but parks until released."""
+    return _make_handle_probe(outcome)
+
+
+def _ready_handle(outcome: str):
+    """A genuinely ready Rust-produced Handle in ``outcome``'s terminal state.
+
+    Released and waited synchronously rather than slept on, so readiness is
+    deterministic. Returns the probe too, so a caller can assert its witnesses.
+    """
+    probe = _make_handle_probe(outcome)
+    # Released before returning, so a caller that fails mid-assertion cannot
+    # strand a parked producer; there is nothing left to reap.
+    probe._release()
+    probe._wait_completed()
+    return probe, cast("Any", probe._handle)
+
+
+# -- observable factories ----------------------------------------------------
+
+
+def _future_observable(outcome: str):
+    """An incumbent-facade observable matching the probe's outcomes."""
+    if outcome == "success":
+        return Future._from_coro(_value(_PROBE_SUCCESS_VALUE))
+    if outcome == "exception":
+        return Future._from_coro(_raise(ValueError("probe failure")))
+    if outcome == "base_exception":
+        return Future._from_coro(_raise(KeyboardInterrupt("probe base failure")))
+    raise AssertionError(f"no incumbent observable for {outcome!r}")
+
+
+class _Facade(NamedTuple):
+    """A facade representation: terminal-state observables plus a pending one.
+
+    Two callables rather than one because a *pending* observable needs a
+    control to end it, and a terminal one does not. A Handle-backed entry
+    supplies its own pair; no assertion body changes.
+    """
+
+    observable: "Callable[[str], Any]"
+    pending: "Callable[[], tuple[Any, Callable[[], None]]]"
+
+
+def _handle_observable(outcome: str):
+    """A ready Rust-produced Handle in ``outcome``'s terminal state."""
+    return _ready_handle(outcome)[1]
+
+
+def _handle_gated():
+    """A (control, observable) pair whose producer is held mid-flight."""
+    probe = _probe("success")
+    return probe, cast("Any", probe._handle)
+
+
+# Target already satisfied by both representations.
+PRESERVED_BY_BOTH = [
+    pytest.param(_future_observable, id="current_future"),
+    pytest.param(_handle_observable, id="raw_handle"),
+]
+
+# Ready-observable rows where only the Handle satisfies the target today.
+TARGET_ONLY = [pytest.param(_handle_observable, id="raw_handle")]
+
+# Rows needing a producer held mid-flight, plus the control that releases it.
+GATED_TARGETS = [pytest.param(_handle_gated, id="raw_handle")]
+
+# Facade-only surfaces: result()/exception()/tracing have no Handle primitive,
+# so the seam starts with the incumbent Future and gains the Handle-backed one.
+FACADE_FACTORIES = [
+    pytest.param(_Facade(_future_observable, _future_pending), id="current_future")
+]
+
+
+# -- target-behavior assertions, shared across representations ---------------
+
+
+def _assert_repeated_observation(make_observable):
+    ok = make_observable("success")
+    assert ok.get() == _PROBE_SUCCESS_VALUE
+    assert ok.get() == _PROBE_SUCCESS_VALUE
+
+    bad = make_observable("exception")
+    with pytest.raises(ValueError, match="probe failure"):
+        bad.get()
+    with pytest.raises(ValueError, match="probe failure"):
+        bad.get()
+
+
+def _assert_exception_identity(make_observable):
+    bad = make_observable("exception")
+    with pytest.raises(ValueError) as first:
+        bad.get()
+    with pytest.raises(ValueError) as second:
+        bad.get()
+    assert second.value is first.value
+
+
+def _assert_off_loop_as_asyncio_refuses(make_observable):
+    ok = make_observable("success")
+    with pytest.raises(RuntimeError) as caught:
+        ok.as_asyncio()
+    assert not isinstance(caught.value, WouldBlockRuntime)
+    assert ok.get() == _PROBE_SUCCESS_VALUE  # refusing consumed nothing
+
+
+def _assert_invalid_timeout_validated(make_observable):
+    ok = make_observable("success")
+    for bad in (float("nan"), -1.0, float("inf")):
+        with pytest.raises(ValueError):
+            ok.get(timeout=bad)
+    assert ok.get() == _PROBE_SUCCESS_VALUE  # rejection was non-destructive
+
+
+def _assert_terminal_baseexception_reobservable(make_observable):
+    base = make_observable("base_exception")
+    with pytest.raises(KeyboardInterrupt) as first:
+        base.get()
+    with pytest.raises(KeyboardInterrupt) as second:
+        base.get()
+    assert second.value is first.value
+
+
+def _assert_off_loop_await_raises_native(make_observable):
+    ok = make_observable("success")
+    with pytest.raises(RuntimeError) as caught:
+        ok.__await__()
+    assert not isinstance(caught.value, WouldBlockRuntime)
+    assert "no running event loop" in str(caught.value)
+    assert ok.get() == _PROBE_SUCCESS_VALUE
+
+
+def _assert_tokio_await_raises_native(make_observable):
+    from monarch._src.actor.actor_mesh import _client_context
+
+    ok = make_observable("success")
+
+    async def attempt():
+        assert is_tokio_thread()
+        # WouldBlockRuntime subclasses RuntimeError, so a bare match would also
+        # accept get()'s refusal or the root-client bootstrap guard. Identify
+        # the raiser, and pin the client as initialized so the guard is
+        # structurally unreachable.
+        assert _client_context._val is not None, "bootstrap guard could fire"
+        with pytest.raises(RuntimeError) as caught:
+            ok.__await__()
+        assert not isinstance(caught.value, WouldBlockRuntime)
+        return str(caught.value)
+
+    assert "no running event loop" in _run_in_tokio(attempt())
+    assert ok.get() == _PROBE_SUCCESS_VALUE  # refusal consumed nothing
+
+
+def _assert_ready_get_on_tokio_refuses(make_observable):
+    from monarch._src.actor.actor_mesh import _client_context
+
+    ok = make_observable("success")
+    assert ok.get() == _PROBE_SUCCESS_VALUE  # ready before crossing over
+
+    async def attempt():
+        assert is_tokio_thread()
+        assert _client_context._val is not None, "bootstrap guard could fire"
+        with pytest.raises(WouldBlockRuntime) as caught:
+            ok.get()
+        return str(caught.value)
+
+    # The Handle-specific message identifies the observer. A Handle-backed
+    # facade delegates to the same observer, so it carries the same message.
+    assert _run_in_tokio(attempt()) == (
+        "get() cannot be called from a Tokio runtime context; "
+        "use poll() or as_asyncio()"
+    )
+
+
+async def _assert_ready_get_on_loop_warns(make_observable):
+    ok = make_observable("success")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert ok.get() == _PROBE_SUCCESS_VALUE
+    matching = [
+        w
+        for w in caught
+        if issubclass(w.category, UserWarning) and "event loop" in str(w.message)
+    ]
+    assert len(matching) == 1
+
+
+def _assert_timeout_then_success(make_gated):
+    control, observable = make_gated()
+    # A gated producer parks until released, so a failing assertion would leave
+    # it running past the test. Release and reap unconditionally.
+    try:
+        with pytest.raises(TimeoutError):
+            observable.get(timeout=0.01)  # still gated
+        control._release()
+        assert observable.get() == _PROBE_SUCCESS_VALUE
+    finally:
+        control._release()
+        control._wait_completed()
+
+
+async def _assert_cancelled_observer(make_gated):
+    control, observable = make_gated()
+    try:
+        first = observable.as_asyncio()
+        assert first.cancel() is True
+        assert first.cancelled()
+        # The producer is provably still running while the observer dies; a
+        # completed producer could otherwise mask a cancelled one.
+        assert not control._completed
+
+        control._release()
+        # Awaiting the second observer is itself proof of publication.
+        assert await observable.as_asyncio() == _PROBE_SUCCESS_VALUE
+        assert control._completed
+    finally:
+        # Teardown only: on the happy path the await above already proved
+        # publication. This blocks the loop, which is acceptable when the test
+        # is already unwinding and the producer must not outlive it.
+        control._release()
+        control._wait_completed()
+
+
+def _assert_result_aliases_get(facade):
+    done = facade.observable("success")
+    assert done.result() == _PROBE_SUCCESS_VALUE
+    assert done.result() == done.get()
+
+    failed = facade.observable("exception")
+    with pytest.raises(ValueError, match="probe failure") as first:
+        failed.result()
+    with pytest.raises(ValueError, match="probe failure") as second:
+        failed.get()
+    assert second.value is first.value
+
+    pending, drain = facade.pending()
+    try:
+        with pytest.raises(TimeoutError):
+            pending.result(timeout=0.01)
+    finally:
+        drain()
+
+
+def _assert_exception_accessor(facade):
+    assert facade.observable("success").exception() is None
+
+    returned = facade.observable("exception").exception()
+    assert isinstance(returned, ValueError)
+    assert str(returned) == "probe failure"
+
+    pending, drain = facade.pending()
+    try:
+        assert isinstance(pending.exception(timeout=0.01), TimeoutError)
+    finally:
+        drain()
+
+    with pytest.raises(KeyboardInterrupt):
+        facade.observable("base_exception").exception()
+
+
+def _assert_get_emits_one_tracing_event(facade, monkeypatch):
+    """Exactly one tracing event per in-loop get(), in both driver contexts.
+
+    Deliberately does not pin the refusal *message*: the incumbent facade and a
+    Handle-backed one word it differently, and the row is about the trace, not
+    the text. It does pin the exception type and rule out the bootstrap guard,
+    so the tokio half cannot pass without the observer actually refusing.
+    """
+    from monarch._src.actor.actor_mesh import _client_context, context
+
+    calls = []
+    monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
+
+    # asyncio: get() blocks the loop but still returns, tracing once.
+    async def runner():
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            assert facade.observable("success").get() == _PROBE_SUCCESS_VALUE
+
+    asyncio.run(runner())
+    assert len(calls) == 1
+    assert calls[0]["extra"]["context"] == "asyncio"
+
+    # tokio: a fresh observable, refused by the observer rather than by the
+    # root-client bootstrap guard, traced exactly once, and non-consuming.
+    context()  # establish the client off-Tokio so the guard cannot fire
+    calls.clear()
+    fresh = facade.observable("success")
+
+    async def attempt():
+        assert is_tokio_thread()
+        assert _client_context._val is not None, "bootstrap guard could fire"
+        with pytest.raises(WouldBlockRuntime):
+            fresh.get()
+
+    _run_in_tokio(attempt())
+    assert len(calls) == 1
+    assert calls[0]["extra"]["context"] == "tokio"
+    assert fresh.get() == _PROBE_SUCCESS_VALUE  # refusal consumed nothing
+
+
+# -- fm.repeated_observation -------------------------------------------------
+
+
+@pytest.mark.parametrize("make_observable", PRESERVED_BY_BOTH)
+def test_fm_repeated_observation_is_non_consuming(make_observable):
+    """Repeated observation returns the same terminal state, for success and
+    for an ordinary error, in every representation."""
+    _assert_repeated_observation(make_observable)
+
+
+# -- fm.exception_identity ---------------------------------------------------
+
+
+@pytest.mark.parametrize("make_observable", PRESERVED_BY_BOTH)
+def test_fm_exception_identity_preserves_object(make_observable):
+    """Repeated observation yields the *same* Python exception object, not an
+    equal copy. Asserted at object identity because comparing messages would
+    pass even if each observation minted a fresh exception."""
+    _assert_exception_identity(make_observable)
+
+
+# -- fm.timeout_then_success -------------------------------------------------
+
+
+@pytest.mark.parametrize("make_gated", GATED_TARGETS)
+def test_fm_timeout_then_success_is_non_cancelling(make_gated):
+    """A timed-out get() leaves the producer running, so a later observer still
+    sees the value."""
+    _assert_timeout_then_success(make_gated)
+
+
+# -- fm.cancelled_observer ---------------------------------------------------
+
+
+@pytest.mark.parametrize("make_gated", GATED_TARGETS)
+async def test_fm_cancelled_observer_survives_cancellation(make_gated):
+    """Cancelling one observer cancels only that observer; the producer runs on
+    and a later observer still receives the value."""
+    await _assert_cancelled_observer(make_gated)
+
+
+async def test_fm_cancelled_observer_current_survives_cancellation():
+    """Incumbent facade: the cancellation is real, and a later await still
+    resolves."""
+    fut: Future[int] = Future._from_coro(_value(5))
+    first = fut.as_asyncio()
+    assert first.cancel() is True
+    assert first.cancelled()
+    assert await fut == 5
+
+
+# -- fm.ready_get_on_loop_warns ----------------------------------------------
+
+
+@pytest.mark.parametrize("make_observable", TARGET_ONLY)
+async def test_fm_ready_get_on_loop_warns_when_ready(make_observable):
+    """Target behavior: get() warns on a running loop *even when already
+    ready*, where a cached current Future reads silently (see
+    test_get_in_loop_on_cached_state_traces_without_warning)."""
+    await _assert_ready_get_on_loop_warns(make_observable)
+
+
+# -- fm.ready_get_on_tokio_refuses -------------------------------------------
+
+
+def test_fm_ready_get_on_tokio_refuses_current_cached_returns_and_reraises():
+    """Incumbent divergence: a *cached* Future read on a Tokio thread is not
+    refused -- the in_tokio guard only covers _Unawaited, so _Complete returns
+    and _Exception re-raises."""
+    done: Future[int] = Future._from_coro(_value(5))
+    assert done.get() == 5  # -> _Complete, off loop
+    failed: Future[int] = Future._from_coro(_raise(ValueError("boom")))
+    with pytest.raises(ValueError, match="boom"):
+        failed.get()  # -> _Exception, off loop
+
+    async def attempt():
+        assert is_tokio_thread()
+        value = done.get()
+        try:
+            failed.get()
+        except ValueError as err:
+            return value, str(err)
+        raise AssertionError("cached _Exception should have re-raised")
+
+    assert _run_in_tokio(attempt()) == (5, "boom")
+
+
+@pytest.mark.parametrize("make_observable", TARGET_ONLY)
+def test_fm_ready_get_on_tokio_refuses_when_ready(make_observable):
+    """Target behavior: get() refuses on Tokio unconditionally, even ready. The
+    observable is driven to ready *before* entering the worker."""
+    _assert_ready_get_on_tokio_refuses(make_observable)
+
+
+# -- fm.invalid_timeout_on_ready ---------------------------------------------
+
+
+def test_fm_invalid_timeout_on_ready_current_bypasses_validation():
+    """Incumbent divergence: a cached Future ignores the timeout argument
+    entirely, so an invalid value is silently accepted. Contrast
+    test_get_invalid_timeout_does_not_spawn_or_mutate, which validates only
+    because the Future is still _Unawaited."""
+    fut: Future[int] = Future._from_coro(_value(8))
+    assert fut.get() == 8  # -> _Complete
+    for bad in (float("nan"), -1.0, float("inf")):
+        assert fut.get(timeout=bad) == 8  # no ValueError
+
+
+@pytest.mark.parametrize("make_observable", TARGET_ONLY)
+def test_fm_invalid_timeout_on_ready_validates_first(make_observable):
+    """Target behavior: the timeout is validated before readiness is observed,
+    so a ready observable still rejects a bad value (HDL-12)."""
+    _assert_invalid_timeout_validated(make_observable)
+
+
+# -- fm.ready_as_asyncio_settlement ------------------------------------------
+
+
+async def test_fm_ready_as_asyncio_settlement_current_is_done_synchronously():
+    """Incumbent divergence: a cached Future hands back an already-done loop
+    future -- ``.done()`` is True before the loop runs."""
+    fut: Future[int] = Future._from_coro(_value(9))
+    await asyncio.to_thread(fut.get)  # resolve off the loop -> _Complete
+    settled = fut.as_asyncio()
+    assert settled.done()
+    assert await settled == 9
+
+
+@pytest.mark.parametrize("make_observable", TARGET_ONLY)
+async def test_fm_ready_as_asyncio_settlement_settles_on_loop(make_observable):
+    """Target behavior: a ready observable's loop future is *not* done
+    synchronously -- it settles through a scheduled callback."""
+    ok = make_observable("success")
+    observer = ok.as_asyncio()
+    assert not observer.done()
+    assert await observer == _PROBE_SUCCESS_VALUE
+
+
+# -- fm.terminal_baseexception_reobservable ----------------------------------
+
+
+def test_fm_terminal_baseexception_current_poisons_the_future():
+    """Incumbent divergence: a terminal BaseException escapes get() without
+    being cached (only ``except Exception`` stores into _Exception), so the
+    one-shot task is consumed while the Future still looks _Unawaited and a
+    second observation no longer yields the original error."""
+    fut: Future[int] = Future._from_coro(_raise(KeyboardInterrupt("stop")))
+    with pytest.raises(KeyboardInterrupt):
+        fut.get()
+    assert isinstance(fut._status, future_mod._Unawaited)  # never cached
+    with pytest.raises(BaseException) as second:
+        fut.get()
+    assert not isinstance(second.value, KeyboardInterrupt)
+    assert isinstance(second.value, ValueError)
+    assert "PythonTask already consumed" in str(second.value)
+
+
+@pytest.mark.parametrize("make_observable", TARGET_ONLY)
+def test_fm_terminal_baseexception_remains_reobservable(make_observable):
+    """Target behavior: a terminal BaseException stays observable, and the same
+    object comes back each time."""
+    _assert_terminal_baseexception_reobservable(make_observable)
+
+
+# -- fm.off_loop_as_asyncio --------------------------------------------------
+
+
+@pytest.mark.parametrize("make_observable", PRESERVED_BY_BOTH)
+def test_fm_off_loop_as_asyncio_refuses_and_is_non_consuming(make_observable):
+    """Off a running loop, as_asyncio() raises RuntimeError and consumes
+    nothing. The two representations differ only in the message, which this row
+    deliberately does not pin."""
+    _assert_off_loop_as_asyncio_refuses(make_observable)
+
+
+# -- fm.off_loop_await -------------------------------------------------------
+
+
+@pytest.mark.parametrize("make_observable", TARGET_ONLY)
+def test_fm_off_loop_await_raises_native(make_observable):
+    """Target behavior: __await__() off a loop raises asyncio's native
+    RuntimeError without consuming the observable, where the incumbent Future
+    raises ValueError (test_await_with_no_event_loop_raises_and_is_non_consuming)."""
+    _assert_off_loop_await_raises_native(make_observable)
+
+
+# -- fm.tokio_await ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("make_observable", TARGET_ONLY)
+def test_fm_tokio_await_raises_native_not_would_block(make_observable):
+    """Target behavior on a runtime worker: no asyncio loop exists, so
+    __await__() raises the native no-running-asyncio-loop RuntimeError, and the
+    observable survives the refusal.
+
+    The permanent Handle-side oracle lives in handle.rs; this case is the
+    reusable facade coverage."""
+    _assert_tokio_await_raises_native(make_observable)
+
+
+# -- fm.get_tracing_event ----------------------------------------------------
+
+
+@pytest.mark.parametrize("facade", FACADE_FACTORIES)
+def test_fm_get_tracing_event_emits_exactly_one(facade, monkeypatch):
+    """Facade-only: an in-loop get() forwards exactly one tracing event with
+    context='asyncio'. The trace belongs to the public facade, not to Handle."""
+    _assert_get_emits_one_tracing_event(facade, monkeypatch)
+
+
+# -- fm.result_alias ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("facade", FACADE_FACTORIES)
+def test_fm_result_alias_matches_get(facade):
+    """Facade-only: result(timeout) is exactly get(timeout) -- same value, same
+    cached exception object, same timeout behavior."""
+    _assert_result_aliases_get(facade)
+
+
+# -- fm.exception_accessor ---------------------------------------------------
+
+
+@pytest.mark.parametrize("facade", FACADE_FACTORIES)
+def test_fm_exception_accessor_contract(facade):
+    """Facade-only: exception() returns None on success, returns a caught
+    Exception (including TimeoutError) rather than raising, and lets a
+    BaseException escape."""
+    _assert_exception_accessor(facade)
+
+
+# -- probe self-checks -------------------------------------------------------
+
+
+def test_probe_is_closed_and_deterministic():
+    """The probe gates completion, exposes its witnesses, and rejects anything
+    outside the closed outcome set -- in particular it takes no producer
+    function."""
+    probe = _probe("success")
+    try:
+        # Only completion is gated. The producer is eager, so it may already
+        # have entered its body and set the started witness before the gate
+        # opens; asserting the negative there would be a race.
+        assert not probe._completed
+        probe._release()
+        probe._wait_completed()
+        assert probe._started
+        assert probe._completed
+        assert cast("Any", probe._handle).get() == _PROBE_SUCCESS_VALUE
+
+        with pytest.raises(ValueError, match="unknown probe outcome"):
+            _make_handle_probe("arbitrary_callable")
+        # The real closure is the signature: the binding takes a str, so a
+        # producer function cannot be smuggled in at all.
+        with pytest.raises(TypeError):
+            _make_handle_probe(lambda: None)
+    finally:
+        probe._release()
+        probe._wait_completed()
+
+
+def test_probe_handle_lookup_is_non_consuming():
+    """Repeated lookup hands back the same live handle rather than consuming
+    it, so one payload of assertions can observe it many times."""
+    probe, first = _ready_handle("success")
+    second = cast("Any", probe._handle)
+    assert first.get() == _PROBE_SUCCESS_VALUE
+    assert second.get() == _PROBE_SUCCESS_VALUE

--- a/scripts/pytokio_removal_census.py
+++ b/scripts/pytokio_removal_census.py
@@ -1,0 +1,1469 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Checked inventory of the remaining ``pytokio`` surface.
+
+Temporary migration tooling for the Stage 6 pytokio removal. It reconciles the
+legacy sites discovered in Monarch source with the reviewed rows in
+``pytokio_removal_census.toml``, so that no later diff can add, remove, or
+reclassify a pytokio boundary without an explicit manifest edit.
+
+Two modes:
+
+``--check``
+    Fail on an unknown hit, a stale row, a duplicate or missing identifier, a
+    total mismatch, a missing required field, an import member-set change, an
+    undeclared or unowned transition, or a malformed migration revision. This
+    is the only landing gate.
+
+``--summary``
+    Print active and tombstoned entry counts by category, file, and owning
+    transition.
+
+Run from the fbsource repository root. Stdlib only, read-only. Deleted in
+Stage 6.8 once the independent searches are zero.
+
+For operational usage -- what the sections mean, what each behavior field
+records, how states and transitions work, and the drift and update workflow --
+read the guide at the top of ``pytokio_removal_census.toml``. That guide is the
+reference for maintaining the data; this docstring is the reference for
+maintaining the code. The two are deliberately not duplicates.
+
+Implementation guide
+====================
+
+Pipeline. ``check`` and ``summarize`` both drive the same front half:
+
+    load manifest
+      -> enumerate bounded sources        (source_files)
+      -> language-specific discovery      (scan_rust, scan_python, scan_stub,
+                                           scan_text)
+      -> normalize and collapse hits      (collapse, applied by discover)
+      -> validate schema and transitions  (validate_rows, validate_transitions,
+                                           validate_matrix)
+      -> reconcile rows against hits      (reconcile)
+      -> validate totals                  (validate_totals)
+      -> report                           (error list, or summarize)
+
+``discover`` owns the first three steps and returns normalized hits.
+Everything after it is pure comparison between those hits and the manifest.
+
+The Hit model. A ``Hit`` is one discovered occurrence: path, symbol, operation,
+line, and optionally the imported ``members`` set or a regex ``capture``.
+Identity is ``(path, symbol, operation)`` -- the ``locator`` -- and the line is
+carried for diagnostics only. Keeping the line out of identity is what lets an
+unrelated edit move code without invalidating rows.
+
+Rust lexical views. Rust has no stdlib parser here, so ``lex_rust`` does the
+one job a regex cannot: it walks the whole file once and returns two views of
+it, both the same length and with the same newline positions as the source, so
+an offset in either maps back to a line.
+
+    scannable   comments blanked, string and char literals kept. This is what
+                patterns match against, so prose in a ``//``, ``///`` or
+                ``/* */`` comment is never inventoried as a call site, while a
+                symbol named inside a string literal -- a config key, say --
+                still is.
+    structural  comments *and* literal contents blanked. This is what block
+                depth is counted from, so a brace inside a string or a ``'{'``
+                char cannot close a block early.
+
+Using one view for both jobs is what produced the two classes of bug this
+replaced: matching raw lines inventoried documentation, and counting braces
+from a naively comment-stripped line let a ``//`` inside a string discard the
+line's closing brace. Whole-file rather than per-line because block comments
+nest, and both block comments and raw strings carry state across newlines.
+
+Rust ownership parsing. ``rust_symbols`` consumes the structural view and
+returns the qualified enclosing symbol for every line, so a hit can be
+attributed without a second pass. It tracks ``impl`` and ``trait`` blocks on a
+stack keyed by brace depth and resolves each impl header through
+``parse_impl_header``, which skips balanced generics and splits on the ``for``
+at depth zero. The result is ``Type::method``, ``<Type as Trait>::method``, or
+``Trait::method`` for a trait default body -- which is what distinguishes two
+methods sharing a bare name, and what keeps a default method's identity stable
+only while it stays in its trait.
+
+``unsafe impl`` and ``default impl`` are recognized as impl headers. They are
+common, and matching only a bare ``impl`` would attribute their methods as free
+functions.
+
+Headers that span lines are buffered until their opening brace. This parsing
+fails closed on purpose: an unbalanced generic or a header that never
+terminates raises ``CensusError`` rather than guessing, because a wrong
+qualifier would silently attribute a block's methods to another type and the
+manifest would then encode that mistake.
+
+``scan_rust`` matches over the whole scannable view rather than line by line,
+under ``re.MULTILINE`` so a leading ``^`` still anchors per line. Whole-file
+matching is what lets a pattern reach a macro's arguments on the lines below
+the line that opens it, and capture from them. Each match is attributed to the
+symbol owning the line where it starts.
+
+Python identity. Calls and imports are found through ``ast`` rather than line
+matching, so a construct split across lines is found and a match inside a
+string or comment is not. Relative imports are resolved against the file's
+repository path before comparison, and matched by dotted suffix, because the
+resolved name carries the directories above the Python package root that the
+configured literal does not. Ignoring ``node.level`` would make every relative
+pytokio import invisible. A call site's symbol is its enclosing scope plus the
+unparsed call target and first argument, ``scope[target(arg)]``. Both halves
+matter: one function can hold two distinct roots, and one function can take the
+inner task of several different receivers. ``ast.unparse`` is used so that
+subscripts and chained calls survive; a lossy renderer would merge sites that
+are genuinely distinct.
+
+Narrower textual scanners. Stubs and documents have no call graph to walk.
+``scan_stub`` matches declarations, and ``scan_text`` records at most one hit
+per document, because a document is inventoried as "this file mentions the
+legacy surface", not once per mention. Both are deliberately weaker than the
+AST path and are used only where an AST would not apply.
+
+Normalization. Some operations are reference-shaped rather than site-shaped.
+``collapse`` reduces those to one hit per surface: operations listed in
+``symbol_capture_operations`` collapse per file and captured symbol, so a
+helper is inventoried as "which files use it" and a second reference in the
+same file does not create a second row; operations listed in
+``per_file_operations`` collapse to one hit per file. Everything else passes
+through untouched. ``collapse`` is defined among the scanners but runs last,
+from ``discover``.
+
+Every alternative of a ``symbol_capture_operations`` pattern must carry a
+capture group, and ``collapse`` raises when a matched hit has none. Falling
+back to the enclosing symbol -- the obvious-looking default -- would key two
+distinct sites in one scope to the same locator and silently merge them, which
+is a false negative in the central bijection.
+
+Scope. ``source_files`` enumerates the Monarch roots only. Downstream callers
+of the public pytokio API are a stated exclusion, swept with code search rather
+than content-scanned here; the manifest guide records why and what it costs.
+
+Four kinds of checking, which are easy to confuse:
+
+    schema validation      (validate_rows, validate_matrix) -- is each row
+                           well formed, are its enum values declared, is its
+                           identity unique?
+    transition validation  (validate_transitions) -- does the owning transition
+                           declare this site, does it permit the state, and is
+                           the provenance revision well formed and consistent
+                           with the state?
+    reconciliation         (reconcile) -- does the source agree with the
+                           manifest, in both directions?
+    totals                 (validate_totals) -- does the expected aggregate
+                           count agree, and does every configured operation
+                           have a total? Reconciliation is what catches a
+                           net-zero swap, reporting the missing locator and
+                           the unknown one. Totals are an independent
+                           aggregate and parity check alongside it, not a
+                           backstop for that case.
+
+``check`` withholds rows that failed the required-field gate from the
+validators that index those fields. Those rows are already reported; passing
+them on would raise ``KeyError`` and replace the accumulated error list with a
+traceback.
+
+Tombstones participate in the first two and not the third. A migrated or
+removed_upstream row is still schema- and transition-validated, and still holds
+its locator against reuse, but ``reconcile`` skips it, because by definition its
+source hit is gone. That is what makes a completed migration auditable without
+making it look like drift.
+
+Adding a new tracked operation. Five edits, all in one diff:
+
+    1. a pattern under the appropriate ``[config.patterns.*]`` table in the
+       manifest, plus ``operation_paths`` scoping if the symbol has an
+       unrelated homonym elsewhere in the tree;
+    2. an expected count in ``[totals]``, and a ``[total_units]`` entry if it
+       is counted by file rather than by hit;
+    3. one ``[[site]]`` row per discovered hit, with a category drawn from
+       ``schema.categories``;
+    4. ownership: each new row listed in the ``owns`` array of the transition
+       that removes it; and
+    5. a counterexample fixture in ``test_pytokio_removal_census.py`` proving
+       the new operation fails when it should -- an unexpected hit, a missing
+       hit, or a mis-scoped homonym.
+
+Pattern literals stay in the manifest rather than here, so this file does not
+itself register as pytokio residue in the source-zero gates. Do not move them
+into the Python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+import tomllib
+from bisect import bisect_right
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+MANIFEST = Path(__file__).with_suffix(".toml")
+
+# Rows whose semantic classification carries migration risk, and which
+# therefore must state the full set of behavior fields.
+BEHAVIOR_KINDS = frozenset({"native_producer", "coroutine_root"})
+
+REQUIRED_FIELDS = (
+    "id",
+    "category",
+    "language",
+    "path",
+    "symbol",
+    "operation",
+    "scope",
+    "state",
+    "transition",
+)
+
+REQUIRED_BEHAVIOR_FIELDS = (
+    "return_surface",
+    "consumer",
+    "driver",
+    "start_point",
+    "abandonment",
+    "eager_effect",
+    "drop_behavior",
+    "unobserved_error",
+    "disposition",
+    "oracle",
+    "semantic_class",
+)
+
+# Reviewed facts a coroutine-root row carries beyond the behavior set: what
+# public API the coroutine backs, who calls it, and what it does first.
+REQUIRED_COROUTINE_ROOT_FIELDS = (
+    "public_operation",
+    "caller_contexts",
+    "first_side_effect",
+)
+
+REQUIRED_MATRIX_FIELDS = ("id", "disposition", "execution_state")
+
+REVISION = re.compile(r"^D\d{6,}$")
+
+LEGACY = "legacy"
+TOMBSTONES = frozenset({"migrated", "removed_upstream"})
+VALID_STATES = frozenset({LEGACY}) | TOMBSTONES
+
+IMPL_START = re.compile(r"^\s*(?:unsafe\s+|default\s+)*impl\b")
+TRAIT_START = re.compile(
+    r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+)?trait\s+(?P<name>[A-Za-z_]\w*)"
+)
+FN_RE = re.compile(r"\bfn\s+(?P<name>[A-Za-z_]\w*)")
+
+
+# --------------------------------------------------------------------------
+# Discovery: Rust ownership parsing
+# --------------------------------------------------------------------------
+
+
+def lex_rust(text: str) -> tuple[str, str]:
+    """Two aligned lexical views of a whole Rust file.
+
+    Both results have the same length and newline positions as the input, so an
+    offset in either maps back to a source line. Removed characters become
+    spaces rather than disappearing.
+
+    ``scannable`` blanks comments but keeps string and char literal contents,
+    so a tracked symbol named inside a string -- a config key, say -- is still
+    inventoried. ``structural`` additionally blanks literal contents, so a
+    brace inside a string or a ``'{'`` char cannot corrupt block-depth
+    accounting.
+
+    Whole-file rather than per-line because block comments, nested block
+    comments and multi-line raw strings all carry state across newlines. A
+    per-line pass reads the second line of ``/* ... */`` as code.
+    """
+    scannable: list[str] = []
+    structural: list[str] = []
+    index = 0
+    length = len(text)
+
+    def emit(chunk: str, keep: bool) -> None:
+        blanked = "".join(c if c == "\n" else " " for c in chunk)
+        scannable.append(chunk if keep else blanked)
+        structural.append(blanked)
+
+    while index < length:
+        char = text[index]
+        if char == "/" and text.startswith("//", index):
+            end = text.find("\n", index)
+            end = length if end == -1 else end
+            emit(text[index:end], keep=False)
+            index = end
+            continue
+        if char == "/" and text.startswith("/*", index):
+            depth = 0
+            end = index
+            while end < length:
+                if text.startswith("/*", end):
+                    depth += 1
+                    end += 2
+                    continue
+                if text.startswith("*/", end):
+                    depth -= 1
+                    end += 2
+                    if not depth:
+                        break
+                    continue
+                end += 1
+            emit(text[index:end], keep=False)
+            index = end
+            continue
+        raw = _raw_string_span(text, index)
+        if raw is not None:
+            emit(text[index:raw], keep=True)
+            index = raw
+            continue
+        if char == '"':
+            end = index + 1
+            while end < length:
+                if text[end] == "\\":
+                    end += 2
+                    continue
+                if text[end] == '"':
+                    end += 1
+                    break
+                end += 1
+            # Literal text stays scannable but is blanked structurally.
+            scannable.append(text[index:end])
+            structural.append("".join(c if c == "\n" else " " for c in text[index:end]))
+            index = end
+            continue
+        if char == "'" and _is_char_literal(text, index):
+            end = index + 1
+            while end < length:
+                if text[end] == "\\":
+                    end += 2
+                    continue
+                if text[end] == "'":
+                    end += 1
+                    break
+                end += 1
+            scannable.append(text[index:end])
+            structural.append(" " * (end - index))
+            index = end
+            continue
+        scannable.append(char)
+        structural.append(char)
+        index += 1
+    return "".join(scannable), "".join(structural)
+
+
+def _raw_string_span(text: str, index: int) -> int | None:
+    """End offset of a raw string starting at ``index``, or ``None``.
+
+    Handles ``r"..."`` and ``r#*"..."#*``. Raw strings honour no escapes, so a
+    trailing backslash must not swallow the closing quote.
+    """
+    cursor = index
+    if text[cursor] == "b":
+        cursor += 1
+    if cursor >= len(text) or text[cursor] != "r":
+        return None
+    cursor += 1
+    hashes = 0
+    while cursor < len(text) and text[cursor] == "#":
+        hashes += 1
+        cursor += 1
+    if cursor >= len(text) or text[cursor] != '"':
+        return None
+    terminator = '"' + "#" * hashes
+    end = text.find(terminator, cursor + 1)
+    if end == -1:
+        raise CensusError(f"unterminated raw string at offset {index}")
+    return end + len(terminator)
+
+
+def _is_char_literal(text: str, index: int) -> bool:
+    """Whether the quote at ``index`` opens a char literal or a lifetime.
+
+    Exact shapes rather than a lookahead heuristic. A quote followed by a
+    backslash is an escaped char literal -- ``'\\n'``, ``'\\u{1f600}'`` -- and is
+    scanned to its closing quote. Otherwise it is a char literal only when it
+    closes immediately after one codepoint, ``'a'``.
+
+    Everything else is a lifetime. This matters for adjacent lifetimes:
+    ``'a, 'b`` offers a second quote four characters along, and treating that
+    as a closing quote blanks the span between them, corrupting the impl
+    header that encloses it.
+    """
+    if index + 1 >= len(text):
+        return False
+    if text[index + 1] == "\\":
+        return True
+    return index + 2 < len(text) and text[index + 2] == "'"
+
+
+def _closes_generic(text: str, index: int) -> bool:
+    """Whether ``text[index]`` closes a generic bracket.
+
+    The ``>`` of a ``->`` return arrow is not a bracket. Counting it closes a
+    generic early and silently mis-slices the header around it, so every
+    generic-depth counter in this module goes through here rather than testing
+    the character directly.
+    """
+    return text[index] == ">" and not (index and text[index - 1] == "-")
+
+
+def _skip_generics(text: str, pos: int) -> int:
+    """Index just past a balanced ``<...>`` at ``pos``, or ``pos`` if absent."""
+    if pos >= len(text) or text[pos] != "<":
+        return pos
+    depth = 0
+    for index in range(pos, len(text)):
+        if text[index] == "<":
+            depth += 1
+        elif _closes_generic(text, index):
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    raise CensusError(f"unbalanced generics in impl header: {text.strip()[:80]!r}")
+
+
+def _split_for(text: str) -> tuple[str, str]:
+    """Split an impl header on the ``for`` that is outside any generic."""
+    depth = 0
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "<":
+            depth += 1
+        elif _closes_generic(text, index):
+            depth -= 1
+        elif depth == 0 and text.startswith(" for ", index):
+            return text[:index].strip(), text[index + 5 :].strip()
+        index += 1
+    return "", text.strip()
+
+
+def _split_top_level(text: str) -> list[str]:
+    """Split a generic argument list on the commas outside nested brackets."""
+    parts: list[str] = []
+    depth = 0
+    start = 0
+    for index, char in enumerate(text):
+        if char == "<":
+            depth += 1
+        elif _closes_generic(text, index):
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append(text[start:index])
+            start = index + 1
+    parts.append(text[start:])
+    return [part.strip() for part in parts if part.strip()]
+
+
+def normalize_type(name: str) -> str:
+    """Canonical form of a type or trait reference, generic arguments retained.
+
+    Generic arguments are part of identity. ``ActorMeshRef<PythonActor>`` and
+    ``ActorMeshRef<OtherActor>`` are separate impls with separate method
+    bodies; erasing the argument to a bare ``ActorMeshRef`` would give two
+    producers one locator and silently merge them, so moving a producer from
+    one specialization to the other would pass the gate unnoticed.
+
+    Whitespace is canonicalized so that reformatting a header is not a move.
+    Lifetime arguments are dropped: ``Thing<'a>`` and ``Thing<'b>`` are the same
+    type, so keeping them would add churn without distinguishing anything.
+    """
+    text = " ".join(name.split())
+    head, bracket, _ = text.partition("<")
+    head = head.strip()
+    if not bracket:
+        return head
+    if not text.endswith(">"):
+        raise CensusError(f"unbalanced generics in header: {name.strip()[:80]!r}")
+    inner = text[len(head) + 1 : -1]
+    kept = [
+        normalize_type(argument)
+        for argument in _split_top_level(inner)
+        if not argument.startswith("'")
+    ]
+    if not kept:
+        return head
+    return f"{head}<{', '.join(kept)}>"
+
+
+def parse_impl_header(text: str) -> str:
+    """Qualifier for an impl header, handling generic and nested-generic forms.
+
+    ``impl<T: Into<U>> Trait<T> for Foo<T>`` yields ``<Foo<T> as Trait<T>>``.
+    The impl's own parameter list is skipped; the arguments applied to the
+    trait and the self type are kept, because they are what distinguishes two
+    specializations. An unparseable header raises rather than silently
+    attributing the block's methods to the wrong type.
+    """
+    body = text.strip()
+    body = body[body.index("impl") + 4 :]  # IMPL_START guarantees a match
+    body = body[_skip_generics(body, len(body) - len(body.lstrip())) :].strip()
+    body = body.split("{")[0].split(" where ")[0].strip()
+    trait, typename = _split_for(body)
+
+    if not typename:
+        raise CensusError(f"unparseable impl header: {text.strip()[:80]!r}")
+    if trait:
+        return f"<{normalize_type(typename)} as {normalize_type(trait)}>"
+    return normalize_type(typename)
+
+
+def parse_trait_header(text: str) -> str:
+    """Qualifier for a trait header: the trait name with its generics.
+
+    A default method body belongs to the trait that declares it, so
+    ``trait Proto<T>: Send`` yields ``Proto<T>``. Supertrait bounds and where
+    clauses are not part of the identity and are cut. An unparseable header
+    raises for the same reason an impl header does.
+    """
+    match = TRAIT_START.match(text.strip())
+    if not match:
+        raise CensusError(f"unparseable trait header: {text.strip()[:80]!r}")
+    body = text.strip()[match.end("name") :]
+    body = body.split("{")[0].split(" where ")[0]
+    depth = 0
+    for index, char in enumerate(body):
+        if char == "<":
+            depth += 1
+        elif _closes_generic(body, index):
+            depth -= 1
+        elif char == ":" and depth == 0:
+            body = body[:index]
+            break
+    return normalize_type(match.group("name") + body)
+
+
+# --------------------------------------------------------------------------
+# Model
+# --------------------------------------------------------------------------
+
+
+class CensusError(Exception):
+    """Manifest or discovery inconsistency."""
+
+
+@dataclass(frozen=True)
+class Hit:
+    """One discovered occurrence of a tracked pattern.
+
+    Identity is ``locator()``, not the whole record. ``line`` is diagnostic
+    only; ``members`` is set for imports and ``capture`` for patterns with a
+    capture group, both consumed during normalization.
+    """
+
+    path: str
+    symbol: str
+    operation: str
+    line: int
+    members: tuple[str, ...] = field(default=())
+    capture: str = ""
+
+    def locator(self) -> tuple[str, str, str]:
+        """Identity key. Deliberately excludes the line number."""
+        return (self.path, self.symbol, self.operation)
+
+
+# --------------------------------------------------------------------------
+# Discovery: manifest and source enumeration
+# --------------------------------------------------------------------------
+
+
+def load_manifest(path: Path) -> dict:
+    """Parse the manifest. A malformed file raises out of ``tomllib``."""
+    with open(path, "rb") as handle:
+        return tomllib.load(handle)
+
+
+def source_files(root: Path, config: dict) -> list[Path]:
+    """Every in-scope source file under the configured roots.
+
+    ``build/`` holds an untracked copy of the Python tree produced by
+    setuptools. Scanning it would double every count, so exclusions are
+    mandatory rather than advisory.
+    """
+    excluded = tuple(config["exclude"])
+    suffixes = tuple(config["suffixes"])
+    found: list[Path] = []
+    for rel in config["roots"]:
+        base = root / rel
+        if not base.exists():
+            raise CensusError(f"configured root is missing: {rel}")
+        for path in sorted(base.rglob("*")):
+            if path.suffix not in suffixes or not path.is_file():
+                continue
+            posix = path.relative_to(root).as_posix()
+            if any(fragment in posix for fragment in excluded):
+                continue
+            found.append(path)
+    return found
+
+
+def rust_symbols(structural_lines: list[str]) -> list[str]:
+    """Qualified enclosing symbol for every line of a Rust file.
+
+    Takes the ``structural`` view from ``lex_rust``, in which comments and
+    literal contents are blanked, so no brace inside a string or comment
+    reaches the depth accounting.
+
+    Tracks ``impl`` blocks by brace depth so that ``LocalPort::resolve_and_send``
+    and ``DroppingPort::resolve_and_send`` are distinct identities. A trait impl
+    renders as ``<Type as Trait>::method``, matching how the two are told apart
+    when reading the source. A ``trait`` block is tracked the same way, so a
+    default method body qualifies as ``Trait::method`` rather than a bare name
+    that any same-named free function would collide with.
+    """
+    out: list[str] = []
+    impls: list[tuple[int, str]] = []  # (depth at entry, qualifier)
+    current_fn = ""
+    depth = 0
+    pending = ""  # an impl or trait header still accumulating across lines
+    pending_kind = ""
+    for stripped in structural_lines:
+        while impls and depth < impls[-1][0]:
+            impls.pop()
+            current_fn = ""
+
+        header = ""
+        kind = ""
+        if pending:
+            pending = f"{pending} {stripped.strip()}"
+            if "{" in stripped:
+                header, kind, pending = pending, pending_kind, ""
+            elif stripped.rstrip().endswith(";") or len(pending) > 2000:
+                # A declaration rather than a block, or a runaway. Attributing
+                # the following methods to a guessed type would be worse than
+                # refusing.
+                raise CensusError(
+                    f"unterminated {pending_kind} header: {pending[:80]!r}"
+                )
+        else:
+            for candidate, matcher in (("impl", IMPL_START), ("trait", TRAIT_START)):
+                if not matcher.match(stripped):
+                    continue
+                if "{" in stripped:
+                    header, kind = stripped, candidate
+                elif stripped.rstrip().endswith(";"):
+                    # A bare declaration, not a block. It owns no methods.
+                    header = ""
+                else:
+                    pending, pending_kind = stripped.strip(), candidate
+                break
+
+        if header:
+            parse = parse_impl_header if kind == "impl" else parse_trait_header
+            impls.append((depth + 1, parse(header)))
+            current_fn = ""
+
+        fn_match = FN_RE.search(stripped)
+        if fn_match:
+            current_fn = fn_match.group("name")
+
+        qualifier = impls[-1][1] if impls else ""
+        if current_fn and qualifier:
+            out.append(f"{qualifier}::{current_fn}")
+        elif current_fn:
+            out.append(current_fn)
+        else:
+            out.append("<module>")
+
+        if not pending:
+            depth += stripped.count("{") - stripped.count("}")
+    return out
+
+
+def scan_rust(path: Path, rel: str, operations: dict[str, str]) -> list[Hit]:
+    """Match every configured Rust pattern against one file.
+
+    Matching runs over the whole ``scannable`` view rather than line by line,
+    so a construct spanning newlines -- a macro invocation whose arguments sit
+    on following lines -- is matched, and a pattern can capture from them. Each
+    match is attributed to the symbol owning the line where the match *starts*.
+    re.MULTILINE keeps a leading ^ anchored to each line rather than to
+    the file.
+
+    Because the view blanks comments, prose in a doc comment is not inventoried
+    as a call site; because it keeps literals, a symbol named inside a string
+    still is. ``finditer`` records two constructions in one place separately. A
+    file whose ownership cannot be parsed raises rather than yielding hits with
+    guessed symbols.
+    """
+    text = path.read_text(encoding="utf-8")
+    scannable, structural = lex_rust(text)
+    symbols = rust_symbols(structural.split("\n"))
+    starts = _line_starts(scannable)
+    hits: list[Hit] = []
+    for name, literal in operations.items():
+        for match in re.finditer(literal, scannable, re.MULTILINE):
+            index = bisect_right(starts, match.start()) - 1
+            groups = [g for g in match.groups() if g]
+            hits.append(
+                Hit(
+                    rel,
+                    symbols[index],
+                    name,
+                    index + 1,
+                    capture=groups[0] if groups else "",
+                )
+            )
+    return hits
+
+
+def _line_starts(text: str) -> list[int]:
+    """Offset of the first character of each line, for offset-to-line lookup."""
+    starts = [0]
+    for index, char in enumerate(text):
+        if char == "\n":
+            starts.append(index + 1)
+    return starts
+
+
+# --------------------------------------------------------------------------
+# Normalization (runs last, from discover)
+# --------------------------------------------------------------------------
+
+
+def collapse(hits: list[Hit], config: dict) -> list[Hit]:
+    """Reduce reference-style operations to one hit per surface.
+
+    A helper such as ``is_tokio_thread`` is inventoried as "which files use
+    it", not as every occurrence, so a row stays meaningful when a file gains a
+    second reference. The captured group names the symbol.
+
+    Every alternative of a ``symbol_capture_operations`` pattern must carry a
+    capture group. A capture-less alternative would key on the *enclosing*
+    symbol instead, silently merging two distinct sites that happen to share a
+    scope -- a false negative in the bijection. That fails closed here rather
+    than falling back.
+    """
+    captured = frozenset(config.get("symbol_capture_operations", ()))
+    per_file = frozenset(config.get("per_file_operations", ()))
+
+    out: list[Hit] = []
+    seen: set[tuple[str, str, str]] = set()
+    for hit in hits:
+        if hit.operation in captured:
+            if not hit.capture:
+                raise CensusError(
+                    f"{hit.path}:{hit.line}: operation {hit.operation} is a "
+                    "symbol-capture operation but the matched alternative "
+                    "produced no capture group; add one to the pattern"
+                )
+            symbol = hit.capture
+            key = (hit.path, symbol, hit.operation)
+        elif hit.operation in per_file:
+            symbol = "<file>"
+            key = (hit.path, symbol, hit.operation)
+        else:
+            out.append(hit)
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(Hit(hit.path, symbol, hit.operation, hit.line, hit.members))
+    return out
+
+
+# --------------------------------------------------------------------------
+# Discovery: Python, stubs, and documents
+# --------------------------------------------------------------------------
+
+
+class PythonVisitor(ast.NodeVisitor):
+    """Collect call and import sites with their enclosing symbol.
+
+    Uses ``ast`` rather than line matching so that calls and imports split
+    across lines are found, and so that a match inside a string or comment is
+    not. Imports record their member set, because swapping one imported name
+    for another leaves a directory count unchanged.
+    """
+
+    def __init__(self, rel: str, calls: dict[str, str], modules: dict[str, str]):
+        self.rel = rel
+        self.calls = calls
+        self.modules = modules
+        self.scope: list[str] = []
+        self.hits: list[Hit] = []
+
+    def _scoped(self) -> str:
+        return ".".join(self.scope) if self.scope else "<module>"
+
+    def _descend(self, node: ast.AST, name: str) -> None:
+        self.scope.append(name)
+        self.generic_visit(node)
+        self.scope.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._descend(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._descend(node, node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._descend(node, node.name)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        rendered = _render(node.func)
+
+        for name, literal in self.calls.items():
+            if rendered == literal or rendered.endswith("." + literal):
+                self.hits.append(
+                    Hit(self.rel, self._qualified(node), name, node.lineno)
+                )
+        self.generic_visit(node)
+
+    def _qualified(self, node: ast.Call) -> str:
+        """Enclosing scope, disambiguated by the wrapped callee.
+
+        The receiver and the wrapped callee both matter. ``shutdown_context``
+        wraps two different coroutines, and ``exec_command`` takes the inner
+        task of three different receivers, so identity carries both.
+        """
+        scope = self._scoped()
+        target = _unparse(node.func)
+        if node.args:
+            target = f"{target}({_unparse(node.args[0])})"
+        return f"{scope}[{target}]"
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        resolved = self._resolved_module(node)
+        relative = bool(node.level)
+        for name, literal in self.modules.items():
+            if _names_module(resolved, literal, relative):
+                members = tuple(sorted(alias.name for alias in node.names))
+                self.hits.append(
+                    Hit(self.rel, self._scoped(), name, node.lineno, members)
+                )
+            elif self._imports_submodule(node, resolved, literal, relative):
+                self.hits.append(
+                    Hit(self.rel, self._scoped(), name, node.lineno, ("<module>",))
+                )
+        self.generic_visit(node)
+
+    def _resolved_module(self, node: ast.ImportFrom) -> str:
+        """Absolute dotted module named by an ``ImportFrom``.
+
+        ``node.level`` counts leading dots: one means the file's own package,
+        each further dot climbs one level. Ignoring it would make every
+        relative pytokio import invisible to the census. The result is rooted
+        at the repository, not at a ``sys.path`` entry, so a relative import is
+        matched by dotted suffix rather than equality.
+        """
+        if not node.level:
+            return node.module or ""
+        parts = self.rel.split("/")[:-1]
+        climb = node.level - 1
+        if climb > len(parts):
+            raise CensusError(
+                f"{self.rel}:{node.lineno}: relative import climbs above the "
+                f"repository root ({node.level} levels)"
+            )
+        base = parts[: len(parts) - climb] if climb else parts
+        tail = (node.module or "").split(".") if node.module else []
+        return ".".join(base + tail)
+
+    def _imports_submodule(
+        self, node: ast.ImportFrom, resolved: str, literal: str, relative: bool
+    ) -> bool:
+        """``from pkg import pytokio`` binds the submodule from its parent."""
+        parent, _, leaf = literal.rpartition(".")
+        if not _names_module(resolved, parent, relative):
+            return False
+        return leaf in [a.name for a in node.names]
+
+    def visit_Import(self, node: ast.Import) -> None:
+        """``import pkg.pytokio`` binds the module itself, member set empty."""
+        for name, literal in self.modules.items():
+            for alias in node.names:
+                if alias.name == literal:
+                    self.hits.append(
+                        Hit(self.rel, self._scoped(), name, node.lineno, ("<module>",))
+                    )
+        self.generic_visit(node)
+
+
+def _names_module(resolved: str, literal: str, relative: bool) -> bool:
+    """Whether a resolved import target names the configured module.
+
+    An absolute import must match exactly. A relative one is resolved against
+    the file's repository path, which carries a prefix -- the directories above
+    the Python package root -- that the configured literal does not, so it
+    matches on dotted suffix.
+    """
+    if resolved == literal:
+        return True
+    return relative and resolved.endswith("." + literal)
+
+
+def _unparse(node: ast.AST) -> str:
+    """Source form of an expression, so subscripts and calls survive.
+
+    ``a[0].b()._take_inner`` must render whole; a lossy renderer would collapse
+    the subscript and merge two distinct sites.
+    """
+    try:
+        return ast.unparse(node)
+    except Exception as err:  # pragma: no cover - defensive
+        raise CensusError(f"cannot render expression: {err}") from err
+
+
+def _render(node: ast.AST) -> str:
+    """Dotted name for a call target, or "" when it is not a plain name.
+
+    A chained call renders with empty parentheses -- ``a.b().c`` -- so that a
+    method invoked on the result of another call is addressable. Mesh storage
+    spawns take that shape.
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _render(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    if isinstance(node, ast.Call):
+        inner = _render(node.func)
+        return f"{inner}()" if inner else ""
+    return ""
+
+
+def scan_python(
+    path: Path, rel: str, calls: dict[str, str], modules: dict[str, str]
+) -> list[Hit]:
+    """Walk one Python file for configured calls and imports.
+
+    A file that does not parse raises ``CensusError``; skipping it would let a
+    site disappear from the census without failing the gate.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError as err:
+        raise CensusError(f"{rel}: {err}") from err
+    visitor = PythonVisitor(rel, calls, modules)
+    visitor.visit(tree)
+    return visitor.hits
+
+
+def scan_text(path: Path, rel: str, operations: dict[str, str]) -> list[Hit]:
+    """Plain-text scan, used for documentation surfaces."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    hits: list[Hit] = []
+    for name, literal in operations.items():
+        needle = re.compile(literal)
+        for index, line in enumerate(lines):
+            if needle.search(line):
+                hits.append(Hit(rel, "<document>", name, index + 1))
+                break  # one row per document, not per mention
+    return hits
+
+
+def scan_stub(path: Path, rel: str, operations: dict[str, str]) -> list[Hit]:
+    """Declaration scan for binding stubs, which have no call sites."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    hits: list[Hit] = []
+    for name, literal in operations.items():
+        needle = re.compile(literal)
+        for index, line in enumerate(lines):
+            match = needle.search(line)
+            if match:
+                groups = [g for g in match.groups() if g]
+                hits.append(
+                    Hit(
+                        rel,
+                        groups[0] if groups else "<module>",
+                        name,
+                        index + 1,
+                        capture=groups[0] if groups else "",
+                    )
+                )
+    return hits
+
+
+def discover(root: Path, config: dict) -> list[Hit]:
+    """Every in-scope hit, normalized.
+
+    Dispatches by suffix, then applies three filters in order: operations
+    restricted by ``operation_paths`` are dropped outside their owning files;
+    ``import_only_roots`` keeps just module imports, because a test is
+    inventoried by whether it imports pytokio at all; and the defining module
+    yields only the operations in ``defining_module_exempt``, since its own
+    constructors are not migration targets. ``collapse`` runs last.
+    """
+    rust_ops = config["patterns"]["rust"]
+    py_calls = config["patterns"]["python_calls"]
+    py_modules = config["patterns"]["python_modules"]
+    doc_ops = config["patterns"].get("docs", {})
+    stub_ops = config["patterns"].get("python_stub", {})
+    def_ops = config["patterns"].get("python_defs", {})
+    defining = config.get("defining_module")
+    defining_exempt = frozenset(config.get("defining_module_exempt", ()))
+    import_only = tuple(config.get("import_only_roots", ()))
+    doc_suffixes = tuple(config.get("doc_suffixes", ()))
+    hits: list[Hit] = []
+    for path in source_files(root, config):
+        rel = path.relative_to(root).as_posix()
+        if path.suffix in doc_suffixes:
+            found = scan_text(path, rel, doc_ops)
+        elif path.suffix == ".rs":
+            found = scan_rust(path, rel, rust_ops)
+        else:
+            found = scan_python(path, rel, py_calls, py_modules)
+            if path.suffix == ".pyi" and stub_ops:
+                found += scan_stub(path, rel, stub_ops)
+            if path.suffix == ".py" and def_ops:
+                found += scan_stub(path, rel, def_ops)
+        if rel.startswith(import_only):
+            # Tests are inventoried by whether they import pytokio at all. Their
+            # individual call sites belong to the suites that own them.
+            found = [h for h in found if h.operation in py_modules]
+        scoped = config.get("operation_paths", {})
+        found = [
+            h for h in found if h.operation not in scoped or rel in scoped[h.operation]
+        ]
+        if rel == defining:
+            # pytokio.rs defines the types under deletion. Its own constructors
+            # are not migration targets, but its exported symbols are.
+            found = [h for h in found if h.operation in defining_exempt]
+        hits.extend(found)
+    return collapse(hits, config)
+
+
+# --------------------------------------------------------------------------
+# Validation: schema
+# --------------------------------------------------------------------------
+
+
+def validate_rows(rows: list[dict], schema: dict, config: dict) -> list[str]:
+    """Per-row schema checks, returning every failure rather than the first.
+
+    Enforces required fields, declared enum values, identifier uniqueness, and
+    locator uniqueness across active rows *and* tombstones, so a completed
+    migration still reserves its identity. Behavior rows additionally must
+    carry the full field set, and coroutine-root rows the three root-only
+    facts on top of it. The obligation to pin an import member set is derived
+    from the row's *operation* -- whether it is a configured Python module
+    pattern -- not from its category, because nothing ties the two together.
+    Provenance is state-dependent: a legacy row must
+    not claim a ``transition_revision``, because that field records a move that
+    has already happened.
+    """
+    errors: list[str] = []
+    seen: set[str] = set()
+    locators: dict[tuple[str, str, str], str] = {}
+    categories = frozenset(schema["categories"])
+    classes = frozenset(schema["semantic_classes"])
+    dispositions = frozenset(schema["dispositions"])
+    import_operations = frozenset(config.get("patterns", {}).get("python_modules", {}))
+    for position, row in enumerate(rows):
+        if "id" not in row:
+            errors.append(f"row {position}: missing id")
+            continue
+        missing = [f for f in REQUIRED_FIELDS if f not in row]
+        if missing:
+            errors.append(f"{row['id']}: missing {', '.join(missing)}")
+            continue
+        if row["id"] in seen:
+            errors.append(f"{row['id']}: duplicate id")
+        seen.add(row["id"])
+        if row["state"] not in VALID_STATES:
+            errors.append(f"{row['id']}: invalid state {row['state']!r}")
+        if row["category"] not in categories:
+            errors.append(f"{row['id']}: unknown category {row['category']!r}")
+        if row["state"] == LEGACY and row.get("transition_revision"):
+            errors.append(
+                f"{row['id']}: transition_revision is provenance for a completed "
+                "move; a legacy row must not carry one"
+            )
+        locator = (row["path"], row["symbol"], row["operation"])
+        if locator in locators:
+            errors.append(
+                f"{row['id']}: duplicate locator, already claimed by "
+                f"{locators[locator]}; identity is unique across active rows "
+                "and tombstones"
+            )
+        locators[locator] = row["id"]
+        if row["operation"] in import_operations and not row.get("members"):
+            errors.append(f"{row['id']}: an import row must record its member set")
+        if "multiplicity" in row:
+            errors.append(
+                f"{row['id']}: multiplicity is not permitted; the inventory is "
+                "one row per site"
+            )
+        if row["category"] not in BEHAVIOR_KINDS:
+            continue
+        absent = [f for f in REQUIRED_BEHAVIOR_FIELDS if not row.get(f)]
+        if absent:
+            errors.append(
+                f"{row['id']}: behavior row missing {', '.join(sorted(absent))}"
+            )
+            continue
+        if row["semantic_class"] not in classes:
+            errors.append(
+                f"{row['id']}: unknown semantic class {row['semantic_class']!r}"
+            )
+        if row["disposition"] not in dispositions:
+            errors.append(f"{row['id']}: unknown disposition {row['disposition']!r}")
+        if row["category"] == "coroutine_root":
+            bare = [f for f in REQUIRED_COROUTINE_ROOT_FIELDS if not row.get(f)]
+            if bare:
+                errors.append(
+                    f"{row['id']}: coroutine-root row missing {', '.join(sorted(bare))}"
+                )
+    return errors
+
+
+# --------------------------------------------------------------------------
+# Validation: transitions
+# --------------------------------------------------------------------------
+
+
+def validate_transitions(rows: list[dict], transitions: list[dict]) -> list[str]:
+    """Enforce transition ownership and the allowed-state model.
+
+    A site changes state only through the transition that declares it, so a
+    migration cannot be recorded against a diff that does not own the site.
+    ``allowed_states`` is required rather than defaulted: a transition that
+    only ever migrates sites in place should not silently also permit
+    ``removed_upstream``.
+    """
+    errors: list[str] = []
+    declared: dict[str, dict] = {}
+    for transition in transitions:
+        if transition["id"] in declared:
+            errors.append(f"transition {transition['id']}: duplicate id")
+        states = transition.get("allowed_states")
+        if not states:
+            errors.append(f"transition {transition['id']}: must declare allowed_states")
+        else:
+            unknown = sorted(set(states) - TOMBSTONES)
+            if unknown:
+                errors.append(
+                    f"transition {transition['id']}: allowed_states may only "
+                    f"name tombstone states, got {', '.join(unknown)}"
+                )
+        declared[transition["id"]] = transition
+
+    owned: dict[str, str] = {}
+    for transition in transitions:
+        for site_id in transition.get("owns", []):
+            if site_id in owned:
+                errors.append(
+                    f"{site_id}: owned by both {owned[site_id]} and {transition['id']}"
+                )
+            owned[site_id] = transition["id"]
+
+    known_ids = {row["id"] for row in rows if "id" in row}
+    for site_id, transition_id in owned.items():
+        if site_id not in known_ids:
+            errors.append(f"transition {transition_id}: owns unknown site {site_id}")
+
+    for row in rows:
+        if "id" not in row or "transition" not in row:
+            continue
+        name = row["transition"]
+        if name not in declared:
+            errors.append(f"{row['id']}: undeclared transition {name!r}")
+            continue
+        if owned.get(row["id"]) != name:
+            errors.append(
+                f"{row['id']}: transition {name!r} does not declare ownership "
+                "of this site"
+            )
+        allowed = declared[name].get("allowed_states", ())
+        state = row["state"]
+        if state != LEGACY:
+            if state not in allowed:
+                errors.append(
+                    f"{row['id']}: transition {name!r} does not permit state {state!r}"
+                )
+            revision = row.get("transition_revision", "")
+            if not REVISION.match(revision):
+                errors.append(
+                    f"{row['id']}: state {state!r} requires a Differential "
+                    f"transition revision, got {revision!r}"
+                )
+        if row.get("amendment_revision"):
+            if not REVISION.match(row["amendment_revision"]):
+                errors.append(f"{row['id']}: malformed amendment revision")
+            if state != LEGACY:
+                errors.append(
+                    f"{row['id']}: a current-behavior amendment cannot mark the "
+                    "producer migrated; the declared transition is still required"
+                )
+    return errors
+
+
+def validate_matrix(matrix: list[dict], schema: dict) -> list[str]:
+    """The matrix is a fixed set of cases, not a free-form list.
+
+    Both directions are checked: a case absent from ``schema.matrix_ids`` is
+    rejected as undeclared, and a declared case with no row is rejected as
+    missing, so the set cannot drift by addition or omission.
+    """
+    errors: list[str] = []
+    expected_ids = list(schema["matrix_ids"])
+    dispositions = frozenset(schema["matrix_dispositions"])
+    states = frozenset(schema["matrix_execution_states"])
+
+    seen: set[str] = set()
+    for position, row in enumerate(matrix):
+        missing = [f for f in REQUIRED_MATRIX_FIELDS if not row.get(f)]
+        if missing:
+            errors.append(f"matrix row {position}: missing {', '.join(missing)}")
+            continue
+        if row["id"] in seen:
+            errors.append(f"matrix {row['id']}: duplicate id")
+        seen.add(row["id"])
+        if row["disposition"] not in dispositions:
+            errors.append(
+                f"matrix {row['id']}: unknown disposition {row['disposition']!r}"
+            )
+        if row["execution_state"] not in states:
+            errors.append(
+                f"matrix {row['id']}: unknown execution state "
+                f"{row['execution_state']!r}"
+            )
+
+    unexpected = sorted(seen - set(expected_ids))
+    absent = [i for i in expected_ids if i not in seen]
+    for extra in unexpected:
+        errors.append(f"matrix {extra}: not a declared matrix case")
+    for gone in absent:
+        errors.append(f"matrix {gone}: declared case is missing")
+    return errors
+
+
+# --------------------------------------------------------------------------
+# Reconciliation: manifest against source
+# --------------------------------------------------------------------------
+
+
+def reconcile(hits: list[Hit], rows: list[dict]) -> list[str]:
+    """Match discovered hits against manifest locators, one to one.
+
+    The bijection is enforced in both directions. A row with no hit fails as
+    stale or removed; a hit no row claims fails as unknown. Moving a site
+    therefore surfaces as a matched pair of both errors. Tombstones are skipped,
+    since their source hit is expected to be gone. Import rows additionally
+    compare their recorded member set, because a file count alone would permit
+    swapping one imported name for another; conversely a hit that carries
+    members must meet a row that pins them, so the comparison cannot be
+    skipped by omitting the key.
+    """
+    errors: list[str] = []
+    by_locator: dict[tuple[str, str, str], list[Hit]] = defaultdict(list)
+    for hit in hits:
+        by_locator[hit.locator()].append(hit)
+
+    claimed: set[tuple[str, str, str]] = set()
+    for row in rows:
+        if "id" not in row or row.get("state") in TOMBSTONES:
+            continue
+        locator = (row["path"], row["symbol"], row["operation"])
+        found = by_locator.get(locator, [])
+        if not found:
+            errors.append(
+                f"{row['id']}: no source hit for "
+                f"{locator[0]}::{locator[1]} [{locator[2]}]"
+            )
+        elif len(found) != 1:
+            lines = ", ".join(str(h.line) for h in found)
+            errors.append(
+                f"{row['id']}: expected 1 site, found {len(found)} at line(s) {lines}"
+            )
+        actual = sorted({m for hit in found for m in hit.members})
+        if "members" in row:
+            if found and actual != sorted(row["members"]):
+                errors.append(
+                    f"{row['id']}: import members changed; manifest "
+                    f"{sorted(row['members'])}, source {actual}"
+                )
+        elif actual:
+            errors.append(
+                f"{row['id']}: source hit imports {actual} but the row pins no "
+                "member set"
+            )
+        claimed.add(locator)
+
+    for locator, found in sorted(by_locator.items()):
+        if locator not in claimed:
+            lines = ", ".join(str(h.line) for h in found)
+            errors.append(
+                f"unknown hit: {locator[0]}::{locator[1]} "
+                f"[{locator[2]}] at line(s) {lines}"
+            )
+    return errors
+
+
+# --------------------------------------------------------------------------
+# Validation: totals
+# --------------------------------------------------------------------------
+
+
+def validate_totals(
+    hits: list[Hit], totals: dict, units: dict, config: dict
+) -> list[str]:
+    """Compare manifest totals with discovery.
+
+    An operation may be counted by hit or by distinct file. Imports are counted
+    by file, because a module that imports pytokio twice is still one file to
+    migrate; their member sets are checked separately.
+
+    Coverage is cross-checked against the configured patterns in both
+    directions first. Iterating ``totals`` alone would leave a newly configured
+    operation with no independent aggregate check, and a total naming no
+    configured operation checks nothing at all. A ``total_units`` key naming no
+    configured operation is likewise a typo that would silently choose the
+    wrong counting unit.
+    """
+    errors: list[str] = []
+    configured = {
+        operation
+        for group in config.get("patterns", {}).values()
+        for operation in group
+    }
+    for operation in sorted(configured - set(totals)):
+        errors.append(f"operation {operation} is configured but has no total")
+    for operation in sorted(set(totals) - configured):
+        errors.append(f"total declared for unconfigured operation {operation}")
+    for operation in sorted(set(units) - configured):
+        errors.append(f"total_units declared for unconfigured operation {operation}")
+    by_hit = Counter(hit.operation for hit in hits)
+    by_file: dict[str, set[str]] = defaultdict(set)
+    for hit in hits:
+        by_file[hit.operation].add(hit.path)
+    for operation, expected in totals.items():
+        unit = units.get(operation, "hit")
+        actual = len(by_file[operation]) if unit == "file" else by_hit.get(operation, 0)
+        if actual != expected:
+            errors.append(
+                f"total mismatch for {operation}: "
+                f"manifest {expected} {unit}s, source {actual}"
+            )
+    return errors
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+
+def check(root: Path, manifest: dict) -> list[str]:
+    """Run the full gate and return every failure found.
+
+    Errors accumulate rather than short-circuiting, so one run shows the whole
+    picture. An empty list means the manifest and the source agree. Rows that
+    fail the required-field gate are reported and then withheld from the
+    validators that index those fields.
+    """
+    rows = manifest["site"]
+    config = manifest["config"]
+    hits = discover(root, config)
+    errors = validate_rows(rows, manifest["schema"], config)
+    # Downstream validators index the required fields directly. A row that
+    # failed the required-field gate is already reported; passing it on would
+    # raise KeyError and replace the accumulated report with a traceback.
+    well_formed = [r for r in rows if all(f in r for f in REQUIRED_FIELDS)]
+    errors += validate_transitions(well_formed, manifest.get("transition", []))
+    errors += validate_matrix(manifest.get("matrix", []), manifest["schema"])
+    errors += reconcile(hits, well_formed)
+    errors += validate_totals(
+        hits, manifest["totals"], manifest.get("total_units", {}), config
+    )
+    return errors
+
+
+def summarize(root: Path, manifest: dict) -> str:
+    """Human-readable inventory, reporting entries rather than rows.
+
+    Active and tombstoned entries are counted separately: tombstones are
+    history, not remaining work.
+    """
+    rows = manifest["site"]
+    hits = discover(root, manifest["config"])
+    out: list[str] = ["pytokio removal census", ""]
+
+    active = [r for r in rows if r.get("state") == LEGACY]
+    tombstones = [r for r in rows if r.get("state") in TOMBSTONES]
+
+    out.append(f"active entries {len(active)}")
+    out.append(f"tombstoned entries {len(tombstones)}")
+
+    out.append("")
+    out.append("active entries by category")
+    counts: Counter[str] = Counter()
+    for row in active:
+        counts[row["category"]] += 1
+    for category in sorted(counts):
+        out.append(f"  {category:<30} {counts[category]:>4}")
+
+    out.append("")
+    out.append("active entries by owning diff")
+    owners: Counter[str] = Counter()
+    for row in active:
+        owners[row["transition"]] += 1
+    for owner in sorted(owners):
+        out.append(f"  {owner:<30} {owners[owner]:>4}")
+
+    out.append("")
+    out.append("discovered hits by file")
+    for path, count in sorted(Counter(h.path for h in hits).items()):
+        out.append(f"  {path:<70} {count:>4}")
+
+    if tombstones:
+        out.append("")
+        out.append("tombstones")
+        for row in tombstones:
+            out.append(
+                f"  {row['id']:<44} {row['state']:<18} "
+                f"{row.get('transition_revision', '?')}"
+            )
+
+    return "\n".join(out)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns 0 when a requested check passed, 1 otherwise."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="validate the manifest")
+    parser.add_argument("--summary", action="store_true", help="print totals")
+    parser.add_argument(
+        "--root", default=".", help="fbsource repository root (default: cwd)"
+    )
+    parser.add_argument("--manifest", default=str(MANIFEST))
+    args = parser.parse_args(argv)
+
+    if not args.check and not args.summary:
+        parser.error("choose --check, --summary, or both")
+
+    root = Path(args.root).resolve()
+    manifest = load_manifest(Path(args.manifest))
+
+    status = 0
+    if args.summary:
+        print(summarize(root, manifest))
+        if args.check:
+            print()
+
+    if args.check:
+        errors = check(root, manifest)
+        if errors:
+            print(f"census check failed with {len(errors)} error(s):", file=sys.stderr)
+            for error in errors:
+                print(f"  {error}", file=sys.stderr)
+            status = 1
+        else:
+            print("census check passed")
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -185,9 +185,19 @@
 # relative and absolute import forms are discovered.
 #
 # [[matrix]] rows record disposition (preserve, intentional change, or
-# implementation-neutral) and execution_state (green_in_6.0b, running against
-# the current Future, or activates_in_6.1, executable once _from_handle
-# exists).
+# implementation-neutral) and execution_state.
+#
+# execution_state is about the *facade* assertion only: when the Handle-backed
+# Future case becomes executable. green_in_6.0b means the final behavior is
+# already established by the paired current-Future and direct-Handle
+# assertions together -- not by the current facade alone; activates_in_6.1
+# means that last assertion needs the Handle-backed Future constructor before
+# it can run.
+#
+# It is not a licence to defer Handle coverage. Every directly expressible
+# Handle primitive is green in 6.0b, including for rows marked
+# activates_in_6.1 -- those rows are pinned on the Handle side now, and only
+# the facade half waits.
 #
 # Grounded at fbsource master c58f6cb66dbe, 2026-08-19.
 

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -1,0 +1,3522 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# How to read this manifest
+#
+# Purpose. A checked inventory of every remaining pytokio site in Monarch, so
+# that each Stage 6 migration diff is mechanically reviewable. It is temporary:
+# Stage 6.8 deletes this file and pytokio_removal_census.py once the
+# independent Sapling searches are zero.
+#
+# Maintenance. Hand-maintained. The checker deliberately has no rewrite mode,
+# so a reviewer sees the source change and the manifest edit in one diff. The
+# initial content was produced once by a throwaway script that was not kept;
+# there is no generator or template to regenerate from. Edit this file
+# directly, in the same diff as the source change it records, then run
+# --check. From the fbsource repository root:
+#
+#     python3 fbcode/monarch/scripts/pytokio_removal_census.py --check
+#     python3 fbcode/monarch/scripts/pytokio_removal_census.py --summary
+#
+# --check is the landing gate. --summary prints entries by category, owning
+# transition, and file.
+#
+# Sections, in file order.
+#   [config]       what to scan and what to match: the Monarch roots,
+#                  exclusions, the defining module, per-operation path
+#                  scoping, and the pattern table naming each operation.
+#                  Patterns live here rather than in the checker so the tool
+#                  is not its own residue.
+#   [totals]       the expected aggregate count per operation, reconciled
+#                  against discovery; [total_units] marks the operations
+#                  counted by file rather than by hit. Reconciliation already
+#                  catches a net-zero swap, reporting the missing old locator
+#                  and the unknown new one; totals are the independent
+#                  aggregate check on top of that. Coverage is exact in both
+#                  directions: every configured operation must have a total
+#                  and every total must name a configured operation, so a
+#                  newly added pattern cannot ship without an aggregate check.
+#   [schema]       the closed vocabularies: categories, semantic classes,
+#                  dispositions, the exact Future-matrix ids, and the matrix
+#                  enums. A value outside them fails.
+#   [[matrix]]     the Future/Handle contract cases, a fixed set validated
+#                  against schema.matrix_ids.
+#   [[transition]] the owning diffs; each declares the sites it owns and the
+#                  states it may move them to.
+#   [[site]]       the inventory, one entry per discovered site.
+#
+# Identity. A site is path plus symbol plus operation. Line numbers are never
+# recorded, so unrelated edits that move code do not invalidate a row. Rust
+# symbols are impl- or trait-qualified (Type::method, <Type as Trait>::method,
+# or Trait::method for a default body) so two methods sharing a bare name stay
+# distinct. Generic arguments are retained and normalized, so
+# <ActorMeshRef<PythonActor> as ActorMeshProtocol>::name is distinct from the
+# same method on another specialization; lifetime arguments are dropped,
+# because they never specialize. Python sites carry the
+# rendered call target and, where present, the wrapped callee, as
+# scope[target(arg)], so two roots in one function -- or three transfers on
+# different receivers -- separate.
+#
+# The invariant is a bijection: exactly one active row per discovered hit.
+# There is no multiplicity field, and a duplicate locator fails. Uniqueness
+# spans active rows and tombstones together, so a completed migration keeps
+# reserving its identity and a later row cannot quietly reuse it.
+#
+# One source location may appear under several categories, because the
+# categories track different obligations. AsyncActorMesh::__reduce__ is both a
+# native_producer and a mesh_carrier; PyValueStream::__next__ is both a
+# native_producer and a rust_future_factory. Each appearance is a distinct
+# operation and therefore its own row.
+#
+# Drift detection and the update workflow. The bijection is what makes drift
+# visible, and --check reports each direction differently.
+#
+#   A discovered hit with no active row fails as an unknown site. Nothing is
+#   silently absorbed: a new pytokio site cannot enter the tree without an
+#   explicit row naming its category, and a transition that declares it.
+#
+#   An active legacy row with no discovered hit fails as stale or removed. The
+#   site went away without being recorded, so either the row is wrong or the
+#   removal was not attributed.
+#
+#   Moving a site reports both at once: the old locator is missing and the new
+#   one is unknown. That pair is the signature of a move, and it is resolved by
+#   editing the row rather than by deleting and re-adding it, so the site keeps
+#   its identity and its history.
+#
+# An intentional migration is one diff that changes the source, sets the row
+# state to migrated or removed_upstream, records transition_revision, and
+# updates the affected totals. Splitting those across diffs leaves --check red
+# in between.
+#
+# Reverting a migration is the same edit backwards: restore the source, return
+# the tombstone to legacy, drop its transition_revision, and restore the
+# totals, all together.
+#
+# Scope: Monarch only, throughout Stage 6.
+#
+# The roots are Monarch itself, and there are no downstream roots in [config].
+# Callers of the public pytokio API that live outside Monarch -- fbcode/mitra,
+# fbcode/pytorch/torchtitan, the AgentTune project under genai, and any not yet
+# identified -- are deliberately not inventoried here. Those roots are large
+# and almost entirely unrelated, so content-scanning them on every gate run
+# would cost far more than the handful of sites it would find.
+#
+# They are covered by audit instead of by continuous scanning. Downstream
+# customers were audited separately at 6.0a, and will be audited again
+# immediately before 6.8. A code search for the module name is sufficient:
+# there is no file in Monarch that names PythonTask without also naming
+# pytokio, so every downstream route to the type carries the token in its
+# import path.
+#
+# The consequence is explicit: a pytokio site in downstream code will not fail
+# this gate. Migrating downstream callers is tracked by the Stage 6 planning
+# documents, and the final zero check in 6.8 is a code search, not this file.
+#
+# TorchTitan is in fbsource, at fbcode/pytorch/torchtitan; it is simply out of
+# scope for this manifest, not out of reach. AIRA Dojo is the one external
+# repository, which no configuration here could reach even if the scope were
+# widened.
+#
+# Detection is bounded by the configured patterns, roots, and exclusions, so
+# the checker can only reconcile what it is told to look for. It is not proof
+# that its own patterns are complete. Independent scoped Sapling searches
+# establish the initial coverage, and they are what performs the final zero
+# check in 6.8 after this file and the checker are deleted.
+#
+# State. legacy means the site still exists and still has to move. migrated
+# means it moved through its declared transition. removed_upstream means work
+# this program does not own removed it. The latter two are tombstones: they
+# stay so that applied transitions and reverts remain auditable, and
+# reconciliation skips them, so no source hit is expected.
+#
+# Transitions. A row names its owning transition, and that transition must
+# list the row in owns, so a site cannot be migrated by a diff that does not
+# own it. allowed_states bounds which tombstone states it may set.
+#
+# transition_revision and amendment_revision are factual, not approvals.
+# transition_revision records the diff that performed the move; it is required
+# once state leaves legacy and rejected while state is legacy.
+# amendment_revision records a diff that corrected a site's current behavior --
+# a bug fix -- without migrating it, and never discharges the declared
+# transition.
+#
+# Behavior rows. native_producer and coroutine_root rows carry the eleven
+# fields below. Each states what the code does now, not what the target should
+# do.
+#
+#   return_surface   the type the site hands to Python -- PyPythonTask, a raw
+#                    PythonTask, or Future[T] -- named so a conversion that
+#                    changes the surface is visible in the diff.
+#   consumer         the immediate consumer of what this site produces: the
+#                    function or expression that receives it. Name it. "see
+#                    oracle" is not an answer.
+#   driver           what actually drives the returned task to completion --
+#                    tokio::spawn, block_on, a queue task, the actor loop, or
+#                    the awaiting caller.
+#   start_point      when the underlying operation begins. Timing only. It is
+#                    not whether abandonment is possible; that is the
+#                    abandonment field. Typical values: lazy until driven,
+#                    eager at construction, already running, already complete.
+#   abandonment      whether the site can be constructed and dropped before
+#                    observation, and by what path.
+#   eager_effect     what an eager Handle conversion would newly do: start a
+#                    side effect, claim a receive, observe already-running
+#                    work, or only wrap a ready value.
+#   drop_behavior    what happens today when the value is dropped unobserved.
+#   unobserved_error how a failure surfaces when nobody observes the result.
+#   disposition      the intended target treatment, from schema.dispositions.
+#   semantic_class   the abandonment class, from schema.semantic_classes; it
+#                    selects the characterization test that covers the site.
+#   oracle           the named test pinning the current behavior.
+#
+# coroutine_root rows add public_operation, caller_contexts, and
+# first_side_effect: the user-facing API, the calling contexts it supports,
+# and the first externally visible effect once the coroutine runs.
+#
+# Import rows record members, the exact set of names imported from the pytokio
+# module at that site. Members are required: a file count alone would permit
+# swapping one imported name for another. The requirement is derived from the
+# row's operation -- whether it is a configured python_modules pattern -- not
+# from its category, so miscategorising a row cannot skip the check. Both
+# relative and absolute import forms are discovered.
+#
+# [[matrix]] rows record disposition (preserve, intentional change, or
+# implementation-neutral) and execution_state (green_in_6.0b, running against
+# the current Future, or activates_in_6.1, executable once _from_handle
+# exists).
+#
+# Grounded at fbsource master c58f6cb66dbe, 2026-08-19.
+
+[config]
+roots = [
+  "fbcode/monarch/monarch_hyperactor/src",
+  "fbcode/monarch/monarch_rdma",
+  "fbcode/monarch/monarch_extension/src",
+  "fbcode/monarch/monarch_distributed_telemetry/src",
+  "fbcode/monarch/hyperactor_config/src",
+  "fbcode/monarch/python/monarch",
+  "fbcode/monarch/python/tests",
+  "fbcode/monarch/docs",
+]
+exclude = ["/build/", "/buck-out/", "/__pycache__/", "/scripts/"]
+suffixes = [".rs", ".py", ".pyi", ".md"]
+doc_suffixes = [".md"]
+import_only_roots = ["fbcode/monarch/python/tests"]
+
+defining_module = "fbcode/monarch/monarch_hyperactor/src/pytokio.rs"
+defining_module_exempt = [
+  "would_block_surface",
+  "pytokio_module_ref",
+  "helper_symbol",
+  "helper_definition",
+  "caller_free_primitive",
+]
+symbol_capture_operations = [
+  "take_inner_retire",
+  "mesh_reserve_fill",
+  "mesh_state_resolve",
+  "shared_reconstruction",
+  "reserve_binding",
+  "would_block_surface",
+  "helper_symbol",
+  "helper_definition",
+  "caller_free_primitive",
+  "binding_stub_symbol",
+]
+per_file_operations = ["pytokio_module_ref"]
+
+# Some patterns name a symbol that exists elsewhere under a different owner:
+# tokio has its own spawn_blocking. Scope those operations to the file that
+# owns them.
+[config.operation_paths]
+take_inner_retire = ["fbcode/monarch/python/monarch/_src/actor/future.py"]
+bootstrap_storage_spawn = ["fbcode/monarch/python/monarch/_src/actor/bootstrap.py"]
+caller_free_primitive = ["fbcode/monarch/monarch_hyperactor/src/pytokio.rs"]
+mesh_state_resolve = ["fbcode/monarch/monarch_hyperactor/src/pickle.rs"]
+reserve_binding = ["fbcode/monarch/monarch_hyperactor/src/pickle.rs"]
+would_block_surface = [
+  "fbcode/monarch/monarch_hyperactor/src/handle.rs",
+  "fbcode/monarch/monarch_hyperactor/src/pytokio.rs",
+]
+binding_stub_symbol = [
+  "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi",
+  "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi",
+]
+
+[config.patterns.rust]
+py_python_task_new = "\\bPyPythonTask::new\\b"
+raw_python_task_new = "(?<!Py)\\bPythonTask::new\\b"
+spawn_abortable = "\\.spawn_abortable\\(\\)"
+mesh_reserve_fill = "\\b(reserve_mesh_reference_if_active|push_mesh_reference_if_active|pop_mesh_reference)\\b"
+mesh_state_resolve = "pub async fn (resolve)\\b"
+reserve_binding = "fn (reserve_mesh_reference)\\b|wrap_pyfunction!\\((reserve_mesh_reference)\\b"
+would_block_surface = "pyo3::create_exception!\\s*\\(\\s*\\w+,\\s*(WouldBlockRuntime)|get_type::<crate::handle::(WouldBlockRuntime)>|add\\(\"(WouldBlockRuntime)\""
+shared_reconstruction = "shared_class\\(py\\)\\.getattr\\(\"(block_on|from_value)\"\\)"
+rust_take_inner = "\"_take_inner\""
+rust_from_coro = "\"_from_coro\""
+pytokio_module_ref = "crate::pytokio|monarch_hyperactor::pytokio|^pub mod pytokio"
+helper_symbol = "(?:crate|monarch_hyperactor)::pytokio::(\\w+)"
+caller_free_primitive = "^\\s*fn\\s+(select_one|with_timeout|spawn_blocking|sleep)\\s*\\("
+helper_definition = "^\\s*(?:pub(?:\\(crate\\))?\\s+)?(?:fn|struct)\\s+(is_tokio_thread|send_result|to_py_error|WouldBlockRuntime)\\b|attr\\s+(ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK)"
+
+[config.patterns.python_calls]
+from_coro = "Future._from_coro"
+from_coroutine = "PythonTask.from_coroutine"
+take_inner = "_take_inner"
+shared_from_value = "Shared.from_value"
+mesh_storage_spawn = "PythonTask.from_coroutine().spawn"
+bootstrap_storage_spawn = "host_mesh.spawn"
+py_mesh_reserve = "reserve_mesh_reference"
+py_is_tokio_thread = "is_tokio_thread"
+
+[config.patterns.python_defs]
+take_inner_retire = "^    def (_take_inner)\\b|^class (_Taken)\\b"
+
+[config.patterns.python_stub]
+binding_stub_symbol = "^class (PythonTask|Shared|WouldBlockRuntime)\\b|^def (is_tokio_thread)\\b|^def (reserve_mesh_reference)\\b"
+
+[config.patterns.python_modules]
+pytokio_import = "monarch._rust_bindings.monarch_hyperactor.pytokio"
+
+[config.patterns.docs]
+doc_legacy_surface = "PythonTask|PyShared|pytokio"
+
+[totals]
+py_python_task_new = 26
+raw_python_task_new = 6
+from_coro = 19
+rust_from_coro = 2
+from_coroutine = 7
+take_inner = 7
+rust_take_inner = 2
+take_inner_retire = 2
+caller_free_primitive = 4
+shared_from_value = 4
+spawn_abortable = 1
+mesh_storage_spawn = 5
+bootstrap_storage_spawn = 1
+mesh_reserve_fill = 10
+mesh_state_resolve = 1
+shared_reconstruction = 2
+reserve_binding = 1
+py_mesh_reserve = 2
+py_is_tokio_thread = 3
+pytokio_import = 31
+pytokio_module_ref = 18
+helper_symbol = 29
+helper_definition = 6
+would_block_surface = 2
+binding_stub_symbol = 5
+doc_legacy_surface = 4
+
+# Imports are counted by file; each row also pins its exact member set, so a
+# net-zero member swap fails.
+[total_units]
+pytokio_import = "file"
+
+[schema]
+categories = [
+  "native_producer",
+  "coroutine_root",
+  "native_wrapping_factory",
+  "rust_future_factory",
+  "driver_root",
+  "ownership_transfer",
+  "ownership_surface",
+  "mesh_carrier",
+  "module_import",
+  "module_reference",
+  "helper_residue",
+  "helper_definition",
+  "binding_stub",
+  "caller_free_primitive",
+  "documentation",
+]
+
+semantic_classes = [
+  "deferred_side_effect",
+  "deferred_receive_claim",
+  "already_started_lazy_observer",
+  "sync_partial_effect_lazy_tail",
+  "ready_no_op_wrapper",
+  "abortable_observer",
+]
+
+dispositions = [
+  "preserve timing",
+  "intentionally become eager",
+  "replace with a direct value",
+  "replace with a direct blocking binding",
+  "replace with the bridge future directly",
+  "require a binding-specific design",
+]
+
+matrix_dispositions = ["preserve", "intentional change", "implementation-neutral"]
+matrix_execution_states = ["green_in_6.0b", "activates_in_6.1"]
+matrix_ids = [
+  "fm.repeated_observation",
+  "fm.exception_identity",
+  "fm.timeout_then_success",
+  "fm.cancelled_observer",
+  "fm.ready_get_on_loop_warns",
+  "fm.ready_get_on_tokio_refuses",
+  "fm.invalid_timeout_on_ready",
+  "fm.ready_as_asyncio_settlement",
+  "fm.terminal_baseexception_reobservable",
+  "fm.off_loop_as_asyncio",
+  "fm.off_loop_await",
+  "fm.tokio_await",
+  "fm.get_tracing_event",
+  "fm.result_alias",
+  "fm.exception_accessor",
+]
+
+# Future/Handle contract matrix. Fifteen declared cases; 6.0b makes the
+# current-facade rows green and 6.1 activates the Handle-backed ones.
+[[matrix]]
+id = "fm.repeated_observation"
+disposition = "preserve"
+execution_state = "green_in_6.0b"
+
+[[matrix]]
+id = "fm.exception_identity"
+disposition = "preserve"
+execution_state = "green_in_6.0b"
+
+[[matrix]]
+id = "fm.timeout_then_success"
+disposition = "preserve"
+execution_state = "green_in_6.0b"
+
+[[matrix]]
+id = "fm.cancelled_observer"
+disposition = "preserve"
+execution_state = "green_in_6.0b"
+
+[[matrix]]
+id = "fm.ready_get_on_loop_warns"
+disposition = "intentional change"
+execution_state = "activates_in_6.1"
+
+[[matrix]]
+id = "fm.ready_get_on_tokio_refuses"
+disposition = "intentional change"
+execution_state = "activates_in_6.1"
+
+[[matrix]]
+id = "fm.invalid_timeout_on_ready"
+disposition = "intentional change"
+execution_state = "activates_in_6.1"
+
+[[matrix]]
+id = "fm.ready_as_asyncio_settlement"
+disposition = "intentional change"
+execution_state = "activates_in_6.1"
+
+[[matrix]]
+id = "fm.terminal_baseexception_reobservable"
+disposition = "intentional change"
+execution_state = "activates_in_6.1"
+
+[[matrix]]
+id = "fm.off_loop_as_asyncio"
+disposition = "preserve"
+execution_state = "green_in_6.0b"
+
+[[matrix]]
+id = "fm.off_loop_await"
+disposition = "intentional change"
+execution_state = "activates_in_6.1"
+
+[[matrix]]
+id = "fm.tokio_await"
+disposition = "intentional change"
+execution_state = "activates_in_6.1"
+
+[[matrix]]
+id = "fm.get_tracing_event"
+disposition = "preserve"
+execution_state = "activates_in_6.1"
+
+[[matrix]]
+id = "fm.result_alias"
+disposition = "preserve"
+execution_state = "activates_in_6.1"
+
+[[matrix]]
+id = "fm.exception_accessor"
+disposition = "preserve"
+execution_state = "activates_in_6.1"
+
+# Transition ownership. A site changes state only through the transition
+# that declares it.
+[[transition]]
+id = "6.1"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "hd.actor.to_py_error",
+  "hd.handle.WouldBlockRuntime",
+  "hd.mesh_controller.to_py_error",
+  "hd.pytokio.WouldBlockRuntime",
+  "hd.pytokio.is_tokio_thread",
+  "hd.pytokio.send_result",
+  "hd.pytokio.to_py_error",
+  "hs.actor_mesh._init_client_context[is_tokio_thread]",
+  "hs.future.Future.__await__[is_tokio_thread]",
+  "hs.future.Future.get[is_tokio_thread]",
+  "hs.handle.ensure_python",
+  "hs.handle.is_tokio_thread",
+  "hs.handle.send_result",
+  "hs.handle.to_py_error",
+  "mr.handle.file"
+]
+
+[[transition]]
+id = "6.2"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "fc.actor_mesh.Port.resolve_and_send[Future._from_corocastAny, message.resolve]",
+  "fc.actor_mesh._Actor.handle[Future._from_cororesponse]",
+  "fc.rdma.RDMAAction.submit[Future._from_coroself._inner.submitclient=client, timeout=timeout, rdma_manager_init=ready]",
+  "fc.rdma.RDMABuffer.drop[Future._from_coroself._buffer.dropclient=client, rdma_manager_init=ready]",
+  "hs.actor.PyPythonTask",
+  "hs.lib.PyPythonTask",
+  "hs.pickle.PyPythonTask",
+  "hs.proc_launcher_probe.PyPythonTask",
+  "im.rdma.module_2",
+  "mr.actor.file",
+  "mr.proc_launcher_probe.file",
+  "np.actor.DroppingPort.resolve_and_send",
+  "np.actor.LocalPort.resolve_and_send",
+  "np.bootstrap.run_worker_loop_forever",
+  "np.lib.PyRdmaAction.submit",
+  "np.lib.PyRdmaBuffer.drop",
+  "np.pickle.PendingMessage.py_resolve",
+  "np.proc_launcher_probe.probe_exit_port_via_mesh"
+]
+
+[[transition]]
+id = "6.3a"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "bs.pickle.reserve_mesh_reference",
+  "ms.actor_mesh.pop_mesh_reference",
+  "ms.actor_mesh.push_mesh_reference_if_active",
+  "ms.actor_mesh.reserve_mesh_reference_if_active",
+  "ms.host_mesh.HostMesh.__reduce_ex__[reserve_mesh_referenceself._hy_host_mesh]",
+  "ms.host_mesh.pop_mesh_reference",
+  "ms.host_mesh.push_mesh_reference_if_active",
+  "ms.pickle.pop_mesh_reference",
+  "ms.pickle.push_mesh_reference_if_active",
+  "ms.pickle.reserve_mesh_reference",
+  "ms.pickle.reserve_mesh_reference_if_active",
+  "ms.pickle.resolve",
+  "ms.proc_mesh.ProcMesh.__reduce_ex__[reserve_mesh_referenceself._proc_mesh]",
+  "ms.proc_mesh.pop_mesh_reference",
+  "ms.proc_mesh.push_mesh_reference_if_active"
+]
+
+[[transition]]
+id = "6.3b"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "fc.actor_mesh.shutdown_context[Future._from_coro_noop]",
+  "fc.actor_mesh.shutdown_context[Future._from_coro_shutdown_sequence]",
+  "fc.host_mesh.HostMesh.shutdown[Future._from_corotask]",
+  "fc.host_mesh.HostMesh.stop[Future._from_corotask]",
+  "fc.proc_mesh.ProcMesh.stop[Future._from_coro_stop_nonblockinginstance]",
+  "hs.context.PyPythonTask",
+  "hs.logging.AwaitPyExt",
+  "hs.logging.PyPythonTask",
+  "hs.logging.ensure_python",
+  "im.logging.module_2",
+  "mr.context.file",
+  "mr.logging.file",
+  "np.context.PyInstance.stop_and_wait",
+  "np.host_mesh.PyHostMesh.shutdown",
+  "np.host_mesh.PyHostMesh.stop",
+  "np.host_mesh.shutdown_local_host_mesh",
+  "np.logging.LoggingMeshClient.flush",
+  "np.logging.LoggingMeshClient.spawn",
+  "np.proc_mesh.PyProcMesh.stop_nonblocking",
+  "ot.proc_mesh.ProcMesh._flush_pending_actor_spawns[mesh.initialized._take_inner]"
+]
+
+[[transition]]
+id = "6.3c"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "dr.bootstrap._as_python_task[PythonTask.from_coroutinejust]",
+  "dr.host_mesh.HostMesh._new_with_shape[PythonTask.from_coroutinetask]",
+  "dr.host_mesh.HostMesh._spawn_nonblocking[PythonTask.from_coroutinetask]",
+  "dr.host_mesh.HostMesh.with_python_executable[PythonTask.from_coroutinetask]",
+  "dr.proc_mesh.ProcMesh._new_with_shape[PythonTask.from_coroutinetask]",
+  "dr.proc_mesh.ProcMesh.from_host_mesh[PythonTask.from_coroutinetaskpm, hy_proc_mesh, setup_actor, host_mesh.stream_logs]",
+  "fc.actor_mesh.ActorMesh._name[Future._from_coroself._inner.name]",
+  "fc.actor_mesh.ActorMesh.initialized[Future._from_coroself._inner.initialized]",
+  "fc.actor_mesh.ActorMesh.stop[Future._from_coroself._inner.stopinstance, reason]",
+  "fc.host_mesh.HostMesh.initialized[Future._from_corotask]",
+  "fc.host_mesh._spawn_admin[Future._from_corotask]",
+  "fc.proc_mesh.ProcMesh._proc_mesh_for_asyncio_fixme[Future._from_coroself._proc_mesh.task]",
+  "fc.proc_mesh.ProcMesh.initialized[Future._from_corotask]",
+  "hs.actor_mesh.PyPythonTask",
+  "hs.actor_mesh.ensure_python",
+  "hs.bootstrap.PyPythonTask",
+  "hs.host_mesh.PyPythonTask",
+  "hs.lib.PyShared",
+  "hs.pickle.PyShared",
+  "hs.proc_mesh.PyPythonTask",
+  "hs.proc_mesh.PyShared",
+  "im.actor_mesh.module_2",
+  "im.bootstrap.module_2",
+  "im.host_mesh.module_2",
+  "im.proc_mesh.module_2",
+  "mr.actor_mesh.file",
+  "mr.bootstrap.file",
+  "mr.host_mesh.file",
+  "mr.lib.file_3",
+  "mr.pickle.file",
+  "mr.proc_mesh.file",
+  "ms.actor_mesh.AsyncActorMesh_as_ActorMeshProtocol.__reduce__",
+  "ms.actor_mesh.block_on",
+  "ms.bootstrap.attach_to_workers[host_mesh.spawn]",
+  "ms.host_mesh.HostMesh._from_initialized_hy_host_mesh[Shared.from_valuehy_host_mesh]",
+  "ms.host_mesh.HostMesh._new_with_shape[PythonTask.from_coroutinetask.spawn]",
+  "ms.host_mesh.HostMesh._new_with_shape[Shared.from_valuehm.slicedshape.region]",
+  "ms.host_mesh.HostMesh._spawn_nonblocking[PythonTask.from_coroutinetask.spawn]",
+  "ms.host_mesh.HostMesh.with_python_executable[PythonTask.from_coroutinetask.spawn]",
+  "ms.pickle.from_value",
+  "ms.proc_mesh.ProcMesh._from_initialized_hy_proc_mesh[Shared.from_valuehy_proc_mesh]",
+  "ms.proc_mesh.ProcMesh._new_with_shape[PythonTask.from_coroutinetask.spawn]",
+  "ms.proc_mesh.ProcMesh._new_with_shape[Shared.from_valuepm.slicedshape.region]",
+  "ms.proc_mesh.ProcMesh.from_host_mesh[PythonTask.from_coroutinetaskpm, hy_proc_mesh, setup_actor, host_mesh.stream_logs.spawn]",
+  "np.actor_mesh.ActorMeshRef_as_ActorMeshProtocol.name",
+  "np.actor_mesh.AsyncActorMesh_as_ActorMeshProtocol.__reduce__",
+  "np.actor_mesh.AsyncActorMesh_as_ActorMeshProtocol.initialized",
+  "np.actor_mesh.AsyncActorMesh_as_ActorMeshProtocol.name",
+  "np.actor_mesh.AsyncActorMesh_as_ActorMeshProtocol.stop",
+  "np.actor_mesh.PythonActorMeshImpl_as_ActorMeshProtocol.name",
+  "np.actor_mesh.PythonActorMeshImpl_as_ActorMeshProtocol.stop",
+  "np.actor_mesh.initialized",
+  "np.bootstrap.attach_to_workers",
+  "np.host_mesh.PyHostMesh.spawn_nonblocking",
+  "np.host_mesh._spawn_admin",
+  "np.host_mesh.bootstrap_host",
+  "ot.bootstrap._as_python_task[s._take_inner]",
+  "ot.proc_mesh.ProcMesh.from_host_mesh.task[setup_actor.setup.call._take_inner]"
+]
+
+[[transition]]
+id = "6.4a"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "fc.actor_mesh.Accumulator.accumulate[Future._from_coroimpl]",
+  "ot.actor_mesh.Accumulator.accumulate.impl[x._take_inner]"
+]
+
+[[transition]]
+id = "6.4b"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "fc.job.exec_command[Future._from_coro_impl]",
+  "ot.job.exec_command._impl[bash_actors.run.callscript, output_dir=output_dir._take_inner]",
+  "ot.job.exec_command._impl[bash_actors.run_python.callcmd, env=env, workdir=workdir, client_cwd=client_cwd, output_dir=output_dir._take_inner]",
+  "ot.job.exec_command._impl[procs.stop._take_inner]"
+]
+
+[[transition]]
+id = "6.4c"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "hs.query_engine.PyPythonTask",
+  "hs.readonly_fuse.PyPythonTask",
+  "mr.query_engine.file",
+  "mr.readonly_fuse.file",
+  "ot.query_engine.DistributedExec_as_ExecutionPlan.execute",
+  "ot.readonly_fuse.take_actor_future"
+]
+
+[[transition]]
+id = "6.5a"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "hs.endpoint.PyPythonTask",
+  "hs.endpoint.PythonTask",
+  "mr.endpoint.file",
+  "np.endpoint.PyValueStream.__next__",
+  "np.endpoint.call",
+  "np.endpoint.value_collector",
+  "rf.endpoint.PyValueStream.__next__",
+  "rf.endpoint.wrap_in_future"
+]
+
+[[transition]]
+id = "6.5b"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "fc.actor_mesh.PortReceiver.recv[Future._from_coroself._recv]",
+  "hs.mailbox.PyPythonTask",
+  "hs.mailbox.PythonTask",
+  "mr.mailbox.file",
+  "np.mailbox.PythonOncePortReceiver.recv_task",
+  "np.mailbox.PythonPortReceiver.recv_task"
+]
+
+[[transition]]
+id = "6.6"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "ret.future._Taken",
+  "ret.future._take_inner"
+]
+
+[[transition]]
+id = "6.7"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "dr.future.Future._from_coro[PythonTask.from_coroutinecoro]",
+  "im.future.module"
+]
+
+[[transition]]
+id = "6.8"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "bs.pytokio.PythonTask",
+  "bs.pytokio.Shared",
+  "bs.pytokio.WouldBlockRuntime",
+  "bs.pytokio.is_tokio_thread",
+  "cf.pytokio.select_one",
+  "cf.pytokio.sleep",
+  "cf.pytokio.spawn_blocking",
+  "cf.pytokio.with_timeout",
+  "doc.SUMMARY.document",
+  "doc.overview.document",
+  "doc.python.document",
+  "doc.pytokio-appendix.document",
+  "hd.pytokio.ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK",
+  "hs.attrs.unawaited_pytokio_traceback",
+  "hs.lib.register_python_bindings",
+  "im.actor_mesh.module",
+  "im.bootstrap.module",
+  "im.context.module",
+  "im.endpoint.module",
+  "im.host_mesh.module",
+  "im.logging.module",
+  "im.mailbox.module",
+  "im.pickle.module",
+  "im.proc_launcher_probe.module",
+  "im.proc_mesh.module",
+  "im.rdma.module",
+  "im.supervision.module",
+  "im.test_actor_driver_characterization.module",
+  "im.test_actor_mesh.module",
+  "im.test_client_context_guard.module",
+  "im.test_future_characterization.module",
+  "im.test_host_mesh.module",
+  "im.test_hyperactor.module",
+  "im.test_logging.module",
+  "im.test_mailbox.module",
+  "im.test_proc_launcher_probe.module",
+  "im.test_proc_mesh.module",
+  "im.test_python_actors.module",
+  "im.test_rdma_initialization.test_ensure_init_observes_its_supplied_shared",
+  "im.test_rdma_initialization.test_ensure_init_returns_handle_that_resolves_over_tcp",
+  "mr.attrs.file",
+  "mr.lib.file",
+  "mr.lib.file_2"
+]
+
+[[transition]]
+id = "D116091231-or-6.2-direct"
+allowed_states = ["migrated", "removed_upstream"]
+owns = [
+  "hs.actor.PythonTask",
+  "np.actor.PythonActor.handle_direct"
+]
+
+# Inventory. One row per discovered site.
+[[site]]
+id = "bs.pickle.reserve_mesh_reference"
+category = "binding_stub"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi"
+symbol = "reserve_mesh_reference"
+operation = "binding_stub_symbol"
+scope = "stub"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "bs.pytokio.PythonTask"
+category = "binding_stub"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi"
+symbol = "PythonTask"
+operation = "binding_stub_symbol"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "bs.pytokio.Shared"
+category = "binding_stub"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi"
+symbol = "Shared"
+operation = "binding_stub_symbol"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "bs.pytokio.WouldBlockRuntime"
+category = "binding_stub"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi"
+symbol = "WouldBlockRuntime"
+operation = "binding_stub_symbol"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "bs.pytokio.is_tokio_thread"
+category = "binding_stub"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi"
+symbol = "is_tokio_thread"
+operation = "binding_stub_symbol"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "ms.bootstrap.attach_to_workers[host_mesh.spawn]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/bootstrap.py"
+symbol = "attach_to_workers[host_mesh.spawn]"
+operation = "bootstrap_storage_spawn"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "cf.pytokio.select_one"
+category = "caller_free_primitive"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pytokio.rs"
+symbol = "select_one"
+operation = "caller_free_primitive"
+scope = "production_compiled_test_only"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "cf.pytokio.sleep"
+category = "caller_free_primitive"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pytokio.rs"
+symbol = "sleep"
+operation = "caller_free_primitive"
+scope = "production_compiled_test_only"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "cf.pytokio.spawn_blocking"
+category = "caller_free_primitive"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pytokio.rs"
+symbol = "spawn_blocking"
+operation = "caller_free_primitive"
+scope = "production_compiled_test_only"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "cf.pytokio.with_timeout"
+category = "caller_free_primitive"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pytokio.rs"
+symbol = "with_timeout"
+operation = "caller_free_primitive"
+scope = "production_compiled_test_only"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "doc.SUMMARY.document"
+category = "documentation"
+language = "doc"
+path = "fbcode/monarch/docs/source/books/hyperactor-mesh-book/src/SUMMARY.md"
+symbol = "<document>"
+operation = "doc_legacy_surface"
+scope = "doc"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "doc.overview.document"
+category = "documentation"
+language = "doc"
+path = "fbcode/monarch/docs/source/books/hyperactor-mesh-book/src/logging/overview.md"
+symbol = "<document>"
+operation = "doc_legacy_surface"
+scope = "doc"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "doc.python.document"
+category = "documentation"
+language = "doc"
+path = "fbcode/monarch/docs/source/books/hyperactor-mesh-book/src/logging/python.md"
+symbol = "<document>"
+operation = "doc_legacy_surface"
+scope = "doc"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "doc.pytokio-appendix.document"
+category = "documentation"
+language = "doc"
+path = "fbcode/monarch/docs/source/books/hyperactor-mesh-book/src/meshes/pytokio-appendix.md"
+symbol = "<document>"
+operation = "doc_legacy_surface"
+scope = "doc"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "fc.actor_mesh.Accumulator.accumulate[Future._from_coroimpl]"
+category = "coroutine_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "Accumulator.accumulate[Future._from_coro(impl())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.4a"
+public_operation = "Accumulator.accumulate(...)"
+caller_contexts = "sync and asyncio"
+return_surface = "Future[T]"
+consumer = "user code"
+driver = "awaited or blocked on by the caller"
+start_point = "the endpoint stream is dispatched when accumulate() is called; combine runs only on observation"
+abandonment = "possible; the stream was already dispatched, so dropping abandons its replies"
+eager_effect = "observes already-running work"
+drop_behavior = "the combine never runs and the dispatched replies are never collected"
+first_side_effect = "endpoint stream dispatch at call time"
+unobserved_error = "silently dropped"
+disposition = "require a binding-specific design"
+semantic_class = "already_started_lazy_observer"
+oracle = "Accumulator exact-once and error behavior (6.0c item 5)"
+
+[[site]]
+id = "fc.actor_mesh.ActorMesh._name[Future._from_coroself._inner.name]"
+category = "native_wrapping_factory"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "ActorMesh._name[Future._from_coro(self._inner.name())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "fc.actor_mesh.ActorMesh.initialized[Future._from_coroself._inner.initialized]"
+category = "native_wrapping_factory"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "ActorMesh.initialized[Future._from_coro(self._inner.initialized())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "fc.actor_mesh.ActorMesh.stop[Future._from_coroself._inner.stopinstance, reason]"
+category = "native_wrapping_factory"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "ActorMesh.stop[Future._from_coro(self._inner.stop(instance, reason))]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "fc.actor_mesh.Port.resolve_and_send[Future._from_corocastAny, message.resolve]"
+category = "native_wrapping_factory"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "Port.resolve_and_send[Future._from_coro(cast(Any, message).resolve())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+
+[[site]]
+id = "fc.actor_mesh.PortReceiver.recv[Future._from_coroself._recv]"
+category = "coroutine_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "PortReceiver.recv[Future._from_coro(self._recv())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.5b"
+public_operation = "PortReceiver.recv()"
+caller_contexts = "sync and asyncio"
+return_surface = "Future[T]"
+consumer = "user code"
+driver = "awaited or blocked on by the caller"
+start_point = "lazy; the native recv_task binding is not called until the coroutine is driven"
+abandonment = "possible; discarding claims nothing because the binding was never called"
+eager_effect = "claims a receive"
+drop_behavior = "no message is consumed"
+first_side_effect = "the native recv_task call"
+unobserved_error = "silently dropped"
+disposition = "require a binding-specific design"
+semantic_class = "deferred_receive_claim"
+oracle = "mailbox ownership (6.0c item 2)"
+
+[[site]]
+id = "fc.actor_mesh._Actor.handle[Future._from_cororesponse]"
+category = "native_wrapping_factory"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "_Actor.handle[Future._from_coro(response)]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+
+[[site]]
+id = "fc.actor_mesh.shutdown_context[Future._from_coro_noop]"
+category = "coroutine_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "shutdown_context[Future._from_coro(_noop())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+public_operation = "monarch.actor.shutdown_context() when shutdown already ran"
+caller_contexts = "sync and asyncio"
+return_surface = "Future[T]"
+consumer = "user code, usually at process exit"
+driver = "awaited or blocked on by the caller"
+start_point = "the wrapped coroutine is an empty no-op; there is nothing to start"
+abandonment = "possible and harmless; shutdown already completed"
+eager_effect = "only wraps a completed no-op"
+drop_behavior = "no effect; _shutdown_done is already True"
+first_side_effect = "none"
+unobserved_error = "none"
+disposition = "replace with a direct value"
+semantic_class = "ready_no_op_wrapper"
+oracle = "lifecycle edge behavior (6.0c item 7)"
+
+[[site]]
+id = "fc.actor_mesh.shutdown_context[Future._from_coro_shutdown_sequence]"
+category = "coroutine_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "shutdown_context[Future._from_coro(_shutdown_sequence())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+public_operation = "monarch.actor.shutdown_context()"
+caller_contexts = "sync and asyncio"
+return_surface = "Future[T]"
+consumer = "user code, usually at process exit"
+driver = "awaited or blocked on by the caller"
+start_point = "lazy; no shutdown work runs until the Future is observed"
+abandonment = "possible; dropping leaves _shutdown_done False and shutdown unperformed"
+eager_effect = "starts a side effect"
+drop_behavior = "shutdown never runs"
+first_side_effect = "setting _shutdown_done = True"
+unobserved_error = "silently dropped"
+disposition = "require a binding-specific design"
+semantic_class = "deferred_side_effect"
+oracle = "lifecycle edge behavior (6.0c item 7)"
+
+[[site]]
+id = "fc.host_mesh.HostMesh.initialized[Future._from_corotask]"
+category = "coroutine_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh.initialized[Future._from_coro(task())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+public_operation = "HostMesh.initialized"
+caller_contexts = "sync and asyncio"
+return_surface = "Future[T]"
+consumer = "user code and internal readiness gates"
+driver = "awaited or blocked on by the caller"
+start_point = "the storage Shared is already being driven; the coroutine only awaits it"
+abandonment = "possible; initialization continues on the storage Shared"
+eager_effect = "observes already-running work"
+drop_behavior = "abandons this observer only"
+first_side_effect = "none; the property access only raises if the mesh is already shut down"
+unobserved_error = "silently dropped"
+disposition = "preserve timing"
+semantic_class = "already_started_lazy_observer"
+oracle = "host mesh readiness coverage"
+
+[[site]]
+id = "fc.host_mesh.HostMesh.shutdown[Future._from_corotask]"
+category = "coroutine_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh.shutdown[Future._from_coro(task())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+public_operation = "HostMesh.shutdown()"
+caller_contexts = "sync and asyncio"
+return_surface = "Future[T]"
+consumer = "user code and context-manager exit"
+driver = "awaited or blocked on by the caller"
+start_point = "lazy; nothing runs until the Future is observed"
+abandonment = "possible; dropping leaves the mesh running and _inner_host_mesh set"
+eager_effect = "starts a side effect"
+drop_behavior = "shutdown never runs"
+first_side_effect = "flushing pending spawns"
+unobserved_error = "silently dropped"
+disposition = "require a binding-specific design"
+semantic_class = "deferred_side_effect"
+oracle = "immediate-shutdown coverage"
+
+[[site]]
+id = "fc.host_mesh.HostMesh.stop[Future._from_corotask]"
+category = "coroutine_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh.stop[Future._from_coro(task())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+public_operation = "HostMesh.stop()"
+caller_contexts = "sync and asyncio"
+return_surface = "Future[T]"
+consumer = "user code"
+driver = "awaited or blocked on by the caller"
+start_point = "lazy; nothing runs until the Future is observed"
+abandonment = "possible; dropping leaves the mesh running"
+eager_effect = "starts a side effect"
+drop_behavior = "stop never runs"
+first_side_effect = "flushing pending spawns"
+unobserved_error = "silently dropped"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "stop idempotence coverage"
+
+[[site]]
+id = "fc.host_mesh._spawn_admin[Future._from_corotask]"
+category = "coroutine_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "_spawn_admin[Future._from_coro(task())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+public_operation = "host mesh admin spawn"
+caller_contexts = "sync and asyncio"
+return_surface = "Future[T]"
+consumer = "internal admin plumbing"
+driver = "awaited or blocked on by the caller"
+start_point = "lazy; nothing runs until the Future is observed"
+abandonment = "possible; dropping leaves MONARCH_ADMIN_URL unset"
+eager_effect = "starts a side effect"
+drop_behavior = "no admin mesh is spawned"
+first_side_effect = "the native admin spawn, which then sets MONARCH_ADMIN_URL"
+unobserved_error = "silently dropped"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "admin spawn coverage"
+
+[[site]]
+id = "fc.proc_mesh.ProcMesh._proc_mesh_for_asyncio_fixme[Future._from_coroself._proc_mesh.task]"
+category = "native_wrapping_factory"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh._proc_mesh_for_asyncio_fixme[Future._from_coro(self._proc_mesh.task())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "fc.proc_mesh.ProcMesh.initialized[Future._from_corotask]"
+category = "coroutine_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh.initialized[Future._from_coro(task())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+public_operation = "ProcMesh.initialized"
+caller_contexts = "sync and asyncio"
+return_surface = "Future[T]"
+consumer = "user code and internal readiness gates"
+driver = "awaited or blocked on by the caller"
+start_point = "the storage Shared is already being driven; the coroutine only awaits it"
+abandonment = "possible; initialization continues on the storage Shared"
+eager_effect = "observes already-running work"
+drop_behavior = "abandons this observer only"
+first_side_effect = "none"
+unobserved_error = "silently dropped"
+disposition = "preserve timing"
+semantic_class = "already_started_lazy_observer"
+oracle = "proc mesh readiness coverage"
+
+[[site]]
+id = "fc.proc_mesh.ProcMesh.stop[Future._from_coro_stop_nonblockinginstance]"
+category = "coroutine_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh.stop[Future._from_coro(_stop_nonblocking(instance))]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+public_operation = "ProcMesh.stop()"
+caller_contexts = "sync and asyncio"
+return_surface = "Future[T]"
+consumer = "user code and context-manager exit"
+driver = "awaited or blocked on by the caller"
+start_point = "lazy; nothing runs until the Future is observed"
+abandonment = "possible; dropping leaves _stopped False and logs unflushed"
+eager_effect = "starts a side effect"
+drop_behavior = "stop never runs"
+first_side_effect = "flushing pending actor spawns"
+unobserved_error = "silently dropped"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "proc mesh stop idempotence coverage"
+
+[[site]]
+id = "fc.job.exec_command[Future._from_coro_impl]"
+category = "coroutine_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/job/job.py"
+symbol = "exec_command[Future._from_coro(_impl())]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.4b"
+public_operation = "job.exec_command(...)"
+caller_contexts = "sync and asyncio"
+return_surface = "Future[T]"
+consumer = "user code"
+driver = "awaited or blocked on by the caller"
+start_point = "lazy; no proc is spawned until the Future is observed"
+abandonment = "possible; dropping prevents the spawn and therefore the finally-block cleanup"
+eager_effect = "starts a side effect"
+drop_behavior = "nothing runs, and no cleanup is owed"
+first_side_effect = "the proc spawn"
+unobserved_error = "silently dropped"
+disposition = "require a binding-specific design"
+semantic_class = "deferred_side_effect"
+oracle = "job.exec_command operation-root behavior (6.0c item 6)"
+
+[[site]]
+id = "fc.rdma.RDMAAction.submit[Future._from_coroself._inner.submitclient=client, timeout=timeout, rdma_manager_init=ready]"
+category = "native_wrapping_factory"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/rdma/rdma.py"
+symbol = "RDMAAction.submit[Future._from_coro(self._inner.submit(client=client, timeout=timeout, rdma_manager_init=ready))]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+
+[[site]]
+id = "fc.rdma.RDMABuffer.drop[Future._from_coroself._buffer.dropclient=client, rdma_manager_init=ready]"
+category = "native_wrapping_factory"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/rdma/rdma.py"
+symbol = "RDMABuffer.drop[Future._from_coro(self._buffer.drop(client=client, rdma_manager_init=ready))]"
+operation = "from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+
+[[site]]
+id = "dr.bootstrap._as_python_task[PythonTask.from_coroutinejust]"
+category = "driver_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/bootstrap.py"
+symbol = "_as_python_task[PythonTask.from_coroutine(just())]"
+operation = "from_coroutine"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "dr.future.Future._from_coro[PythonTask.from_coroutinecoro]"
+category = "driver_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/future.py"
+symbol = "Future._from_coro[PythonTask.from_coroutine(coro)]"
+operation = "from_coroutine"
+scope = "production"
+state = "legacy"
+transition = "6.7"
+
+[[site]]
+id = "dr.host_mesh.HostMesh._new_with_shape[PythonTask.from_coroutinetask]"
+category = "driver_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh._new_with_shape[PythonTask.from_coroutine(task())]"
+operation = "from_coroutine"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "dr.host_mesh.HostMesh._spawn_nonblocking[PythonTask.from_coroutinetask]"
+category = "driver_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh._spawn_nonblocking[PythonTask.from_coroutine(task())]"
+operation = "from_coroutine"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "dr.host_mesh.HostMesh.with_python_executable[PythonTask.from_coroutinetask]"
+category = "driver_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh.with_python_executable[PythonTask.from_coroutine(task())]"
+operation = "from_coroutine"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "dr.proc_mesh.ProcMesh._new_with_shape[PythonTask.from_coroutinetask]"
+category = "driver_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh._new_with_shape[PythonTask.from_coroutine(task())]"
+operation = "from_coroutine"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "dr.proc_mesh.ProcMesh.from_host_mesh[PythonTask.from_coroutinetaskpm, hy_proc_mesh, setup_actor, host_mesh.stream_logs]"
+category = "driver_root"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh.from_host_mesh[PythonTask.from_coroutine(task(pm, hy_proc_mesh, setup_actor, host_mesh.stream_logs))]"
+operation = "from_coroutine"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "hd.mesh_controller.to_py_error"
+category = "helper_definition"
+language = "rust"
+path = "fbcode/monarch/monarch_extension/src/mesh_controller.rs"
+symbol = "to_py_error"
+operation = "helper_definition"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hd.actor.to_py_error"
+category = "helper_definition"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor.rs"
+symbol = "to_py_error"
+operation = "helper_definition"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hd.pytokio.ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK"
+category = "helper_definition"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pytokio.rs"
+symbol = "ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK"
+operation = "helper_definition"
+scope = "production"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "hd.pytokio.is_tokio_thread"
+category = "helper_definition"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pytokio.rs"
+symbol = "is_tokio_thread"
+operation = "helper_definition"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hd.pytokio.send_result"
+category = "helper_definition"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pytokio.rs"
+symbol = "send_result"
+operation = "helper_definition"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hd.pytokio.to_py_error"
+category = "helper_definition"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pytokio.rs"
+symbol = "to_py_error"
+operation = "helper_definition"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hs.attrs.unawaited_pytokio_traceback"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/hyperactor_config/src/attrs.rs"
+symbol = "unawaited_pytokio_traceback"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "hs.query_engine.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_distributed_telemetry/src/query_engine.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.4c"
+
+[[site]]
+id = "hs.lib.register_python_bindings"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_extension/src/lib.rs"
+symbol = "register_python_bindings"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "hs.readonly_fuse.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_extension/src/readonly_fuse.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.4c"
+
+[[site]]
+id = "hs.actor.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+
+[[site]]
+id = "hs.actor.PythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor.rs"
+symbol = "PythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "D116091231-or-6.2-direct"
+
+[[site]]
+id = "hs.actor_mesh.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "hs.actor_mesh.ensure_python"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "ensure_python"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "hs.bootstrap.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/bootstrap.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "hs.context.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/context.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+
+[[site]]
+id = "hs.endpoint.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/endpoint.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.5a"
+
+[[site]]
+id = "hs.endpoint.PythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/endpoint.rs"
+symbol = "PythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.5a"
+
+[[site]]
+id = "hs.handle.ensure_python"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/handle.rs"
+symbol = "ensure_python"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hs.handle.is_tokio_thread"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/handle.rs"
+symbol = "is_tokio_thread"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hs.handle.send_result"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/handle.rs"
+symbol = "send_result"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hs.handle.to_py_error"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/handle.rs"
+symbol = "to_py_error"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hs.host_mesh.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/host_mesh.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "hs.logging.AwaitPyExt"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/logging.rs"
+symbol = "AwaitPyExt"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+
+[[site]]
+id = "hs.logging.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/logging.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+
+[[site]]
+id = "hs.logging.ensure_python"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/logging.rs"
+symbol = "ensure_python"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+
+[[site]]
+id = "hs.mailbox.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/mailbox.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.5b"
+
+[[site]]
+id = "hs.mailbox.PythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/mailbox.rs"
+symbol = "PythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.5b"
+
+[[site]]
+id = "hs.pickle.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pickle.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+
+[[site]]
+id = "hs.pickle.PyShared"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pickle.rs"
+symbol = "PyShared"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "hs.proc_launcher_probe.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/proc_launcher_probe.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production_compiled_test_only"
+state = "legacy"
+transition = "6.2"
+
+[[site]]
+id = "hs.proc_mesh.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/proc_mesh.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "hs.proc_mesh.PyShared"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/proc_mesh.rs"
+symbol = "PyShared"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "hs.lib.PyPythonTask"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_rdma/extension/lib.rs"
+symbol = "PyPythonTask"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+
+[[site]]
+id = "hs.lib.PyShared"
+category = "helper_residue"
+language = "rust"
+path = "fbcode/monarch/monarch_rdma/extension/lib.rs"
+symbol = "PyShared"
+operation = "helper_symbol"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ms.actor_mesh.pop_mesh_reference"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "pop_mesh_reference"
+operation = "mesh_reserve_fill"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.actor_mesh.push_mesh_reference_if_active"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "push_mesh_reference_if_active"
+operation = "mesh_reserve_fill"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.actor_mesh.reserve_mesh_reference_if_active"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "reserve_mesh_reference_if_active"
+operation = "mesh_reserve_fill"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.host_mesh.pop_mesh_reference"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/host_mesh.rs"
+symbol = "pop_mesh_reference"
+operation = "mesh_reserve_fill"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.host_mesh.push_mesh_reference_if_active"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/host_mesh.rs"
+symbol = "push_mesh_reference_if_active"
+operation = "mesh_reserve_fill"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.pickle.pop_mesh_reference"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pickle.rs"
+symbol = "pop_mesh_reference"
+operation = "mesh_reserve_fill"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.pickle.push_mesh_reference_if_active"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pickle.rs"
+symbol = "push_mesh_reference_if_active"
+operation = "mesh_reserve_fill"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.pickle.reserve_mesh_reference_if_active"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pickle.rs"
+symbol = "reserve_mesh_reference_if_active"
+operation = "mesh_reserve_fill"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.proc_mesh.pop_mesh_reference"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/proc_mesh.rs"
+symbol = "pop_mesh_reference"
+operation = "mesh_reserve_fill"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.proc_mesh.push_mesh_reference_if_active"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/proc_mesh.rs"
+symbol = "push_mesh_reference_if_active"
+operation = "mesh_reserve_fill"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.pickle.resolve"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pickle.rs"
+symbol = "resolve"
+operation = "mesh_state_resolve"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.host_mesh.HostMesh._new_with_shape[PythonTask.from_coroutinetask.spawn]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh._new_with_shape[PythonTask.from_coroutine(task()).spawn]"
+operation = "mesh_storage_spawn"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ms.host_mesh.HostMesh._spawn_nonblocking[PythonTask.from_coroutinetask.spawn]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh._spawn_nonblocking[PythonTask.from_coroutine(task()).spawn]"
+operation = "mesh_storage_spawn"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ms.host_mesh.HostMesh.with_python_executable[PythonTask.from_coroutinetask.spawn]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh.with_python_executable[PythonTask.from_coroutine(task()).spawn]"
+operation = "mesh_storage_spawn"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ms.proc_mesh.ProcMesh._new_with_shape[PythonTask.from_coroutinetask.spawn]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh._new_with_shape[PythonTask.from_coroutine(task()).spawn]"
+operation = "mesh_storage_spawn"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ms.proc_mesh.ProcMesh.from_host_mesh[PythonTask.from_coroutinetaskpm, hy_proc_mesh, setup_actor, host_mesh.stream_logs.spawn]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh.from_host_mesh[PythonTask.from_coroutine(task(pm, hy_proc_mesh, setup_actor, host_mesh.stream_logs)).spawn]"
+operation = "mesh_storage_spawn"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "hs.actor_mesh._init_client_context[is_tokio_thread]"
+category = "helper_residue"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "_init_client_context[is_tokio_thread]"
+operation = "py_is_tokio_thread"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hs.future.Future.__await__[is_tokio_thread]"
+category = "helper_residue"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/future.py"
+symbol = "Future.__await__[is_tokio_thread]"
+operation = "py_is_tokio_thread"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hs.future.Future.get[is_tokio_thread]"
+category = "helper_residue"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/future.py"
+symbol = "Future.get[is_tokio_thread]"
+operation = "py_is_tokio_thread"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "ms.host_mesh.HostMesh.__reduce_ex__[reserve_mesh_referenceself._hy_host_mesh]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh.__reduce_ex__[reserve_mesh_reference(self._hy_host_mesh)]"
+operation = "py_mesh_reserve"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "ms.proc_mesh.ProcMesh.__reduce_ex__[reserve_mesh_referenceself._proc_mesh]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh.__reduce_ex__[reserve_mesh_reference(self._proc_mesh)]"
+operation = "py_mesh_reserve"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "np.actor.DroppingPort.resolve_and_send"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor.rs"
+symbol = "DroppingPort::resolve_and_send"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from DroppingPort::resolve_and_send"
+consumer = "_Actor.handle, through its isinstance(response, PythonTask) branch"
+driver = "awaited on the actor loop by _Actor.handle"
+start_point = "already complete at construction"
+abandonment = "possible; _Actor.handle may return before awaiting the branch"
+eager_effect = "only wraps a ready value"
+drop_behavior = "no effect; the send is a no-op by construction"
+unobserved_error = "none; the future resolves to Ok(())"
+disposition = "replace with a direct value"
+semantic_class = "ready_no_op_wrapper"
+oracle = "test_python_actors response-port coverage"
+
+[[site]]
+id = "np.actor.LocalPort.resolve_and_send"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor.rs"
+symbol = "LocalPort::resolve_and_send"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from LocalPort::resolve_and_send"
+consumer = "_Actor.handle, through its isinstance(response, PythonTask) branch"
+driver = "awaited on the actor loop by _Actor.handle"
+start_point = "already complete at construction"
+abandonment = "possible; _Actor.handle may return before awaiting the branch"
+eager_effect = "only wraps a ready value"
+drop_behavior = "no effect; port.send already happened synchronously"
+unobserved_error = "none; the future resolves to Ok(())"
+disposition = "replace with a direct value"
+semantic_class = "ready_no_op_wrapper"
+oracle = "test_python_actors response-port coverage"
+
+[[site]]
+id = "np.actor_mesh.ActorMeshRef_as_ActorMeshProtocol.name"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "<ActorMeshRef<PythonActor> as ActorMeshProtocol>::name"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from <ActorMeshRef<PythonActor> as ActorMeshProtocol>::name"
+consumer = "ActorMesh._name via Future._from_coro"
+driver = "awaited by the Python ActorMesh._name coroutine"
+start_point = "already complete; the name is read from the mesh ref before the future is built"
+abandonment = "possible; a caller may drop the returned task"
+eager_effect = "only wraps a ready value"
+drop_behavior = "no effect; the name was already computed"
+unobserved_error = "none"
+disposition = "replace with a direct value"
+semantic_class = "ready_no_op_wrapper"
+oracle = "actor mesh naming coverage"
+
+[[site]]
+id = "np.actor_mesh.AsyncActorMesh_as_ActorMeshProtocol.__reduce__"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "<AsyncActorMesh as ActorMeshProtocol>::__reduce__"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from <AsyncActorMesh as ActorMeshProtocol>::__reduce__"
+consumer = "reserve_mesh_reference_if_active, or Shared.block_on named in the payload"
+driver = "spawn_abortable onto the shared tokio runtime, immediately after construction"
+start_point = "eager; spawn_abortable drives it as soon as __reduce__ returns"
+abandonment = "possible; the pickler may drop the reduction observer before it resolves"
+eager_effect = "observes already-running work"
+drop_behavior = "aborts the transient waiter only; new_queue drives root initialization independently, and a sliced derived Shared remains re-observable rather than cancelled"
+unobserved_error = "send_result logs an unobserved error"
+disposition = "require a binding-specific design"
+semantic_class = "abortable_observer"
+oracle = "root and sliced reduction abandonment (6.0c items 3 and 4)"
+
+[[site]]
+id = "np.actor_mesh.AsyncActorMesh_as_ActorMeshProtocol.initialized"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "<AsyncActorMesh as ActorMeshProtocol>::initialized"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from <AsyncActorMesh as ActorMeshProtocol>::initialized"
+consumer = "ActorMesh.initialized via Future._from_coro"
+driver = "awaits a clone of the shared mesh future; for a root, new_queue drives that clone independently, while a slice from new_with_region has a derived Shared with no independent driver"
+start_point = "the root is already running under its queue driver; a sliced derived Shared is driven only by whoever polls it"
+abandonment = "possible; root initialization continues, and a dropped slice observer leaves the derived Shared re-observable"
+eager_effect = "observes already-running work"
+drop_behavior = "abandons this observer only; it never cancels root initialization, and a slice stays re-observable"
+unobserved_error = "surfaced on the next observation of the shared future"
+disposition = "preserve timing"
+semantic_class = "already_started_lazy_observer"
+oracle = "root and sliced readiness abandonment (6.0c items 3 and 4)"
+
+[[site]]
+id = "np.actor_mesh.AsyncActorMesh_as_ActorMeshProtocol.name"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "<AsyncActorMesh as ActorMeshProtocol>::name"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from <AsyncActorMesh as ActorMeshProtocol>::name"
+consumer = "ActorMesh._name via Future._from_coro"
+driver = "the per-mesh queue task runs the work; the returned task only reads a oneshot rx"
+start_point = "already started; push() enqueues the work before the observer is returned, so the returned task is a lazy observer of an operation already in flight"
+abandonment = "possible and currently fatal; the observer may be dropped while the queue task runs"
+eager_effect = "observes already-running work"
+drop_behavior = "dropping rx makes tx.send fail and the queue task panics with 'oneshot failed'"
+unobserved_error = "the queue driver panics rather than reporting"
+disposition = "require a binding-specific design"
+semantic_class = "already_started_lazy_observer"
+oracle = "queued observer abandonment (6.0c item 8)"
+
+[[site]]
+id = "np.actor_mesh.AsyncActorMesh_as_ActorMeshProtocol.stop"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "<AsyncActorMesh as ActorMeshProtocol>::stop"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from <AsyncActorMesh as ActorMeshProtocol>::stop"
+consumer = "ActorMesh.stop via Future._from_coro"
+driver = "the per-mesh queue task runs the work; the returned task only reads a oneshot rx"
+start_point = "already started; push() enqueues the work before the observer is returned, so the returned task is a lazy observer of an operation already in flight"
+abandonment = "possible and currently fatal; the observer may be dropped while the queue task runs"
+eager_effect = "observes already-running work"
+drop_behavior = "dropping rx makes tx.send fail and the queue task panics with 'oneshot failed'"
+unobserved_error = "the queue driver panics rather than reporting"
+disposition = "require a binding-specific design"
+semantic_class = "already_started_lazy_observer"
+oracle = "queued observer abandonment (6.0c item 8)"
+
+[[site]]
+id = "np.actor_mesh.PythonActorMeshImpl_as_ActorMeshProtocol.name"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "<PythonActorMeshImpl as ActorMeshProtocol>::name"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from <PythonActorMeshImpl as ActorMeshProtocol>::name"
+consumer = "ActorMesh._name via Future._from_coro"
+driver = "awaited by the Python ActorMesh._name coroutine"
+start_point = "already complete; the name is read from the mesh ref before the future is built"
+abandonment = "possible; a caller may drop the returned task"
+eager_effect = "only wraps a ready value"
+drop_behavior = "no effect; the name was already computed"
+unobserved_error = "none"
+disposition = "replace with a direct value"
+semantic_class = "ready_no_op_wrapper"
+oracle = "actor mesh naming coverage"
+
+[[site]]
+id = "np.actor_mesh.PythonActorMeshImpl_as_ActorMeshProtocol.stop"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "<PythonActorMeshImpl as ActorMeshProtocol>::stop"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from <PythonActorMeshImpl as ActorMeshProtocol>::stop"
+consumer = "ActorMesh.stop via Future._from_coro"
+driver = "awaited by the Python ActorMesh.stop coroutine"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; a caller may drop the returned task"
+eager_effect = "starts a side effect"
+drop_behavior = "the mesh is never stopped"
+unobserved_error = "surfaced on observation"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "actor mesh stop coverage"
+
+[[site]]
+id = "np.actor_mesh.initialized"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "ActorMeshProtocol::initialized"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from initialized"
+consumer = "ActorMesh.initialized via Future._from_coro"
+driver = "awaited by the Python ActorMesh.initialized coroutine"
+start_point = "already complete; the trait default resolves to None without work"
+abandonment = "possible; a caller may drop the returned task"
+eager_effect = "only wraps a ready value"
+drop_behavior = "no effect; there is no underlying operation"
+unobserved_error = "none; resolves to Ok(None)"
+disposition = "replace with a direct value"
+semantic_class = "ready_no_op_wrapper"
+oracle = "actor mesh readiness coverage"
+
+[[site]]
+id = "np.bootstrap.attach_to_workers"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/bootstrap.rs"
+symbol = "attach_to_workers"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from attach_to_workers"
+consumer = "HostMesh construction, through the bootstrap _as_python_task adapter"
+driver = "awaited inside the host mesh setup coroutine"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; the adapter's task may be dropped before it is driven"
+eager_effect = "starts a side effect"
+drop_behavior = "no worker attach is performed"
+unobserved_error = "surfaced on observation"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "bootstrap attach-to-workers coverage"
+
+[[site]]
+id = "np.bootstrap.run_worker_loop_forever"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/bootstrap.rs"
+symbol = "run_worker_loop_forever"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from run_worker_loop_forever"
+consumer = "bootstrap_main, which blocks the worker's main thread on it"
+driver = "PythonTask.block_on on the calling thread"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "not reachable in practice; the caller blocks immediately after construction"
+eager_effect = "starts a side effect"
+drop_behavior = "the worker server loop never starts"
+unobserved_error = "propagated synchronously out of block_on"
+disposition = "replace with a direct blocking binding"
+semantic_class = "deferred_side_effect"
+oracle = "bootstrap worker-loop coverage"
+
+[[site]]
+id = "np.context.PyInstance.stop_and_wait"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/context.rs"
+symbol = "PyInstance::stop_and_wait"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from PyInstance::stop_and_wait"
+consumer = "shutdown_context's no-host fallback"
+driver = "awaited inside _shutdown_sequence"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; reachable only when the shutdown coroutine itself is abandoned"
+eager_effect = "starts a side effect"
+drop_behavior = "the root client instance is never stopped"
+unobserved_error = "surfaced on observation"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "lifecycle edge behavior (6.0c item 7)"
+
+[[site]]
+id = "np.host_mesh.PyHostMesh.shutdown"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/host_mesh.rs"
+symbol = "PyHostMesh::shutdown"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from PyHostMesh::shutdown"
+consumer = "HostMesh.shutdown, after flushing pending spawns"
+driver = "awaited inside the HostMesh.shutdown coroutine"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; reachable only when the shutdown coroutine is abandoned"
+eager_effect = "starts a side effect"
+drop_behavior = "the host mesh is never shut down"
+unobserved_error = "surfaced on observation"
+disposition = "require a binding-specific design"
+semantic_class = "deferred_side_effect"
+oracle = "immediate-shutdown and drain coverage"
+
+[[site]]
+id = "np.host_mesh.PyHostMesh.spawn_nonblocking"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/host_mesh.rs"
+symbol = "PyHostMesh::spawn_nonblocking"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from PyHostMesh::spawn_nonblocking"
+consumer = "HostMesh._spawn_nonblocking"
+driver = "driven by PythonTask.from_coroutine(task()).spawn() on the Python side"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; the storage Shared may be built and never observed"
+eager_effect = "starts a side effect"
+drop_behavior = "no proc mesh is spawned"
+unobserved_error = "send_result logs an unobserved error once spawned"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "proc mesh setup coverage"
+
+[[site]]
+id = "np.host_mesh.PyHostMesh.stop"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/host_mesh.rs"
+symbol = "PyHostMesh::stop"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from PyHostMesh::stop"
+consumer = "HostMesh.stop, after flushing pending spawns"
+driver = "awaited inside the HostMesh.stop coroutine"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; reachable only when the stop coroutine is abandoned"
+eager_effect = "starts a side effect"
+drop_behavior = "the host mesh is never stopped"
+unobserved_error = "surfaced on observation"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "stop idempotence coverage"
+
+[[site]]
+id = "np.host_mesh._spawn_admin"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/host_mesh.rs"
+symbol = "_spawn_admin"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from _spawn_admin"
+consumer = "the Python _spawn_admin coroutine, which then sets MONARCH_ADMIN_URL"
+driver = "awaited inside the Python _spawn_admin coroutine"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; the admin coroutine may be abandoned"
+eager_effect = "starts a side effect"
+drop_behavior = "no admin mesh is spawned and the environment variable is not set"
+unobserved_error = "surfaced on observation"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "admin spawn coverage"
+
+[[site]]
+id = "np.host_mesh.bootstrap_host"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/host_mesh.rs"
+symbol = "bootstrap_host"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from bootstrap_host"
+consumer = "host mesh construction"
+driver = "awaited inside the host mesh setup coroutine"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; the setup coroutine may be abandoned"
+eager_effect = "starts a side effect"
+drop_behavior = "no host is bootstrapped"
+unobserved_error = "surfaced on observation"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "host mesh setup coverage"
+
+[[site]]
+id = "np.host_mesh.shutdown_local_host_mesh"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/host_mesh.rs"
+symbol = "shutdown_local_host_mesh"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from shutdown_local_host_mesh"
+consumer = "_shutdown_sequence, as the local-host path"
+driver = "awaited inside _shutdown_sequence"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; reachable only when the shutdown coroutine is abandoned"
+eager_effect = "starts a side effect"
+drop_behavior = "the local host mesh is never shut down and logs are not flushed"
+unobserved_error = "surfaced on observation"
+disposition = "require a binding-specific design"
+semantic_class = "deferred_side_effect"
+oracle = "global shutdown sequence coverage"
+
+[[site]]
+id = "np.logging.LoggingMeshClient.flush"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/logging.rs"
+symbol = "LoggingMeshClient::flush"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from LoggingMeshClient::flush"
+consumer = "ProcMesh.stop and the logging manager's tokio flush"
+driver = "awaited during teardown"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; teardown may abandon it"
+eager_effect = "starts a side effect"
+drop_behavior = "the flush never runs and buffered logs are lost"
+unobserved_error = "currently suppressed rather than reported"
+disposition = "preserve timing"
+semantic_class = "deferred_side_effect"
+oracle = "logging flush ordering coverage"
+
+[[site]]
+id = "np.logging.LoggingMeshClient.spawn"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/logging.rs"
+symbol = "LoggingMeshClient::spawn"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from LoggingMeshClient::spawn"
+consumer = "proc mesh logging initialization"
+driver = "awaited during proc mesh setup"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; this is the known fast-bootstrap gap"
+eager_effect = "starts a side effect"
+drop_behavior = "the logging client is never created and early logs are lost"
+unobserved_error = "currently suppressed rather than reported"
+disposition = "preserve timing"
+semantic_class = "deferred_side_effect"
+oracle = "logging initialization and suppression coverage"
+
+[[site]]
+id = "np.pickle.PendingMessage.py_resolve"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pickle.rs"
+symbol = "PendingMessage::py_resolve"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from PendingMessage::py_resolve"
+consumer = "Port.resolve_and_send, on the actor loop"
+driver = "awaited on the actor loop before the reply is sent"
+start_point = "self.take() consumes the PendingMessage synchronously at construction; only the slot fill in resolve() is deferred to the returned task"
+abandonment = "possible; the message has already been taken out of the PendingMessage, so the source cannot be reused"
+eager_effect = "starts a side effect"
+drop_behavior = "the taken message is lost: slots are never filled and no reply is sent"
+unobserved_error = "surfaced on observation"
+disposition = "preserve timing"
+semantic_class = "sync_partial_effect_lazy_tail"
+oracle = "PicklingState::resolve slot-order in-crate test (6.0c)"
+
+[[site]]
+id = "np.proc_launcher_probe.probe_exit_port_via_mesh"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/proc_launcher_probe.rs"
+symbol = "probe_exit_port_via_mesh"
+operation = "py_python_task_new"
+scope = "production_compiled_test_only"
+state = "legacy"
+transition = "6.2"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from probe_exit_port_via_mesh"
+consumer = "test_proc_launcher_probe"
+driver = "awaited by the probe's test caller"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; the probe task may be dropped"
+eager_effect = "starts a side effect"
+drop_behavior = "the probe never runs"
+unobserved_error = "surfaced on observation"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "test_proc_launcher_probe"
+
+[[site]]
+id = "np.proc_mesh.PyProcMesh.stop_nonblocking"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/proc_mesh.rs"
+symbol = "PyProcMesh::stop_nonblocking"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from PyProcMesh::stop_nonblocking"
+consumer = "ProcMesh.stop, after flushing pending actor spawns and logs"
+driver = "awaited inside the _stop_nonblocking coroutine"
+start_point = "lazy; the boxed future is not polled until the returned task is driven"
+abandonment = "possible; reachable only when the stop coroutine is abandoned"
+eager_effect = "starts a side effect"
+drop_behavior = "the proc mesh is never stopped and _stopped stays False"
+unobserved_error = "surfaced on observation"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "proc mesh stop idempotence coverage"
+
+[[site]]
+id = "np.lib.PyRdmaAction.submit"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_rdma/extension/lib.rs"
+symbol = "PyRdmaAction::submit"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from PyRdmaAction::submit"
+consumer = "RDMAAction.submit via Future._from_coro"
+driver = "awaited by the caller through the public Future"
+start_point = "gated on RDMA readiness, then lazy until driven"
+abandonment = "possible; a caller may drop the returned Future"
+eager_effect = "starts a side effect"
+drop_behavior = "the transfer is never submitted"
+unobserved_error = "surfaced on observation"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "test_rdma submit coverage"
+
+[[site]]
+id = "np.lib.PyRdmaBuffer.drop"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_rdma/extension/lib.rs"
+symbol = "PyRdmaBuffer::drop"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+constructor = "PyPythonTask"
+return_surface = "PyPythonTask returned from PyRdmaBuffer::drop"
+consumer = "RDMABuffer.drop via Future._from_coro"
+driver = "awaited by the caller through the public Future"
+start_point = "gated on RDMA readiness, then lazy until driven"
+abandonment = "possible; a caller may drop the returned Future"
+eager_effect = "starts a side effect"
+drop_behavior = "the buffer registration is never released"
+unobserved_error = "surfaced on observation"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "test_rdma drop coverage"
+
+[[site]]
+id = "im.actor_mesh.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.bootstrap.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/bootstrap.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.context.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/context.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.endpoint.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/endpoint.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.host_mesh.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.logging.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/logging.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.mailbox.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/mailbox.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.pickle.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["Shared"]
+
+[[site]]
+id = "im.proc_launcher_probe.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/proc_launcher_probe.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.proc_mesh.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.supervision.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/monarch_hyperactor/supervision.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["Shared"]
+
+[[site]]
+id = "im.rdma.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_rust_bindings/rdma.pyi"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "stub"
+state = "legacy"
+transition = "6.8"
+members = ["Handle", "PythonTask"]
+
+[[site]]
+id = "im.actor_mesh.module_2"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+members = ["PythonTask", "WouldBlockRuntime", "is_tokio_thread"]
+
+[[site]]
+id = "im.bootstrap.module_2"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/bootstrap.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.future.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/future.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "production"
+state = "legacy"
+transition = "6.7"
+members = ["Handle", "PythonTask", "WouldBlockRuntime", "is_tokio_thread"]
+
+[[site]]
+id = "im.host_mesh.module_2"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.logging.module_2"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/logging.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.proc_mesh.module_2"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.rdma.module_2"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/rdma/rdma.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+members = ["Handle"]
+
+[[site]]
+id = "im.test_actor_mesh.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/_monarch/test_actor_mesh.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.test_hyperactor.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/_monarch/test_hyperactor.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.test_logging.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/_monarch/test_logging.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.test_mailbox.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/_monarch/test_mailbox.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.test_actor_driver_characterization.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_actor_driver_characterization.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.test_client_context_guard.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_client_context_guard.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask", "WouldBlockRuntime", "is_tokio_thread"]
+
+[[site]]
+id = "im.test_future_characterization.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_future_characterization.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["Handle", "PythonTask", "WouldBlockRuntime", "is_tokio_thread"]
+
+[[site]]
+id = "im.test_host_mesh.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_host_mesh.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.test_proc_launcher_probe.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_proc_launcher_probe.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
+
+[[site]]
+id = "im.test_proc_mesh.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_proc_mesh.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.test_python_actors.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_python_actors.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.test_rdma_initialization.test_ensure_init_observes_its_supplied_shared"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_rdma_initialization.py"
+symbol = "test_ensure_init_observes_its_supplied_shared"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["Shared"]
+
+[[site]]
+id = "im.test_rdma_initialization.test_ensure_init_returns_handle_that_resolves_over_tcp"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_rdma_initialization.py"
+symbol = "test_ensure_init_returns_handle_that_resolves_over_tcp"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["Handle"]
+
+[[site]]
+id = "mr.attrs.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/hyperactor_config/src/attrs.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "mr.query_engine.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_distributed_telemetry/src/query_engine.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.4c"
+
+[[site]]
+id = "mr.lib.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_extension/src/lib.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "mr.readonly_fuse.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_extension/src/readonly_fuse.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.4c"
+
+[[site]]
+id = "mr.actor.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+
+[[site]]
+id = "mr.actor_mesh.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "mr.bootstrap.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/bootstrap.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "mr.context.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/context.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+
+[[site]]
+id = "mr.endpoint.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/endpoint.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.5a"
+
+[[site]]
+id = "mr.handle.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/handle.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "mr.host_mesh.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/host_mesh.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "mr.lib.file_2"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/lib.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.8"
+
+[[site]]
+id = "mr.logging.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/logging.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+
+[[site]]
+id = "mr.mailbox.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/mailbox.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.5b"
+
+[[site]]
+id = "mr.pickle.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pickle.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "mr.proc_launcher_probe.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/proc_launcher_probe.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production_compiled_test_only"
+state = "legacy"
+transition = "6.2"
+
+[[site]]
+id = "mr.proc_mesh.file"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/proc_mesh.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "mr.lib.file_3"
+category = "module_reference"
+language = "rust"
+path = "fbcode/monarch/monarch_rdma/extension/lib.rs"
+symbol = "<file>"
+operation = "pytokio_module_ref"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "np.actor.PythonActor.handle_direct"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor.rs"
+symbol = "PythonActor::handle_direct"
+operation = "raw_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "D116091231-or-6.2-direct"
+constructor = "raw PythonTask"
+return_surface = "raw PythonTask returned from PythonActor::handle_direct"
+consumer = "handle_async_endpoint_panic, which immediately calls task.take()"
+driver = "tokio::spawn in the same expression that constructs it"
+start_point = "eager; the pyo3-async-runtimes future is already scheduled on the actor loop"
+abandonment = "none; construction and spawn are one expression, so no caller can drop it"
+eager_effect = "observes already-running work"
+drop_behavior = "not reachable; the task is never handed to a caller"
+unobserved_error = "a panic reaches the actor as Signal::Kill via the side channel"
+disposition = "replace with the bridge future directly"
+semantic_class = "already_started_lazy_observer"
+oracle = "test_actor_driver_characterization"
+
+[[site]]
+id = "np.endpoint.PyValueStream.__next__"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/endpoint.rs"
+symbol = "PyValueStream::__next__"
+operation = "raw_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.5a"
+constructor = "raw PythonTask"
+return_surface = "raw PythonTask returned from PyValueStream::__next__"
+consumer = "the per-element Future yielded by ValueStream iteration"
+driver = "awaited by the caller, one element at a time"
+start_point = "lazy; the raw task is not polled at construction, and the receiver claim begins only when it is driven"
+abandonment = "possible; a yielded element Future may be discarded"
+eager_effect = "claims a receive"
+drop_behavior = "the reply is left for the next observer"
+unobserved_error = "surfaced on observation"
+disposition = "require a binding-specific design"
+semantic_class = "deferred_receive_claim"
+oracle = "ValueStream reverse observation (6.0c item 2)"
+
+[[site]]
+id = "np.endpoint.call"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/endpoint.rs"
+symbol = "Endpoint::call"
+operation = "raw_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.5a"
+constructor = "raw PythonTask"
+return_surface = "raw PythonTask returned from call"
+consumer = "the public Future built by make_future for call"
+driver = "awaited by the caller through Future.get or as_asyncio"
+start_point = "the cast already happened; only ValueMesh accumulation is deferred"
+abandonment = "possible; a caller may drop the returned Future"
+eager_effect = "observes already-running work"
+drop_behavior = "accumulation is abandoned"
+unobserved_error = "surfaced on observation"
+disposition = "preserve timing"
+semantic_class = "already_started_lazy_observer"
+oracle = "collect_valuemesh refs and lazy-decode coverage"
+
+[[site]]
+id = "np.endpoint.value_collector"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/endpoint.rs"
+symbol = "value_collector"
+operation = "raw_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.5a"
+constructor = "raw PythonTask"
+return_surface = "raw PythonTask returned from value_collector"
+consumer = "the public Future built by make_future for call_one and choose"
+driver = "awaited by the caller through Future.get or as_asyncio"
+start_point = "the request was already cast; only reply collection is deferred"
+abandonment = "possible; a caller may drop the returned Future"
+eager_effect = "observes already-running work"
+drop_behavior = "collection is abandoned and the reply is discarded"
+unobserved_error = "surfaced on observation"
+disposition = "preserve timing"
+semantic_class = "already_started_lazy_observer"
+oracle = "endpoint reply coverage"
+
+[[site]]
+id = "np.mailbox.PythonOncePortReceiver.recv_task"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/mailbox.rs"
+symbol = "PythonOncePortReceiver::recv_task"
+operation = "raw_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.5b"
+constructor = "raw PythonTask"
+return_surface = "raw PythonTask returned from PythonOncePortReceiver::recv_task"
+consumer = "PortReceiver._recv for a once port"
+driver = "awaited by the PortReceiver.recv coroutine"
+start_point = "the once receiver is taken synchronously at construction; only the await is deferred"
+abandonment = "possible, and the receiver is already consumed"
+eager_effect = "claims a receive at construction"
+drop_behavior = "the reply is lost; the receiver cannot be reused"
+unobserved_error = "surfaced on observation"
+disposition = "require a binding-specific design"
+semantic_class = "sync_partial_effect_lazy_tail"
+oracle = "mailbox ownership, once receiver (6.0c item 2)"
+
+[[site]]
+id = "np.mailbox.PythonPortReceiver.recv_task"
+category = "native_producer"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/mailbox.rs"
+symbol = "PythonPortReceiver::recv_task"
+operation = "raw_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.5b"
+constructor = "raw PythonTask"
+return_surface = "raw PythonTask returned from PythonPortReceiver::recv_task"
+consumer = "PortReceiver._recv, which decodes the message"
+driver = "awaited by the PortReceiver.recv coroutine"
+start_point = "lazy; the receiver Arc is cloned but the lock and recv happen only when driven"
+abandonment = "possible; discarding the task claims nothing"
+eager_effect = "claims a receive"
+drop_behavior = "no message is consumed; the next observer gets it"
+unobserved_error = "surfaced on observation"
+disposition = "require a binding-specific design"
+semantic_class = "deferred_receive_claim"
+oracle = "mailbox ownership, regular receiver (6.0c item 2)"
+
+[[site]]
+id = "ms.pickle.reserve_mesh_reference"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pickle.rs"
+symbol = "reserve_mesh_reference"
+operation = "reserve_binding"
+scope = "production"
+state = "legacy"
+transition = "6.3a"
+
+[[site]]
+id = "rf.endpoint.PyValueStream.__next__"
+category = "rust_future_factory"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/endpoint.rs"
+symbol = "PyValueStream::__next__"
+operation = "rust_from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.5a"
+
+[[site]]
+id = "rf.endpoint.wrap_in_future"
+category = "rust_future_factory"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/endpoint.rs"
+symbol = "wrap_in_future"
+operation = "rust_from_coro"
+scope = "production"
+state = "legacy"
+transition = "6.5a"
+
+[[site]]
+id = "ot.query_engine.DistributedExec_as_ExecutionPlan.execute"
+category = "ownership_transfer"
+language = "rust"
+path = "fbcode/monarch/monarch_distributed_telemetry/src/query_engine.rs"
+symbol = "<DistributedExec as ExecutionPlan>::execute"
+operation = "rust_take_inner"
+scope = "production"
+state = "legacy"
+transition = "6.4c"
+
+[[site]]
+id = "ot.readonly_fuse.take_actor_future"
+category = "ownership_transfer"
+language = "rust"
+path = "fbcode/monarch/monarch_extension/src/readonly_fuse.rs"
+symbol = "take_actor_future"
+operation = "rust_take_inner"
+scope = "production"
+state = "legacy"
+transition = "6.4c"
+
+[[site]]
+id = "ms.host_mesh.HostMesh._from_initialized_hy_host_mesh[Shared.from_valuehy_host_mesh]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh._from_initialized_hy_host_mesh[Shared.from_value(hy_host_mesh)]"
+operation = "shared_from_value"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ms.host_mesh.HostMesh._new_with_shape[Shared.from_valuehm.slicedshape.region]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/host_mesh.py"
+symbol = "HostMesh._new_with_shape[Shared.from_value(hm.sliced(shape.region))]"
+operation = "shared_from_value"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ms.proc_mesh.ProcMesh._from_initialized_hy_proc_mesh[Shared.from_valuehy_proc_mesh]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh._from_initialized_hy_proc_mesh[Shared.from_value(hy_proc_mesh)]"
+operation = "shared_from_value"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ms.proc_mesh.ProcMesh._new_with_shape[Shared.from_valuepm.slicedshape.region]"
+category = "mesh_carrier"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh._new_with_shape[Shared.from_value(pm.sliced(shape.region))]"
+operation = "shared_from_value"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ms.actor_mesh.block_on"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "block_on"
+operation = "shared_reconstruction"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ms.pickle.from_value"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pickle.rs"
+symbol = "from_value"
+operation = "shared_reconstruction"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ms.actor_mesh.AsyncActorMesh_as_ActorMeshProtocol.__reduce__"
+category = "mesh_carrier"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs"
+symbol = "<AsyncActorMesh as ActorMeshProtocol>::__reduce__"
+operation = "spawn_abortable"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ot.actor_mesh.Accumulator.accumulate.impl[x._take_inner]"
+category = "ownership_transfer"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/actor_mesh.py"
+symbol = "Accumulator.accumulate.impl[x._take_inner]"
+operation = "take_inner"
+scope = "production"
+state = "legacy"
+transition = "6.4a"
+
+[[site]]
+id = "ot.bootstrap._as_python_task[s._take_inner]"
+category = "ownership_transfer"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/bootstrap.py"
+symbol = "_as_python_task[s._take_inner]"
+operation = "take_inner"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ot.proc_mesh.ProcMesh._flush_pending_actor_spawns[mesh.initialized._take_inner]"
+category = "ownership_transfer"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh._flush_pending_actor_spawns[mesh.initialized._take_inner]"
+operation = "take_inner"
+scope = "production"
+state = "legacy"
+transition = "6.3b"
+
+[[site]]
+id = "ot.proc_mesh.ProcMesh.from_host_mesh.task[setup_actor.setup.call._take_inner]"
+category = "ownership_transfer"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/proc_mesh.py"
+symbol = "ProcMesh.from_host_mesh.task[setup_actor.setup.call()._take_inner]"
+operation = "take_inner"
+scope = "production"
+state = "legacy"
+transition = "6.3c"
+
+[[site]]
+id = "ot.job.exec_command._impl[bash_actors.run.callscript, output_dir=output_dir._take_inner]"
+category = "ownership_transfer"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/job/job.py"
+symbol = "exec_command._impl[bash_actors.run.call(script, output_dir=output_dir)._take_inner]"
+operation = "take_inner"
+scope = "production"
+state = "legacy"
+transition = "6.4b"
+
+[[site]]
+id = "ot.job.exec_command._impl[bash_actors.run_python.callcmd, env=env, workdir=workdir, client_cwd=client_cwd, output_dir=output_dir._take_inner]"
+category = "ownership_transfer"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/job/job.py"
+symbol = "exec_command._impl[bash_actors.run_python.call(cmd, env=env, workdir=workdir, client_cwd=client_cwd, output_dir=output_dir)._take_inner]"
+operation = "take_inner"
+scope = "production"
+state = "legacy"
+transition = "6.4b"
+
+[[site]]
+id = "ot.job.exec_command._impl[procs.stop._take_inner]"
+category = "ownership_transfer"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/job/job.py"
+symbol = "exec_command._impl[procs.stop()._take_inner]"
+operation = "take_inner"
+scope = "production"
+state = "legacy"
+transition = "6.4b"
+
+[[site]]
+id = "ret.future._Taken"
+category = "ownership_surface"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/future.py"
+symbol = "_Taken"
+operation = "take_inner_retire"
+scope = "production"
+state = "legacy"
+transition = "6.6"
+
+[[site]]
+id = "ret.future._take_inner"
+category = "ownership_surface"
+language = "python"
+path = "fbcode/monarch/python/monarch/_src/actor/future.py"
+symbol = "_take_inner"
+operation = "take_inner_retire"
+scope = "production"
+state = "legacy"
+transition = "6.6"
+
+[[site]]
+id = "hd.handle.WouldBlockRuntime"
+category = "helper_definition"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/handle.rs"
+symbol = "WouldBlockRuntime"
+operation = "would_block_surface"
+scope = "production"
+state = "legacy"
+transition = "6.1"
+
+[[site]]
+id = "hd.pytokio.WouldBlockRuntime"
+category = "helper_definition"
+language = "rust"
+path = "fbcode/monarch/monarch_hyperactor/src/pytokio.rs"
+symbol = "WouldBlockRuntime"
+operation = "would_block_surface"
+scope = "production"
+state = "legacy"
+transition = "6.1"

--- a/scripts/test_pytokio_removal_census.py
+++ b/scripts/test_pytokio_removal_census.py
@@ -1,0 +1,1310 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fixture coverage for the pytokio removal census checker.
+
+Every later Stage 6 gate depends on this checker rejecting the failure modes
+below, so the coverage is mandatory rather than a self-test. The fixtures build
+synthetic source trees; they do not read Monarch source. The live repository
+census runs as an explicit per-diff test-plan command, not from here.
+"""
+
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+import pytokio_removal_census as census
+
+BASE_CONFIG = """
+[config]
+roots = ["src"]
+exclude = ["/build/"]
+suffixes = [".rs", ".py", ".pyi", ".md"]
+doc_suffixes = [".md"]
+defining_module = "src/pytokio.rs"
+defining_module_exempt = ["helper_symbol"]
+symbol_capture_operations = ["helper_symbol"]
+per_file_operations = ["pytokio_module_ref"]
+
+[config.operation_paths]
+scoped_only = ["src/owner.rs"]
+
+[config.patterns.rust]
+py_python_task_new = "\\\\bPyPythonTask::new\\\\b"
+raw_python_task_new = "(?<!Py)\\\\bPythonTask::new\\\\b"
+pytokio_module_ref = "crate::pytokio"
+helper_symbol = "crate::pytokio::(\\\\w+)"
+scoped_only = "\\\\bspawn_blocking\\\\b"
+
+[config.patterns.python_calls]
+from_coro = "Future._from_coro"
+mesh_storage_spawn = "PythonTask.from_coroutine().spawn"
+
+[config.patterns.python_modules]
+pytokio_import = "pkg.pytokio"
+
+[config.patterns.docs]
+doc_legacy_surface = "pytokio"
+
+# Every configured operation needs a total: validate_totals enforces exact
+# parity with the pattern set, so an operation with no aggregate check cannot
+# exist.
+[totals]
+py_python_task_new = 1
+raw_python_task_new = 0
+pytokio_module_ref = 0
+helper_symbol = 0
+scoped_only = 0
+from_coro = 0
+mesh_storage_spawn = 0
+pytokio_import = 0
+doc_legacy_surface = 0
+
+[schema]
+categories = [
+  "native_producer",
+  "coroutine_root",
+  "module_import",
+  "helper_residue",
+]
+semantic_classes = [
+  "deferred_side_effect",
+  "ready_no_op_wrapper",
+  "already_started_lazy_observer",
+]
+dispositions = [
+  "intentionally become eager",
+  "replace with a direct value",
+  "replace with the bridge future directly",
+]
+matrix_dispositions = ["preserve", "intentional change"]
+matrix_execution_states = ["green_in_6.0b", "activates_in_6.1"]
+matrix_ids = []
+"""
+
+PRODUCER_ROW = """
+[[site]]
+id = "np.one"
+category = "native_producer"
+language = "rust"
+path = "src/a.rs"
+symbol = "Thing::make"
+operation = "py_python_task_new"
+scope = "production"
+state = "legacy"
+transition = "6.2"
+return_surface = "PyPythonTask"
+consumer = "caller"
+driver = "await"
+start_point = "lazy"
+abandonment = "possible"
+eager_effect = "starts a side effect"
+drop_behavior = "nothing runs"
+unobserved_error = "dropped"
+disposition = "intentionally become eager"
+semantic_class = "deferred_side_effect"
+oracle = "fixture"
+"""
+
+TRANSITION = """
+[[transition]]
+id = "6.2"
+allowed_states = ["migrated", "removed_upstream"]
+owns = ["np.one"]
+"""
+
+RUST_ONE_PRODUCER = """
+impl Thing {
+    fn make() -> PyResult<PyPythonTask> {
+        PyPythonTask::new(async move { Ok(()) })
+    }
+}
+"""
+
+
+class Fixture:
+    """A synthetic repository root plus manifest."""
+
+    def __init__(self, stack: tempfile.TemporaryDirectory):
+        self.root = Path(stack.name)
+        (self.root / "src").mkdir()
+
+    def write(self, rel: str, body: str) -> None:
+        path = self.root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+    def manifest(
+        self, extra: str = "", base: str = "", totals: dict | None = None
+    ) -> dict:
+        """Assemble a manifest. ``totals`` patches counts a fixture changes.
+
+        Totals cannot be overridden in ``extra``: TOML rejects a second
+        ``[totals]`` header, and the parity check rejects omitting one.
+        """
+        parsed = tomllib.loads(
+            (base or BASE_CONFIG) + PRODUCER_ROW + TRANSITION + extra
+        )
+        if totals:
+            parsed["totals"].update(totals)
+        return parsed
+
+    def check(self, manifest: dict) -> list[str]:
+        return census.check(self.root, manifest)
+
+
+class CensusCheckerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.stack = tempfile.TemporaryDirectory()
+        self.addCleanup(self.stack.cleanup)
+        self.fixture = Fixture(self.stack)
+        self.fixture.write("src/a.rs", RUST_ONE_PRODUCER)
+
+    def assert_reports(self, errors: list[str], fragment: str) -> None:
+        joined = "\n".join(errors)
+        self.assertIn(fragment, joined, f"expected {fragment!r} in:\n{joined}")
+
+    def test_baseline_passes(self) -> None:
+        self.assertEqual(self.fixture.check(self.fixture.manifest()), [])
+
+    # -- discovery -------------------------------------------------------
+
+    def test_impl_qualified_identity_separates_same_named_methods(self) -> None:
+        """Two methods with one bare name are distinct sites."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl Left {\n    fn go() { PyPythonTask::new(async {}); }\n}\n"
+            "impl Right {\n    fn go() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            sorted(h.symbol for h in hits if h.operation == "py_python_task_new"),
+            ["Left::go", "Right::go"],
+        )
+
+    def test_trait_impl_qualifies_with_trait_name(self) -> None:
+        self.fixture.write(
+            "src/a.rs",
+            "impl Proto for Mesh {\n    fn stop() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["<Mesh as Proto>::stop"],
+        )
+
+    def test_wrapped_and_raw_constructors_are_separate_operations(self) -> None:
+        """26 wrapped and six raw constructors are tracked apart."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl Thing {\n"
+            "    fn make() { PyPythonTask::new(async {}); }\n"
+            "    fn raw() { PythonTask::new(fut); }\n"
+            "}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        kinds = {h.operation: h.symbol for h in hits if "task_new" in h.operation}
+        self.assertEqual(
+            kinds,
+            {"py_python_task_new": "Thing::make", "raw_python_task_new": "Thing::raw"},
+        )
+
+    def test_python_roots_disambiguated_by_wrapped_callee(self) -> None:
+        """One enclosing function may hold two distinct roots."""
+        self.fixture.write(
+            "src/m.py",
+            "def shutdown_context():\n"
+            "    if done:\n"
+            "        return Future._from_coro(_noop())\n"
+            "    return Future._from_coro(_shutdown_sequence())\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            sorted(h.symbol for h in hits if h.operation == "from_coro"),
+            [
+                "shutdown_context[Future._from_coro(_noop())]",
+                "shutdown_context[Future._from_coro(_shutdown_sequence())]",
+            ],
+        )
+
+    def test_multiline_python_call_and_import_found(self) -> None:
+        """``ast`` finds calls and imports that a line matcher would miss."""
+        self.fixture.write(
+            "src/m.py",
+            "from pkg.pytokio import (\n    PythonTask,\n)\n"
+            "def go():\n"
+            "    return Future._from_coro(\n        thing(),\n    )\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        found = {(h.operation, h.symbol) for h in hits}
+        self.assertIn(("from_coro", "go[Future._from_coro(thing())]"), found)
+        self.assertIn(("pytokio_import", "<module>"), found)
+
+    def test_plain_import_form_is_found(self) -> None:
+        """``import pkg.pytokio`` binds the module and must be inventoried."""
+        self.fixture.write("src/m.py", "import pkg.pytokio\n")
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        imports = [h for h in hits if h.operation == "pytokio_import"]
+        self.assertEqual([h.members for h in imports], [("<module>",)])
+
+    def test_rust_qualified_form_found(self) -> None:
+        self.fixture.write(
+            "src/a.rs",
+            "impl Thing {\n    fn make() { crate::pytokio::PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertIn("py_python_task_new", {h.operation for h in hits})
+
+    def test_helper_symbol_collapses_per_file_and_symbol(self) -> None:
+        self.fixture.write(
+            "src/h.rs",
+            "use crate::pytokio::send_result;\n"
+            "fn a() { crate::pytokio::send_result(x); }\n"
+            "fn b() { crate::pytokio::to_py_error(y); }\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        helpers = sorted(h.symbol for h in hits if h.operation == "helper_symbol")
+        self.assertEqual(helpers, ["send_result", "to_py_error"])
+
+    def test_module_reference_collapses_per_file(self) -> None:
+        self.fixture.write(
+            "src/h.rs", "use crate::pytokio::A;\nuse crate::pytokio::B;\n"
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        refs = [h for h in hits if h.operation == "pytokio_module_ref"]
+        self.assertEqual(len(refs), 1)
+        self.assertEqual(refs[0].symbol, "<file>")
+
+    def test_documents_yield_one_row_each(self) -> None:
+        self.fixture.write("src/d.md", "pytokio appears\nand pytokio again\n")
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            len([h for h in hits if h.operation == "doc_legacy_surface"]), 1
+        )
+
+    def test_chained_call_is_addressable(self) -> None:
+        """Mesh storage spawns invoke a method on another call's result."""
+        self.fixture.write(
+            "src/m.py",
+            "def make():\n    return PythonTask.from_coroutine(task()).spawn()\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "mesh_storage_spawn"],
+            ["make[PythonTask.from_coroutine(task()).spawn]"],
+        )
+
+    def test_operation_scoped_to_owning_file(self) -> None:
+        """A symbol with an unrelated homonym is scoped to its owner."""
+        self.fixture.write("src/owner.rs", "fn a() { spawn_blocking(x); }\n")
+        self.fixture.write("src/other.rs", "fn b() { spawn_blocking(y); }\n")
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        scoped = [h.path for h in hits if h.operation == "scoped_only"]
+        self.assertEqual(scoped, ["src/owner.rs"])
+
+    def test_two_matches_on_one_line_are_both_found(self) -> None:
+        """A single line may hold more than one construction."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl Thing {\n    fn make() { PyPythonTask::new(a); PyPythonTask::new(b); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            len([h for h in hits if h.operation == "py_python_task_new"]), 2
+        )
+
+    def test_multiline_impl_header_is_handled(self) -> None:
+        """An impl header split across lines still owns its methods."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl VeryLongTrait\n    for Thing\n{\n"
+            "    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["<Thing as VeryLongTrait>::make"],
+        )
+
+    def test_impl_prefixed_macro_is_not_an_impl(self) -> None:
+        """``impl_foo!(...)`` is a macro, not an impl block."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl_something!(\n  a, b,\n);\n"
+            "impl Thing {\n    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["Thing::make"],
+        )
+
+    def test_multiline_generic_impl_is_recognized(self) -> None:
+        """``impl<T>`` split across lines still owns its methods."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl<T: Clone>\n    Trait<T> for Foo<T>\n{\n"
+            "    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["<Foo<T> as Trait<T>>::make"],
+        )
+
+    def test_nested_generics_in_impl_header(self) -> None:
+        self.assertEqual(
+            census.parse_impl_header("impl<T: Into<U>> Proto<T, V<W>> for Bar<T> {"),
+            "<Bar<T> as Proto<T, V<W>>>",
+        )
+
+    def test_unbalanced_generics_fail_closed(self) -> None:
+        with self.assertRaises(census.CensusError):
+            census.parse_impl_header("impl<T: Into<U> Trait for Foo {")
+
+    def test_unterminated_impl_header_fails_closed(self) -> None:
+        self.fixture.write("src/a.rs", "impl Thing\n" + "    where T: X\n" * 400)
+        with self.assertRaises(census.CensusError):
+            census.discover(self.fixture.root, self.fixture.manifest()["config"])
+
+    def test_receiver_is_part_of_python_identity(self) -> None:
+        """Same-named calls on different receivers are distinct sites."""
+        self.fixture.write(
+            "src/m.py",
+            "def go():\n"
+            "    a = Future._from_coro(one.call())\n"
+            "    b = Future._from_coro(two.call())\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            sorted(h.symbol for h in hits if h.operation == "from_coro"),
+            [
+                "go[Future._from_coro(one.call())]",
+                "go[Future._from_coro(two.call())]",
+            ],
+        )
+
+    def test_subscript_receiver_is_rendered_whole(self) -> None:
+        """A lossy renderer would collapse the subscript and merge two sites."""
+        self.fixture.write(
+            "src/m.py",
+            "def go():\n"
+            "    a = Future._from_coro(items[0].run())\n"
+            "    b = Future._from_coro(items[1].run())\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            sorted(h.symbol for h in hits if h.operation == "from_coro"),
+            [
+                "go[Future._from_coro(items[0].run())]",
+                "go[Future._from_coro(items[1].run())]",
+            ],
+        )
+
+    def test_parent_module_import_is_detected(self) -> None:
+        """``from pkg import pytokio`` binds the submodule."""
+        self.fixture.write("src/m.py", "from pkg import pytokio\n")
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.members for h in hits if h.operation == "pytokio_import"],
+            [("<module>",)],
+        )
+
+    def test_excluded_tree_is_not_scanned(self) -> None:
+        """build/ mirrors the source tree and would double every count."""
+        self.fixture.write("src/build/copy.rs", RUST_ONE_PRODUCER)
+        self.assertEqual(self.fixture.check(self.fixture.manifest()), [])
+
+    def test_defining_module_producers_are_not_migration_targets(self) -> None:
+        self.fixture.write("src/pytokio.rs", RUST_ONE_PRODUCER)
+        self.assertEqual(self.fixture.check(self.fixture.manifest()), [])
+
+    def test_line_movement_does_not_change_identity(self) -> None:
+        manifest = self.fixture.manifest()
+        self.assertEqual(self.fixture.check(manifest), [])
+        self.fixture.write("src/a.rs", "// pad\n" * 40 + RUST_ONE_PRODUCER)
+        self.assertEqual(self.fixture.check(manifest), [])
+
+    # -- discovery: Rust lexical views -----------------------------------
+
+    def test_line_comment_is_not_a_call_site(self) -> None:
+        """Prose naming a tracked symbol is documentation, not a site."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl Thing {\n"
+            "    /// Returns a PyPythonTask::new wrapper eventually.\n"
+            "    fn make() { PyPythonTask::new(async {}); }\n"
+            "}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        found = [h for h in hits if h.operation == "py_python_task_new"]
+        self.assertEqual([(h.symbol, h.line) for h in found], [("Thing::make", 3)])
+
+    def test_block_comment_spanning_lines_is_not_scanned(self) -> None:
+        """A per-line pass reads the second line of a block comment as code."""
+        self.fixture.write(
+            "src/a.rs",
+            "/*\n PyPythonTask::new\n PyPythonTask::new\n*/\n"
+            "impl Thing {\n    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            len([h for h in hits if h.operation == "py_python_task_new"]), 1
+        )
+
+    def test_nested_block_comment_terminates_at_the_outer_close(self) -> None:
+        """Rust block comments nest; a naive scan resumes one level too early."""
+        self.fixture.write(
+            "src/a.rs",
+            "/* outer /* inner */ PyPythonTask::new */\n"
+            "impl Thing {\n    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            len([h for h in hits if h.operation == "py_python_task_new"]), 1
+        )
+
+    def test_url_in_string_does_not_start_a_comment(self) -> None:
+        """The // in a URL must not discard the rest of the line."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl Thing {\n"
+            '    fn make() { let _ = "https://x/y"; PyPythonTask::new(async {}); }\n'
+            "}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["Thing::make"],
+        )
+
+    def test_brace_in_string_does_not_skew_block_depth(self) -> None:
+        """A literal brace would close the impl early and misattribute."""
+        self.fixture.write(
+            "src/a.rs",
+            'impl Alpha {\n    fn keep() { let _ = "}"; }\n'
+            "    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["Alpha::make"],
+        )
+
+    def test_brace_in_char_literal_does_not_skew_block_depth(self) -> None:
+        self.fixture.write(
+            "src/a.rs",
+            "impl Alpha {\n    fn keep() { let _ = '{'; }\n"
+            "    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["Alpha::make"],
+        )
+
+    def test_raw_string_contents_are_inert(self) -> None:
+        """A raw string honours no escapes and may hold braces and slashes."""
+        self.fixture.write(
+            "src/a.rs",
+            'impl Alpha {\n    fn keep() { let _ = r#"} // "#; }\n'
+            "    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["Alpha::make"],
+        )
+
+    def test_lifetime_is_not_read_as_a_char_literal(self) -> None:
+        self.fixture.write(
+            "src/a.rs",
+            "impl<'a> Thing<'a> {\n    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["Thing::make"],
+        )
+
+    def test_unsafe_impl_qualifies_its_methods(self) -> None:
+        """A bare impl matcher attributes these to a free function name."""
+        self.fixture.write(
+            "src/a.rs",
+            "unsafe impl Proto for Thing {\n"
+            "    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["<Thing as Proto>::make"],
+        )
+
+    def test_default_impl_qualifies_its_methods(self) -> None:
+        self.fixture.write(
+            "src/a.rs",
+            "default impl Thing {\n    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["Thing::make"],
+        )
+
+    def test_trait_default_method_is_qualified_by_its_trait(self) -> None:
+        """An unqualified name would survive a move to another trait."""
+        self.fixture.write(
+            "src/a.rs",
+            "pub(crate) trait Proto: Send {\n"
+            "    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["Proto::make"],
+        )
+
+    def test_trait_default_and_free_function_are_distinct(self) -> None:
+        self.fixture.write(
+            "src/a.rs",
+            "trait Proto {\n    fn make() { PyPythonTask::new(async {}); }\n}\n"
+            "fn make() { PyPythonTask::new(async {}); }\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            sorted(h.symbol for h in hits if h.operation == "py_python_task_new"),
+            ["Proto::make", "make"],
+        )
+
+    def test_pattern_matches_across_lines(self) -> None:
+        """A macro names its subject below the line that opens it."""
+        config = BASE_CONFIG.replace(
+            'helper_symbol = "crate::pytokio::(\\\\w+)"',
+            'helper_symbol = "make_exception!\\\\s*\\\\(\\\\s*(\\\\w+)"',
+        )
+        self.fixture.write("src/a.rs", "make_exception!(\n    Boom,\n);\n")
+        hits = census.discover(
+            self.fixture.root, self.fixture.manifest(base=config)["config"]
+        )
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "helper_symbol"], ["Boom"]
+        )
+
+    def test_capture_operation_without_a_capture_fails_closed(self) -> None:
+        """Keying on the enclosing symbol would merge two distinct sites."""
+        config = BASE_CONFIG.replace(
+            'helper_symbol = "crate::pytokio::(\\\\w+)"',
+            'helper_symbol = "crate::pytokio::helper_symbol"',
+        )
+        self.fixture.write("src/a.rs", "fn f() { crate::pytokio::helper_symbol(); }\n")
+        with self.assertRaises(census.CensusError) as caught:
+            census.discover(
+                self.fixture.root, self.fixture.manifest(base=config)["config"]
+            )
+        self.assertIn("no capture group", str(caught.exception))
+
+    # -- discovery: Python imports ---------------------------------------
+
+    def test_relative_import_is_discovered(self) -> None:
+        """Reading only node.module makes every relative import invisible."""
+        self.fixture.write("src/pkg/__init__.py", "")
+        self.fixture.write("src/pkg/m.py", "from .pytokio import PythonTask\n")
+        hits = census.discover(
+            self.fixture.root,
+            self.fixture.manifest(totals={"pytokio_import": 1})["config"],
+        )
+        found = [h for h in hits if h.operation == "pytokio_import"]
+        self.assertEqual([h.members for h in found], [("PythonTask",)])
+
+    def test_parent_relative_import_is_discovered(self) -> None:
+        self.fixture.write("src/pkg/sub/m.py", "from ..pytokio import PythonTask\n")
+        hits = census.discover(
+            self.fixture.root,
+            self.fixture.manifest(totals={"pytokio_import": 1})["config"],
+        )
+        self.assertEqual(
+            [h.members for h in hits if h.operation == "pytokio_import"],
+            [("PythonTask",)],
+        )
+
+    def test_relative_import_above_the_root_fails(self) -> None:
+        self.fixture.write("src/m.py", "from ....... pytokio import PythonTask\n")
+        with self.assertRaises(census.CensusError) as caught:
+            census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertIn("climbs above the repository root", str(caught.exception))
+
+    def test_unrelated_relative_import_is_not_a_hit(self) -> None:
+        self.fixture.write("src/pkg/m.py", "from .other import Thing\n")
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual([h for h in hits if h.operation == "pytokio_import"], [])
+
+    def test_import_only_root_drops_call_sites(self) -> None:
+        """A test suite is inventoried by whether it imports pytokio at all."""
+        config = BASE_CONFIG.replace(
+            'defining_module = "src/pytokio.rs"',
+            'import_only_roots = ["src/tests"]\ndefining_module = "src/pytokio.rs"',
+        )
+        self.fixture.write(
+            "src/tests/t.py",
+            "from pkg.pytokio import PythonTask\nFuture._from_coro(x)\n",
+        )
+        manifest = self.fixture.manifest(base=config, totals={"pytokio_import": 1})
+        hits = census.discover(self.fixture.root, manifest["config"])
+        self.assertEqual(
+            sorted({h.operation for h in hits if h.path.startswith("src/tests")}),
+            ["pytokio_import"],
+        )
+
+    # -- discovery: generic specialization and trait headers -------------
+
+    def test_generic_specializations_are_distinct_owners(self) -> None:
+        """Erasing the argument would give two impls one locator."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl Proto for Ref<PythonActor> {\n"
+            "    fn go() { PyPythonTask::new(async {}); }\n}\n"
+            "impl Proto for Ref<OtherActor> {\n"
+            "    fn go() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            sorted(h.symbol for h in hits if h.operation == "py_python_task_new"),
+            [
+                "<Ref<OtherActor> as Proto>::go",
+                "<Ref<PythonActor> as Proto>::go",
+            ],
+        )
+
+    def test_moving_a_producer_between_specializations_fails_the_check(self) -> None:
+        """The counterexample: erased identities would pass this silently."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl Proto for Ref<PythonActor> {\n"
+            "    fn make() { PyPythonTask::new(async {}); }\n}\n"
+            "impl Proto for Ref<OtherActor> {\n}\n",
+        )
+        row = (
+            '\n[[site]]\nid = "np.spec"\ncategory = "native_producer"\n'
+            'language = "rust"\npath = "src/a.rs"\n'
+            'symbol = "<Ref<PythonActor> as Proto>::make"\n'
+            'operation = "py_python_task_new"\nscope = "production"\n'
+            'state = "legacy"\ntransition = "6.2"\n'
+            'return_surface = "PyPythonTask"\nconsumer = "caller"\n'
+            'driver = "await"\nstart_point = "lazy"\nabandonment = "possible"\n'
+            'eager_effect = "starts a side effect"\n'
+            'drop_behavior = "nothing runs"\nunobserved_error = "dropped"\n'
+            'disposition = "intentionally become eager"\n'
+            'semantic_class = "deferred_side_effect"\noracle = "fixture"\n'
+        )
+        manifest = self.fixture.manifest(row, totals={"py_python_task_new": 1})
+        manifest["site"] = [r for r in manifest["site"] if r["id"] != "np.one"]
+        manifest["transition"][0]["owns"] = ["np.spec"]
+        self.assertEqual(self.fixture.check(manifest), [])
+
+        # Move the producer to the other specialization. Nothing else changes:
+        # same file, same method name, same count.
+        self.fixture.write(
+            "src/a.rs",
+            "impl Proto for Ref<PythonActor> {\n}\n"
+            "impl Proto for Ref<OtherActor> {\n"
+            "    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        errors = self.fixture.check(manifest)
+        self.assert_reports(errors, "<Ref<PythonActor> as Proto>::make")
+        self.assert_reports(errors, "<Ref<OtherActor> as Proto>::make")
+
+    def test_lifetime_argument_is_not_part_of_identity(self) -> None:
+        """Thing<'a> and Thing<'b> are one type; keeping them is churn."""
+        self.assertEqual(census.parse_impl_header("impl<'a> Thing<'a> {"), "Thing")
+
+    def test_generic_whitespace_is_normalized(self) -> None:
+        """Reformatting a header must not read as a move."""
+        self.assertEqual(
+            census.parse_impl_header("impl Proto for Ref< PythonActor > {"),
+            census.parse_impl_header("impl Proto for Ref<PythonActor> {"),
+        )
+
+    def test_multiline_traits_sharing_a_method_name_stay_distinct(self) -> None:
+        """A trait header may span lines exactly as an impl header may."""
+        self.fixture.write(
+            "src/a.rs",
+            "pub trait Alpha<T>:\n    Send + Sync\n{\n"
+            "    fn go() { PyPythonTask::new(async {}); }\n}\n"
+            "trait Beta<T>\n    : Send\n{\n"
+            "    fn go() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            sorted(h.symbol for h in hits if h.operation == "py_python_task_new"),
+            ["Alpha<T>::go", "Beta<T>::go"],
+        )
+
+    def test_unterminated_trait_header_fails_closed(self) -> None:
+        """A runaway header must refuse rather than guess an owner."""
+        self.fixture.write("src/a.rs", "trait Alpha\n" + "    where T: X\n" * 400)
+        with self.assertRaises(census.CensusError) as caught:
+            census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertIn("unterminated trait header", str(caught.exception))
+
+    def test_malformed_trait_header_fails_closed(self) -> None:
+        with self.assertRaises(census.CensusError):
+            census.parse_trait_header("trait Alpha<T: Bound {")
+
+    def test_trait_supertraits_are_not_part_of_identity(self) -> None:
+        self.assertEqual(
+            census.parse_trait_header("pub(crate) trait Proto: Send + Sync {"), "Proto"
+        )
+
+    # -- discovery: lifetimes and return arrows --------------------------
+
+    def test_adjacent_lifetimes_stay_structural_text(self) -> None:
+        """The second lifetime's quote is not a closing quote."""
+        header = "impl<'a, 'b> Trait for Foo<'a, 'b> {"
+        self.assertEqual(census.lex_rust(header)[1], header)
+
+    def test_adjacent_lifetimes_do_not_corrupt_the_qualifier(self) -> None:
+        """Blanking the span between them yielded ``<Foo<b> as Trait>``."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl<'a, 'b> Trait for Foo<'a, 'b> {\n"
+            "    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["<Foo as Trait>::make"],
+        )
+
+    def test_elided_lifetime_pair_keeps_the_trait_bare(self) -> None:
+        """The live shape: ``impl FromPyObject<'_, '_> for T``.
+
+        Parsed through the lexer, which is where the corruption arose: the
+        blanked span left ``FromPyObject<_>`` as the trait.
+        """
+        header = "impl FromPyObject<'_, '_> for PyDuration {"
+        self.assertEqual(
+            census.parse_impl_header(census.lex_rust(header)[1]),
+            "<PyDuration as FromPyObject>",
+        )
+
+    def test_char_literals_are_still_blanked_structurally(self) -> None:
+        """A brace in a char literal must not reach block-depth accounting."""
+        for source in ("let d = '{';", "let e = '\\u{1f600}';"):
+            with self.subTest(source=source):
+                self.assertNotIn("{", census.lex_rust(source)[1])
+
+    def test_escaped_char_literal_is_scanned_to_its_close(self) -> None:
+        self.assertEqual(census.lex_rust("let b = '\\n';")[1], "let b =     ;")
+
+    def test_return_arrow_in_impl_binder_does_not_close_the_generic(self) -> None:
+        """The ``>`` of ``->`` closed the binder early, mis-slicing the head."""
+        self.assertEqual(
+            census.parse_impl_header("impl<F: Fn() -> u32> Proto for Foo<F> {"),
+            "<Foo<F> as Proto>",
+        )
+
+    def test_return_arrow_in_nested_generic_argument(self) -> None:
+        self.assertEqual(
+            census.parse_impl_header("impl Proto for Foo<Box<dyn Fn() -> u32>> {"),
+            "<Foo<Box<dyn Fn() -> u32>> as Proto>",
+        )
+
+    def test_return_arrow_in_trait_binder(self) -> None:
+        """The trait header splits on its supertrait colon at depth zero."""
+        self.assertEqual(
+            census.parse_trait_header("trait Alpha<F: Fn() -> u32>: Send {"),
+            "Alpha<F: Fn() -> u32>",
+        )
+
+    def test_return_arrow_binder_attributes_methods_correctly(self) -> None:
+        """End to end: the mis-sliced header produced a garbage owner."""
+        self.fixture.write(
+            "src/a.rs",
+            "impl<F: Fn() -> u32> Proto for Foo<F> {\n"
+            "    fn make() { PyPythonTask::new(async {}); }\n}\n",
+        )
+        hits = census.discover(self.fixture.root, self.fixture.manifest()["config"])
+        self.assertEqual(
+            [h.symbol for h in hits if h.operation == "py_python_task_new"],
+            ["<Foo<F> as Proto>::make"],
+        )
+
+    # -- reconciliation --------------------------------------------------
+
+    def test_unexpected_producer_fails(self) -> None:
+        self.fixture.write("src/b.rs", RUST_ONE_PRODUCER)
+        self.assert_reports(
+            self.fixture.check(self.fixture.manifest()), "unknown hit: src/b.rs"
+        )
+
+    def test_missing_producer_fails(self) -> None:
+        self.fixture.write("src/a.rs", "fn make() {}\n")
+        self.assert_reports(
+            self.fixture.check(self.fixture.manifest()), "no source hit for src/a.rs"
+        )
+
+    def test_locator_matching_multiple_sites_fails(self) -> None:
+        self.fixture.write(
+            "src/a.rs",
+            "impl Thing {\n    fn make() {\n"
+            "        PyPythonTask::new(async {});\n"
+            "        PyPythonTask::new(async {});\n"
+            "    }\n}\n",
+        )
+        manifest = self.fixture.manifest()
+        manifest["totals"]["py_python_task_new"] = 2
+        self.assert_reports(self.fixture.check(manifest), "expected 1 site, found 2")
+
+    def test_total_mismatch_fails(self) -> None:
+        """Totals check the expected aggregate count for an operation.
+
+        A net-zero swap is caught by reconciliation, not here.
+        """
+        manifest = self.fixture.manifest()
+        manifest["totals"]["py_python_task_new"] = 5
+        self.assert_reports(self.fixture.check(manifest), "total mismatch")
+
+    def test_import_member_swap_fails(self) -> None:
+        """A directory count alone would permit this swap."""
+        self.fixture.write("src/m.py", "from pkg.pytokio import PythonTask, Shared\n")
+        extra = (
+            '\n[[site]]\nid = "im.m"\ncategory = "module_import"\n'
+            'language = "python"\npath = "src/m.py"\nsymbol = "<module>"\n'
+            'operation = "pytokio_import"\nscope = "production"\n'
+            'state = "legacy"\ntransition = "6.2"\n'
+            'members = ["PythonTask", "Shared"]\n'
+        )
+        manifest = self.fixture.manifest(extra, totals={"pytokio_import": 1})
+        manifest["transition"][0]["owns"].append("im.m")
+        self.assertEqual(self.fixture.check(manifest), [])
+
+        self.fixture.write("src/m.py", "from pkg.pytokio import PythonTask, Handle\n")
+        self.assert_reports(self.fixture.check(manifest), "import members changed")
+
+    def test_hit_with_members_and_unpinned_row_fails(self) -> None:
+        """Miscategorising an import row must not skip the member check."""
+        self.fixture.write("src/m.py", "from pkg.pytokio import PythonTask\n")
+        extra = (
+            '\n[[site]]\nid = "im.m"\ncategory = "helper_residue"\n'
+            'language = "python"\npath = "src/m.py"\nsymbol = "<module>"\n'
+            'operation = "pytokio_import"\nscope = "production"\n'
+            'state = "legacy"\ntransition = "6.2"\n'
+        )
+        manifest = self.fixture.manifest(extra, totals={"pytokio_import": 1})
+        manifest["transition"][0]["owns"].append("im.m")
+        errors = self.fixture.check(manifest)
+        self.assert_reports(errors, "must record its member set")
+        self.assert_reports(errors, "the row pins no member set")
+
+    # -- schema ----------------------------------------------------------
+
+    def test_duplicate_active_locator_fails(self) -> None:
+        """Two active rows must not claim one site."""
+        manifest = self.fixture.manifest()
+        clone = dict(manifest["site"][0])
+        clone["id"] = "np.two"
+        manifest["site"].append(clone)
+        manifest["transition"][0]["owns"].append("np.two")
+        self.assert_reports(
+            self.fixture.check(manifest), "identity is unique across active rows"
+        )
+
+    def test_locator_unique_against_tombstones(self) -> None:
+        """A tombstone still owns its locator; a new row may not reuse it."""
+        manifest = self.fixture.manifest()
+        clone = dict(manifest["site"][0])
+        clone["id"] = "np.ghosted"
+        clone["state"] = "migrated"
+        clone["transition_revision"] = "D123456"
+        manifest["site"].append(clone)
+        manifest["transition"][0]["owns"].append("np.ghosted")
+        self.assert_reports(
+            self.fixture.check(manifest), "identity is unique across active rows"
+        )
+
+    def test_multiplicity_is_rejected_anywhere(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["site"][0]["multiplicity"] = 2
+        self.assert_reports(
+            self.fixture.check(manifest), "multiplicity is not permitted"
+        )
+
+    def test_import_row_requires_members(self) -> None:
+        self.fixture.write("src/m.py", "from pkg.pytokio import PythonTask\n")
+        extra = (
+            '\n[[site]]\nid = "im.m"\ncategory = "module_import"\n'
+            'language = "python"\npath = "src/m.py"\nsymbol = "<module>"\n'
+            'operation = "pytokio_import"\nscope = "production"\n'
+            'state = "legacy"\ntransition = "6.2"\n'
+        )
+        manifest = self.fixture.manifest(extra)
+        manifest["transition"][0]["owns"].append("im.m")
+        self.assert_reports(self.fixture.check(manifest), "must record its member set")
+
+    def test_unknown_category_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["site"][0]["category"] = "invented"
+        self.assert_reports(self.fixture.check(manifest), "unknown category")
+
+    def test_unknown_semantic_class_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["site"][0]["semantic_class"] = "invented"
+        self.assert_reports(self.fixture.check(manifest), "unknown semantic class")
+
+    def test_unknown_disposition_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["site"][0]["disposition"] = "invented"
+        self.assert_reports(self.fixture.check(manifest), "unknown disposition")
+
+    def test_transition_revision_on_legacy_row_fails(self) -> None:
+        """Provenance belongs to a completed move, not a pending one."""
+        manifest = self.fixture.manifest()
+        manifest["site"][0]["transition_revision"] = "D123456"
+        self.assert_reports(
+            self.fixture.check(manifest), "a legacy row must not carry one"
+        )
+
+    def test_duplicate_id_fails(self) -> None:
+        manifest = self.fixture.manifest(PRODUCER_ROW)
+        self.assert_reports(self.fixture.check(manifest), "duplicate id")
+
+    def test_missing_id_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        del manifest["site"][0]["id"]
+        self.assert_reports(self.fixture.check(manifest), "missing id")
+
+    def test_incomplete_abandonment_data_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        del manifest["site"][0]["drop_behavior"]
+        self.assert_reports(
+            self.fixture.check(manifest), "behavior row missing drop_behavior"
+        )
+
+    def test_reviewed_facts_are_required(self) -> None:
+        """Each behavior row still states its class, disposition, and oracle.
+
+        These are what the row is reviewed on, so their absence must fail.
+        """
+        for missing in ("semantic_class", "disposition", "oracle"):
+            with self.subTest(field=missing):
+                manifest = self.fixture.manifest()
+                del manifest["site"][0][missing]
+                self.assert_reports(
+                    self.fixture.check(manifest),
+                    f"behavior row missing {missing}",
+                )
+
+    def test_owning_transition_is_required(self) -> None:
+        manifest = self.fixture.manifest()
+        del manifest["site"][0]["transition"]
+        self.assert_reports(self.fixture.check(manifest), "missing transition")
+
+    def test_malformed_amendment_revision_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["site"][0]["amendment_revision"] = "nope"
+        self.assert_reports(
+            self.fixture.check(manifest), "malformed amendment revision"
+        )
+
+    def test_behavior_row_may_not_use_multiplicity(self) -> None:
+        """Behavior-bearing sites are one row each."""
+        manifest = self.fixture.manifest()
+        manifest["site"][0]["multiplicity"] = 2
+        self.assert_reports(
+            self.fixture.check(manifest), "multiplicity is not permitted"
+        )
+
+    # -- totals ----------------------------------------------------------
+
+    def test_configured_operation_without_a_total_fails(self) -> None:
+        """Every configured operation needs its independent aggregate check."""
+        manifest = self.fixture.manifest()
+        del manifest["totals"]["pytokio_import"]
+        self.assert_reports(
+            self.fixture.check(manifest),
+            "operation pytokio_import is configured but has no total",
+        )
+
+    def test_total_for_unconfigured_operation_fails(self) -> None:
+        """A renamed pattern would otherwise leave a total checking nothing."""
+        manifest = self.fixture.manifest()
+        manifest["totals"]["typo_operation"] = 3
+        self.assert_reports(
+            self.fixture.check(manifest),
+            "total declared for unconfigured operation typo_operation",
+        )
+
+    def test_total_units_for_unconfigured_operation_fails(self) -> None:
+        """A typo here silently selects the wrong counting unit."""
+        manifest = self.fixture.manifest()
+        manifest["total_units"] = {"typo_operation": "file"}
+        self.assert_reports(
+            self.fixture.check(manifest),
+            "total_units declared for unconfigured operation typo_operation",
+        )
+
+    def test_file_counted_total_ignores_repeat_imports(self) -> None:
+        """A module importing pytokio twice is still one file to migrate."""
+        self.fixture.write(
+            "src/m.py",
+            "from pkg.pytokio import PythonTask\n"
+            "def later():\n    from pkg.pytokio import Shared\n",
+        )
+        rows = "".join(
+            f'\n[[site]]\nid = "im.m.{name}"\ncategory = "module_import"\n'
+            f'language = "python"\npath = "src/m.py"\nsymbol = "{symbol}"\n'
+            'operation = "pytokio_import"\nscope = "production"\n'
+            f'state = "legacy"\ntransition = "6.2"\nmembers = ["{member}"]\n'
+            for name, symbol, member in [
+                ("module", "<module>", "PythonTask"),
+                ("later", "later", "Shared"),
+            ]
+        )
+        manifest = self.fixture.manifest(rows, totals={"pytokio_import": 1})
+        manifest["total_units"] = {"pytokio_import": "file"}
+        manifest["transition"][0]["owns"].extend(["im.m.module", "im.m.later"])
+        self.assertEqual(self.fixture.check(manifest), [])
+
+        # The same inventory counted by hit is two, not one.
+        manifest["total_units"] = {}
+        self.assert_reports(self.fixture.check(manifest), "manifest 1 hits, source 2")
+
+    def test_file_counted_total_mismatch_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["total_units"] = {"pytokio_import": "file"}
+        manifest["totals"]["pytokio_import"] = 2
+        self.assert_reports(self.fixture.check(manifest), "manifest 2 files, source 0")
+
+    def test_coroutine_root_missing_root_fields_fails(self) -> None:
+        """The three root-only reviewed facts are not optional."""
+        manifest = self.fixture.manifest()
+        row = dict(manifest["site"][0])
+        row["category"] = "coroutine_root"
+        row["public_operation"] = "Actor.call"
+        row["caller_contexts"] = "endpoint"
+        manifest["site"][0] = row
+        self.assert_reports(
+            self.fixture.check(manifest),
+            "coroutine-root row missing first_side_effect",
+        )
+
+    def test_coroutine_root_with_all_root_fields_passes(self) -> None:
+        manifest = self.fixture.manifest()
+        row = dict(manifest["site"][0])
+        row["category"] = "coroutine_root"
+        row["public_operation"] = "Actor.call"
+        row["caller_contexts"] = "endpoint"
+        row["first_side_effect"] = "sends a message"
+        manifest["site"][0] = row
+        self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_malformed_row_reports_rather_than_crashing(self) -> None:
+        """Downstream validators index the required fields directly."""
+        manifest = self.fixture.manifest()
+        row = dict(manifest["site"][0])
+        del row["symbol"]
+        manifest["site"].append(row)
+        errors = self.fixture.check(manifest)
+        self.assert_reports(errors, "missing symbol")
+
+    def test_malformed_row_does_not_suppress_other_errors(self) -> None:
+        """Withholding the bad row must not stop the rest of the gate."""
+        manifest = self.fixture.manifest()
+        broken = dict(manifest["site"][0])
+        broken["id"] = "np.broken"
+        del broken["path"]
+        manifest["site"].append(broken)
+        manifest["totals"]["py_python_task_new"] = 9
+        errors = self.fixture.check(manifest)
+        self.assert_reports(errors, "np.broken: missing path")
+        self.assert_reports(errors, "total mismatch for py_python_task_new")
+
+    # -- transitions -----------------------------------------------------
+
+    def test_undeclared_transition_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["site"][0]["transition"] = "6.9"
+        self.assert_reports(self.fixture.check(manifest), "undeclared transition '6.9'")
+
+    def test_transition_must_declare_ownership(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["transition"][0]["owns"] = []
+        self.assert_reports(
+            self.fixture.check(manifest), "does not declare ownership of this site"
+        )
+
+    def test_two_transitions_cannot_own_one_site(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["transition"].append(
+            {"id": "6.3c", "allowed_states": ["migrated"], "owns": ["np.one"]}
+        )
+        self.assert_reports(self.fixture.check(manifest), "owned by both")
+
+    def test_transition_owning_unknown_site_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["transition"][0]["owns"].append("np.ghost")
+        self.assert_reports(self.fixture.check(manifest), "owns unknown site np.ghost")
+
+    def test_state_change_requires_differential_revision(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["site"][0]["state"] = "migrated"
+        manifest["site"][0]["transition_revision"] = "nope"
+        self.fixture.write("src/a.rs", "fn make() {}\n")
+        manifest["totals"]["py_python_task_new"] = 0
+        self.assert_reports(
+            self.fixture.check(manifest), "requires a Differential transition revision"
+        )
+
+    def test_disallowed_state_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["transition"][0]["allowed_states"] = ["migrated"]
+        manifest["site"][0]["state"] = "removed_upstream"
+        manifest["site"][0]["transition_revision"] = "D123456"
+        self.fixture.write("src/a.rs", "fn make() {}\n")
+        manifest["totals"]["py_python_task_new"] = 0
+        self.assert_reports(self.fixture.check(manifest), "does not permit state")
+
+    def test_amendment_cannot_mark_producer_migrated(self) -> None:
+        """A bug fix amends behavior; it does not discharge the migration."""
+        manifest = self.fixture.manifest()
+        row = manifest["site"][0]
+        row["amendment_revision"] = "D999999"
+        row["state"] = "migrated"
+        row["transition_revision"] = "D888888"
+        self.fixture.write("src/a.rs", "fn make() {}\n")
+        manifest["totals"]["py_python_task_new"] = 0
+        self.assert_reports(self.fixture.check(manifest), "amendment cannot mark the")
+
+    def test_direct_removal_models_one_site_drop(self) -> None:
+        """The modeled D116091231 change removes only Direct."""
+        self.fixture.write(
+            "src/a.rs",
+            RUST_ONE_PRODUCER
+            + "\nimpl Actor {\n    fn handle_direct() { PythonTask::new(fut); }\n}\n",
+        )
+        direct = (
+            '\n[[site]]\nid = "np.direct"\ncategory = "native_producer"\n'
+            'language = "rust"\npath = "src/a.rs"\nsymbol = "Actor::handle_direct"\n'
+            'operation = "raw_python_task_new"\nscope = "production"\n'
+            'state = "legacy"\ntransition = "6.2"\n'
+            'return_surface = "PythonTask"\nconsumer = "waiter"\n'
+            'driver = "tokio::spawn"\nstart_point = "eager"\n'
+            'abandonment = "none"\neager_effect = "observes already-running work"\n'
+            'drop_behavior = "n/a"\nunobserved_error = "kill signal"\n'
+            'disposition = "replace with the bridge future directly"\n'
+            'semantic_class = "already_started_lazy_observer"\n'
+            'oracle = "fixture"\n'
+        )
+        manifest = self.fixture.manifest(direct)
+        manifest["transition"][0]["owns"].append("np.direct")
+        manifest["totals"]["raw_python_task_new"] = 1
+        self.assertEqual(self.fixture.check(manifest), [])
+
+        self.fixture.write("src/a.rs", RUST_ONE_PRODUCER)
+        manifest["site"][1]["state"] = "removed_upstream"
+        manifest["site"][1]["transition_revision"] = "D116091231"
+        manifest["totals"]["raw_python_task_new"] = 0
+        self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_transition_without_allowed_states_fails(self) -> None:
+        """Defaulting to both tombstones grants a permission never reviewed."""
+        manifest = self.fixture.manifest()
+        del manifest["transition"][0]["allowed_states"]
+        self.assert_reports(self.fixture.check(manifest), "must declare allowed_states")
+
+    def test_transition_allowed_states_must_be_tombstones(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["transition"][0]["allowed_states"] = ["legacy"]
+        self.assert_reports(
+            self.fixture.check(manifest), "may only name tombstone states"
+        )
+
+    # -- Future matrix ---------------------------------------------------
+
+    def test_matrix_duplicate_id_fails(self) -> None:
+        row = (
+            '\n[[matrix]]\nid = "fm.x"\ndisposition = "preserve"\n'
+            'execution_state = "green_in_6.0b"\n'
+        )
+        manifest = self.fixture.manifest(row + row)
+        manifest["schema"]["matrix_ids"] = ["fm.x"]
+        self.assert_reports(self.fixture.check(manifest), "matrix fm.x: duplicate id")
+
+    def test_matrix_missing_id_fails(self) -> None:
+        manifest = self.fixture.manifest(
+            '\n[[matrix]]\ndisposition = "preserve"\n'
+            'execution_state = "green_in_6.0b"\n'
+        )
+        manifest["schema"]["matrix_ids"] = ["fm.x"]
+        self.assert_reports(self.fixture.check(manifest), "matrix row 0: missing id")
+
+    def test_matrix_unexpected_id_fails(self) -> None:
+        manifest = self.fixture.manifest(
+            '\n[[matrix]]\nid = "fm.rogue"\ndisposition = "preserve"\n'
+            'execution_state = "green_in_6.0b"\n'
+        )
+        manifest["schema"]["matrix_ids"] = []
+        self.assert_reports(
+            self.fixture.check(manifest), "matrix fm.rogue: not a declared matrix case"
+        )
+
+    def test_matrix_declared_case_missing_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        manifest["schema"]["matrix_ids"] = ["fm.absent"]
+        self.assert_reports(
+            self.fixture.check(manifest), "matrix fm.absent: declared case is missing"
+        )
+
+    def test_matrix_renamed_id_reports_both_directions(self) -> None:
+        """Renaming a case is an undeclared id and a missing declared one."""
+        manifest = self.fixture.manifest(
+            '\n[[matrix]]\nid = "fm.renamed"\ndisposition = "preserve"\n'
+            'execution_state = "green_in_6.0b"\n'
+        )
+        manifest["schema"]["matrix_ids"] = ["fm.original"]
+        errors = self.fixture.check(manifest)
+        self.assert_reports(errors, "matrix fm.renamed: not a declared matrix case")
+        self.assert_reports(errors, "matrix fm.original: declared case is missing")
+
+    def test_matrix_missing_disposition_fails(self) -> None:
+        manifest = self.fixture.manifest(
+            '\n[[matrix]]\nid = "fm.x"\nexecution_state = "green_in_6.0b"\n'
+        )
+        manifest["schema"]["matrix_ids"] = ["fm.x"]
+        self.assert_reports(
+            self.fixture.check(manifest), "matrix row 0: missing disposition"
+        )
+
+    def test_matrix_invalid_disposition_fails(self) -> None:
+        manifest = self.fixture.manifest(
+            '\n[[matrix]]\nid = "fm.x"\ndisposition = "invented"\n'
+            'execution_state = "green_in_6.0b"\n'
+        )
+        manifest["schema"]["matrix_ids"] = ["fm.x"]
+        self.assert_reports(self.fixture.check(manifest), "unknown disposition")
+
+    def test_matrix_missing_execution_state_fails(self) -> None:
+        manifest = self.fixture.manifest(
+            '\n[[matrix]]\nid = "fm.x"\ndisposition = "preserve"\n'
+        )
+        manifest["schema"]["matrix_ids"] = ["fm.x"]
+        self.assert_reports(
+            self.fixture.check(manifest), "matrix row 0: missing execution_state"
+        )
+
+    def test_matrix_invalid_execution_state_fails(self) -> None:
+        manifest = self.fixture.manifest(
+            '\n[[matrix]]\nid = "fm.x"\ndisposition = "preserve"\n'
+            'execution_state = "invented"\n'
+        )
+        manifest["schema"]["matrix_ids"] = ["fm.x"]
+        self.assert_reports(self.fixture.check(manifest), "unknown execution state")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

a follow-up will add a way to create Monarch’s Python `Future` directly from a Rust `Handle`. before changing that implementation, we need to make the behavior callers rely on explicit and separate it from behavior that is expected to change.

this adds a private test helper that creates a real Rust `Handle` and completes it deterministically with a value, an ordinary exception, or a `BaseException`. it accepts no user-provided work and is not part of Monarch’s public API.

the tests cover repeated reads, exception identity, timeouts, cancelled observers, already-completed work, calls from asyncio and Tokio, tracing, and the `result()` and `exception()` helpers. they exercise today’s `Future` and the corresponding direct `Handle` behavior separately, including where they intentionally differ.

the shared assertions let the follow-up test the new `Future` implementation without rewriting the expected behavior alongside it. the census notes now clarify that direct `Handle` behavior is covered even where the matching `Future` case cannot run yet.

this changes no production behavior. the only Rust change outside the private test helper is a unit test for observing a `Handle` from a Tokio worker.

Reviewed By: zdevito

Differential Revision: D116841881


