### PR TITLE
add exact test references to the pytokio census

### DIFF
--- a/scripts/pytokio_removal_census.py
+++ b/scripts/pytokio_removal_census.py
@@ -244,6 +244,151 @@ REQUIRED_COROUTINE_ROOT_FIELDS = (
     "first_side_effect",
 )
 
+# An oracle reference names one test: a Buck target, then the test within it,
+# split at the first `::`. The target half allows the path and hyphen forms Buck
+# uses; the test half is identifier segments, which covers a Rust module path
+# and a class-qualified Python method equally.
+ORACLE_PREFIX = "fbcode//"
+
+# Buck's own target-name grammar, mirrored from buck2_core/src/target/name.rs
+# rather than guessed: a narrower class rejects legal targets like `foo+bar`,
+# a laxer one blesses names Buck reserves, and both failures are silent here
+# because the label is never resolved.
+#
+# The character list is taken from TARGET_NAME_VALID_CHARS, not from the
+# InvalidName error text, which omits the backslash the set actually contains.
+ORACLE_TARGET_NAME = re.compile(r"^[A-Za-z0-9,.=/~@!+$_\\-]+$")
+RESERVED_TARGET_NAME = "..."
+# Buck substitutes this for `=` in generated names and rejects it in a written
+# one.
+TARGET_NAME_SUBSTITUTION = "_eqsb_"
+# TargetName::MAX_NAME_LEN, which is u16::MAX.
+TARGET_NAME_MAX_LEN = 0xFFFF
+
+# Package path segments are a different grammar: a cell-relative path, so an
+# empty, `.` or `..` component is traversal rather than a name.
+ORACLE_PACKAGE_SEGMENT = re.compile(r"^[A-Za-z0-9_.-]+$")
+ORACLE_TEST = re.compile(r"^[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*$")
+
+
+def oracle_target_problem(target: str) -> str | None:
+    """Why ``target`` is not a well-formed Buck label, or ``None``.
+
+    The two halves have different grammars and are checked differently. The
+    package is a cell-relative path, so an empty, ``.`` or ``..`` segment is
+    traversal and is rejected. The target name is whatever Buck accepts, which
+    includes ``.``, ``..`` and a good deal of punctuation; it rejects the
+    reserved name ``...``, any name containing the substitution ``_eqsb_``, and
+    a name over ``u16::MAX`` characters. Neither half is resolved: the label is
+    checked for shape, never for existence.
+    """
+    if not target.startswith(ORACLE_PREFIX):
+        return f"has a malformed target {target!r}"
+    package, separator, name = target[len(ORACLE_PREFIX) :].partition(":")
+    if not separator:
+        return f"has a malformed target {target!r}"
+    # Same order Buck checks in, so the diagnostic names the first thing wrong.
+    if len(name) > TARGET_NAME_MAX_LEN:
+        return (
+            f"has a target name of {len(name)} characters, over the "
+            f"{TARGET_NAME_MAX_LEN} limit, in {target!r}"
+        )
+    if not ORACLE_TARGET_NAME.match(name):
+        return f"has a malformed target name in {target!r}"
+    if TARGET_NAME_SUBSTITUTION in name:
+        return (
+            f"has a target name containing the reserved substring "
+            f"{TARGET_NAME_SUBSTITUTION!r} in {target!r}"
+        )
+    if name == RESERVED_TARGET_NAME:
+        return f"uses the reserved target name {RESERVED_TARGET_NAME!r} in {target!r}"
+    segments = package.split("/")
+    if not package or any(
+        segment in ("", ".", "..") or not ORACLE_PACKAGE_SEGMENT.match(segment)
+        for segment in segments
+    ):
+        return f"has a malformed package path in {target!r}"
+    return None
+
+
+def oracle_reference_problem(reference: object) -> str | None:
+    """Why ``reference`` is not a well-formed oracle reference, or ``None``.
+
+    Structure only. Whether the named test exists, or exercises the row, is a
+    review question: resolving a Buck target or searching for a test function
+    would make the checker depend on the build graph to answer a question it
+    cannot settle anyway.
+    """
+    if not isinstance(reference, str):
+        return f"is {type(reference).__name__}, expected a string"
+    if any(character.isspace() for character in reference):
+        return "contains whitespace"
+    target, separator, test = reference.partition("::")
+    if not separator:
+        return "has no '::' between the Buck target and the test name"
+    target_problem = oracle_target_problem(target)
+    if target_problem is not None:
+        return target_problem
+    if not ORACLE_TEST.match(test):
+        return f"has a malformed test name {test!r}"
+    return None
+
+
+def oracle_problem(value: object) -> str | None:
+    """Why a present ``oracle`` value is unusable, or ``None``.
+
+    Two accepted shapes while rows are being converted: the canonical list of
+    references, and a legacy prose label. Any bare string that starts with the
+    Buck prefix is rejected rather than read as prose -- valid or malformed --
+    because it is a half-finished conversion wearing the old shape.
+    """
+    if isinstance(value, str):
+        if not value.strip():
+            return "oracle is empty"
+        if value.strip().startswith(ORACLE_PREFIX):
+            # Anything reaching for the canonical form is a half-finished
+            # conversion, whether or not it parses. Accepting a *malformed*
+            # attempt as prose would hide precisely the typo worth catching.
+            problem = oracle_reference_problem(value)
+            syntax = "" if problem is None else f", and it {problem}"
+            return (
+                f"oracle is a bare reference string{syntax}; canonical "
+                "references go in a list, as oracle = [...]"
+            )
+        return None
+    if not isinstance(value, list):
+        return (
+            f"oracle is {type(value).__name__}; expected a list of references "
+            "or a legacy label"
+        )
+    if not value:
+        return "oracle is an empty list; give at least one reference"
+    seen: set[str] = set()
+    for position, reference in enumerate(value):
+        if (
+            isinstance(reference, str)
+            and not reference.startswith(ORACLE_PREFIX)
+            and "::" not in reference
+        ):
+            # A legacy label typed into the new shape. Say so directly: the
+            # generic reference diagnostic would blame whatever the label
+            # happens to trip first, usually a space. Something carrying `::`
+            # is a botched reference rather than prose, so it falls through to
+            # the reference diagnostic, which can name the actual defect.
+            return (
+                f"oracle[{position}] {reference!r} is not a reference; a legacy "
+                "prose label stays a bare string, and list entries must be "
+                "canonical references"
+            )
+        problem = oracle_reference_problem(reference)
+        if problem is not None:
+            return f"oracle[{position}] {problem}"
+        if reference in seen:
+            return f"oracle[{position}] repeats {reference!r}"
+        seen.add(reference)
+    return None
+
+
 REQUIRED_MATRIX_FIELDS = ("id", "disposition", "execution_state")
 
 REVISION = re.compile(r"^D\d{6,}$")
@@ -1041,7 +1186,9 @@ def validate_rows(rows: list[dict], schema: dict, config: dict) -> list[str]:
 
     Enforces required fields, declared enum values, identifier uniqueness, and
     locator uniqueness across active rows *and* tombstones, so a completed
-    migration still reserves its identity. Behavior rows additionally must
+    migration still reserves its identity. A present ``oracle`` is shape-checked
+    before the required-field gate, so an empty or malformed one is reported as
+    such rather than as a missing field. Behavior rows additionally must
     carry the full field set, and coroutine-root rows the three root-only
     facts on top of it. The obligation to pin an import member set is derived
     from the row's *operation* -- whether it is a configured Python module
@@ -1094,6 +1241,18 @@ def validate_rows(rows: list[dict], schema: dict, config: dict) -> list[str]:
             )
         if row["category"] not in BEHAVIOR_KINDS:
             continue
+        if "oracle" in row:
+            # Shape first, for this field only. While rows are being converted
+            # `oracle` accepts two representations, so a present value can be
+            # structurally wrong rather than merely absent, and the truthiness
+            # gate below would misreport it as missing. The other required
+            # fields are single free-form values with nothing to check, so this
+            # is a local exception and not the start of a field-validation
+            # framework.
+            problem = oracle_problem(row["oracle"])
+            if problem is not None:
+                errors.append(f"{row['id']}: {problem}")
+                continue
         absent = [f for f in REQUIRED_BEHAVIOR_FIELDS if not row.get(f)]
         if absent:
             errors.append(

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -171,7 +171,33 @@
 #   disposition      the intended target treatment, from schema.dispositions.
 #   semantic_class   the abandonment class, from schema.semantic_classes; it
 #                    selects the characterization test that covers the site.
-#   oracle           the named test pinning the current behavior.
+#   oracle           the tests pinning the current behavior, as a list of
+#                    references of the form
+#                    "fbcode//package:target::test_name". Several entries are
+#                    conjunctive: the row needs all of them. The test half may
+#                    be qualified, which is how a Rust module path or a Python
+#                    class method is named:
+#
+#                      "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest\
+#                       ::pickle::tests::resolve_fills_slots_in_order"
+#                      "fbcode//monarch/python/tests:test_job::TestJob::test_exec_command"
+#
+#                    A legacy label stays a *bare string*. Prose inside the list
+#                    is rejected: the list is the canonical form and every entry
+#                    in it must be a reference.
+#
+#                    A prose label on an *active* row is transitional: those
+#                    rows are being converted to exact references and the label
+#                    will be replaced. A historical tombstone may keep its prose
+#                    label permanently, because the path it described is gone
+#                    and there is no live test left to name.
+#
+#                    A bare string starting with "fbcode//" is rejected whether
+#                    or not it parses, because that is a half-finished
+#                    conversion rather than a label. The checker validates
+#                    reference shape only -- whether the named test exists, and
+#                    whether it actually exercises the row, is a review
+#                    question it cannot answer.
 #
 # coroutine_root rows add public_operation, caller_contexts, and
 # first_side_effect: the user-facing API, the calling contexts it supports,

--- a/scripts/test_pytokio_removal_census.py
+++ b/scripts/test_pytokio_removal_census.py
@@ -108,7 +108,7 @@ drop_behavior = "nothing runs"
 unobserved_error = "dropped"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "fixture"
+oracle = ["fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes"]
 """
 
 TRANSITION = """
@@ -699,7 +699,8 @@ class CensusCheckerTest(unittest.TestCase):
             'eager_effect = "starts a side effect"\n'
             'drop_behavior = "nothing runs"\nunobserved_error = "dropped"\n'
             'disposition = "intentionally become eager"\n'
-            'semantic_class = "deferred_side_effect"\noracle = "fixture"\n'
+            'semantic_class = "deferred_side_effect"\n'
+            'oracle = ["fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes"]\n'
         )
         manifest = self.fixture.manifest(row, totals={"py_python_task_new": 1})
         manifest["site"] = [r for r in manifest["site"] if r["id"] != "np.one"]
@@ -1198,7 +1199,7 @@ class CensusCheckerTest(unittest.TestCase):
             'drop_behavior = "n/a"\nunobserved_error = "kill signal"\n'
             'disposition = "replace with the bridge future directly"\n'
             'semantic_class = "already_started_lazy_observer"\n'
-            'oracle = "fixture"\n'
+            'oracle = ["fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes"]\n'
         )
         manifest = self.fixture.manifest(direct)
         manifest["transition"][0]["owns"].append("np.direct")
@@ -1304,6 +1305,241 @@ class CensusCheckerTest(unittest.TestCase):
         )
         manifest["schema"]["matrix_ids"] = ["fm.x"]
         self.assert_reports(self.fixture.check(manifest), "unknown execution state")
+
+    # -- oracle references ------------------------------------------------
+
+    def _behavior_row(self, manifest):
+        """The synthetic producer row, which is a behavior row."""
+        return manifest["site"][0]
+
+    def _tombstoned_producer(self, manifest, oracle):
+        """Append a tombstoned behavior row carrying ``oracle``.
+
+        Its locator names no source file, so reconciliation -- which skips
+        tombstones -- neither expects a hit nor reports an unknown one.
+        """
+        row = dict(manifest["site"][0])
+        row.update(
+            id="np.gone",
+            path="src/deleted.rs",
+            symbol="Gone::make",
+            state="removed_upstream",
+            transition_revision="D111111",
+            oracle=oracle,
+        )
+        manifest["site"].append(row)
+        manifest["transition"][0]["owns"].append("np.gone")
+        return manifest
+
+    def test_oracle_canonical_single_reference_passes(self) -> None:
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            "fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes"
+        ]
+        self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_oracle_multiple_qualified_references_pass(self) -> None:
+        """Conjunctive references, module-qualified and class-qualified."""
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest"
+            "::pickle::tests::resolve_fills_slots_in_order",
+            "fbcode//monarch/python/tests:test_job::TestJob::test_exec_command",
+        ]
+        self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_oracle_legacy_label_accepted_on_active_row(self) -> None:
+        """Prose is still accepted while rows are being converted."""
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = "endpoint reply coverage"
+        self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_oracle_legacy_label_accepted_on_tombstone(self) -> None:
+        """A deleted path has no live test to name, so its label stays."""
+        manifest = self._tombstoned_producer(
+            self.fixture.manifest(), "test_actor_driver_characterization"
+        )
+        self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_oracle_scalar_reference_attempts_fail(self) -> None:
+        """Any bare string reaching for the canonical form is a half-finished
+        conversion, valid or not.
+
+        Accepting a *malformed* attempt as prose would silently swallow the
+        typo, so the prefix alone decides, and the diagnostic names the syntax
+        problem as well as the shape."""
+        cases = [
+            ("fbcode//monarch/scripts:target::test_name", None),
+            ("fbcode//monarch/scripts:target::9bad", "malformed test name"),
+            ("fbcode//monarch/scripts:target", "no '::'"),
+            ("fbcode//monarch/scripts:target::test name", "whitespace"),
+            ("  fbcode//monarch/scripts:target::test_name", "whitespace"),
+        ]
+        for reference, syntax in cases:
+            with self.subTest(reference=reference):
+                manifest = self.fixture.manifest()
+                self._behavior_row(manifest)["oracle"] = reference
+                errors = self.fixture.check(manifest)
+                self.assert_reports(errors, "canonical references go in a list")
+                if syntax is not None:
+                    self.assert_reports(errors, syntax)
+
+    def test_oracle_target_names_follow_buck_grammar(self) -> None:
+        """Buck's grammar, not a guessed subset.
+
+        A narrower class silently rejects legal targets; a laxer one blesses
+        ``...``, which Buck reserves. Both failures are invisible here because
+        the checker never resolves the label.
+        """
+        for name in (
+            ".",
+            "..",
+            "foo+bar",
+            "a@b!c=d~e",
+            "with.dots-and_score",
+            "back\\slash",
+        ):
+            with self.subTest(name=name):
+                manifest = self.fixture.manifest()
+                self._behavior_row(manifest)["oracle"] = [
+                    f"fbcode//monarch/scripts:{name}::test_name"
+                ]
+                self.assertEqual(self.fixture.check(manifest), [])
+
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            "fbcode//monarch/scripts:...::test_name"
+        ]
+        self.assert_reports(self.fixture.check(manifest), "reserved target name")
+
+    def test_oracle_target_name_boundary_rules(self) -> None:
+        """The three rules Buck applies beyond its character set.
+
+        Each is a boundary rather than a shape, so none of them is caught by
+        the character class alone.
+        """
+        limit = census.TARGET_NAME_MAX_LEN
+
+        # `_eqsb_` is Buck's substitution for `=`; a written name may not carry it.
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            "fbcode//monarch/scripts:a_eqsb_b::test_name"
+        ]
+        self.assert_reports(self.fixture.check(manifest), "reserved substring")
+
+        # Exactly at the limit is legal; one over is not.
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            f"fbcode//monarch/scripts:{'x' * limit}::test_name"
+        ]
+        self.assertEqual(self.fixture.check(manifest), [])
+
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            f"fbcode//monarch/scripts:{'x' * (limit + 1)}::test_name"
+        ]
+        self.assert_reports(self.fixture.check(manifest), f"over the {limit} limit")
+
+    def test_oracle_prose_inside_list_is_named_directly(self) -> None:
+        """Prose in the list gets its own diagnostic.
+
+        Falling through to the reference check would blame whatever the label
+        trips first -- usually a space -- instead of the real mistake. An entry
+        carrying '::' is a botched reference, not prose, and still gets the
+        reference diagnostic.
+        """
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = ["endpoint reply coverage"]
+        self.assert_reports(
+            self.fixture.check(manifest), "a legacy prose label stays a bare string"
+        )
+
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            "fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes",
+            "lifecycle_coverage",
+        ]
+        self.assert_reports(self.fixture.check(manifest), "oracle[1]")
+
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = ["//monarch/scripts:target::test_name"]
+        self.assert_reports(self.fixture.check(manifest), "malformed target")
+
+    def test_oracle_whitespace_only_label_fails(self) -> None:
+        """A blank label names nothing, and was passing because it is truthy."""
+        for blank in ("   ", "\t", " \n "):
+            with self.subTest(blank=repr(blank)):
+                manifest = self.fixture.manifest()
+                self._behavior_row(manifest)["oracle"] = blank
+                self.assert_reports(self.fixture.check(manifest), "oracle is empty")
+
+    def test_oracle_ordinary_prose_label_still_passes(self) -> None:
+        """The contrast case: prose that does not reach for the canonical form
+        is untouched by the prefix rule."""
+        for label in ("endpoint reply coverage", "lifecycle edge behavior"):
+            with self.subTest(label=label):
+                manifest = self.fixture.manifest()
+                self._behavior_row(manifest)["oracle"] = label
+                self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_oracle_empty_list_reports_shape_not_missing_field(self) -> None:
+        """The empty list is present but unusable; the truthiness gate would
+        otherwise misreport it as an absent field."""
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = []
+        errors = self.fixture.check(manifest)
+        self.assert_reports(errors, "oracle is an empty list")
+        joined = "\n".join(errors)
+        self.assertNotIn("behavior row missing", joined)
+
+    def test_oracle_absent_still_reports_missing_field(self) -> None:
+        """Shape checking must not swallow the absent-field diagnostic."""
+        manifest = self.fixture.manifest()
+        del self._behavior_row(manifest)["oracle"]
+        self.assert_reports(self.fixture.check(manifest), "behavior row missing oracle")
+
+    def test_oracle_wrong_top_level_type_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = 7
+        self.assert_reports(self.fixture.check(manifest), "oracle is int")
+
+    def test_oracle_non_string_member_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [7]
+        self.assert_reports(self.fixture.check(manifest), "oracle[0] is int")
+
+    def test_oracle_duplicate_references_fail(self) -> None:
+        reference = (
+            "fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes"
+        )
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [reference, reference]
+        self.assert_reports(self.fixture.check(manifest), "oracle[1] repeats")
+
+    def test_oracle_malformed_references_fail(self) -> None:
+        """Each malformed shape is rejected, and named in the diagnostic."""
+        cases = [
+            ("//monarch/scripts:target::test_name", "malformed target"),
+            ("fbcode//:target::test_name", "malformed package path"),
+            ("fbcode//monarch/scripts::test_name", "malformed target"),
+            ("fbcode//monarch/scripts:target", "no '::'"),
+            ("fbcode//monarch/scripts:target::", "malformed test name"),
+            ("fbcode//monarch/scripts:target::9test", "malformed test name"),
+            ("fbcode//monarch/scripts:target::test name", "whitespace"),
+            ("fbcode//monarch/scripts:tar get::test_name", "whitespace"),
+            ("fbcode///pkg:target::test", "malformed package path"),
+            ("fbcode//pkg//sub:target::test", "malformed package path"),
+            ("fbcode//pkg/../sub:target::test", "malformed package path"),
+            ("fbcode//pkg/./sub:target::test", "malformed package path"),
+            ("fbcode//pkg/:target::test", "malformed package path"),
+            ("fbcode//pkg:...::test", "reserved target name"),
+            ("fbcode//pkg:tar get::test", "whitespace"),
+        ]
+        for reference, expected in cases:
+            with self.subTest(reference=reference):
+                manifest = self.fixture.manifest()
+                self._behavior_row(manifest)["oracle"] = [reference]
+                self.assert_reports(self.fixture.check(manifest), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
every behavior entry in the census says which test protects it. today those entries are free-form notes, so the checker cannot distinguish an exact test from a vague label or a mistyped reference.

this change lets an entry name one or more tests using their Buck target and test name. it catches malformed references, duplicates, empty values, and partially converted entries. existing prose labels remain valid while later diffs replace them, and deleted entries may keep their historical labels.

the checker validates how a reference is written; review and test execution still establish that the named test exists and covers the behavior. this changes no live census entry and no production behavior.

Differential Revision: D116990226


