### PR TITLE
Mark rdma actors as system actor

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -188,6 +188,7 @@ pub struct IbvManagerActor<I: IbvDeviceImpl> {
 #[async_trait]
 impl<I: IbvDeviceImpl> Actor for IbvManagerActor<I> {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        this.set_system();
         let owner = if let Some(owner) = this.parent_handle() {
             owner
         } else {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1190,6 +1190,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
 #[async_trait]
 impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        this.set_system();
         let local_info = self.qp.get_qp_info().map_err(|e| {
             tracing::error!(qp_key = ?self.qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
             anyhow::anyhow!("could not extract local QP info: {e}")

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -370,6 +370,7 @@ impl TcpManagerActor {
 #[async_trait]
 impl Actor for TcpManagerActor {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        this.set_system();
         let owner = this.parent_handle().ok_or_else(|| {
             anyhow::anyhow!("RdmaManagerActor not found as parent of TcpManagerActor")
         })?;

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -175,6 +175,7 @@ impl RemoteSpawn for RdmaManagerActor {
 #[async_trait]
 impl Actor for RdmaManagerActor {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        this.set_system();
         // An explicit per-manager target takes precedence over
         // `RDMA_IBVERBS_TARGET`. Otherwise validate the process setting here:
         // `spawn_available` may ignore an ibverbs initialization failure when

--- a/monarch_rdma/src/rdma_manager_owner.rs
+++ b/monarch_rdma/src/rdma_manager_owner.rs
@@ -556,6 +556,11 @@ impl RemoteSpawn for RdmaManagerOwnerActor {
 
 #[async_trait]
 impl Actor for RdmaManagerOwnerActor {
+    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        this.set_system();
+        Ok(())
+    }
+
     /// The manager-mesh controller is a direct child of the owner, so any
     /// *terminal* status of the controller itself — clean `Stopped` as well as
     /// `Failed` — is delivered here (RMO-14). It is matched by `event.actor_id`


### PR DESCRIPTION
Summary: correctly mark them as system actor. Observed in some tcp fallback path {F1994607116}

Differential Revision: D116865353


