### PR TITLE
Add reporting logic in the rdma benchmark (#4729)

### DIFF
--- a/python/benches/multihost_rdma/bench_stats.py
+++ b/python/benches/multihost_rdma/bench_stats.py
@@ -240,7 +240,6 @@ class ConfigColumns:
 
     schema_version: int
     transport: str
-    tcp_serialized: int
     source_device: str
     dest_device: str
     payload_size_mb: float
@@ -249,7 +248,7 @@ class ConfigColumns:
     runs: int
     warmup_iters_per_run: int
     warm_iters_per_run: int
-    local_sender: int
+    local_only: int
     verify_mode: str
     rdma_runtime_threads: str
     integrity_ok: str

--- a/python/benches/multihost_rdma/benchmark_driver.py
+++ b/python/benches/multihost_rdma/benchmark_driver.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+All of the scheduler-independent logic to configure and drive a multihost RDMA
+benchmark.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+from bench_peer import VERIFY_MODES, VERIFY_SAMPLED
+from bench_topology import PAIRINGS, PATTERNS, SAME
+
+
+RUN_COMMAND: str = "run"
+BATCH_COMMAND: str = "run-batch"
+
+# When to kill the job once the benchmark is done.
+TEARDOWN_NEVER: str = "never"
+TEARDOWN_ON_FAILURE: str = "on_failure"
+TEARDOWN_ALWAYS: str = "always"
+TEARDOWN_POLICIES: tuple[str, ...] = (
+    TEARDOWN_NEVER,
+    TEARDOWN_ON_FAILURE,
+    TEARDOWN_ALWAYS,
+)
+
+_MB: int = 1000**2
+
+
+@dataclass(frozen=True)
+class BenchConfig:
+    """Everything the benchmark needs that is not scheduler-specific."""
+
+    # ibverbs or tcp
+    transport: str
+    # Shape of the edges between hosts (see `PATTERNS`)
+    pattern: str
+    # How many hosts take part in the benchmark.
+    num_hosts: int
+    # How procs on each host are paired with each other:
+    # - same: proc i -> proc i
+    # - shifted: proc i -> proc (i + lane_shift) % num_lanes
+    # - all: proc i -> proc j for all i, j
+    lane_pairing: str
+    lane_shift: int
+    # Size of the payload per op per edge between lanes.
+    payload_size_mb: float
+    # Number of concurrent ops per edge between lanes.
+    concurrent_ops: int
+    # Number of times the benchmark will run on a set of
+    # freshly allocated buffers. Each run does
+    # `warmup_iters_per_run + warm_iters_per_run` total iterations.
+    runs: int
+    # Number of iterations at the beginning of a run whose timings
+    # will be discarded.
+    warmup_iters_per_run: int
+    # Number of iterations within a run whose timings will be counted.
+    warm_iters_per_run: int
+    procs_per_host: int
+    # Whether each proc's outgoing buffers reside on gpu.
+    source_on_gpu: bool
+    # Whether each proc's incoming buffers reside on gpu.
+    dest_on_gpu: bool
+    # Verification mode (see `VERIFY_MODES`): whether or not, and to what
+    # extent, to validate each tensor's value after each iteration.
+    verify: str
+    # In `VERIFY_SAMPLED` mode, instead of creating a hash digest of the
+    # entire tensor, we create hash digest from a window of size
+    # `verify_window_mb` at the front, middle and end of the tensor.
+    verify_window_mb: float
+    # How much gpu memory each proc is entitled to. Validated before
+    # launching.
+    max_device_gb_per_proc: float
+    # How much host memory each host is entitled to. Validated before
+    # launching.
+    max_host_gb_per_host: float
+    # How many threads the RDMA runtime was configured to use.
+    rdma_runtime_threads: int | None
+    # Path to the file where the output will live.
+    output_csv: str
+    # Batch or non-batch mode.
+    command: str
+    # Run the benchmark locally on the current host.
+    local_only: bool
+    # Path to the monarch job's cached state.
+    cached_path: str | None
+    # When to teardown the monarch job when the benchmark is done.
+    teardown_policy: str
+
+    @property
+    def payload_bytes(self) -> int:
+        return int(self.payload_size_mb * _MB)
+
+    @property
+    def iterations_per_run(self) -> int:
+        return self.warmup_iters_per_run + self.warm_iters_per_run
+
+    @property
+    def job_hosts(self) -> int:
+        """Hosts the job must provision. Zero under ``--local-only``, which puts
+        every host on this machine and so needs no job at all."""
+        return 0 if self.local_only else self.num_hosts
+
+    @property
+    def source_label(self) -> str:
+        return "gpu" if self.source_on_gpu else "cpu"
+
+    @property
+    def dest_label(self) -> str:
+        return "gpu" if self.dest_on_gpu else "cpu"
+
+
+def add_benchmark_args(parser: argparse.ArgumentParser, *, batch: bool = True) -> None:
+    """Add the scheduler-independent flags, then the subcommands.
+
+    Wrappers add their own flags on top; because those land on the parent parser
+    they are given before the subcommand, as in
+    ``slurm_benchmark.py --partition x run --teardown-policy on_failure``.
+
+    Set ``batch=False`` for a backend that cannot run the benchmark inside its
+    own allocation, which drops the ``run-batch`` subcommand entirely rather
+    than accepting it and failing later.
+    """
+    _add_shape_args(parser)
+    _add_workload_args(parser)
+    _add_reporting_args(parser)
+    _add_subcommands(parser, batch=batch)
+
+
+def _add_shape_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--pattern",
+        choices=PATTERNS,
+        default="p2p",
+        help="Shape of the edges between hosts (default: p2p).",
+    )
+    parser.add_argument(
+        "--num-hosts",
+        type=int,
+        default=2,
+        help=(
+            "How many hosts take part in the benchmark. Setting to 1 makes "
+            "every pattern the loopback self-edge (default: 2)."
+        ),
+    )
+    parser.add_argument(
+        "--lane-pairing",
+        choices=PAIRINGS,
+        default=SAME,
+        help=(
+            "How procs on each host are paired with each other: 'same' pairs "
+            "proc i with proc i, 'shifted' pairs proc i with proc "
+            "(i + --lane-shift) %% --procs-per-host, and 'all' pairs proc i "
+            "with proc j for all i, j (default: same)."
+        ),
+    )
+    parser.add_argument(
+        "--lane-shift",
+        type=int,
+        default=1,
+        help="Offset used by --lane-pairing shifted (default: 1).",
+    )
+    parser.add_argument(
+        "--procs-per-host",
+        type=int,
+        default=8,
+        help=(
+            "Procs to spawn per host. The local rank of a proc determines "
+            "which gpu ordinal it uses, when relevant (default: 8)."
+        ),
+    )
+
+
+def _add_workload_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--transport",
+        choices=["ibverbs", "tcp"],
+        default="ibverbs",
+        help="Transport every proc must use: ibverbs or tcp (default: ibverbs).",
+    )
+    parser.add_argument(
+        "--payload-size-mb",
+        type=float,
+        default=1024,
+        help=(
+            "Size of the payload per op per edge between lanes, in MB (default: 1024)."
+        ),
+    )
+    parser.add_argument(
+        "--concurrent-ops",
+        type=int,
+        default=1,
+        help=(
+            "Number of concurrent ops per edge between lanes. An initiator "
+            "batches every edge it drives and all of its ops into one "
+            "RDMAAction per iteration (default: 1)."
+        ),
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=3,
+        help=(
+            "Number of times to run against freshly allocated buffers. Each "
+            "run does --warmup-iters-per-run + --warm-iters-per-run "
+            "iterations (default: 3)."
+        ),
+    )
+    parser.add_argument(
+        "--warmup-iters-per-run",
+        type=int,
+        default=3,
+        help=(
+            "Number of iterations at the beginning of a run whose timings are "
+            "discarded (default: 3)."
+        ),
+    )
+    parser.add_argument(
+        "--warm-iters-per-run",
+        type=int,
+        default=10,
+        help=(
+            "Number of iterations within a run whose timings are counted (default: 10)."
+        ),
+    )
+    parser.add_argument(
+        "--rdma-runtime-threads",
+        type=int,
+        default=None,
+        help="How many threads the RDMA runtime should use (default: monarch's own).",
+    )
+
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--gpu",
+        action="store_true",
+        default=False,
+        help="Put both sides' buffers on gpu, which is the default.",
+    )
+    mode_group.add_argument(
+        "--cpu",
+        action="store_true",
+        default=False,
+        help="Put both sides' buffers on host memory.",
+    )
+    parser.add_argument(
+        "--source-device",
+        choices=["cpu", "gpu"],
+        default=None,
+        help=(
+            "Where each proc's outgoing buffers reside. Defaults to the "
+            "--gpu/--cpu setting, which sets both sides."
+        ),
+    )
+    parser.add_argument(
+        "--dest-device",
+        choices=["cpu", "gpu"],
+        default=None,
+        help=(
+            "Where each proc's incoming buffers reside. Defaults to the "
+            "--gpu/--cpu setting, which sets both sides."
+        ),
+    )
+
+
+def _add_reporting_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--verify",
+        choices=VERIFY_MODES,
+        default=VERIFY_SAMPLED,
+        help=(
+            "Whether, and to what extent, to validate each tensor's value "
+            "after each iteration (default: sampled)."
+        ),
+    )
+    parser.add_argument(
+        "--verify-window-mb",
+        type=float,
+        default=1.0,
+        help=(
+            "Under --verify sampled, the size of the window to check at the "
+            "front, middle and end of each tensor (default: 1.0)."
+        ),
+    )
+    parser.add_argument(
+        "--max-device-gb-per-proc",
+        type=float,
+        default=80.0,
+        help=(
+            "How much gpu memory each proc is entitled to. Validated before "
+            "launching (default: 80)."
+        ),
+    )
+    parser.add_argument(
+        "--max-host-gb-per-host",
+        type=float,
+        default=256.0,
+        help=(
+            "How much host memory each host is entitled to. Validated "
+            "before launching (default: 256)."
+        ),
+    )
+    parser.add_argument(
+        "--output-csv",
+        default="/tmp/rdma_benchmark_results.csv",
+        help=(
+            "Path to the file where the output will live, one row per "
+            "(pattern, direction, phase) (default: "
+            "/tmp/rdma_benchmark_results.csv). Override it per parallel run so "
+            "concurrent benchmarks do not clobber each other."
+        ),
+    )
+
+
+def _add_subcommands(parser: argparse.ArgumentParser, *, batch: bool) -> None:
+    """Attach the ``run`` / ``run-batch`` subcommands and their options."""
+
+    sub = parser.add_subparsers(dest="command", required=True, metavar="COMMAND")
+
+    run_parser = sub.add_parser(
+        RUN_COMMAND,
+        help="Drive the benchmark from this process, exiting non-zero on failure.",
+    )
+    run_parser.add_argument(
+        "--local-only",
+        action="store_true",
+        default=False,
+        help=(
+            "Run the benchmark locally on the current host, provisioning no "
+            "job. This uses a local proc mesh with a 'hosts' dimension whose "
+            "size is equal to the number of requested hosts."
+        ),
+    )
+    run_parser.add_argument(
+        "--teardown-policy",
+        choices=TEARDOWN_POLICIES,
+        default=TEARDOWN_ALWAYS,
+        help=(
+            "When to tear the monarch job down once the benchmark is done "
+            f"(default: {TEARDOWN_ALWAYS}). '{TEARDOWN_ON_FAILURE}' leaves a "
+            "fully successful run's job up so the next run can reuse it via "
+            "--cached-path, while still tearing down a failed one. "
+            f"'{TEARDOWN_NEVER}' always leaves it up."
+        ),
+    )
+    run_parser.add_argument(
+        "--cached-path",
+        default=None,
+        help=(
+            "Path to the monarch job's cached state, used to reconnect to a "
+            "job instead of creating one. When unset (default) no cache is "
+            "used and a fresh job is always created. Set it to a unique path "
+            "per parallel benchmark run so concurrent runs do not collide."
+        ),
+    )
+
+    if batch:
+        sub.add_parser(
+            BATCH_COMMAND,
+            help=(
+                "Submit the benchmark to run inside its own allocation and "
+                "return immediately. Exits 0 once submitted: the scheduler "
+                "exposes no completion status, so read the job's log or "
+                "--output-csv for the result. --output-csv is written by the "
+                "in-allocation client, so point it somewhere still visible "
+                "to the launching node."
+            ),
+        )
+
+
+def config_from_args(args: argparse.Namespace) -> BenchConfig:
+    """Build a :py:class:`BenchConfig` from :py:func:`add_benchmark_args` flags."""
+    # --gpu/--cpu set both sides; --source-device/--dest-device override
+    # each side independently.
+    default_on_gpu: bool = not args.cpu
+    cfg = BenchConfig(
+        transport=args.transport,
+        pattern=args.pattern,
+        num_hosts=int(args.num_hosts),
+        lane_pairing=args.lane_pairing,
+        lane_shift=int(args.lane_shift),
+        payload_size_mb=float(args.payload_size_mb),
+        concurrent_ops=int(args.concurrent_ops),
+        runs=int(args.runs),
+        warmup_iters_per_run=int(args.warmup_iters_per_run),
+        warm_iters_per_run=int(args.warm_iters_per_run),
+        procs_per_host=int(args.procs_per_host),
+        source_on_gpu=(
+            args.source_device == "gpu" if args.source_device else default_on_gpu
+        ),
+        dest_on_gpu=(args.dest_device == "gpu" if args.dest_device else default_on_gpu),
+        verify=args.verify,
+        verify_window_mb=float(args.verify_window_mb),
+        max_device_gb_per_proc=float(args.max_device_gb_per_proc),
+        max_host_gb_per_host=float(args.max_host_gb_per_host),
+        rdma_runtime_threads=args.rdma_runtime_threads,
+        output_csv=args.output_csv,
+        command=args.command,
+        # These exist only on the `run` subparser.
+        local_only=getattr(args, "local_only", False),
+        cached_path=getattr(args, "cached_path", None),
+        teardown_policy=getattr(args, "teardown_policy", TEARDOWN_ALWAYS),
+    )
+    if cfg.warmup_iters_per_run < 1:
+        raise ValueError(
+            "--warmup-iters-per-run must be at least 1, so that the cold "
+            "iteration takes a discarded slot rather than a warm one"
+        )
+    if cfg.warm_iters_per_run < 1:
+        raise ValueError("--warm-iters-per-run must be at least 1")
+    if cfg.runs < 1:
+        raise ValueError("--runs must be at least 1")
+    return cfg

--- a/python/benches/multihost_rdma/benchmark_driver.py
+++ b/python/benches/multihost_rdma/benchmark_driver.py
@@ -10,15 +10,54 @@
 """
 All of the scheduler-independent logic to configure and drive a multihost RDMA
 benchmark.
+
+Each configuration is run in two directions. Both move the same bytes over the
+same edges; only the side that initiates the transfers changes, so ``write`` has
+the source pushing into the destination's buffers and ``read`` has the
+destination pulling from the source's. Each side's memory kind is set
+independently with ``--source-device`` and ``--dest-device``.
+
+A *run* allocates and registers fresh tensors and then iterates. Within a run, the
+first ``--warmup-iters-per-run`` iterations are discarded and the rest are warm.
+The very first iteration of all needs to establish QP connections and is therefore
+reported separately.
 """
 
 from __future__ import annotations
 
 import argparse
+from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any
 
 from bench_peer import VERIFY_MODES, VERIFY_SAMPLED
-from bench_topology import PAIRINGS, PATTERNS, SAME
+from bench_stats import (
+    ConfigColumns,
+    KeyColumns,
+    MetricColumns,
+    metrics_for,
+    phase_table,
+    RunRecord,
+    SCHEMA_VERSION,
+    ShapeColumns,
+    summary_header,
+    summary_row,
+    write_rows,
+)
+from bench_topology import (
+    bytes_per_iteration,
+    describe,
+    DIRECTIONS,
+    max_ops_per_action,
+    MemoryPlan,
+    PAIRINGS,
+    PATTERNS,
+    PHASES,
+    SAME,
+    Topology,
+    unused_hosts,
+)
+from monarch.config import get_global_config
 
 
 RUN_COMMAND: str = "run"
@@ -34,6 +73,7 @@ TEARDOWN_POLICIES: tuple[str, ...] = (
     TEARDOWN_ALWAYS,
 )
 
+_GB: int = 1000**3
 _MB: int = 1000**2
 
 
@@ -421,3 +461,116 @@ def config_from_args(args: argparse.Namespace) -> BenchConfig:
     if cfg.runs < 1:
         raise ValueError("--runs must be at least 1")
     return cfg
+
+
+def _shape_columns(
+    cfg: BenchConfig, topo: Topology, plan: MemoryPlan, direction: str
+) -> ShapeColumns:
+    return ShapeColumns(
+        num_hosts=topo.num_hosts,
+        procs_per_host=topo.procs_per_host,
+        lane_pairing=topo.pairing,
+        lane_shift=topo.shift,
+        num_edges=len(topo.edges),
+        num_initiators=len(topo.initiators(direction)),
+        max_degree=topo.max_degree(direction),
+        max_ops_per_action=max_ops_per_action(topo, direction, ops=cfg.concurrent_ops),
+        max_in_degree=max((topo.in_degree(s) for s in topo.slots()), default=0),
+        bytes_per_iteration=bytes_per_iteration(
+            topo, ops=cfg.concurrent_ops, payload_bytes=cfg.payload_bytes
+        ),
+        max_buffers_per_proc=max(plan.buffers.values(), default=0),
+        max_device_bytes_per_proc=max(plan.device_bytes.values(), default=0),
+        max_host_bytes_per_host=max(plan.host_bytes_per_host.values(), default=0),
+    )
+
+
+def _config_columns(cfg: BenchConfig, record: RunRecord) -> ConfigColumns:
+    return ConfigColumns(
+        schema_version=SCHEMA_VERSION,
+        transport=cfg.transport,
+        source_device=cfg.source_label,
+        dest_device=cfg.dest_label,
+        payload_size_mb=cfg.payload_size_mb,
+        concurrent_ops=cfg.concurrent_ops,
+        # One generation of procs, so `cold_qp` has exactly one iteration behind
+        # it however many runs there were.
+        cold_proc_runs=1,
+        runs=cfg.runs,
+        warmup_iters_per_run=cfg.warmup_iters_per_run,
+        warm_iters_per_run=cfg.warm_iters_per_run,
+        local_only=int(cfg.local_only),
+        verify_mode=cfg.verify,
+        rdma_runtime_threads=str(get_global_config()["rdma_runtime_worker_threads"]),
+        integrity_ok=_flag(record.integrity_ok),
+        negative_control_ok=_flag(record.negative_control_ok),
+    )
+
+
+def _flag(value: bool | None) -> str:
+    return "skipped" if value is None else str(value)
+
+
+def _report(
+    cfg: BenchConfig,
+    topo: Topology,
+    plan: MemoryPlan,
+    records: dict[str, RunRecord],
+) -> None:
+    """Write the CSV and print the per-phase digest."""
+    rows: list[Sequence[Any]] = []
+    table: list[tuple[KeyColumns, MetricColumns]] = []
+    for direction, record in records.items():
+        shape = _shape_columns(cfg, topo, plan, direction)
+        config = _config_columns(cfg, record)
+        for phase in PHASES:
+            key = KeyColumns(pattern=topo.pattern, direction=direction, phase=phase)
+            metrics = metrics_for(phase, record)
+            rows.append(summary_row(key, shape, config, metrics))
+            table.append((key, metrics))
+
+    with open(cfg.output_csv, "w") as stream:
+        write_rows(stream, summary_header(), rows)
+
+    print()
+    for line in phase_table(table):
+        print(line)
+    print(f"\nResults written to {cfg.output_csv}")
+
+
+def _print_banner(
+    cfg: BenchConfig, topo: Topology, plan: MemoryPlan, banner: Sequence[str]
+) -> None:
+    print("=" * 78)
+    print("RDMA Benchmark")
+    print("=" * 78)
+    for line in banner:
+        print(line)
+    for direction in DIRECTIONS:
+        print(
+            describe(
+                topo,
+                direction,
+                ops=cfg.concurrent_ops,
+                payload_bytes=cfg.payload_bytes,
+            )
+        )
+    idle = unused_hosts(topo)
+    if idle:
+        print(f"Hosts this pattern never touches: {list(idle)}")
+    print(
+        f"Memory: source={cfg.source_label} dest={cfg.dest_label}; "
+        f"up to {max(plan.buffers.values(), default=0)} buffers per proc, "
+        f"{_gb(max(plan.device_bytes.values(), default=0))} device per proc, "
+        f"{_gb(max(plan.host_bytes_per_host.values(), default=0))} host per host"
+    )
+    print(
+        f"Runs: {cfg.runs} x ({cfg.warmup_iters_per_run} ramp + "
+        f"{cfg.warm_iters_per_run} warm) iterations, first iteration "
+        f"cold; verify={cfg.verify}"
+    )
+    print(f"Transport: {cfg.transport}  |  Output: {cfg.output_csv}")
+
+
+def _gb(num_bytes: int) -> str:
+    return f"{num_bytes / _GB:.2f} GB"

--- a/python/tests/test_rdma_bench_driver.py
+++ b/python/tests/test_rdma_bench_driver.py
@@ -12,7 +12,10 @@ Unit tests for the multi-host RDMA benchmark's driver.
 """
 
 import argparse
+import csv
 
+import bench_stats as bs
+import bench_topology as bt
 import benchmark_driver as bd
 import pytest
 
@@ -147,3 +150,141 @@ def test_run_batch_gets_the_run_only_flags_defaulted() -> None:
     assert cfg.local_only is False
     assert cfg.cached_path is None
     assert cfg.teardown_policy == bd.TEARDOWN_ALWAYS
+
+
+_GB: int = 1000**3
+
+
+def _topology(cfg: bd.BenchConfig) -> bt.Topology:
+    return bt.build_topology(
+        cfg.pattern, cfg.num_hosts, cfg.procs_per_host, cfg.lane_pairing, cfg.lane_shift
+    )
+
+
+def _plan(cfg: bd.BenchConfig, topo: bt.Topology) -> bt.MemoryPlan:
+    return bt.plan_memory(
+        topo,
+        ops=cfg.concurrent_ops,
+        payload_bytes=cfg.payload_bytes,
+        source_on_gpu=cfg.source_on_gpu,
+        dest_on_gpu=cfg.dest_on_gpu,
+    )
+
+
+def _record(*, submit_ms: float = 200.0, spans: int = 4) -> bs.RunRecord:
+    """A record holding one cold iteration and ``spans`` warm ones."""
+    runs = bs.RunRecord()
+    runs.register_ms.append(5.0)
+    for index in range(spans + 1):
+        phase = bt.COLD_QP if index == 0 else bt.WARM
+        into = runs.record(phase)
+        into.add_sample(
+            bs.Sample(bt.Slot(0, 0), build_ms=1.0, submit_ms=submit_ms),
+            initiator_bytes=_GB,
+        )
+        into.add_iteration(
+            span_ms=submit_ms + 5.0, iteration_bytes=2 * _GB, slowest_ms=submit_ms
+        )
+    runs.integrity_ok = True
+    runs.negative_control_ok = True
+    return runs
+
+
+def test_the_banner_states_the_shape_before_anything_is_provisioned(capsys) -> None:
+    cfg = _config("--pattern", "ring", "--num-hosts", "4", "--procs-per-host", "2")
+    topo = _topology(cfg)
+
+    bd._print_banner(cfg, topo, _plan(cfg, topo), ["Mode: test"])
+
+    printed = capsys.readouterr().out
+    assert "Mode: test" in printed
+    # One line per direction, each naming the graph that direction will drive.
+    assert printed.count("ring: 4x2 procs, 8 edges, same lanes") == 2
+    assert "read;" in printed and "write;" in printed
+    assert "Memory: source=gpu dest=gpu" in printed
+    # One outgoing pool plus one incoming, at one op of 1024 MB each.
+    assert "up to 2 buffers per proc, 2.05 GB device per proc" in printed
+    assert "3 x (3 ramp + 10 warm) iterations" in printed
+    assert "Transport: ibverbs" in printed
+    assert cfg.output_csv in printed
+
+
+def test_the_banner_names_the_hosts_a_pattern_leaves_idle(capsys) -> None:
+    """A p2p run over an eight-host job uses two of them, which is worth saying
+    out loud before the other six sit there costing capacity."""
+    cfg = _config("--pattern", "p2p", "--num-hosts", "8")
+    topo = _topology(cfg)
+
+    bd._print_banner(cfg, topo, _plan(cfg, topo), [])
+
+    assert "never touches: [2, 3, 4, 5, 6, 7]" in capsys.readouterr().out
+
+
+def test_the_shape_columns_describe_the_graph() -> None:
+    cfg = _config(
+        "--pattern", "all-to-all", "--num-hosts", "4", "--procs-per-host", "2"
+    )
+    topo = _topology(cfg)
+
+    shape = bd._shape_columns(cfg, topo, _plan(cfg, topo), bt.READ)
+
+    assert (shape.num_hosts, shape.procs_per_host) == (4, 2)
+    assert shape.num_edges == 24, "4 hosts fully connected, 2 same-lane pairs each"
+    assert shape.num_initiators == 8, "every proc pulls under read"
+    assert shape.max_degree == 3
+    assert shape.max_in_degree == 3
+    assert shape.max_ops_per_action == 3, "one op per edge, three edges in"
+    assert shape.bytes_per_iteration == 24 * 1024 * 1000**2
+    assert shape.max_buffers_per_proc == 4, "one outgoing plus three incoming"
+
+
+def test_the_config_columns_record_what_was_asked_for() -> None:
+    cfg = _config("--cpu", "--pattern", "ring", "--verify", "off")
+
+    config = bd._config_columns(cfg, _record())
+
+    assert config.schema_version == bs.SCHEMA_VERSION
+    assert (config.source_device, config.dest_device) == ("cpu", "cpu")
+    assert config.verify_mode == "off"
+    assert config.local_only == 0
+    assert config.cold_proc_runs == 1, "one generation of procs, so one cold_qp"
+    assert config.integrity_ok == "True"
+
+
+def test_a_check_that_never_ran_is_neither_pass_nor_fail() -> None:
+    """`--verify off` leaves the flags unset, and reporting them as False would
+    read as a corrupted transfer."""
+    assert bd._flag(None) == "skipped"
+    assert bd._flag(True) == "True"
+    assert bd._flag(False) == "False"
+
+
+def test_reporting_writes_a_row_per_direction_and_phase(tmp_path, capsys) -> None:
+    output_csv = str(tmp_path / "results.csv")
+    cfg = _config("--pattern", "ring", "--num-hosts", "4", "--output-csv", output_csv)
+    topo = _topology(cfg)
+    records = {bt.READ: _record(submit_ms=400.0), bt.WRITE: _record(submit_ms=200.0)}
+
+    bd._report(cfg, topo, _plan(cfg, topo), records)
+
+    with open(output_csv) as stream:
+        rows = list(csv.DictReader(stream))
+    assert list(rows[0]) == list(bs.summary_header())
+    assert {(row["direction"], row["phase"]) for row in rows} == {
+        (direction, phase) for direction in bt.DIRECTIONS for phase in bt.PHASES
+    }
+    assert all(row["pattern"] == "ring" for row in rows)
+
+    warm = {row["direction"]: row for row in rows if row["phase"] == bt.WARM}
+    assert float(warm[bt.READ]["submit_ms_median"]) == 400.0
+    assert float(warm[bt.WRITE]["submit_ms_median"]) == 200.0
+    # Halving the time doubles the rate, and only warm rows carry one at all.
+    assert float(warm[bt.WRITE]["agg_gbs_median"]) > float(
+        warm[bt.READ]["agg_gbs_median"]
+    )
+    cold = [row for row in rows if row["phase"] == bt.COLD_QP]
+    assert all(row["agg_gbs_median"] == "" for row in cold)
+
+    printed = capsys.readouterr().out
+    assert "build p50 (ms)" in printed
+    assert output_csv in printed

--- a/python/tests/test_rdma_bench_driver.py
+++ b/python/tests/test_rdma_bench_driver.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Unit tests for the multi-host RDMA benchmark's driver.
+"""
+
+import argparse
+
+import benchmark_driver as bd
+import pytest
+
+
+def _parse(*flags: str, batch: bool = True, command: str = bd.RUN_COMMAND):
+    """The namespace the CLI would build for ``flags`` plus a subcommand."""
+    parser = argparse.ArgumentParser()
+    bd.add_benchmark_args(parser, batch=batch)
+    return parser.parse_args([*flags, command])
+
+
+def _config(*flags: str, **kwargs) -> bd.BenchConfig:
+    return bd.config_from_args(_parse(*flags, **kwargs))
+
+
+def test_the_defaults_describe_a_two_host_gpu_run() -> None:
+    cfg = _config()
+
+    assert cfg.pattern == "p2p"
+    assert cfg.num_hosts == 2
+    assert cfg.procs_per_host == 8
+    assert cfg.lane_pairing == "same"
+    assert cfg.transport == "ibverbs"
+    assert cfg.payload_size_mb == 1024
+    assert cfg.concurrent_ops == 1
+    assert cfg.runs == 3
+    assert (cfg.source_on_gpu, cfg.dest_on_gpu) == (True, True)
+    assert cfg.verify == "sampled"
+    assert cfg.command == bd.RUN_COMMAND
+    assert cfg.local_only is False
+    assert cfg.cached_path is None
+    assert cfg.teardown_policy == bd.TEARDOWN_ALWAYS
+
+
+def test_every_shape_flag_reaches_the_config() -> None:
+    cfg = _config(
+        "--pattern",
+        "all-to-all",
+        "--num-hosts",
+        "8",
+        "--procs-per-host",
+        "4",
+        "--lane-pairing",
+        "shifted",
+        "--lane-shift",
+        "3",
+    )
+
+    assert (cfg.pattern, cfg.num_hosts, cfg.procs_per_host) == ("all-to-all", 8, 4)
+    assert (cfg.lane_pairing, cfg.lane_shift) == ("shifted", 3)
+
+
+@pytest.mark.parametrize(
+    ("flags", "source_on_gpu", "dest_on_gpu"),
+    [
+        ((), True, True),
+        (("--cpu",), False, False),
+        (("--gpu",), True, True),
+        (("--cpu", "--dest-device", "gpu"), False, True),
+        (("--gpu", "--dest-device", "cpu"), True, False),
+        (("--source-device", "cpu"), False, True),
+        (("--gpu", "--source-device", "cpu"), False, True),
+        (("--cpu", "--source-device", "gpu"), True, False),
+    ],
+)
+def test_each_sides_memory_kind_can_be_set_on_its_own(
+    flags, source_on_gpu, dest_on_gpu
+) -> None:
+    """``--gpu``/``--cpu`` set both sides; either side then overrides it."""
+    cfg = _config(*flags)
+
+    assert (cfg.source_on_gpu, cfg.dest_on_gpu) == (source_on_gpu, dest_on_gpu)
+    assert (cfg.source_label, cfg.dest_label) == (
+        "gpu" if source_on_gpu else "cpu",
+        "gpu" if dest_on_gpu else "cpu",
+    )
+
+
+def test_gpu_and_cpu_cannot_both_be_given() -> None:
+    with pytest.raises(SystemExit):
+        _parse("--gpu", "--cpu")
+
+
+def test_a_payload_is_counted_in_decimal_megabytes() -> None:
+    assert _config("--payload-size-mb", "1024").payload_bytes == 1024 * 1000**2
+    assert _config("--payload-size-mb", "0.5").payload_bytes == 500_000
+
+
+def test_a_run_is_its_ramp_plus_its_warm_iterations() -> None:
+    cfg = _config("--warmup-iters-per-run", "4", "--warm-iters-per-run", "10")
+
+    assert cfg.iterations_per_run == 14
+
+
+def test_local_only_provisions_nothing() -> None:
+    parser = argparse.ArgumentParser()
+    bd.add_benchmark_args(parser)
+    local = bd.config_from_args(
+        parser.parse_args(["--num-hosts", "8", "run", "--local-only"])
+    )
+
+    assert local.num_hosts == 8
+    assert local.local_only is True
+    assert local.job_hosts == 0, "no job at all, however many hosts take part"
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["--warmup-iters-per-run", "--warm-iters-per-run", "--runs"],
+)
+def test_a_run_shape_that_reports_nothing_is_refused(flag) -> None:
+    """Each of these at zero leaves a phase with no samples, or spends the cold
+    iteration on a warm slot, so the CLI rejects it before provisioning."""
+    with pytest.raises(ValueError, match=flag):
+        _config(flag, "0")
+
+    assert _config(flag, "1") is not None
+
+
+def test_run_batch_is_offered_only_to_schedulers_that_have_it() -> None:
+    assert _config(command=bd.BATCH_COMMAND).command == bd.BATCH_COMMAND
+
+    with pytest.raises(SystemExit):
+        _parse(batch=False, command=bd.BATCH_COMMAND)
+
+
+def test_run_batch_gets_the_run_only_flags_defaulted() -> None:
+    """They live on the ``run`` subparser, so the namespace lacks them entirely
+    and the config has to supply the same values ``run`` would have."""
+    cfg = _config(command=bd.BATCH_COMMAND)
+
+    assert cfg.local_only is False
+    assert cfg.cached_path is None
+    assert cfg.teardown_policy == bd.TEARDOWN_ALWAYS

--- a/python/tests/test_rdma_bench_stats.py
+++ b/python/tests/test_rdma_bench_stats.py
@@ -262,7 +262,6 @@ def _columns() -> tuple[
         bs.ConfigColumns(
             schema_version=bs.SCHEMA_VERSION,
             transport="ibverbs",
-            tcp_serialized=0,
             source_device="gpu",
             dest_device="gpu",
             payload_size_mb=1024.0,
@@ -271,7 +270,7 @@ def _columns() -> tuple[
             runs=3,
             warmup_iters_per_run=3,
             warm_iters_per_run=10,
-            local_sender=0,
+            local_only=0,
             verify_mode="sampled",
             rdma_runtime_threads="16",
             integrity_ok="True",


### PR DESCRIPTION
Summary:

Add logic to report the per-phase result summaries and store the full set of results in an output csv.

Differential Revision: D116996191


