### PR TITLE
Share one definition of a proc's slot in the rdma benchmark (#4721)

### DIFF
--- a/python/benches/multihost_rdma/bench_peer.py
+++ b/python/benches/multihost_rdma/bench_peer.py
@@ -46,7 +46,8 @@ import xxhash
 from bench_stats import Sample
 from bench_topology import InitiatorPlan, Slot, SlotAllocation, SlotValues
 from monarch.actor import Actor, context, endpoint
-from monarch.rdma import get_rdma_backend, RDMAAction, RDMABuffer
+from monarch.config import get_global_config
+from monarch.rdma import is_ibverbs_available, RDMAAction, RDMABuffer
 
 
 VERIFY_OFF: str = "off"
@@ -73,13 +74,19 @@ class Peer(Actor):
         self.plan: InitiatorPlan = InitiatorPlan()
 
     @endpoint
-    async def backend(self) -> str:
-        """The RDMA backend this proc actually resolved.
+    async def transport(self) -> str:
+        """Which transport this proc's configuration will actually use.
 
-        Checked against the requested transport so a silent TCP fallback fails
-        loudly instead of showing up as a hundred-fold outlier.
+        The driver checks this against what was asked for, so a silent
+        fallback fails loudly instead of showing up as a hundred-fold
+        outlier.
         """
-        return get_rdma_backend()
+        config = get_global_config()
+        if not config["rdma_disable_ibverbs"] and is_ibverbs_available():
+            return "ibverbs"
+        if config["rdma_allow_tcp_fallback"]:
+            return "tcp"
+        return "none"
 
     @endpoint
     async def setup(

--- a/python/benches/multihost_rdma/bench_peer.py
+++ b/python/benches/multihost_rdma/bench_peer.py
@@ -45,7 +45,7 @@ import torch
 import xxhash
 from bench_stats import Sample
 from bench_topology import InitiatorPlan, Slot, SlotAllocation, SlotValues
-from monarch.actor import Actor, context, endpoint
+from monarch.actor import Actor, context, endpoint, Point
 from monarch.config import get_global_config
 from monarch.rdma import is_ibverbs_available, RDMAAction, RDMABuffer
 
@@ -61,11 +61,8 @@ class Peer(Actor):
 
     def __init__(self) -> None:
         # `Instance.rank` is where this proc sits in the mesh it was spawned
-        # into. A mesh over a single host carries no hosts dimension at all,
-        # which is the same thing as sitting at index zero of one.
-        rank = context().actor_instance.rank
-        host = rank["hosts"] if "hosts" in rank.extent.labels else 0
-        self.slot: Slot = Slot(host, rank["lanes"])
+        # into, which is what the driver addresses it by.
+        self.slot: Slot = slot_of(context().actor_instance.rank)
         # Byte tensors, because an RDMA op moves opaque bytes. A slot's outgoing
         # tensors live on the source device and its incoming ones on the
         # destination device.
@@ -212,6 +209,12 @@ class Peer(Actor):
 def _nothing() -> SlotValues[Any]:
     """A slot holding no tensors yet, or none at all."""
     return SlotValues(outgoing=(), incoming={})
+
+
+def slot_of(point: Point) -> Slot:
+    """Which slot the proc at ``point`` is."""
+    host = point["hosts"] if "hosts" in point.extent.labels else 0
+    return Slot(host, point["lanes"])
 
 
 def _ms(seconds: float) -> float:

--- a/python/tests/test_rdma_bench_peer.py
+++ b/python/tests/test_rdma_bench_peer.py
@@ -29,6 +29,7 @@ import bench_topology as bt  # noqa: E402
 import pytest  # noqa: E402
 import torch  # noqa: E402
 from monarch.actor import this_host  # noqa: E402
+from monarch.config import get_global_config  # noqa: E402
 from proc_mesh_test_utils import stop_all_proc_meshes  # noqa: E402, F401
 from rdma_test_utils import rdma_backends  # noqa: E402
 
@@ -85,6 +86,19 @@ async def _compare(peers, topo):
 def _skip_without_cuda(source_on_gpu: bool, dest_on_gpu: bool) -> None:
     if (source_on_gpu or dest_on_gpu) and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
+
+
+@rdma_backends
+async def test_a_peer_reports_the_transport_its_configuration_selects() -> None:
+    # The rdma_backends decorator skips the test if rdma_disable_ibverbs == False
+    # and ibverbs is unavailable, and always enables tcp fallback when ibverbs is
+    # disabled, so this computation for `expected` is correct.
+    expected = "tcp" if get_global_config()["rdma_disable_ibverbs"] else "ibverbs"
+    peers = _spawn(lanes=1)
+
+    reported = {value for _point, value in (await peers.transport.call()).items()}
+
+    assert reported == {expected}
 
 
 @rdma_backends

--- a/python/tests/test_rdma_bench_peer.py
+++ b/python/tests/test_rdma_bench_peer.py
@@ -49,12 +49,6 @@ DEVICE_VARIANTS: list[tuple[bool, bool]] = [
 DEVICE_IDS = ["cpu", "gpu", "cpu2gpu", "gpu2cpu"]
 
 
-def _slot_of(point) -> bt.Slot:
-    """Which slot a value in a cast's result came from."""
-    host = point["hosts"] if "hosts" in point.extent.labels else 0
-    return bt.Slot(host, point["lanes"])
-
-
 def _spawn(lanes: int = _LANES):
     procs = this_host().spawn_procs(per_host={"lanes": lanes})
     return procs.spawn("peer", bench_peer.Peer)
@@ -68,14 +62,14 @@ async def _drive(peers, topo, direction, *, source_on_gpu=False, dest_on_gpu=Fal
     results = await peers.setup.call(
         allocations, _PAYLOAD_BYTES, _SEED, source_on_gpu, dest_on_gpu
     )
-    buffers = {_slot_of(point): value[1] for point, value in results.items()}
+    buffers = {bench_peer.slot_of(point): value[1] for point, value in results.items()}
     await peers.wire.call(bt.plan_for(topo, direction, buffers, ops=_OPS))
     return results
 
 
 async def _compare(peers, topo):
     digests = {
-        _slot_of(point): value
+        bench_peer.slot_of(point): value
         for point, value in (
             await peers.digest.call(bench_peer.VERIFY_FULL, _PAYLOAD_BYTES)
         ).items()
@@ -161,7 +155,7 @@ async def test_a_proc_outside_the_topology_stays_idle() -> None:
     await _drive(peers, topo, bt.WRITE)
 
     samples = {
-        _slot_of(point): sample
+        bench_peer.slot_of(point): sample
         for point, sample in (await peers.execute_iteration.call()).items()
     }
     assert set(topo.slots()) < set(samples), "more procs than the topology uses"


### PR DESCRIPTION
Summary:

A proc's `Slot` was derived in two places already, and the driver needs a third.
Both sides of a cast have to agree about which proc a value came from, so put
the mapping in one function that the actor, the driver and the tests all call.

Differential Revision: D116857465


