### PR TITLE
Report the transport a benchmark peer's configuration selects (#4720)

### DIFF
--- a/python/benches/multihost_rdma/bench_peer.py
+++ b/python/benches/multihost_rdma/bench_peer.py
@@ -46,7 +46,8 @@ import xxhash
 from bench_stats import Sample
 from bench_topology import InitiatorPlan, Slot, SlotAllocation, SlotValues
 from monarch.actor import Actor, context, endpoint
-from monarch.rdma import get_rdma_backend, RDMAAction, RDMABuffer
+from monarch.config import get_global_config
+from monarch.rdma import is_ibverbs_available, RDMAAction, RDMABuffer
 
 
 VERIFY_OFF: str = "off"
@@ -73,13 +74,19 @@ class Peer(Actor):
         self.plan: InitiatorPlan = InitiatorPlan()
 
     @endpoint
-    async def backend(self) -> str:
-        """The RDMA backend this proc actually resolved.
+    async def transport(self) -> str:
+        """Which transport this proc's configuration will actually use.
 
-        Checked against the requested transport so a silent TCP fallback fails
-        loudly instead of showing up as a hundred-fold outlier.
+        The driver checks this against what was asked for, so a silent
+        fallback fails loudly instead of showing up as a hundred-fold
+        outlier.
         """
-        return get_rdma_backend()
+        config = get_global_config()
+        if not config["rdma_disable_ibverbs"] and is_ibverbs_available():
+            return "ibverbs"
+        if config["rdma_allow_tcp_fallback"]:
+            return "tcp"
+        return "none"
 
     @endpoint
     async def setup(

--- a/python/tests/test_rdma_bench_peer.py
+++ b/python/tests/test_rdma_bench_peer.py
@@ -29,6 +29,7 @@ import bench_topology as bt  # noqa: E402
 import pytest  # noqa: E402
 import torch  # noqa: E402
 from monarch.actor import this_host  # noqa: E402
+from monarch.config import get_global_config  # noqa: E402
 from proc_mesh_test_utils import stop_all_proc_meshes  # noqa: E402, F401
 from rdma_test_utils import rdma_backends  # noqa: E402
 
@@ -85,6 +86,19 @@ async def _compare(peers, topo):
 def _skip_without_cuda(source_on_gpu: bool, dest_on_gpu: bool) -> None:
     if (source_on_gpu or dest_on_gpu) and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
+
+
+@rdma_backends
+async def test_a_peer_reports_the_transport_its_configuration_selects() -> None:
+    # The rdma_backends decorator skips the test if rdma_disable_ibverbs == False
+    # and ibverbs is unavailable, and always enables tcp fallback when ibverbs is
+    # disabled, so this computation for `expected` is correct.
+    expected = "tcp" if get_global_config()["rdma_disable_ibverbs"] else "ibverbs"
+    peers = _spawn(lanes=1)
+
+    reported = {value for _point, value in (await peers.transport.call()).items()}
+
+    assert reported == {expected}
 
 
 @rdma_backends


### PR DESCRIPTION
Summary:

`Peer.backend` returned `get_rdma_backend()`, which reports the RDMA hardware
the host has rather than the transport the configuration selects. On an ibverbs
host it answers "ibverbs" even when `rdma_disable_ibverbs` is set, so a driver
checking that it got the transport it asked for would reject a perfectly good
`--transport tcp` run.

Read the configuration instead: ibverbs when it is neither disabled nor absent,
otherwise tcp when fallback is allowed, and otherwise nothing.

Differential Revision: D116856851


