### PR TITLE
Skip tests in test_rdma_bench_peer.py if insufficient GPUs

### DIFF
--- a/python/tests/test_rdma_bench_peer.py
+++ b/python/tests/test_rdma_bench_peer.py
@@ -82,9 +82,9 @@ async def _compare(peers, topo):
     return bt.compare_digests(topo, digests)
 
 
-def _skip_without_cuda(source_on_gpu: bool, dest_on_gpu: bool) -> None:
-    if (source_on_gpu or dest_on_gpu) and not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
+def _skip_without_enough_cuda_devices(source_on_gpu: bool, dest_on_gpu: bool) -> None:
+    if (source_on_gpu or dest_on_gpu) and torch.cuda.device_count() < _LANES:
+        pytest.skip(f"requires {_LANES} CUDA devices")
 
 
 @rdma_backends
@@ -101,7 +101,7 @@ async def test_every_edge_delivers_its_own_bytes(
     so this fails if any op is routed to the wrong peer's memory -- the failure
     the RDMA layer cannot detect for itself.
     """
-    _skip_without_cuda(source_on_gpu, dest_on_gpu)
+    _skip_without_enough_cuda_devices(source_on_gpu, dest_on_gpu)
     topo = bt.build_topology("p2p", 1, _LANES, bt.ALL)
     peers = _spawn()
     await _drive(


### PR DESCRIPTION
Summary:
Fixes: https://github.com/meta-pytorch/monarch/issues/4724
resolve:
```
FAILED python/tests/test_rdma_bench_peer.py::test_every_edge_delivers_its_own_bytes[gpu-read-rdma_disable_ibverbs=True-rdma_allow_tcp_fallback=True] - monarch._src.actor.actor_mesh.ActorError: Actor call peer.setup failed.
 Traceback of where the remote call failed (most recent call last):
  File "/opt/conda/envs/venv/lib/python3.10/site-packages/monarch/_src/actor/actor_mesh.py", line 1449, in handle
    result = await the_method(*args, **kwargs)
  File "/meta-pytorch/monarch/python/benches/multihost_rdma/bench_peer.py", line 112, in setup
    outgoing=tuple(
  File "/meta-pytorch/monarch/python/benches/multihost_rdma/bench_peer.py", line 113, in <genexpr>
    torch.empty(payload_bytes, dtype=torch.uint8, device=outgoing_device)
torch.AcceleratorError: CUDA error: invalid device ordinal
GPU device may be out of range, do you have enough GPUs?
The CUDA driver logged these messages, which may provide useful details:
Invalid device number 1 provided, must be in the range of 0 to 0
```

Reviewed By: dulinriley

Differential Revision: D116968188


