### PR TITLE
Serve a buffer from several NICs, paired by peer device affinity

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -87,6 +87,7 @@ use monarch_rdma::RdmaRemoteBuffer;
 use monarch_rdma::backend::ibverbs::device_selection::IbvDeviceTarget;
 use monarch_rdma::backend::ibverbs::manager_actor::RawQueuePair;
 use monarch_rdma::backend::ibverbs::memory_region::IbvRemoteMemoryRegionView;
+use monarch_rdma::backend::ibverbs::mlx_device::MlxDevice;
 use monarch_rdma::backend::ibverbs::primitives::IbvQpInfo;
 use monarch_rdma::backend::ibverbs::queue_pair::legacy::IbvQueuePair;
 use monarch_rdma::cu_check;
@@ -148,9 +149,7 @@ pub fn ping_pong(
     if result == 0 { Ok(()) } else { Err(result) }
 }
 
-/// The NIC serving a buffer's first registration. A buffer may be registered on
-/// several; this example drives a single queue pair, and taking the first entry
-/// is a stable choice because the registrations come back in device-name order.
+/// The NIC serving a buffer's first registration.
 fn first_device(buffers: &[IbvRemoteMemoryRegionView]) -> Result<String, anyhow::Error> {
     Ok(buffers
         .first()
@@ -646,7 +645,7 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
             .local_memory
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Local buffer not registered"))?
-            .registered_mr(&local_device)?
+            .registered_mr::<MlxDevice>(&local_device)?
             .ok_or_else(|| anyhow::anyhow!("local buffer has no registration on {local_device}"))?;
         let remote_ibv = remote_buffer
             .resolve_mlx()

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -11,12 +11,14 @@
 
 use std::collections::BTreeSet;
 use std::num::NonZeroU32;
+use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
 use anyhow::Context;
 use anyhow::Result;
 use dashmap::DashMap;
+use dashmap::DashSet;
 
 use super::device::IbvDevice;
 use super::device::IbvDeviceImpl;
@@ -139,11 +141,6 @@ impl PeerDeviceAffinityPolicy {
     /// Whatever is left over pairs subject to the policy, taking the
     /// first NIC in `remote` it can still reach.
     ///
-    /// Both lists are expected in [`select_optimal_ibv_devices`] order, which
-    /// is what makes that choice reproducible: two processes ranking the same
-    /// NICs list them identically, so each arrives at the same pairing without
-    /// exchanging anything.
-    ///
     /// The leftovers are matched greedily in order, so an earlier device can
     /// take the only partner a later one could have used. Maximizing the number
     /// of pairs is likely not worth a matching algorithm here.
@@ -177,6 +174,89 @@ impl PeerDeviceAffinityPolicy {
             }
         }
         pairs
+    }
+
+    /// The devices to serve one buffer from: at most `max` of `devices`, or all
+    /// of them when `max` is `None`.
+    ///
+    /// Which devices are dropped is decided by position, so the caller decides
+    /// what "first" means by how it orders `devices`.
+    ///
+    /// Selection logic depends on the policy:
+    ///
+    /// - [`Self::Any`]: any two NICs can talk to each other, so buffers should
+    ///   spread across tied devices rather than always funneling through
+    ///   the first. `choose` picks a random offset into `devices`, then
+    ///   takes up to `max` starting from that offset, wrapping around if
+    ///   necessary.
+    /// - [`Self::MatchName`]: takes the first `max` NICs in the order in which
+    ///   they appear in devices. Callers should pass `devices` in a known,
+    ///   consistent order so that different processes agree on the choice.
+    /// - [`Self::Groups`]: takes one device from every group `devices` touches
+    ///   before taking a second from any of them, so a peer served by any of
+    ///   those groups still finds a partner here. A device no group names comes
+    ///   last: it reaches no peer device, so it is worth registering only once
+    ///   nothing else fills `max`.
+    pub fn choose(&self, devices: &[String], max: Option<NonZeroUsize>) -> Vec<String> {
+        if devices.is_empty() {
+            return Vec::new();
+        }
+        let limit = max
+            .map_or(devices.len(), NonZeroUsize::get)
+            .min(devices.len());
+        match self {
+            Self::Any => devices
+                .iter()
+                .cycle()
+                .skip(rand::random_range(0..devices.len()))
+                .take(limit)
+                .cloned()
+                .collect(),
+            Self::MatchName => devices.iter().take(limit).cloned().collect(),
+            Self::Groups(groups) => Self::choose_across_groups(groups, devices, limit),
+        }
+    }
+
+    /// [`Self::Groups`]'s arm of [`Self::choose`].
+    fn choose_across_groups(
+        groups: &[BTreeSet<String>],
+        devices: &[String],
+        limit: usize,
+    ) -> Vec<String> {
+        // One bucket per group `devices` touches, created on first touch and
+        // filled in `devices` order.
+        let mut buckets: Vec<Vec<&String>> = Vec::new();
+        let mut bucket_of: Vec<Option<usize>> = vec![None; groups.len()];
+        let mut ungrouped: Vec<&String> = Vec::new();
+        for device in devices {
+            let Some(group) = groups.iter().position(|names| names.contains(device)) else {
+                ungrouped.push(device);
+                continue;
+            };
+            match bucket_of[group] {
+                Some(bucket) => buckets[bucket].push(device),
+                None => {
+                    bucket_of[group] = Some(buckets.len());
+                    buckets.push(vec![device]);
+                }
+            }
+        }
+        if buckets.len() > limit {
+            warn_uncovered_groups(limit, buckets.len(), &buckets[limit..]);
+        }
+
+        let rounds = buckets.iter().map(Vec::len).max().unwrap_or(0);
+        let mut ordered: Vec<&String> = Vec::with_capacity(devices.len());
+        for round in 0..rounds {
+            ordered.extend(
+                buckets
+                    .iter()
+                    .filter_map(|bucket| bucket.get(round))
+                    .copied(),
+            );
+        }
+        ordered.extend(ungrouped);
+        ordered.into_iter().take(limit).cloned().collect()
     }
 
     /// Whether a transfer may run between `local` and `remote`.
@@ -234,6 +314,31 @@ impl FromStr for PeerDeviceAffinityPolicy {
                 Ok(Self::Groups(groups))
             }
         }
+    }
+}
+
+/// Report, at most once per distinct set of left-out devices, that
+/// `rdma_max_nics_per_buffer` is too low for a buffer to reach every
+/// peer-affinity group that it could hypothetically reach.
+///
+/// `uncovered` holds the buckets [`PeerDeviceAffinityPolicy::choose`] had to
+/// drop, one per group it could not reach.
+fn warn_uncovered_groups(max: usize, groups: usize, uncovered: &[Vec<&String>]) {
+    static WARNED: LazyLock<DashSet<String>> = LazyLock::new(DashSet::new);
+    let mut left_out: Vec<&str> = uncovered
+        .iter()
+        .flatten()
+        .map(|device| device.as_str())
+        .collect();
+    left_out.sort();
+    // `insert` is true only for the first caller to claim this key, and it takes
+    // the shard lock, so exactly one of them warns.
+    if WARNED.insert(left_out.join(",")) {
+        tracing::warn!(
+            "rdma_max_nics_per_buffer is {max}, but this buffer's RDMA devices span {groups} \
+             peer-affinity groups; raise it to {groups} to also serve {left_out:?}, or else \
+             some peers may be unreachable.",
+        );
     }
 }
 
@@ -492,10 +597,10 @@ mod tests {
         );
     }
 
-    /// Device names as a caller passes them: in [`select_optimal_ibv_devices`]
-    /// order, which is sorted by name.
+    /// Device names in [`select_optimal_ibv_devices`] order, which is sorted by
+    /// name -- what [`PeerDeviceAffinityPolicy::choose`] is handed.
     fn devices<const N: usize>(names: [&str; N]) -> Vec<String> {
-        assert!(names.is_sorted(), "callers pass device names in order");
+        assert!(names.is_sorted(), "a ranking comes back sorted by name");
         names.map(str::to_owned).to_vec()
     }
 
@@ -600,6 +705,150 @@ mod tests {
             vec![None; local.len()],
             "a peer advertising no device leaves every local NIC unpaired",
         );
+    }
+
+    /// [`PeerDeviceAffinityPolicy::choose`] with a budget of `max`.
+    fn chosen(policy: &PeerDeviceAffinityPolicy, devices: &[String], max: usize) -> Vec<String> {
+        policy.choose(
+            devices,
+            Some(NonZeroUsize::new(max).expect("a device budget is at least one")),
+        )
+    }
+
+    #[test]
+    fn each_group_is_reached_before_any_is_doubled_up() {
+        let policy: PeerDeviceAffinityPolicy =
+            "groups:mlx5_0,mlx5_1|mlx5_2,mlx5_3|mlx5_4,mlx5_5|mlx5_6,mlx5_7"
+                .parse()
+                .expect("group spec should parse");
+        let local = devices([
+            "mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_7",
+        ]);
+        // One device out of each group. A prefix of the ranking would have taken
+        // mlx5_0 through mlx5_3 and left the last two groups unreachable.
+        assert_eq!(
+            chosen(&policy, &local, 4),
+            devices(["mlx5_0", "mlx5_2", "mlx5_4", "mlx5_6"]),
+        );
+        // Once every group is covered the budget doubles up within them.
+        assert_eq!(
+            chosen(&policy, &local, 6),
+            ["mlx5_0", "mlx5_2", "mlx5_4", "mlx5_6", "mlx5_1", "mlx5_3"].map(str::to_owned),
+        );
+        // The best-ranked device is still taken first.
+        assert_eq!(chosen(&policy, &local, 1), devices(["mlx5_0"]));
+    }
+
+    #[test]
+    fn a_group_the_devices_do_not_reach_costs_no_budget() {
+        let policy: PeerDeviceAffinityPolicy = "groups:mlx5_0,mlx5_1|mlx5_2,mlx5_3|mlx5_4,mlx5_5"
+            .parse()
+            .expect("group spec should parse");
+        // A buffer only two groups can serve — a GPU buffer, say — spends its
+        // whole budget on those two rather than holding room for the third.
+        let local = devices(["mlx5_1", "mlx5_2", "mlx5_3"]);
+        assert_eq!(
+            chosen(&policy, &local, 3),
+            devices(["mlx5_1", "mlx5_2", "mlx5_3"]),
+        );
+    }
+
+    #[test]
+    fn a_device_no_group_names_is_taken_last() {
+        let policy: PeerDeviceAffinityPolicy = "groups:mlx5_2,mlx5_3"
+            .parse()
+            .expect("group spec should parse");
+        // `mlx5_0` and `mlx5_1` reach no peer device under this policy, so the
+        // budget goes to the group first even though they rank higher.
+        let local = devices(["mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3"]);
+        assert_eq!(chosen(&policy, &local, 1), devices(["mlx5_2"]));
+        assert_eq!(
+            chosen(&policy, &local, 3),
+            ["mlx5_2", "mlx5_3", "mlx5_0"].map(str::to_owned),
+        );
+    }
+
+    #[test]
+    fn match_name_takes_devices_in_order() {
+        // Both sides have to land on the same name.
+        let local = devices(["mlx5_0", "mlx5_1", "mlx5_2"]);
+        assert_eq!(
+            chosen(&PeerDeviceAffinityPolicy::MatchName, &local, 2),
+            devices(["mlx5_0", "mlx5_1"]),
+        );
+    }
+
+    #[test]
+    fn any_starts_at_a_random_device_and_wraps() {
+        let policy = PeerDeviceAffinityPolicy::Any;
+        let ranked = devices(["mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3"]);
+        // Every pair of devices adjacent in the ranking, wrapping around.
+        let windows: BTreeSet<Vec<String>> = [
+            ["mlx5_0", "mlx5_1"].map(str::to_owned).to_vec(),
+            ["mlx5_1", "mlx5_2"].map(str::to_owned).to_vec(),
+            ["mlx5_2", "mlx5_3"].map(str::to_owned).to_vec(),
+            ["mlx5_3", "mlx5_0"].map(str::to_owned).to_vec(),
+        ]
+        .into();
+        let mut seen: BTreeSet<Vec<String>> = BTreeSet::new();
+        for _ in 0..64 {
+            let picked = chosen(&policy, &ranked, 2);
+            assert!(
+                windows.contains(&picked),
+                "{picked:?} does not start somewhere in {ranked:?} and run on from there",
+            );
+            seen.insert(picked);
+        }
+        // 64 draws that all miss one of four starts would be a one-in-billions
+        // coincidence.
+        assert_eq!(seen, windows);
+    }
+
+    #[test]
+    fn no_limit_takes_every_device() {
+        let local = devices(["mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3"]);
+        for policy in [
+            PeerDeviceAffinityPolicy::Any,
+            PeerDeviceAffinityPolicy::MatchName,
+            "groups:mlx5_0,mlx5_1|mlx5_2,mlx5_3"
+                .parse()
+                .expect("group spec should parse"),
+        ] {
+            let mut unbounded = policy.choose(&local, None);
+            unbounded.sort();
+            assert_eq!(unbounded, local, "{policy:?} should leave no device behind");
+            // A budget larger than the list is the same as no budget at all.
+            let mut over_budget = chosen(&policy, &local, local.len() + 5);
+            over_budget.sort();
+            assert_eq!(
+                over_budget, local,
+                "{policy:?} should not repeat a device to fill its budget",
+            );
+        }
+    }
+
+    #[test]
+    fn one_device_per_group_pairs_with_a_peer_in_any_of_them() {
+        // What spreading over groups buys: a buffer that only one group can
+        // serve -- a GPU buffer bound to a single NIC -- still finds a partner,
+        // whichever group that NIC falls in.
+        let policy: PeerDeviceAffinityPolicy =
+            "groups:mlx5_0,mlx5_1|mlx5_2,mlx5_3|mlx5_4,mlx5_5|mlx5_6,mlx5_7"
+                .parse()
+                .expect("group spec should parse");
+        let ranked = devices([
+            "mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_7",
+        ]);
+        let local = chosen(&policy, &ranked, 4);
+        for peer in &ranked {
+            let remote = chosen(&policy, std::slice::from_ref(peer), 4);
+            let pairs = policy.pairs(&local, &remote);
+            assert_eq!(
+                pairs.iter().flatten().count(),
+                1,
+                "{peer} should pair with one of {local:?}, got {pairs:?}",
+            );
+        }
     }
 
     #[test]

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -776,7 +776,7 @@ mod tests {
         let view = unsafe { register_host_or_dmabuf_mr(&domain, &mem) }.unwrap();
         // Tie the view's lifetime to the allocation's lifetime so that the safety contract
         // above holds.
-        mem.install_mr(view.clone())
+        mem.install_mr::<MlxDevice>(view.clone())
             .expect("the region has no registration on this device yet");
         assert_eq!(view.virtual_addr, alloc.ptr());
         assert_eq!(view.size, alloc.size());
@@ -803,7 +803,7 @@ mod tests {
         let view = unsafe { register_host_or_dmabuf_mr(&domain, &mem) }.unwrap();
         // Tie the view's lifetime to the allocation's lifetime so that the safety contract
         // above holds.
-        mem.install_mr(view.clone())
+        mem.install_mr::<MlxDevice>(view.clone())
             .expect("the region has no registration on this device yet");
         assert_eq!(view.virtual_addr, alloc.ptr() + offset);
         assert_eq!(view.size, size);
@@ -826,7 +826,7 @@ mod tests {
         let view = unsafe { register_host_or_dmabuf_mr(&domain, &mem) }.unwrap();
         // Tie the view's lifetime to the allocation's lifetime so that the safety contract
         // above holds.
-        mem.install_mr(view.clone())
+        mem.install_mr::<MlxDevice>(view.clone())
             .expect("the region has no registration on this device yet");
         assert_eq!(view.virtual_addr, alloc.ptr() + offset);
         assert_eq!(view.size, size);
@@ -846,7 +846,7 @@ mod tests {
         let view = unsafe { register_host_or_dmabuf_mr(&domain, &mem) }.unwrap();
         // Tie the view's lifetime to the allocation's lifetime so that the safety contract
         // above holds.
-        mem.install_mr(view.clone())
+        mem.install_mr::<MlxDevice>(view.clone())
             .expect("the region has no registration on this device yet");
         assert_eq!(view.virtual_addr, alloc.ptr());
         assert_eq!(view.size, size);

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -576,7 +576,7 @@ async fn local_view(
         .next()
         .ok_or_else(|| anyhow::anyhow!("local buffer carries no registration"))?
         .device_name;
-    mem.registered_mr(&device)?
+    mem.registered_mr::<MlxDevice>(&device)?
         .ok_or_else(|| anyhow::anyhow!("request_buffer should have registered on {device}"))
 }
 

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -17,10 +17,7 @@
 //! - Device selection and PCI-to-RDMA device mapping
 
 use std::collections::HashMap;
-use std::collections::hash_map::DefaultHasher;
 use std::fmt::Write as _;
-use std::hash::Hash;
-use std::hash::Hasher;
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -38,6 +35,7 @@ use hyperactor::OncePortHandle;
 use hyperactor::OncePortRef;
 use hyperactor::PortHandle;
 use hyperactor::actor::Referable;
+use rand::seq::IteratorRandom;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -45,6 +43,8 @@ use typeuri::Named;
 use super::IbvOp;
 use super::device::IbvDevice;
 use super::device::IbvDeviceImpl;
+use super::device_selection::PeerDeviceAffinityPolicy;
+use super::device_selection::configured_peer_device_affinity;
 use super::device_selection::resolve_target;
 use super::device_selection::select_optimal_ibv_devices;
 use super::domain::IbvDomain;
@@ -68,7 +68,6 @@ use crate::RdmaTransportLevel;
 use crate::backend::RdmaBackend;
 use crate::backend::RdmaConfig;
 use crate::backend::ResolveRemoteBackendContext;
-use crate::device_selection::MemoryLocation;
 use crate::local_memory::KeepaliveLocalMemory;
 use crate::rdma_components::RdmaRemoteBuffer;
 use crate::rdma_manager_actor::RdmaManagerActor;
@@ -97,11 +96,13 @@ wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<EfaDevice>>);
 
 /// Local-only message: submit a batch of RDMA ops for end-to-end
 /// execution. The manager iterates the batch, resolves each op's
-/// local MR via [`IbvManagerActor::resolve_local_mr`], looks up
-/// (or spawns) the active-side [`QueuePairActor`] for the op's
-/// [`QpKey`], and immediately dispatches a one-item [`ProcessOps`]
-/// to that QP — so the QP can start posting op `i` while the
-/// manager resolves the MR for op `i+1`.
+/// local MRs via [`IbvManagerActor::resolve_local_mrs`], settles on the
+/// NIC pair to run it over with
+/// [`IbvManagerActor::pick_peer_pair`], looks up (or spawns) the
+/// active-side [`QueuePairActor`] for the op's [`QpKey`], and
+/// immediately dispatches a one-item [`ProcessOps`] to that QP — so
+/// the QP can start posting op `i` while the manager resolves the MRs
+/// for op `i+1`.
 ///
 /// Per-op completion notifications stream back on `reply` as
 /// [`OpResult`] values.
@@ -181,6 +182,11 @@ pub struct IbvManagerActor<I: IbvDeviceImpl> {
     /// which owns the per-device `Arc<IbvContext>` and the `DEFAULT_DOMAIN`
     /// `Arc<IbvDomain>`.
     devices: HashMap<String, IbvDevice<I>>,
+
+    /// Which of a peer's NICs each of this manager's NICs may pair with, from
+    /// [`RDMA_PEER_DEVICE_AFFINITY`](crate::config::RDMA_PEER_DEVICE_AFFINITY).
+    /// Read once, when the manager starts.
+    peer_device_affinity: PeerDeviceAffinityPolicy,
 
     config: IbvConfig,
 }
@@ -275,6 +281,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             qp_handles: HashMap::new(),
             peer_created_qps: HashMap::new(),
             devices: HashMap::new(),
+            peer_device_affinity: configured_peer_device_affinity()?,
             config,
         };
 
@@ -308,21 +315,56 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             .expect("device just inserted or already present"))
     }
 
-    /// Resolve `mem` to an [`IbvMemoryRegionView`] on the device this manager
-    /// would choose for it: an explicit `config.target` if set, else one of
-    /// the NICs with the best path to `mem`'s [`MemoryLocation`].
-    fn resolve_local_mr(
+    /// Chooses a set of NICs on which to register `mem`, then registers
+    /// `mem` on those NICs (caching the registrations inside the handle)
+    /// and returns the relevant [`IbvMemoryRegionView`]s. The call fails
+    /// only when there are no successful registrations.
+    ///
+    /// If an explicit `config.target` is set, then that is the NIC that is
+    /// chosen. Otherwise, NICs are chosen based on `pick_optimal_devices`.
+    ///
+    /// A region already registered on this backend keeps the NICs it has: the
+    /// set is chosen once, on the first call.
+    fn resolve_local_mrs(
         &mut self,
         mem: &KeepaliveLocalMemory,
-    ) -> Result<IbvMemoryRegionView, anyhow::Error> {
-        let device_name = match &self.config.target {
-            Some(target) => resolve_target::<I>(target)?
-                .ok_or_else(|| anyhow::anyhow!("configured device target {:?} not found", target))?
-                .name()
-                .clone(),
-            None => Self::pick_optimal_device(mem)?,
+    ) -> Result<Vec<IbvMemoryRegionView>, anyhow::Error> {
+        let already_serving = mem.registered_mrs::<I>();
+        if !already_serving.is_empty() {
+            return Ok(already_serving);
+        }
+
+        let device_names = match &self.config.target {
+            Some(target) => vec![
+                resolve_target::<I>(target)?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("configured device target {:?} not found", target)
+                    })?
+                    .name()
+                    .clone(),
+            ],
+            None => self.pick_optimal_devices(mem)?,
         };
-        self.resolve_local_mr_on(mem, &device_name)
+
+        let mut views = Vec::with_capacity(device_names.len());
+        let mut failure: Option<anyhow::Error> = None;
+        for device_name in &device_names {
+            match self.resolve_local_mr_on(mem, device_name) {
+                Ok(view) => views.push(view),
+                Err(error) => {
+                    tracing::warn!(
+                        "not serving [{:#x}, {:#x}) from {device_name}: {error:#}",
+                        mem.addr(),
+                        mem.addr() + mem.size(),
+                    );
+                    failure.get_or_insert(error);
+                }
+            }
+        }
+        if views.is_empty() {
+            return Err(failure.expect("`device_names` is never empty, so one of them failed"));
+        }
+        Ok(views)
     }
 
     /// Resolve `mem` to its [`IbvMemoryRegionView`] on `device_name`,
@@ -339,7 +381,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         mem: &KeepaliveLocalMemory,
         device_name: &str,
     ) -> Result<IbvMemoryRegionView, anyhow::Error> {
-        if let Some(mrv) = mem.registered_mr(device_name)? {
+        if let Some(mrv) = mem.registered_mr::<I>(device_name)? {
             return Ok(mrv);
         }
         tracing::debug!(
@@ -354,20 +396,22 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             .get_or_create_device_domain(device_name)
             .and_then(|domain| domain.register_mr(mem));
         match registered {
-            Ok(mrv) => mem.install_mr(mrv),
+            Ok(mrv) => mem.install_mr::<I>(mrv),
             Err(error) => {
-                mem.record_mr_failure(device_name, &error);
+                mem.record_mr_failure::<I>(device_name, &error);
                 Err(error)
             }
         }
     }
 
-    /// One of the NICs of backend `I` tied for the best path to `mem`.
-    ///
-    /// Host memory picks by hashing the region's `(addr, size)` instead of
-    /// funneling every host registration through a single device. GPU memory
-    /// just takes the first, for now.
-    fn pick_optimal_device(mem: &KeepaliveLocalMemory) -> Result<String, anyhow::Error> {
+    /// The NICs of backend `I` to serve `mem` from: up to
+    /// [`RDMA_MAX_NICS_PER_BUFFER`](crate::config::RDMA_MAX_NICS_PER_BUFFER)
+    /// of the optimal NICs returned by [`select_optimal_ibv_devices`], chosen
+    /// using [`PeerDeviceAffinityPolicy::choose`].
+    fn pick_optimal_devices(
+        &self,
+        mem: &KeepaliveLocalMemory,
+    ) -> Result<Vec<String>, anyhow::Error> {
         let location = mem.location();
         let devices = select_optimal_ibv_devices::<I>(location)?;
         anyhow::ensure!(
@@ -375,15 +419,48 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             "no {} RDMA device has a path to {location:?}",
             I::backend_name(),
         );
-        let index = match location {
-            MemoryLocation::Cpu(_) => {
-                let mut hasher = DefaultHasher::new();
-                (mem.addr(), mem.size()).hash(&mut hasher);
-                (hasher.finish() % devices.len() as u64) as usize
-            }
-            MemoryLocation::Gpu(_) => 0,
-        };
-        Ok(devices[index].name().clone())
+        let names: Vec<String> = devices.iter().map(|device| device.name().clone()).collect();
+        let max = hyperactor_config::global::get(crate::config::RDMA_MAX_NICS_PER_BUFFER);
+        // `names` is passed in the order returned by `select_optimal_ibv_devices`, which is
+        // lexicographic. `PeerDeviceAffinityPolicy::choose` is sensitive to input order,
+        // so ensuring `names` has the same order across procs is important for consistency.
+        Ok(self
+            .peer_device_affinity
+            .choose(&names, max.map(hyperactor_config::NonZeroUsize::into_std)))
+    }
+
+    /// Given a list of local registrations and remote registrations, uses
+    /// [`Self::peer_device_affinity`] to decide on one local/remote pair
+    /// to use. Errors when the policy gives no valid pair.
+    fn pick_peer_pair<'a>(
+        &self,
+        local: &'a [IbvMemoryRegionView],
+        remote: &'a [IbvRemoteMemoryRegionView],
+    ) -> Result<(&'a IbvMemoryRegionView, &'a IbvRemoteMemoryRegionView), anyhow::Error> {
+        // Sort both sides by device name because `PeerDeviceAffinityPolicy::pairs` is
+        // sensitive to input order. This ensures that `pick_peer_pair`'s behavior is
+        // dependent only on the unordered set of local and remote devices, and it is
+        // therefore consistent across processes.
+        let mut local: Vec<&IbvMemoryRegionView> = local.iter().collect();
+        local.sort_by(|a, b| a.device_name.cmp(&b.device_name));
+        let mut remote: Vec<&IbvRemoteMemoryRegionView> = remote.iter().collect();
+        remote.sort_by(|a, b| a.device_name.cmp(&b.device_name));
+
+        let local_names: Vec<String> = local.iter().map(|mr| mr.device_name.clone()).collect();
+        let remote_names: Vec<String> = remote.iter().map(|mr| mr.device_name.clone()).collect();
+        self.peer_device_affinity
+            .pairs(&local_names, &remote_names)
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, peer)| peer.map(|j| (local[i], remote[j])))
+            .choose(&mut rand::rng())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no NIC of {local_names:?} pairs with a peer NIC of {remote_names:?} under \
+                     {:?}",
+                    self.peer_device_affinity,
+                )
+            })
     }
 
     /// Build a passive-side mirror QP for `qp_key`, connect it to
@@ -459,24 +536,25 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
         let SubmitOps { ops, reply } = msg;
 
         // Interleave MR resolution with QP dispatch: as soon as op `i`'s
-        // local MR is resolved and its QP actor is in place, ship a
+        // local MRs are resolved and its QP actor is in place, ship a
         // one-item `ProcessOps` to that QP. The QP can then post and
-        // poll op `i` while we run `resolve_local_mr` for op `i+1`.
+        // poll op `i` while we run `resolve_local_mrs` for op `i+1`.
         for (i, op) in ops.into_iter().enumerate() {
-            // One pair per op for now: the peer's first registration against
-            // whichever NIC this side resolves the local MR on.
-            let Some(remote) = op.remote_buffers.first().cloned() else {
-                reply.try_post(
-                    cx,
-                    OpResult {
-                        op_idx: i,
-                        result: Err("the remote buffer carries no ibverbs registration".to_owned()),
-                    },
-                )?;
-                continue;
+            let local_mrs = match self.resolve_local_mrs(&op.local_memory) {
+                Ok(mrs) => mrs,
+                Err(e) => {
+                    reply.try_post(
+                        cx,
+                        OpResult {
+                            op_idx: i,
+                            result: Err(e.to_string()),
+                        },
+                    )?;
+                    continue;
+                }
             };
-            let self_device = match self.resolve_local_mr(&op.local_memory) {
-                Ok(mrv) => mrv.device_name.clone(),
+            let (local, remote) = match self.pick_peer_pair(&local_mrs, &op.remote_buffers) {
+                Ok((local, remote)) => (local.clone(), remote.clone()),
                 Err(e) => {
                     reply.try_post(
                         cx,
@@ -489,7 +567,7 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
                 }
             };
             let qp_key = QpKey {
-                self_device,
+                self_device: local.device_name.clone(),
                 other_id: op.remote_manager.actor_addr().id().clone(),
                 other_device: remote.device_name.clone(),
             };
@@ -513,6 +591,7 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
                         op_idx: i,
                         op_type: op.op_type,
                         local_memory: op.local_memory,
+                        local,
                         remote,
                     }],
                     reply: reply.clone(),
@@ -577,8 +656,8 @@ impl<I: IbvDeviceImpl> IbvManagerLocalMessageHandler for IbvManagerActor<I> {
         // of this handle — including the one the caller holds — reuses it rather
         // than registering the same region on that device again.
         Ok(self
-            .resolve_local_mr(&local)
-            .map(|mrv| vec![IbvRemoteMemoryRegionView::from(&mrv)])
+            .resolve_local_mrs(&local)
+            .map(|mrs| mrs.iter().map(IbvRemoteMemoryRegionView::from).collect())
             .map_err(|error| format!("{error:#}")))
     }
 }
@@ -620,9 +699,6 @@ impl<I: IbvDeviceImpl> std::ops::Deref for IbvBackend<I> {
 /// Serializable per-buffer context for an ibverbs backend: the manager to route
 /// ops through and the wire description of every MR the buffer is registered
 /// under, one per NIC serving it.
-///
-/// The order is [`select_optimal_ibv_devices`]'s, so an initiator that takes,
-/// say, the first entry picks the same NIC the owner would have named first.
 #[derive(Serialize, Deserialize, Named)]
 #[serde(bound = "")]
 pub struct IbvRemoteBackendContext<I: IbvDeviceImpl> {
@@ -722,8 +798,8 @@ where
     /// Translates each op to an `IbvOp`, then ships the whole batch to
     /// [`IbvManagerActor`] via [`SubmitOps`]. The manager interleaves
     /// local-MR resolution with per-op dispatch: each op is sent to its
-    /// [`QueuePairActor`] as a one-item [`ProcessOps`] the moment its MR
-    /// is ready, so QP work on op `i` overlaps MR registration for op
+    /// [`QueuePairActor`] as a one-item [`ProcessOps`] the moment its MRs
+    /// are ready, so QP work on op `i` overlaps MR registration for op
     /// `i+1`.
     ///
     /// Always waits for exactly `ops.len()` per-op replies before
@@ -824,6 +900,7 @@ mod tests {
     //! allocations when the actor stops; [`TestEnv::shutdown`]
     //! explicitly drains both procs.
 
+    use std::collections::BTreeSet;
     use std::sync::Arc;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
@@ -861,8 +938,10 @@ mod tests {
     use crate::backend::ibverbs::device::list_all_devices;
     use crate::backend::ibverbs::device_selection::IbvDeviceTarget;
     use crate::backend::ibverbs::device_selection::resolve_target;
+    use crate::backend::ibverbs::device_selection::select_optimal_ibv_devices;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvQpType;
+    use crate::device_selection::MemoryLocation;
     use crate::local_memory::KeepaliveLocalMemory;
 
     // ====================================================================
@@ -1350,7 +1429,7 @@ mod tests {
 
     /// `register_remote_buffer` must record its registration on the
     /// `KeepaliveLocalMemory` it is handed — under the name of the device it
-    /// registered on — so that later `resolve_local_mr` calls for that device
+    /// registered on — so that later `resolve_local_mrs` calls for that device
     /// reuse it instead of registering the same region again.
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_register_remote_buffer_records_its_registration() -> Result<(), anyhow::Error> {
@@ -1364,15 +1443,102 @@ mod tests {
         let buf: Box<[u8]> = vec![0u8; 1024].into_boxed_slice();
         let local = KeepaliveLocalMemory::try_new(Arc::new(buf))?;
         assert!(
-            local.registered_mr(&device)?.is_none(),
+            local.registered_mr::<MlxDevice>(&device)?.is_none(),
             "the region should have no registration before it is registered",
         );
         RdmaManagerActor::local_handle(&env.client)
             .request_buffer(&env.client, local.clone())
             .await?;
         assert!(
-            local.registered_mr(&device)?.is_some(),
+            local.registered_mr::<MlxDevice>(&device)?.is_some(),
             "registration should be recorded under the pinned device {device}",
+        );
+        env.shutdown().await
+    }
+
+    /// With `rdma_max_nics_per_buffer` above 1, a buffer is registered on that
+    /// many of its tied-for-best NICs. Under the `match_name` policy, a remote
+    /// buffer must always be registered on the first N devices returned by
+    /// `select_optimal_ibv_devices` -- otherwise, a mismatch could make a transfer
+    /// impossible.
+    #[timed_test::async_timed_test(timeout_secs = 120)]
+    async fn test_match_name_nic_selection() -> Result<(), anyhow::Error> {
+        require_rdma();
+        const MAX_NICS: usize = 4;
+        let lock = hyperactor_config::global::lock();
+        let _max_guard = lock.override_key(
+            crate::config::RDMA_MAX_NICS_PER_BUFFER,
+            Some(hyperactor_config::NonZeroUsize::new(MAX_NICS).expect("MAX_NICS is 4")),
+        );
+        let _policy_guard = lock.override_key(
+            crate::config::RDMA_PEER_DEVICE_AFFINITY,
+            "match_name".to_string(),
+        );
+        let expected: BTreeSet<String> =
+            select_optimal_ibv_devices::<MlxDevice>(MemoryLocation::Cpu(None))?
+                .iter()
+                .take(MAX_NICS)
+                .map(|nic| nic.name().clone())
+                .collect();
+
+        let env = TestEnv::same_config(IbvConfig::default()).await?;
+        let buffer = env
+            .helper_a
+            .allocate(&env.client, 32, BufferDevice::Cpu, 0)
+            .await?;
+        let served_by: BTreeSet<String> = buffer
+            .resolve_mlx()
+            .expect("the buffer is registered on a Mellanox NIC")
+            .buffers
+            .iter()
+            .map(|mr| mr.device_name.clone())
+            .collect();
+        assert_eq!(served_by, expected);
+
+        for pattern in 0..2 * MAX_NICS as u8 {
+            run_cross_actor_write(&env, BufferDevice::Cpu, BufferDevice::Cpu, 32, pattern, 5)
+                .await?;
+        }
+        env.shutdown().await
+    }
+
+    /// Under `any` a buffer starts at a NIC drawn at random, so at one NIC per
+    /// buffer the buffers spread over the tied NICs instead of all landing on
+    /// the first.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_any_nic_selection() -> Result<(), anyhow::Error> {
+        require_rdma();
+        let lock = hyperactor_config::global::lock();
+        let _max_guard = lock.override_key(
+            crate::config::RDMA_MAX_NICS_PER_BUFFER,
+            Some(hyperactor_config::NonZeroUsize::MIN),
+        );
+        let _policy_guard =
+            lock.override_key(crate::config::RDMA_PEER_DEVICE_AFFINITY, "any".to_string());
+        let tied = select_optimal_ibv_devices::<MlxDevice>(MemoryLocation::Cpu(None))?.len();
+
+        let env = TestEnv::same_config(IbvConfig::default()).await?;
+        let mut served_by: BTreeSet<String> = BTreeSet::new();
+        for _ in 0..16 {
+            let buffer = env
+                .helper_a
+                .allocate(&env.client, 32, BufferDevice::Cpu, 0)
+                .await?;
+            let registrations = buffer
+                .resolve_mlx()
+                .expect("the buffer is registered on a Mellanox NIC")
+                .buffers;
+            let [mr] = registrations.as_slice() else {
+                panic!("one NIC serves a buffer here, got {registrations:?}");
+            };
+            served_by.insert(mr.device_name.clone());
+        }
+        // Sixteen buffers all drawing the same one of several NICs would be a
+        // one-in-billions coincidence.
+        assert_eq!(
+            served_by.len() > 1,
+            tied > 1,
+            "{tied} NICs tie for host memory, but the buffers landed on {served_by:?}",
         );
         env.shutdown().await
     }

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -267,8 +267,7 @@ pub fn resolve_qp_type(qp_type: IbvQpType) -> u32 {
 pub struct IbvConfig {
     /// `target` - An explicit RDMA device target, resolved to a concrete
     /// device via [`resolve_target`]. When `None`, the consumer picks the
-    /// device itself (the co-located NIC for GPU memory, or a hash-assigned
-    /// NIC for host memory).
+    /// devices itself.
     pub target: Option<IbvDeviceTarget>,
     /// `port_num` - The physical port number on the device.
     pub port_num: u8,

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -853,6 +853,8 @@ pub(super) struct QueuePairOp {
     pub(super) op_idx: usize,
     pub(super) op_type: RdmaOpType,
     pub(super) local_memory: KeepaliveLocalMemory,
+    /// `local_memory`'s registration on this queue pair's own device.
+    pub(super) local: IbvMemoryRegionView,
     pub(super) remote: IbvRemoteMemoryRegionView,
 }
 
@@ -887,13 +889,15 @@ struct PendingOp {
 struct PostedOpEntry {
     op_idx: usize,
     pending_wrs: HashSet<u64>,
-    /// Kept alive so both the memory and its registration outlive every
-    /// in-flight WR touching it.
+    /// Kept alive so the memory outlives every in-flight WR touching it.
     _local_memory: KeepaliveLocalMemory,
+    /// Kept alive so the memory *registration* outlives every in-flight
+    /// WR touching it.
+    _local_mrv: IbvMemoryRegionView,
     reply: PortHandle<OpResult>,
     /// First per-WR error observed for this op. The op's final reply is
-    /// held back until `pending_wrs.is_empty()`, so `_local_memory` outlives
-    /// every WR still in flight.
+    /// held back until `pending_wrs.is_empty()`, so the two fields above
+    /// outlive every WR still in flight.
     first_error: Option<String>,
 }
 
@@ -1031,36 +1035,8 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
             return Ok(false);
         }
 
-        // 3. Resolve the local side. A QP is bound to one device on each side,
-        //    so the only registration it can address is the one on
-        //    `self_device`: an `lkey` from any other protection domain means
-        //    nothing here.
-        let local = match op.local_memory.registered_mr(&self.qp_key.self_device) {
-            Ok(Some(view)) => view,
-            other => {
-                let err = match other {
-                    Ok(None) => format!(
-                        "local memory is not registered on this QP's device [op_idx={}, qp_key={:?}, local: {:?}]",
-                        op_idx, self.qp_key, op.local_memory,
-                    ),
-                    Err(error) => format!(
-                        "local memory cannot be registered on this QP's device [op_idx={}, qp_key={:?}]: {error:#}",
-                        op_idx, self.qp_key,
-                    ),
-                    Ok(Some(_)) => unreachable!("matched by the arm above"),
-                };
-                reply.try_post(
-                    cx,
-                    OpResult {
-                        op_idx,
-                        result: Err(err),
-                    },
-                )?;
-                return Ok(true);
-            }
-        };
-
-        // 4. Post.
+        // 3. Post.
+        let local = op.local;
         let post_result = match op.op_type {
             RdmaOpType::WriteFromLocal => self.qp.put(op.remote.clone(), local.clone()),
             RdmaOpType::ReadIntoLocal => self.qp.get(local.clone(), op.remote.clone()),
@@ -1080,7 +1056,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
             )
         })?;
 
-        // 5. Track in-flight state.
+        // 4. Track in-flight state.
         let op_id = self.next_op_id;
         self.next_op_id += 1;
         let mut pending_wrs = HashSet::with_capacity(wr_ids.len());
@@ -1095,6 +1071,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 op_idx,
                 pending_wrs,
                 _local_memory: op.local_memory,
+                _local_mrv: local,
                 reply,
                 first_error: None,
             },
@@ -1315,6 +1292,7 @@ mod tests {
     use hyperactor::Handler;
     use hyperactor::proc::Proc;
 
+    use super::super::memory_region::IbvMemoryRegionKeepalive;
     use super::*;
     use crate::backend::ibverbs::device::IbvDevice;
     use crate::backend::ibverbs::device::list_all_devices;
@@ -1992,20 +1970,10 @@ mod tests {
         }
     }
 
-    /// Local memory already registered on [`SELF_DEVICE`], which is what the QP
-    /// resolves to post an op.
+    /// The allocation an op's [`QueuePairOp::local`] view describes.
     fn fake_local_memory(addr: usize, size: usize) -> KeepaliveLocalMemory {
-        registered(
-            KeepaliveLocalMemory::try_new(Arc::new(FakeKeepalive { addr, size }))
-                .expect("a fake host address has a location"),
-        )
-    }
-
-    /// Install a [`SELF_DEVICE`] registration over the whole of `mem`.
-    fn registered(mem: KeepaliveLocalMemory) -> KeepaliveLocalMemory {
-        mem.install_mr(fake_mrv(mem.addr(), mem.size()))
-            .expect("a fresh handle carries no registration");
-        mem
+        KeepaliveLocalMemory::try_new(Arc::new(FakeKeepalive { addr, size }))
+            .expect("a fake host address has a location")
     }
 
     /// [`Keepalive`] that sets `dropped` when it goes away, so a test can
@@ -2042,8 +2010,7 @@ mod tests {
         )
     }
 
-    /// Devices of the QP `spawn_ready_actor` builds. The local memory of an op
-    /// must be registered on `SELF_DEVICE` for the QP to post it.
+    /// Devices of the QP `spawn_ready_actor` builds.
     const SELF_DEVICE: &str = "mlx5_0";
     const PEER_DEVICE: &str = "mlx5_0";
 
@@ -2052,12 +2019,48 @@ mod tests {
             op_idx,
             op_type,
             local_memory: fake_local_memory(addr, size),
+            local: fake_mrv(addr, size),
             remote: IbvRemoteMemoryRegionView {
                 rkey: 0,
                 addr: 0x4000_0000,
                 size,
                 device_name: PEER_DEVICE.to_string(),
             },
+        }
+    }
+
+    /// MR keepalive that sets `dropped` when it goes away, so a test can tell
+    /// whether anything still holds the registration open.
+    #[derive(Debug)]
+    struct DropFlagMr {
+        dropped: Arc<AtomicBool>,
+    }
+    impl IbvMemoryRegionKeepalive for DropFlagMr {}
+    impl Drop for DropFlagMr {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// Like [`make_op`], but the registration reports when it drops.
+    fn make_op_watching_mr_drop(
+        op_idx: usize,
+        op_type: RdmaOpType,
+        addr: usize,
+        size: usize,
+        dropped: Arc<AtomicBool>,
+    ) -> QueuePairOp {
+        QueuePairOp {
+            local: IbvMemoryRegionView::new(
+                addr,
+                addr,
+                size,
+                0x1234,
+                0x5678,
+                SELF_DEVICE.to_string(),
+                Arc::new(DropFlagMr { dropped }),
+            ),
+            ..make_op(op_idx, op_type, addr, size)
         }
     }
 
@@ -2070,14 +2073,12 @@ mod tests {
         dropped: Arc<AtomicBool>,
     ) -> QueuePairOp {
         QueuePairOp {
-            local_memory: registered(
-                KeepaliveLocalMemory::try_new(Arc::new(DropFlagKeepalive {
-                    addr,
-                    size,
-                    dropped,
-                }))
-                .expect("a fake host address has a location"),
-            ),
+            local_memory: KeepaliveLocalMemory::try_new(Arc::new(DropFlagKeepalive {
+                addr,
+                size,
+                dropped,
+            }))
+            .expect("a fake host address has a location"),
             ..make_op(op_idx, op_type, addr, size)
         }
     }
@@ -2243,41 +2244,6 @@ mod tests {
         Ok(())
     }
 
-    /// The QP addresses local memory through its registration on `self_device`,
-    /// which the manager makes before dispatching. An op whose memory carries no
-    /// such registration fails on its own, and nothing is posted.
-    #[timed_test::async_timed_test(timeout_secs = 60)]
-    async fn qpa_rejects_op_not_registered_on_its_device() -> Result<()> {
-        let harness = QpaHarness::build()?;
-        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
-
-        let items = vec![QueuePairOp {
-            local_memory: KeepaliveLocalMemory::try_new(Arc::new(FakeKeepalive {
-                addr: 0x1000,
-                size: 4096,
-            }))
-            .expect("a fake host address has a location"),
-            ..make_op(3, RdmaOpType::WriteFromLocal, 0x1000, 4096)
-        }];
-        let mut rx = submit_ops(&harness, &actor, items)?;
-
-        let replies = collect_replies(&mut rx, 1).await;
-        let [(op_idx, result)] = replies.as_slice() else {
-            panic!("expected exactly one reply, got {replies:?}");
-        };
-        assert_eq!(*op_idx, 3);
-        let error = result
-            .as_ref()
-            .expect_err("unregistered local memory cannot be posted");
-        assert!(
-            error.contains("not registered on this QP's device"),
-            "the error should name the missing registration: {error}",
-        );
-        assert_no_post(&mut posted_rx, Duration::from_millis(200)).await;
-        harness.teardown().await;
-        Ok(())
-    }
-
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn qpa_posted_op_pins_local_memory() -> Result<()> {
         let harness = QpaHarness::build()?;
@@ -2315,6 +2281,44 @@ mod tests {
         await_dropped(&dropped).await;
 
         // Retire op 1 too, so no op is left in flight at teardown.
+        qp.queue_completion(other_wr_ids[0]);
+        assert_eq!(
+            collect_replies(&mut rx, 2).await,
+            vec![(0, Ok(())), (1, Ok(()))]
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_posted_op_pins_local_registration() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
+
+        // As above, op 1 only proves op 0 has left `try_post_head`.
+        let dropped = Arc::new(AtomicBool::new(false));
+        let items = vec![
+            make_op_watching_mr_drop(
+                0,
+                RdmaOpType::WriteFromLocal,
+                0x1000,
+                4096,
+                Arc::clone(&dropped),
+            ),
+            make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
+        ];
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        let (_, _, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
+        let (_, _, other_wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
+        assert!(
+            !dropped.load(Ordering::SeqCst),
+            "the registration must stay alive while a WR that touches it is in flight"
+        );
+
+        qp.queue_completion(wr_ids[0]);
+        await_dropped(&dropped).await;
+
         qp.queue_completion(other_wr_ids[0]);
         assert_eq!(
             collect_replies(&mut rx, 2).await,

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -107,6 +107,36 @@ declare_attrs! {
     ))
     pub attr RDMA_PEER_DEVICE_AFFINITY: String = String::new();
 
+    /// How many NICs a buffer is registered on, at most. `None`, which an
+    /// empty environment value parses to, sets no limit: every equally good
+    /// NIC serves the buffer.
+    ///
+    /// Depending on where in memory a buffer lives, there may be many
+    /// NICs that would be equally good for serving it. Registering the
+    /// buffer on each NIC improves flexibility and provides performance
+    /// optimization opportunities, but comes at the cost of an expensive
+    /// memory registration per NIC. This config attribute lets the user
+    /// tune this tradeoff.
+    ///
+    /// When multiple optimal NICs are available for a buffer, selecting
+    /// among them depends on [`RDMA_PEER_DEVICE_AFFINITY`]:
+    /// - `any`: first chosen at random, then the rest are taken
+    ///    lexicographically starting from the first.
+    /// - `match_name`: taken lexicographically.
+    /// - `groups`: round robin across groups, taken lexicographically
+    ///    within each group (so `groups:nic0,nic1|nic2,nic3`
+    ///    with `RDMA_MAX_NICS_PER_BUFFER = 2` would choose
+    ///    `nic0` and `nic2`).
+    ///
+    /// A manager pinned to one device by [`RDMA_IBVERBS_TARGET`] registers
+    /// there and ignores this.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_MAX_NICS_PER_BUFFER".to_string()),
+        Some("rdma_max_nics_per_buffer".to_string()),
+    ))
+    pub attr RDMA_MAX_NICS_PER_BUFFER: Option<NonZeroUsize> =
+        Some(NonZeroUsize::new(1).expect("1 is non-zero"));
+
     /// How many queue pairs share one completion queue.
     ///
     /// Sharing is what lets one poller reap for several queue pairs. Each

--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -11,14 +11,16 @@
 //! [`KeepaliveLocalMemory`] wraps a raw pointer with a [`Keepalive`]
 //! guard and dispatches reads/writes to CPU or CUDA paths.
 
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex;
 
 use dashmap::DashMap;
-use dashmap::mapref::entry::Entry;
 
+use crate::backend::ibverbs::device::IbvDeviceImpl;
 use crate::backend::ibverbs::memory_region::IbvMemoryRegionView;
 use crate::device_selection::MemoryLocation;
 
@@ -397,12 +399,11 @@ pub(crate) struct LocalMemoryInner {
     /// Bandwidth (bytes/s) for direct device-thread pointer access, or
     /// `None` if the memory is not device-accessible.
     direct_access_device_bandwidth: Option<u64>,
-    /// The registrations this handle has made, keyed by RDMA device name.
-    /// Populated lazily by `IbvManagerActor::resolve_local_mr` as devices are
-    /// needed. Keying by device is what makes the entries substitutable for
-    /// one another: an `lkey`/`rkey` pair is only meaningful to the device
-    /// whose protection domain issued it.
-    mrs: Arc<DashMap<String, MrEntry>>,
+    /// The registrations this handle has made, keyed by the backend that made
+    /// them ([`IbvDeviceImpl::typename`]) and then by RDMA device name.
+    /// Populated lazily by `IbvManagerActor::resolve_local_mrs` as devices are
+    /// needed.
+    mrs: Arc<DashMap<&'static str, HashMap<String, MrEntry>>>,
     /// Coordinates concurrent reads, exclusive writes, and parallel
     /// disjoint writes against this region.
     access: Arc<AccessLock>,
@@ -519,7 +520,8 @@ impl KeepaliveLocalMemory {
         self.inner.location
     }
 
-    /// This handle's registration of the region on `device`, if it has one.
+    /// This handle's registration of the region on backend `I`'s `device`, if
+    /// it has one.
     ///
     /// `Err` means a previous attempt to register on `device` failed and
     /// carries that error; the caller should not retry. `Ok(None)` means this
@@ -529,12 +531,17 @@ impl KeepaliveLocalMemory {
     /// with any [`WeakLocalMemory`] downgraded from it, so one clone's
     /// registration is visible to all of them. Handles built separately over
     /// the same region share nothing.
-    pub fn registered_mr(
+    pub fn registered_mr<I: IbvDeviceImpl>(
         &self,
         device: &str,
     ) -> Result<Option<IbvMemoryRegionView>, anyhow::Error> {
-        match self.inner.mrs.get(device).as_deref() {
-            Some(MrEntry::Registered(view)) => Ok(Some(view.clone())),
+        match self
+            .inner
+            .mrs
+            .get(I::typename())
+            .and_then(|backend| backend.get(device).cloned())
+        {
+            Some(MrEntry::Registered(view)) => Ok(Some(view)),
             Some(MrEntry::Failed(error)) => anyhow::bail!(
                 "registering [{:#x}, {:#x}) on {device} failed earlier: {error}",
                 self.inner.addr,
@@ -544,8 +551,25 @@ impl KeepaliveLocalMemory {
         }
     }
 
-    /// Record `view` as this handle's registration on `view.device_name` and
-    /// return the registration now in force there.
+    /// Every registration this handle has on a device of backend `I`.
+    pub fn registered_mrs<I: IbvDeviceImpl>(&self) -> Vec<IbvMemoryRegionView> {
+        self.inner
+            .mrs
+            .get(I::typename())
+            .map(|backend| {
+                backend
+                    .values()
+                    .filter_map(|entry| match entry {
+                        MrEntry::Registered(view) => Some(view.clone()),
+                        MrEntry::Failed(_) => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Record `view` as this handle's registration on backend `I`'s
+    /// `view.device_name` and return the registration now in force there.
     ///
     /// Idempotent: a registration already present wins, and `view` is dropped
     /// (deregistering it, since nothing else holds it).
@@ -556,11 +580,12 @@ impl KeepaliveLocalMemory {
     /// The recorded failure stands and `view` is dropped, so the region keeps
     /// answering with the failure rather than flip-flopping on who got there
     /// last.
-    pub fn install_mr(
+    pub fn install_mr<I: IbvDeviceImpl>(
         &self,
         view: IbvMemoryRegionView,
     ) -> Result<IbvMemoryRegionView, anyhow::Error> {
-        match self.inner.mrs.entry(view.device_name.clone()) {
+        let mut backend = self.inner.mrs.entry(I::typename()).or_default();
+        match backend.entry(view.device_name.clone()) {
             Entry::Vacant(vacant) => {
                 vacant.insert(MrEntry::Registered(view.clone()));
                 Ok(view)
@@ -577,13 +602,15 @@ impl KeepaliveLocalMemory {
         }
     }
 
-    /// Record that registering this region on `device` failed, so later
-    /// transfers see the failure instead of retrying it. A registration
+    /// Record that registering this region on backend `I`'s `device` failed, so
+    /// later transfers see the failure instead of retrying it. A registration
     /// already in force on `device` wins: one caller's failure does not
     /// invalidate another's working keys.
-    pub fn record_mr_failure(&self, device: &str, error: &anyhow::Error) {
+    pub fn record_mr_failure<I: IbvDeviceImpl>(&self, device: &str, error: &anyhow::Error) {
         self.inner
             .mrs
+            .entry(I::typename())
+            .or_default()
             .entry(device.to_string())
             .or_insert_with(|| MrEntry::Failed(format!("{error:#}")));
     }
@@ -756,6 +783,7 @@ impl WeakLocalMemory {
 mod tests {
     use super::*;
     use crate::backend::cuda_test_utils::CudaAllocator;
+    use crate::backend::ibverbs::mlx_device::MlxDevice;
 
     // -- KeepaliveLocalMemory (host) --
 
@@ -787,38 +815,41 @@ mod tests {
     fn registrations_are_independent_per_device() {
         let mem = host_keepalive_mem(vec![0; 8].into_boxed_slice());
         let first = mem
-            .install_mr(IbvMemoryRegionView::for_test("mlx5_0", 10))
+            .install_mr::<MlxDevice>(IbvMemoryRegionView::for_test("mlx5_0", 10))
             .unwrap();
         assert_eq!(first.device_name, "mlx5_0");
-        mem.install_mr(IbvMemoryRegionView::for_test("mlx5_1", 20))
+        mem.install_mr::<MlxDevice>(IbvMemoryRegionView::for_test("mlx5_1", 20))
             .unwrap();
 
         // Each device answers with its own registration; keys issued by one
         // device's protection domain mean nothing to another.
         for (device, key) in [("mlx5_0", 10), ("mlx5_1", 20)] {
-            let view = mem.registered_mr(device).unwrap().unwrap();
+            let view = mem.registered_mr::<MlxDevice>(device).unwrap().unwrap();
             assert_eq!(view.device_name, device);
             assert_eq!(
                 view.lkey, key,
                 "{device} answered with another device's key"
             );
         }
-        assert!(mem.registered_mr("mlx5_2").unwrap().is_none());
+        assert!(mem.registered_mr::<MlxDevice>("mlx5_2").unwrap().is_none());
     }
 
     #[test]
     fn install_mr_keeps_the_registration_already_in_force() {
         let mem = host_keepalive_mem(vec![0; 8].into_boxed_slice());
-        mem.install_mr(IbvMemoryRegionView::for_test("mlx5_0", 10))
+        mem.install_mr::<MlxDevice>(IbvMemoryRegionView::for_test("mlx5_0", 10))
             .unwrap();
         // A second registration of the same region on the same device loses:
         // holders of the first view keep addressing through it.
         let second = mem
-            .install_mr(IbvMemoryRegionView::for_test("mlx5_0", 20))
+            .install_mr::<MlxDevice>(IbvMemoryRegionView::for_test("mlx5_0", 20))
             .unwrap();
         assert_eq!(second.lkey, 10, "the loser's key must not be handed back");
         assert_eq!(
-            mem.registered_mr("mlx5_0").unwrap().unwrap().lkey,
+            mem.registered_mr::<MlxDevice>("mlx5_0")
+                .unwrap()
+                .unwrap()
+                .lkey,
             10,
             "nor recorded for later resolutions",
         );
@@ -827,12 +858,12 @@ mod tests {
     #[test]
     fn install_mr_leaves_a_recorded_failure_standing() {
         let mem = host_keepalive_mem(vec![0; 8].into_boxed_slice());
-        mem.record_mr_failure("mlx5_0", &anyhow::anyhow!("out of memory keys"));
+        mem.record_mr_failure::<MlxDevice>("mlx5_0", &anyhow::anyhow!("out of memory keys"));
         // Reached when two callers register the same region on the same device
         // at once and only one of them fails.
         let error = format!(
             "{:#}",
-            mem.install_mr(IbvMemoryRegionView::for_test("mlx5_0", 10))
+            mem.install_mr::<MlxDevice>(IbvMemoryRegionView::for_test("mlx5_0", 10))
                 .expect_err("installing over a recorded failure should fail")
         );
         assert!(
@@ -840,7 +871,7 @@ mod tests {
             "the error should carry the recorded failure: {error}",
         );
         assert!(
-            mem.registered_mr("mlx5_0").is_err(),
+            mem.registered_mr::<MlxDevice>("mlx5_0").is_err(),
             "the recorded failure should still be what the device answers with",
         );
     }
@@ -848,10 +879,10 @@ mod tests {
     #[test]
     fn a_recorded_failure_is_reported_rather_than_retried() {
         let mem = host_keepalive_mem(vec![0; 8].into_boxed_slice());
-        mem.record_mr_failure("mlx5_0", &anyhow::anyhow!("out of memory keys"));
+        mem.record_mr_failure::<MlxDevice>("mlx5_0", &anyhow::anyhow!("out of memory keys"));
         let error = format!(
             "{:#}",
-            mem.registered_mr("mlx5_0")
+            mem.registered_mr::<MlxDevice>("mlx5_0")
                 .expect_err("a recorded failure should surface")
         );
         assert!(
@@ -859,7 +890,7 @@ mod tests {
             "the error should carry the original failure: {error}",
         );
         // Other devices are unaffected by one device's failure.
-        assert!(mem.registered_mr("mlx5_1").unwrap().is_none());
+        assert!(mem.registered_mr::<MlxDevice>("mlx5_1").unwrap().is_none());
     }
 
     #[test]

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -11,7 +11,7 @@ Type hints for the monarch_hyperactor.config Rust bindings.
 """
 
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 
@@ -84,6 +84,7 @@ def configure(
     rdma_max_chunk_size_mb: int = ...,
     rdma_ibverbs_target: str = ...,
     rdma_peer_device_affinity: str = ...,
+    rdma_max_nics_per_buffer: Optional[int] = ...,
     **kwargs: object,
 ) -> None:
     """Configure Hyperactor runtime defaults for this process.
@@ -193,6 +194,8 @@ def configure(
             "groups:mlx5_0,mlx5_1|mlx5_2,mlx5_3|mlx5_4". Groups must be
             disjoint. Empty, the default, means "any". Value syntax is
             validated when the RDMA manager starts.
+        rdma_max_nics_per_buffer: How many NICs a buffer is registered
+            on, at most (default: 1); None sets no limit.
         **kwargs: Reserved for future configuration keys
 
     For historical reasons, this API is named ``configure(...)``;

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -88,6 +88,7 @@ if TYPE_CHECKING:
             rdma_max_chunk_size_mb: NotRequired[int]
             rdma_ibverbs_target: NotRequired[str]
             rdma_peer_device_affinity: NotRequired[str]
+            rdma_max_nics_per_buffer: NotRequired[int | None]
             rdma_runtime_worker_threads: NotRequired[int]
 
         # pyrefly: ignore [invalid-annotation]
@@ -198,6 +199,8 @@ def configure(**kwargs: "ConfigureKwargsType") -> None:
                 ``"groups:mlx5_0,mlx5_1|mlx5_2,mlx5_3|mlx5_4"``. Groups must be
                 disjoint. Empty, the default, means ``"any"``. Value syntax is
                 validated when the RDMA manager starts.
+            rdma_max_nics_per_buffer: How many NICs a buffer is registered on,
+                at most (default 1); ``None`` sets no limit.
             rdma_runtime_worker_threads: Worker threads for the shared RDMA
                 data-plane runtime, which every queue pair's poll loop runs on.
                 Latched at the first RDMA use in a process; setting it later

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -120,6 +120,25 @@ def test_rdma_peer_device_affinity_round_trip() -> None:
     assert get_global_config()["rdma_peer_device_affinity"] == ""
 
 
+def test_rdma_max_nics_per_buffer_round_trip() -> None:
+    assert get_global_config()["rdma_max_nics_per_buffer"] == 1
+
+    with configured(rdma_max_nics_per_buffer=4) as config:
+        assert config["rdma_max_nics_per_buffer"] == 4
+
+    # None means no limit: every equally good NIC serves the buffer.
+    with configured(rdma_max_nics_per_buffer=None) as config:
+        assert config["rdma_max_nics_per_buffer"] is None
+
+    assert get_global_config()["rdma_max_nics_per_buffer"] == 1
+
+    # The attribute is non-zero, so zero is rejected rather than silently
+    # meaning "no NIC".
+    with pytest.raises(ValueError):
+        with configured(rdma_max_nics_per_buffer=0):
+            pass
+
+
 def test_rdma_runtime_worker_threads_round_trip() -> None:
     assert get_global_config()["rdma_runtime_worker_threads"] == 16
 


### PR DESCRIPTION
Summary:
Carry multiple NIC registrations per buffer, capped by the new configuration value `rdma_max_nics_per_buffer` (default 1, with None -> no limit). The set of devices each buffer is registered on is determined by the user-configurable `PeerDeviceAffinityPolicy`. Specifically, `PeerDeviceAffinityPolicy::choose` takes a list of candidate devices *just for the local buffer* and returns at most `rdma_max_nics_per_buffer` contingent on the value of the policy. See the method's doc comment for a more detailed explanation of the selection strategy.

When an rdma op is submitted, the manager actor looks at the local buffer's NICs and the remote buffer's NICs, then uses `PeerDeviceAffinityPolicy::pairs` to match each local NIC with one compatible remote NIC. For now, the manager actor then chooses one local-remote pair at random on which to dispatch the op. Soon, it will stripe the op across all available local-remote pairs.

Default behavior is basically preserved, with a small exception: under `PeerDeviceAffinityPolicy::Any` (default), NICs are chosen for cpu buffers randomly rather than by hashing `addr` and `size`; and unlike before, under the `Any` policy, if a gpu buffer has multiple optimal NICs, it also chooses one at random.

Differential Revision: D117027980


