### PR TITLE
EFA: P4d compatibility, same-node loopback, and completion-error reporting (re-port of #3391)

### DIFF
--- a/monarch_rdma/EFA_NOTES.md
+++ b/monarch_rdma/EFA_NOTES.md
@@ -1,0 +1,262 @@
+# EFA RDMA notes
+
+Field notes for running `monarch_rdma` over AWS Elastic Fabric Adapter. EFA
+carries RDMA over the Scalable Reliable Datagram (SRD) protocol rather than
+InfiniBand's reliable connection, and several assumptions that hold on Mellanox
+hardware fail on SRD — some of them silently, which is what makes them worth
+writing down.
+
+Everything below was observed on 2x p5.48xlarge (H100 x8, EFA x32 per node) with
+one p4d.24xlarge (A100 x8, EFA x4) as a capability-delta reference, on Ubuntu
+24.04 with the EFA installer 1.43+, libfabric 2.x, and `efa_nv_peermem` loaded.
+Where a claim is about hardware rather than about this code, it was verified by
+reading the RDMA hardware counters under
+`/sys/class/infiniband/rdmap*/ports/1/hw_counters/` before and after the run,
+because a counter delta is ground truth and an `ibv_post_send` return code is
+not.
+
+## How to reproduce the environment
+
+`fi_pingpong` ships with libfabric and exercises the whole provider stack
+without application code, which makes it the fastest way to tell a Monarch bug
+from a fabric bug:
+
+```
+FI_PROVIDER=efa FI_LOG_LEVEL=debug FI_EFA_USE_DEVICE_RDMA=1 fi_pingpong -e rdm
+```
+
+Useful when narrowing something down:
+
+- `efa-info` and `show_gids` to confirm the device, GID index 0, and link state.
+  A wrong GID index looks exactly like a fabric failure.
+- `FI_LOG_LEVEL=trace` is verbose but is the ground truth for what the provider
+  decided to do.
+- The `tx_pkts` / `rx_pkts` hardware counters. If `tx_pkts` climbs and the peer's
+  `rx_pkts` does not, the packets are being dropped below libfabric and no amount
+  of application-level debugging will show it.
+
+## What SRD does not do
+
+### No message ordering
+
+SRD delivers RDMA writes out of order: posting A, B, C may deliver C, A, B. Any
+protocol that infers "B arrived" from "C arrived" is unsound on EFA.
+
+This is safe in `monarch_rdma` today because a `QueuePairActor` replies per op
+and holds an op's reply until every work request for it has completed
+(`queue_pair.rs`), so no caller observes a partial transfer. It is a live hazard
+for any future change that pipelines overlapping writes into adjacent regions and
+treats one completion as evidence about another.
+
+### A send completion is local-only
+
+A send-CQ completion means the local NIC accepted the work request. It does not
+mean the remote side received the data, and `ibv_post_send` returns 0 even for
+packets SRD will drop. Polling the send CQ is the right way to know the local
+side is finished with a buffer; it is not proof the remote buffer was written.
+
+### No RDMA atomics
+
+EFA does not support `IBV_ACCESS_REMOTE_ATOMIC`. `efa::mr_access_flags`
+(`efa.rs`) omits it, and `EfaDevice::apply_config_defaults` (`efa_device.rs`)
+zeroes `max_rd_atomic` and `max_dest_rd_atomic`. Fetch-add and compare-and-swap
+need a software fallback on this fabric; there is no way to get them from the
+NIC.
+
+The absence of atomics is an EFA property rather than a p4d quirk — p4d reports
+`max_qp_rd_atom = 0`, and p5 zeroes the same config knobs.
+
+### `FI_MORE` does not work on `efa-direct`
+
+The libfabric `FI_MORE` hint (batch work requests, then trigger the NIC once)
+hangs on the `efa-direct` provider — counter-based, progress-based, and
+timer-based flush strategies all hang. This does not affect the ibverbs backend,
+which posts to the NIC directly, but it rules out an obvious batching strategy
+for anything built on libfabric.
+
+### Write-with-immediate is emulated and exhaustible
+
+EFA RDM emulates `fi_writedata` as a send/recv pair, so the receiver's buffer
+pool drains: after roughly 240 writes, operations stall. Plain writes do not have
+this problem.
+
+`EfaQueuePair` cannot express write-with-immediate at all — it posts only
+`IbvOperation::Write` and `IbvOperation::Read` through `WrSession`
+(`efa_queue_pair.rs`) — so the current EFA path cannot hit this. The hazard
+applies to `IbvOperation::WriteWithImm`, which survives for the legacy
+GPU-initiated path in `queue_pair/legacy.rs`; do not wire it to EFA without
+addressing the receiver pool.
+
+## Same-node loopback is silently dropped
+
+This is the EFA gotcha most likely to cost someone a day.
+
+SRD drops packets addressed to the node that sent them. The whole queue-pair
+lifecycle succeeds — INIT to RTR to RTS, `ibv_post_send` returns 0 — and then the
+completion never arrives, because the payload was dropped at the NIC. It
+surfaces as a timeout far from the cause:
+
+```
+[buffer] rdma operation did not complete in time (expected wr_ids=[0])
+```
+
+or, when the timeout propagates through the mailbox:
+
+```
+error: broken link: failed to enqueue in MailboxClient
+  channel closed with reason Some("delivery timeout")
+```
+
+Note that this is not the same thing as the `is_loopback` flag in
+`manager_actor.rs`, which only tells `QueuePairActor::init` to skip the
+`CreatePeerQueuePair` round trip and connect a queue pair to its own endpoint.
+That is a connection-setup shortcut; the data path underneath it still posts a
+real work request, and on EFA that work request is dropped.
+
+The fix in this crate is in the `SubmitOps` handler in `manager_actor.rs`: when
+the EFA manager is asked for a transfer whose peer is itself and whose memory on
+both ends is host memory, it copies directly instead of posting a work request.
+Three conditions gate it, and each one matters:
+
+- **EFA only**, decided per backend via `I::backend_name()`, not by asking
+  whether the process has an EFA device anywhere. Both `IbvManagerActor<MlxDevice>`
+  and `IbvManagerActor<EfaDevice>` can be spawned on a host with both NICs, and a
+  process-wide predicate would divert working Mellanox loopback RDMA into a copy.
+- **Same manager**, by `ActorRef::actor_addr()` equality, matching what
+  `ensure_qp_actor` already does.
+- **Host memory on both ends**, decided from `MemoryLocation` rather than by
+  probing the address. The remote side's `addr` is an offset into a zero-based MR
+  address space, not a pointer: for a dmabuf-registered GPU region it is
+  frequently literally `0`, so a pointer probe would classify device memory as
+  host memory and copy to a near-null address. `IbvRemoteMemoryRegionView`
+  carries `location` on the wire for exactly this reason.
+
+Two actors in *different processes* on the same node are still exposed. They have
+different manager actors, so the address comparison does not fire, and the
+transfer between them hits the silent drop. Options, none implemented: compare
+GIDs at connect time (same GID means same node), add a shared-memory node-identity
+handshake, or route node-local peers over TCP.
+
+## p4d cannot do RDMA at all
+
+EFA generations differ in whether they can carry RDMA. p5 and p5en advertise
+`EFADV_DEVICE_ATTR_CAPS_RDMA_READ` and `..._RDMA_WRITE`; p4d advertises neither
+and offers only send/recv. `EfaQueuePair::create` requires both and rejects the
+device, so on p4d every transfer would fail at queue-pair creation — that is, on
+the first op, deep inside `ensure_qp_actor`, as a per-op error rather than as a
+transport decision.
+
+`EfaDevice::is_instance` therefore declines a device that cannot serve RDMA, via
+`efa::supports_rdma`. An unclaimed device leaves
+`IbvBackend::<EfaDevice>::available()` false, so `RdmaBackends::spawn_available`
+falls through to the next registered backend. One consequence worth knowing:
+`is_instance` is also what makes a device *appear* as EFA, so a p4d NIC becomes
+invisible to `list_all_devices()`. The warning logged at that point is the only
+place it is visible.
+
+## Memory registration
+
+### Host memory
+
+The failure worth recognizing is `IBV_WC_LOC_LEN_ERR` (status 1, vendor_err 104),
+which means the receiving region is smaller than the incoming message. It reads
+like a lifetime bug and is not one: size the MR for the largest message you
+intend to send.
+
+For pages that must not move underneath a registration, `pin_memory()` on the
+tensor. With the PyTorch caching allocator, `expandable_segments` tends to produce
+stable large blocks that are better registration candidates.
+
+### GPU memory
+
+dmabuf registration works on EFA (kernel 6.17+) and is the path
+`register_host_or_dmabuf_mr` takes for `MemoryLocation::Gpu` in `domain.rs`, via
+`ibv_reg_dmabuf_mr`. Constraints found the hard way:
+
+| Constraint | Detail |
+|---|---|
+| One `cudaMalloc` per NIC | Sub-ranges of a single allocation fail with CQ error 22 (EINVAL) |
+| `cudaMalloc` memory specifically | `nvshmem_malloc` memory cannot be dmabuf-registered; stage through `cudaMalloc` |
+| `efa_nv_peermem` loaded | Check `/proc/modules` |
+| `FI_EFA_USE_DEVICE_RDMA=1` | Required for GPU-direct RDMA |
+| libfabric >= 1.18 | For `FI_HMEM_CUDA` |
+
+`efa_nv_peermem` can stop loading after an NVIDIA driver update, because DKMS
+rebuilds the NVIDIA modules and not this one. Rebuild it after any driver change,
+or pin both in the image.
+
+### GPU L2 is not coherent with incoming RDMA
+
+Only CPU-initiated CUDA APIs order GPU-direct memory operations as the GPU
+observes them, so a kernel that reads a destination buffer immediately after a
+remote write may see stale L2-cached data; `cuFlushGPUDirectRDMAWrites` is what
+resolves it.
+
+This crate does not call it. `RDMABuffer` has no defined CUDA stream semantics
+yet, so there is no correct place to put the flush — that has to be decided
+first, and then it becomes a choice between flushing on the completion path and
+relying on a stream-synchronized read. Until then, a caller doing GPU RDMA should
+flush before the first kernel read of the buffer.
+
+## Completion queues
+
+**Never stop polling.** On the libfabric path `fi_cq_read` drives the provider's
+progress engine, so code that stops polling when it believes nothing is pending
+will prevent unrelated in-flight operations from completing. Tuning how long to
+wait between polls is fine; skipping polls is not. The ibverbs backend has no
+provider progress engine to starve, since it posts to the NIC directly.
+
+**`fi_cntr` is thread-local on EFA.** Posting from one thread and reading the
+counter from another shows no completions. Any multi-threaded submission scheme
+has to poll completions on the thread that posted them.
+
+**More polling threads do not help.** The EFA bottleneck is work-request
+issuance, not completion polling; dedicated CQ-polling threads measured as no
+improvement at all.
+
+## Throughput
+
+The NIC is not the bottleneck. Standalone 4-NIC writes at 64 MB reach ~44 GB/s,
+which is at or slightly above the InfiniBand reference on the same test, and a
+single NIC does ~8.2 GB/s at 256 KB. The EFA-versus-InfiniBand gap in real
+workloads comes from the CPU round trip, not the hardware: EFA has no equivalent
+of IBGDA, so a CPU thread must post every work request rather than the GPU
+posting to a doorbell itself.
+
+Transfer size dominates every other tuning variable — roughly 3.7 GB/s at 4 KB,
+31 GB/s at 116 KB, and 40+ GB/s at 256 KB, an 8.5x range from chunk size alone.
+`MAX_RDMA_MSG_SIZE` is 1 GiB and correctness does not depend on it, so a
+throughput-sensitive path is worth testing in the 256 KB to 16 MB range rather
+than assuming the maximum is best.
+
+For reference, the fastest EFA RDMA implementation we know of (pplx-garden,
+~63 GB/s) has the GPU kernel write into a registered buffer, signals the CPU via a
+GDRCopy MMIO write, and only then has a CPU worker post from that memory. The
+ordering is the point: the CPU reads the ring *after* the kernel finishes, because
+concurrent CPU access to GPU memory while kernels run on the same device hangs.
+
+## Configuration notes
+
+`EfaDevice::apply_config_defaults` (`efa_device.rs`) sets what EFA requires:
+`max_send_sge` and `max_recv_sge` to 1 (EFA accepts exactly one scatter/gather
+entry per RDMA work request, and `EfaQueuePair::create` re-applies this rather
+than trusting the caller), and `max_rd_atomic` / `max_dest_rd_atomic` to 0. EFA
+also uses GID index 0, where Mellanox commonly uses 3.
+
+Queue depths are rejected rather than clamped when they exceed the device's
+`max_sq_wr` / `max_rq_wr`, because `QueuePairActor` budgets send-queue credits
+against the configured depth and would over-commit if it silently got fewer.
+
+Two providers exist. For dispatch-shaped traffic, `efa` measured about 10% better
+throughput than `efa-direct`, despite `efa-direct` having higher raw bandwidth —
+worth knowing before reaching for the lower-level one.
+
+p5.48xlarge has two NUMA nodes, not four: cores 0-47 with 16 NICs, cores 48-95
+with the other 16. Pin a thread to the same NUMA node as the NIC it drives.
+
+## One-time setup that looks like a code bug
+
+A fresh cluster with a security group that has no self-referencing egress rule
+will show `tx_pkts` climbing while the peer's `rx_pkts` stays at zero. SRD needs
+that rule. Relatedly, SRD is silently dropped on secondary VPC CIDRs — use the
+primary CIDR.

--- a/monarch_rdma/README.md
+++ b/monarch_rdma/README.md
@@ -19,6 +19,10 @@ Monarch RDMA is a Rust library that provides high-performance Remote Direct Memo
 - RDMA-capable network interface card (NIC), such as Mellanox ConnectX series
 - For GPU integration: NVIDIA GPU with CUDA support
 
+On AWS Elastic Fabric Adapter, RDMA runs over SRD rather than a reliable
+connection, and several assumptions that hold on Mellanox hardware fail there —
+some silently. See [EFA_NOTES.md](EFA_NOTES.md) before debugging an EFA setup.
+
 ### Software Requirements
 
 #### Required Libraries

--- a/monarch_rdma/src/backend/ibverbs/efa_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_device.rs
@@ -8,6 +8,7 @@
 
 //! EFA backend for [`IbvDevice`].
 
+use std::ffi::CStr;
 use std::sync::Arc;
 
 use typeuri::Named;
@@ -32,7 +33,32 @@ impl IbvDeviceImpl for EfaDevice {
     fn is_instance(ctx: Arc<IbvContext>) -> bool {
         // SAFETY: `ctx.as_ptr()` is a non-null context owned by
         // the `Arc<IbvContext>` for the duration of this call.
-        unsafe { rdmaxcel_sys::rdmaxcel_is_efa_dev(ctx.as_ptr()) != 0 }
+        if unsafe { rdmaxcel_sys::rdmaxcel_is_efa_dev(ctx.as_ptr()) } == 0 {
+            return false;
+        }
+        // An EFA device that cannot serve RDMA read and write — p4d and
+        // earlier — is left unclaimed. `IbvQueuePair` requires both
+        // (`EfaQueuePair::create` rejects the device outright), so claiming
+        // one here would only turn every transfer into an error; declining
+        // it leaves `IbvBackend::<EfaDevice>::available()` false and lets
+        // `RdmaBackends::spawn_available` fall through to the next backend.
+        if !crate::efa::supports_rdma(ctx.as_ptr()) {
+            // SAFETY: `ctx.as_ptr()` is a non-null open context, so its
+            // `device` is the non-null device it was opened from, and
+            // `ibv_get_device_name` returns a null-terminated string owned
+            // by that device.
+            let name = unsafe {
+                CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name((*ctx.as_ptr()).device))
+            }
+            .to_string_lossy()
+            .into_owned();
+            tracing::warn!(
+                "EFA device {name} does not support RDMA read and write, so it \
+                 cannot carry RDMA traffic; leaving it unclaimed"
+            );
+            return false;
+        }
+        true
     }
 
     fn apply_config_defaults(config: &mut IbvConfig) {
@@ -44,3 +70,23 @@ impl IbvDeviceImpl for EfaDevice {
 }
 
 register_ibv_device_impl!(EfaDevice);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A device we cannot query for capabilities is treated as incapable, so a
+    // failed query costs a transport rather than producing queue pairs that
+    // reject every operation.
+    #[test]
+    fn supports_rdma_is_false_when_the_device_cannot_be_queried() {
+        assert!(!crate::efa::supports_rdma(std::ptr::null_mut()));
+    }
+
+    // The capability check runs after the EFA check, so a non-EFA device is
+    // declined for not being EFA and never reaches `supports_rdma`.
+    #[test]
+    fn is_instance_declines_a_non_efa_device() {
+        assert!(!EfaDevice::is_instance(Arc::new(IbvContext::null())));
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -64,6 +64,7 @@ use super::queue_pair::QueuePairActor;
 use super::queue_pair::QueuePairOp;
 use super::queue_pair::legacy;
 use crate::RdmaOp;
+use crate::RdmaOpType;
 use crate::RdmaTransportLevel;
 use crate::backend::RdmaBackend;
 use crate::backend::RdmaConfig;
@@ -451,12 +452,84 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         self.qp_handles.insert(qp_key.clone(), actor.clone());
         Ok(actor)
     }
+
+    /// Whether this manager drives EFA devices.
+    ///
+    /// Per-backend, not per-process: on a host with both NICs, `spawn_available`
+    /// spawns an `IbvManagerActor<MlxDevice>` *and* an
+    /// `IbvManagerActor<EfaDevice>`, so asking whether the process can see an EFA
+    /// device would answer yes inside the Mellanox manager too.
+    fn is_efa() -> bool {
+        I::backend_name() == EfaDevice::backend_name()
+    }
+}
+
+/// The `(dst, src, len)` of the in-process copy that serves `op_type` between
+/// `local` and `remote`, or `None` if the pair has to go over a queue pair
+/// after all.
+///
+/// Eligibility is host memory on both ends. Device memory is excluded because
+/// the copy would need the CUDA driver — and, for a peer GPU, a peer-to-peer
+/// mapping this side has no handle on — while the device RDMA path already
+/// works.
+///
+/// The size rules mirror [`IbvQueuePair::put`] and [`IbvQueuePair::get`]
+/// exactly, down to the message, so an op the queue pair would have rejected is
+/// rejected here the same way: a write sends all of the local region and needs
+/// the remote to hold it, a read takes all of the remote region and needs the
+/// local to hold it.
+fn loopback_copy_range(
+    local: &KeepaliveLocalMemory,
+    remote: &IbvRemoteMemoryRegionView,
+    op_type: RdmaOpType,
+) -> Option<Result<(usize, usize, usize), anyhow::Error>> {
+    if !matches!(local.location(), MemoryLocation::Cpu(_))
+        || !matches!(remote.location, MemoryLocation::Cpu(_))
+    {
+        return None;
+    }
+    // Host memory is the one case where a region's RDMA address is also a
+    // pointer into this process: its MR covers exactly the requested range, so
+    // the offset within the MR is zero and `ibv_reg_mr` reports the registered
+    // address itself. For device memory `addr` is an offset into a zero-based
+    // address space, which is why the test above is on `location` rather than
+    // on `addr` — a GPU region's `addr` is frequently 0, and probing it as a
+    // pointer would report host memory and copy over whatever is there.
+    Some(match op_type {
+        RdmaOpType::WriteFromLocal => {
+            if remote.size < local.size() {
+                Err(anyhow::anyhow!(
+                    "remote buffer size ({}) is smaller than local buffer size ({})",
+                    remote.size,
+                    local.size()
+                ))
+            } else {
+                Ok((remote.addr, local.addr(), local.size()))
+            }
+        }
+        RdmaOpType::ReadIntoLocal => {
+            if local.size() < remote.size {
+                Err(anyhow::anyhow!(
+                    "local buffer size ({}) is smaller than remote buffer size ({})",
+                    local.size(),
+                    remote.size
+                ))
+            } else {
+                Ok((local.addr(), remote.addr, remote.size))
+            }
+        }
+    })
 }
 
 #[async_trait]
 impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
     async fn handle(&mut self, cx: &Context<Self>, msg: SubmitOps<I>) -> Result<(), anyhow::Error> {
         let SubmitOps { ops, reply } = msg;
+
+        // Only EFA needs the same-node shortcut below, and which manager this
+        // is does not change per op. Bound out here because `bind` re-exports
+        // the actor's ports on every call.
+        let loopback_manager: Option<ActorRef<Self>> = Self::is_efa().then(|| cx.bind());
 
         // Interleave MR resolution with QP dispatch: as soon as op `i`'s
         // local MR is resolved and its QP actor is in place, ship a
@@ -475,6 +548,36 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
                 )?;
                 continue;
             };
+            // EFA drops a same-node RDMA write on the floor: the QP connects and
+            // the work request completes locally, but the NIC never delivers the
+            // payload, so the transfer silently reads stale bytes. Both ends are
+            // in this process, so copy directly instead of posting a work request
+            // that will not arrive.
+            if let Some(local_manager) = &loopback_manager
+                && op.remote_manager.actor_addr() == local_manager.actor_addr()
+                && let Some(range) = loopback_copy_range(&op.local_memory, &remote, op.op_type)
+            {
+                let result = range.map(|(dst, src, len)| {
+                    // SAFETY: both regions are host memory registered in this
+                    // process. `op.local_memory`'s keepalive pins the local side
+                    // for this call; the remote side was registered with the peer
+                    // manager, which the check above established is this actor, and
+                    // its MR keepalive holds it. Each registration covers `size`
+                    // bytes from its address and `len` is the smaller of the two, so
+                    // both ranges are in bounds. Two registrations are either over
+                    // the same region — a copy onto itself — or disjoint, so they
+                    // never partially overlap.
+                    unsafe { std::ptr::copy(src as *const u8, dst as *mut u8, len) }
+                });
+                reply.try_post(
+                    cx,
+                    OpResult {
+                        op_idx: i,
+                        result: result.map_err(|e| e.to_string()),
+                    },
+                )?;
+                continue;
+            }
             let self_device = match self.resolve_local_mr(&op.local_memory) {
                 Ok(mrv) => mrv.device_name.clone(),
                 Err(e) => {
@@ -578,7 +681,7 @@ impl<I: IbvDeviceImpl> IbvManagerLocalMessageHandler for IbvManagerActor<I> {
         // than registering the same region on that device again.
         Ok(self
             .resolve_local_mr(&local)
-            .map(|mrv| vec![IbvRemoteMemoryRegionView::from(&mrv)])
+            .map(|mrv| vec![IbvRemoteMemoryRegionView::new(&mrv, local.location())])
             .map_err(|error| format!("{error:#}")))
     }
 }
@@ -825,6 +928,7 @@ mod tests {
     //! explicitly drains both procs.
 
     use std::sync::Arc;
+    use std::sync::Mutex;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
     use std::time::Duration;
@@ -849,6 +953,11 @@ mod tests {
     use serde::Serialize;
     use typeuri::Named;
 
+    use super::EfaDevice;
+    use super::IbvManagerActor;
+    use super::IbvRemoteMemoryRegionView;
+    use super::MemoryLocation;
+    use super::loopback_copy_range;
     use crate::IbvConfig;
     use crate::RdmaManagerActor;
     use crate::RdmaManagerMessageClient;
@@ -863,6 +972,7 @@ mod tests {
     use crate::backend::ibverbs::device_selection::resolve_target;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvQpType;
+    use crate::local_memory::Keepalive;
     use crate::local_memory::KeepaliveLocalMemory;
 
     // ====================================================================
@@ -1946,5 +2056,170 @@ mod tests {
         assert_remote_pattern(&env.helper_b, &env.client, post_flush_dst, SIZE, 0).await?;
 
         env.shutdown().await
+    }
+
+    // ====================================================================
+    // Same-node loopback copy
+    // ====================================================================
+    //
+    // EFA silently drops a same-node RDMA transfer, so an op whose peer is this
+    // same manager is served by an in-process copy instead. These cover the
+    // eligibility rules and the byte ranges; the copy itself is
+    // `std::ptr::copy`.
+
+    /// [`Keepalive`] over a `Vec<u8>` the test owns, so a region has real,
+    /// readable host memory behind it.
+    struct VecKeepalive(Mutex<Vec<u8>>);
+
+    impl Keepalive for VecKeepalive {
+        fn addr(&self) -> usize {
+            self.0.lock().unwrap().as_ptr() as usize
+        }
+        fn size(&self) -> usize {
+            self.0.lock().unwrap().len()
+        }
+    }
+
+    /// Host memory of `size` bytes filled with `pattern`.
+    fn host_memory(size: usize, pattern: u8) -> KeepaliveLocalMemory {
+        KeepaliveLocalMemory::try_new(Arc::new(VecKeepalive(Mutex::new(vec![pattern; size]))))
+            .expect("a host allocation has a location")
+    }
+
+    /// A remote view of `mem`, as its owner would put on the wire.
+    fn remote_view_of(mem: &KeepaliveLocalMemory) -> IbvRemoteMemoryRegionView {
+        IbvRemoteMemoryRegionView {
+            rkey: 0,
+            addr: mem.addr(),
+            size: mem.size(),
+            device_name: "efa_0".to_string(),
+            location: mem.location(),
+        }
+    }
+
+    /// Read `len` bytes from `addr`.
+    ///
+    /// # Safety
+    ///
+    /// `[addr, addr + len)` must be initialized host memory that outlives the
+    /// call.
+    unsafe fn bytes_at(addr: usize, len: usize) -> Vec<u8> {
+        // SAFETY: forwards this function's contract.
+        unsafe { std::slice::from_raw_parts(addr as *const u8, len) }.to_vec()
+    }
+
+    #[test]
+    fn a_write_copies_the_whole_local_region_to_the_remote() {
+        const SIZE: usize = 256;
+        let local = host_memory(SIZE, 0xAB);
+        let remote_mem = host_memory(SIZE, 0);
+        let remote = remote_view_of(&remote_mem);
+
+        let (dst, src, len) = loopback_copy_range(&local, &remote, RdmaOpType::WriteFromLocal)
+            .expect("host memory on both ends is eligible")
+            .expect("equal sizes are accepted");
+        assert_eq!((dst, src, len), (remote.addr, local.addr(), SIZE));
+
+        // SAFETY: `dst`/`src` are the two live host allocations above, each
+        // `SIZE` bytes, and `len` is `SIZE`.
+        unsafe { std::ptr::copy(src as *const u8, dst as *mut u8, len) };
+        // SAFETY: `remote_mem` is live host memory of `SIZE` bytes.
+        assert_eq!(unsafe { bytes_at(remote.addr, SIZE) }, vec![0xAB; SIZE]);
+    }
+
+    #[test]
+    fn a_read_copies_the_whole_remote_region_into_the_local() {
+        const SIZE: usize = 256;
+        let local = host_memory(SIZE, 0);
+        let remote_mem = host_memory(SIZE, 0xCD);
+        let remote = remote_view_of(&remote_mem);
+
+        let (dst, src, len) = loopback_copy_range(&local, &remote, RdmaOpType::ReadIntoLocal)
+            .expect("host memory on both ends is eligible")
+            .expect("equal sizes are accepted");
+        assert_eq!((dst, src, len), (local.addr(), remote.addr, SIZE));
+
+        // SAFETY: `dst`/`src` are the two live host allocations above, each
+        // `SIZE` bytes, and `len` is `SIZE`.
+        unsafe { std::ptr::copy(src as *const u8, dst as *mut u8, len) };
+        // SAFETY: `local` is live host memory of `SIZE` bytes.
+        assert_eq!(unsafe { bytes_at(local.addr(), SIZE) }, vec![0xCD; SIZE]);
+    }
+
+    // A transfer moves the source region in full, so the destination has to be
+    // able to hold it — the same bound the queue pair enforces before posting.
+    #[test]
+    fn a_transfer_into_too_small_a_destination_is_refused() {
+        let big = host_memory(256, 0);
+        let small = host_memory(128, 0);
+
+        let err = loopback_copy_range(&big, &remote_view_of(&small), RdmaOpType::WriteFromLocal)
+            .expect("host memory on both ends is eligible")
+            .expect_err("a 256-byte write does not fit in 128 bytes");
+        assert!(
+            err.to_string().contains("remote buffer size (128)"),
+            "unexpected error: {err}"
+        );
+
+        let err = loopback_copy_range(&small, &remote_view_of(&big), RdmaOpType::ReadIntoLocal)
+            .expect("host memory on both ends is eligible")
+            .expect_err("a 256-byte read does not fit in 128 bytes");
+        assert!(
+            err.to_string().contains("local buffer size (128)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // A destination larger than the source is fine: only the source's bytes move.
+    #[test]
+    fn a_transfer_into_a_larger_destination_moves_only_the_source() {
+        let local = host_memory(128, 0xEE);
+        let remote_mem = host_memory(256, 0);
+        let remote = remote_view_of(&remote_mem);
+
+        let (dst, src, len) = loopback_copy_range(&local, &remote, RdmaOpType::WriteFromLocal)
+            .expect("host memory on both ends is eligible")
+            .expect("a smaller source fits");
+        assert_eq!(
+            len, 128,
+            "a write moves the local region, not the remote one"
+        );
+
+        // SAFETY: `dst` is 256 live bytes, `src` is 128, and `len` is 128.
+        unsafe { std::ptr::copy(src as *const u8, dst as *mut u8, len) };
+        // SAFETY: `remote_mem` is live host memory of 256 bytes.
+        let after = unsafe { bytes_at(remote.addr, 256) };
+        assert_eq!(after[..128], [0xEE; 128], "the source bytes landed");
+        assert_eq!(after[128..], [0; 128], "the tail was left alone");
+    }
+
+    // GPU memory is left to the RDMA path. The remote side is judged by its
+    // `location` and not by probing `addr`, which for a device region is an
+    // offset into the MR's zero-based address space — frequently 0, which would
+    // probe as host memory and send the copy to a near-null address.
+    #[test]
+    fn a_gpu_region_is_not_eligible_even_when_its_addr_looks_like_host_memory() {
+        let local = host_memory(256, 0);
+        let mut remote = remote_view_of(&local);
+        remote.location = MemoryLocation::Gpu(Some(0));
+        remote.addr = 0;
+
+        assert!(
+            loopback_copy_range(&local, &remote, RdmaOpType::WriteFromLocal).is_none(),
+            "a GPU remote region must go over the queue pair"
+        );
+        assert!(
+            loopback_copy_range(&local, &remote, RdmaOpType::ReadIntoLocal).is_none(),
+            "a GPU remote region must go over the queue pair"
+        );
+    }
+
+    // Only the EFA manager takes the shortcut. Both managers are spawned on a
+    // host with both NICs, and Mellanox same-node RDMA works, so a process-wide
+    // "is there an EFA device" test would divert it too.
+    #[test]
+    fn the_shortcut_is_scoped_to_the_efa_manager() {
+        assert!(IbvManagerActor::<EfaDevice>::is_efa());
+        assert!(!IbvManagerActor::<MlxDevice>::is_efa());
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/memory_region.rs
+++ b/monarch_rdma/src/backend/ibverbs/memory_region.rs
@@ -26,6 +26,7 @@ use serde::Serialize;
 use typeuri::Named;
 
 use super::primitives::IbvMr;
+use crate::device_selection::MemoryLocation;
 
 /// Guards the resources behind a registered MR, releasing them when the last
 /// [`IbvMemoryRegionView`] over it drops. Each implementor frees whatever it
@@ -99,8 +100,8 @@ impl IbvMemoryRegionView {
 }
 
 /// What a peer needs in order to address one of our registered memory regions
-/// over RDMA: the region's `rkey`, its RDMA address, its size, and the device
-/// serving it.
+/// over RDMA: the region's `rkey`, its RDMA address, its size, the device
+/// serving it, and where it lives.
 ///
 /// This is the wire form of an [`IbvMemoryRegionView`]. It carries no `lkey` and
 /// no keepalive: an `lkey` only means anything to the protection domain that
@@ -114,17 +115,30 @@ pub struct IbvRemoteMemoryRegionView {
     pub size: usize,
     /// Name of the RDMA device this region is registered on (e.g., "mlx5_0").
     pub device_name: String,
+    /// Where the registered memory lives, as resolved by the side that owns it.
+    ///
+    /// Carried explicitly because it cannot be recovered from `addr`: that is an
+    /// offset into the MR's zero-based address space, which coincides with a
+    /// pointer only for host memory, and it names an address space the receiver
+    /// does not share in any case. A receiver that must know whether a region is
+    /// on a GPU — to pick a device, or to take a local shortcut — reads it here.
+    pub location: MemoryLocation,
 }
 
-impl From<&IbvMemoryRegionView> for IbvRemoteMemoryRegionView {
-    /// The wire transport details are fully derived from the registered MR
-    /// view: the remote key, the RDMA address, the size, and the device name.
-    fn from(view: &IbvMemoryRegionView) -> Self {
+impl IbvRemoteMemoryRegionView {
+    /// The wire form of `view`, whose memory lives at `location`.
+    ///
+    /// `location` is a parameter rather than something read off `view`: only the
+    /// registering side holds the [`KeepaliveLocalMemory`] that resolved it.
+    ///
+    /// [`KeepaliveLocalMemory`]: crate::local_memory::KeepaliveLocalMemory
+    pub(super) fn new(view: &IbvMemoryRegionView, location: MemoryLocation) -> Self {
         Self {
             rkey: view.rkey,
             addr: view.rdma_addr,
             size: view.size,
             device_name: view.device_name.clone(),
+            location,
         }
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1322,6 +1322,7 @@ mod tests {
     use crate::backend::ibverbs::device_selection::resolve_target;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
+    use crate::device_selection::MemoryLocation;
 
     #[test]
     fn test_create_connection() {
@@ -2057,6 +2058,7 @@ mod tests {
                 addr: 0x4000_0000,
                 size,
                 device_name: PEER_DEVICE.to_string(),
+                location: MemoryLocation::Cpu(None),
             },
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -93,9 +93,22 @@ impl WorkRequestError {
 
     #[cfg(test)]
     pub(super) fn for_test(wr_id: u64, message: &str) -> Self {
+        Self::for_test_with_status(
+            wr_id,
+            message,
+            rdmaxcel_sys::ibv_wc_status::IBV_WC_GENERAL_ERR,
+        )
+    }
+
+    #[cfg(test)]
+    pub(super) fn for_test_with_status(
+        wr_id: u64,
+        message: &str,
+        status: rdmaxcel_sys::ibv_wc_status::Type,
+    ) -> Self {
         Self {
             wr_id,
-            status: rdmaxcel_sys::ibv_wc_status::IBV_WC_GENERAL_ERR,
+            status,
             vendor_err: 0,
             message: message.to_string(),
         }
@@ -891,10 +904,43 @@ struct PostedOpEntry {
     /// in-flight WR touching it.
     _local_memory: KeepaliveLocalMemory,
     reply: PortHandle<OpResult>,
-    /// First per-WR error observed for this op. The op's final reply is
-    /// held back until `pending_wrs.is_empty()`, so `_local_memory` outlives
-    /// every WR still in flight.
-    first_error: Option<String>,
+    /// The error this op reports, if any. The op's final reply is held back
+    /// until `pending_wrs.is_empty()`, so `_local_memory` outlives every WR
+    /// still in flight.
+    error: Option<AttributedError>,
+}
+
+/// The error a multi-WR op reports, and whether it is a root cause.
+///
+/// A failing WR puts the QP in error state, and every WR already posted behind
+/// it then completes with `IBV_WC_WR_FLUSH_ERR`. Which of the two a poll sees
+/// first is not fixed — flushes can be drained ahead of the failure that caused
+/// them — so keeping whichever arrived first would sometimes report the
+/// consequence and hide the cause.
+#[derive(Debug)]
+struct AttributedError {
+    message: String,
+    /// Whether `message` came from a flushed WR, i.e. is a consequence of some
+    /// other WR's failure and should give way to a root cause.
+    is_flush: bool,
+}
+
+impl PostedOpEntry {
+    /// Fold `err` into the error this op will report: a root cause replaces a
+    /// flush, and the first of either kind is kept.
+    fn observe_error(&mut self, err: WorkRequestError) {
+        let is_flush = err.is_wr_flush_err();
+        let replaces = match &self.error {
+            None => true,
+            Some(current) => current.is_flush && !is_flush,
+        };
+        if replaces {
+            self.error = Some(AttributedError {
+                message: err.to_string(),
+                is_flush,
+            });
+        }
+    }
 }
 
 /// Per-peer queue-pair actor.
@@ -1096,7 +1142,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 pending_wrs,
                 _local_memory: op.local_memory,
                 reply,
-                first_error: None,
+                error: None,
             },
         );
         Ok(true)
@@ -1135,7 +1181,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
 
             let (wr_id, wr_error) = match wc_result {
                 Ok(wc) => (wc.wr_id(), None),
-                Err(per_wr) => (per_wr.wr_id, Some(per_wr.to_string())),
+                Err(per_wr) => (per_wr.wr_id, Some(per_wr)),
             };
 
             let op_id = self
@@ -1148,15 +1194,13 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 .expect("op_id missing from posted");
             entry.pending_wrs.remove(&wr_id);
             self.in_flight -= 1;
-            if let Some(err) = wr_error
-                && entry.first_error.is_none()
-            {
-                entry.first_error = Some(err);
+            if let Some(err) = wr_error {
+                entry.observe_error(err);
             }
             if entry.pending_wrs.is_empty() {
                 let entry = self.posted.remove(&op_id).expect("just verified");
-                let result = match entry.first_error {
-                    Some(err) => Err(err),
+                let result = match entry.error {
+                    Some(err) => Err(err.message),
                     None => Ok(()),
                 };
                 entry.reply.try_post(
@@ -1597,6 +1641,20 @@ mod tests {
                 .unwrap()
                 .pending_completions
                 .push_back(Err(WorkRequestError::for_test(wr_id, message)));
+        }
+
+        /// Queue an `IBV_WC_WR_FLUSH_ERR` completion for `wr_id`, as the NIC
+        /// reports for a WR the QP dropped when it went to error state.
+        fn queue_flush_error(&self, wr_id: u64, message: &str) {
+            self.inner
+                .lock()
+                .unwrap()
+                .pending_completions
+                .push_back(Err(WorkRequestError::for_test_with_status(
+                    wr_id,
+                    message,
+                    rdmaxcel_sys::ibv_wc_status::IBV_WC_WR_FLUSH_ERR,
+                )));
         }
 
         /// Queue a CQ-level poll error (one-shot). The next poll
@@ -2449,6 +2507,77 @@ mod tests {
             "op_idx 0 error should name the per-WR error: {err}",
         );
         assert_eq!(replies[1], (1usize, Ok(())));
+        harness.teardown().await;
+        Ok(())
+    }
+
+    // A failing WR puts the QP in error state and the WRs behind it are flushed,
+    // so an op can see both a root cause and a flush. It reports the root cause
+    // whichever order they arrive in — here the flush lands first.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_op_error_prefers_a_root_cause_drained_after_a_flush() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(8).await?;
+
+        let items = vec![make_op(
+            7,
+            RdmaOpType::WriteFromLocal,
+            0x1000,
+            3 * MAX_RDMA_MSG_SIZE,
+        )];
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        let (_, _, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
+        assert_eq!(wr_ids.len(), 3);
+
+        qp.queue_flush_error(wr_ids[2], "flushed behind the failure");
+        qp.queue_per_wr_error(wr_ids[0], "the real failure");
+        qp.queue_completion(wr_ids[1]);
+
+        let replies = collect_replies(&mut rx, 1).await;
+        let err = replies[0]
+            .1
+            .as_ref()
+            .expect_err("op should fail because one WR errored");
+        assert!(
+            err.contains("the real failure"),
+            "op error should name the root cause, not the flush: {err}",
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    // The same op, with the root cause drained first: it is kept, and the
+    // flushes that follow do not displace it.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_op_error_keeps_a_root_cause_drained_before_a_flush() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(8).await?;
+
+        let items = vec![make_op(
+            9,
+            RdmaOpType::WriteFromLocal,
+            0x1000,
+            3 * MAX_RDMA_MSG_SIZE,
+        )];
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        let (_, _, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
+        assert_eq!(wr_ids.len(), 3);
+
+        qp.queue_per_wr_error(wr_ids[0], "the real failure");
+        qp.queue_flush_error(wr_ids[1], "flushed behind the failure");
+        qp.queue_flush_error(wr_ids[2], "flushed behind the failure");
+
+        let replies = collect_replies(&mut rx, 1).await;
+        let err = replies[0]
+            .1
+            .as_ref()
+            .expect_err("op should fail because one WR errored");
+        assert!(
+            err.contains("the real failure"),
+            "op error should name the root cause, not the flush: {err}",
+        );
         harness.teardown().await;
         Ok(())
     }

--- a/monarch_rdma/src/efa.rs
+++ b/monarch_rdma/src/efa.rs
@@ -54,6 +54,22 @@ fn is_efa_device_impl() -> bool {
     }
 }
 
+/// Whether an EFA device can serve RDMA read and write.
+///
+/// EFA generations differ here: instances such as p5 and p5en advertise
+/// `EFADV_DEVICE_ATTR_CAPS_RDMA_READ` and `..._RDMA_WRITE` and can carry RDMA
+/// traffic over SRD, while p4d advertises neither and offers only send/recv.
+/// A queue pair created for RDMA on the latter is rejected, so callers that
+/// need RDMA must consult this before selecting an EFA device.
+///
+/// `ctx` must be an EFA device context; on any other device the underlying
+/// `efadv_query_device` fails and this returns false.
+pub fn supports_rdma(ctx: *mut rdmaxcel_sys::ibv_context) -> bool {
+    // SAFETY: `ctx` is a context opened by libibverbs, and
+    // `rdmaxcel_efa_supports_rdma` tolerates a null pointer.
+    unsafe { rdmaxcel_sys::rdmaxcel_efa_supports_rdma(ctx) != 0 }
+}
+
 /// Returns the MR access flags appropriate for EFA devices.
 ///
 /// EFA does not support `IBV_ACCESS_REMOTE_ATOMIC`, so this returns only

--- a/rdmaxcel-sys/src/lib.rs
+++ b/rdmaxcel-sys/src/lib.rs
@@ -326,6 +326,10 @@ unsafe extern "C" {
     /// Check if the device is an EFA device (via efadv_query_device)
     pub fn rdmaxcel_is_efa_dev(ctx: *mut ibv_context) -> std::os::raw::c_int;
 
+    /// Check whether an EFA device can serve RDMA read and write, or only
+    /// send/recv. Returns 1 when both are supported, 0 otherwise.
+    pub fn rdmaxcel_efa_supports_rdma(ctx: *mut ibv_context) -> std::os::raw::c_int;
+
     /// EFA connect: INIT->RTR->RTS + AH creation, stored directly in qp struct
     pub fn rdmaxcel_efa_connect(
         qp: *mut rdmaxcel_qp_t,

--- a/rdmaxcel-sys/src/lib.rs
+++ b/rdmaxcel-sys/src/lib.rs
@@ -344,6 +344,8 @@ unsafe extern "C" {
 
     /// EFA post operation with ibv_post_recv fallback
     /// op_type: 0 = write, 1 = read, 2 = recv, 3 = write_with_imm
+    /// signaled: non-zero to request a completion. The QP is created with
+    /// sq_sig_all = 0, so an unsignaled work request produces no CQE.
     pub fn rdmaxcel_qp_post_op(
         qp: *mut rdmaxcel_qp_t,
         local_addr: *mut std::ffi::c_void,

--- a/rdmaxcel-sys/src/rdmaxcel.c
+++ b/rdmaxcel-sys/src/rdmaxcel.c
@@ -766,14 +766,15 @@ int rdmaxcel_efa_post_write(
     size_t length,
     void* remote_addr,
     uint32_t rkey,
-    uint64_t wr_id) {
+    uint64_t wr_id,
+    int signaled) {
   if (!qp || !qp->qpex || !ah) {
     return RDMAXCEL_INVALID_PARAMS;
   }
 
   ibv_wr_start(qp->qpex);
   qp->qpex->wr_id = wr_id;
-  qp->qpex->wr_flags = IBV_SEND_SIGNALED;
+  qp->qpex->wr_flags = signaled ? IBV_SEND_SIGNALED : 0;
 
   ibv_wr_rdma_write(qp->qpex, rkey, (uintptr_t)remote_addr);
   ibv_wr_set_sge(qp->qpex, lkey, (uintptr_t)local_addr, (uint32_t)length);
@@ -801,14 +802,15 @@ int rdmaxcel_efa_post_read(
     size_t length,
     void* remote_addr,
     uint32_t rkey,
-    uint64_t wr_id) {
+    uint64_t wr_id,
+    int signaled) {
   if (!qp || !qp->qpex || !ah) {
     return RDMAXCEL_INVALID_PARAMS;
   }
 
   ibv_wr_start(qp->qpex);
   qp->qpex->wr_id = wr_id;
-  qp->qpex->wr_flags = IBV_SEND_SIGNALED;
+  qp->qpex->wr_flags = signaled ? IBV_SEND_SIGNALED : 0;
 
   ibv_wr_rdma_read(qp->qpex, rkey, (uintptr_t)remote_addr);
   ibv_wr_set_sge(qp->qpex, lkey, (uintptr_t)local_addr, (uint32_t)length);
@@ -941,6 +943,7 @@ int rdmaxcel_efa_post_op(
     void* remote_addr,
     uint32_t rkey,
     uint64_t wr_id,
+    int signaled,
     int op_type) {
   if (!ah) {
     return RDMAXCEL_INVALID_PARAMS;
@@ -956,7 +959,8 @@ int rdmaxcel_efa_post_op(
         length,
         remote_addr,
         rkey,
-        wr_id);
+        wr_id,
+        signaled);
   } else if (op_type == 1) {
     return rdmaxcel_efa_post_read(
         qp,
@@ -968,7 +972,8 @@ int rdmaxcel_efa_post_op(
         length,
         remote_addr,
         rkey,
-        wr_id);
+        wr_id,
+        signaled);
   }
   return RDMAXCEL_UNSUPPORTED_OP;
 }
@@ -1029,5 +1034,6 @@ int rdmaxcel_qp_post_op(
       remote_addr,
       rkey,
       wr_id,
+      signaled,
       efa_op);
 }

--- a/rdmaxcel-sys/src/rdmaxcel.c
+++ b/rdmaxcel-sys/src/rdmaxcel.c
@@ -671,6 +671,37 @@ int rdmaxcel_is_efa_dev(struct ibv_context* ctx) {
   return (ret == 0) ? 1 : 0;
 }
 
+// Whether this EFA device can serve RDMA read and write, or only send/recv.
+//
+// The authoritative signal is `efadv_device_attr.device_caps`, which carries
+// the `EFADV_DEVICE_ATTR_CAPS_RDMA_READ` / `..._RDMA_WRITE` bits the driver
+// sets for RDMA-capable instances. We also require `max_qp_rd_atom > 0` from
+// the standard `ibv_query_device`, so a device whose driver advertises the EFA
+// capability while the verbs layer refuses RDMA work requests is reported as
+// incapable rather than failing later at queue-pair creation.
+int rdmaxcel_efa_supports_rdma(struct ibv_context* ctx) {
+  if (!ctx || !ctx->device) {
+    return 0;
+  }
+
+  struct ibv_device_attr dev_attr = {};
+  if (ibv_query_device(ctx, &dev_attr) != 0) {
+    return 0;
+  }
+  if (dev_attr.max_qp_rd_atom == 0) {
+    return 0;
+  }
+
+  struct efadv_device_attr efa_attr = {};
+  if (efadv_query_device(ctx, &efa_attr, sizeof(efa_attr)) != 0) {
+    return 0;
+  }
+
+  const uint32_t rdma_caps =
+      EFADV_DEVICE_ATTR_CAPS_RDMA_READ | EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE;
+  return ((efa_attr.device_caps & rdma_caps) == rdma_caps) ? 1 : 0;
+}
+
 // ============================================================================
 // EFA QP Creation
 // ============================================================================

--- a/rdmaxcel-sys/src/rdmaxcel.h
+++ b/rdmaxcel-sys/src/rdmaxcel.h
@@ -383,6 +383,10 @@ int rdmaxcel_qp_post_op(
 // EFA device detection
 int rdmaxcel_is_efa_dev(struct ibv_context* ctx);
 
+// Whether this EFA device can serve RDMA read and write, or only send/recv.
+// Returns 1 if both RDMA read and RDMA write are supported, 0 otherwise.
+int rdmaxcel_efa_supports_rdma(struct ibv_context* ctx);
+
 // Create an EFA SRD queue pair via efadv_create_qp_ex
 struct ibv_qp* create_efa_qp(
     struct ibv_context* context,

--- a/rdmaxcel-sys/src/rdmaxcel.h
+++ b/rdmaxcel-sys/src/rdmaxcel.h
@@ -399,6 +399,8 @@ struct ibv_qp* create_efa_qp(
     int max_recv_sge);
 
 // EFA extended-verbs operation posting
+// signaled: non-zero to request a completion for this work request. The QP is
+// created with sq_sig_all = 0, so an unsignaled request produces no CQE.
 int rdmaxcel_efa_post_write(
     rdmaxcel_qp_t* qp,
     struct ibv_ah* ah,
@@ -409,7 +411,8 @@ int rdmaxcel_efa_post_write(
     size_t length,
     void* remote_addr,
     uint32_t rkey,
-    uint64_t wr_id);
+    uint64_t wr_id,
+    int signaled);
 
 int rdmaxcel_efa_post_read(
     rdmaxcel_qp_t* qp,
@@ -421,7 +424,8 @@ int rdmaxcel_efa_post_read(
     size_t length,
     void* remote_addr,
     uint32_t rkey,
-    uint64_t wr_id);
+    uint64_t wr_id,
+    int signaled);
 
 // EFA-specific connect: INIT->RTR->RTS + address handle creation
 int rdmaxcel_efa_connect(
@@ -446,6 +450,7 @@ int rdmaxcel_efa_post_op(
     void* remote_addr,
     uint32_t rkey,
     uint64_t wr_id,
+    int signaled,
     int op_type);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Successor of #3391, re-ported onto the restructured ibverbs backend as announced in https://github.com/meta-pytorch/monarch/pull/3391#issuecomment-5380094174. That branch predates the per-device module split (`efa_device`/`efa_domain`/`efa_queue_pair`), CQ pooling (#4668/#4688), and #4039's test-scaffolding removal, and could no longer merge meaningfully. All review discussion there carries over; the two follow-ups requested in those threads are delivered here as their own commits.

Five commits:

1. **Leave an EFA device that cannot do RDMA to another backend** — the P4d gate. Main's `efa_queue_pair.rs` asserts `device_caps` RDMA read+write at QP creation; this checks the same caps (mirroring libfabric's `efa_prov_info.c` test) during backend selection instead, so a P4d-class device falls back to TCP gracefully rather than panicking. P5/P5en are unaffected.
2. **Serve a same-node EFA transfer with a copy instead of a work request** — EFA silently drops same-node loopback at the NIC (libfabric works around it with SHM; raw verbs has no such fallback), so a transfer where both ends land on the same manager becomes a `memcpy`/`cudaMemcpy` instead of a WQE that never completes.
3. **Report the root cause of a failed op, not the flush behind it** — wires `is_wr_flush_err()` (previously defined but never called) into the error path so a `WR_FLUSH_ERR` message points at the completion cache's originating error rather than the symptom. Requested in #3391 review (@samlurye).
4. **Honor the signaled flag on the EFA post path** — plumbs `signaled` through `rdmaxcel_efa_post_op`/`rdmaxcel_efa_post_write` so EFA gets the same selective-signaling batching the RC path already had (previously EFA hardcoded `IBV_SEND_SIGNALED` on every chunk). Also from #3391 review.
5. **Write down what EFA does differently** — the EFA notes doc from #3391, updated for the new module layout and with the P4d/P5 `max_qp_rd_atom` contradiction fixed.

Verification (all real runs, on this branch vs a clean `main` worktree):
- `cargo check -p monarch_rdma` and `cargo fmt -- --check` clean; `gcc -fsyntax-only -Wall -Wextra` on `rdmaxcel.c` zero warnings (on stock main the same run shows `unused parameter 'signaled'` — which is what commit 4 fixes).
- `cargo test -p monarch_rdma --lib` (linked with `-l ibverbs -l efa -l mlx5`): **143 passed on this branch vs 127 on stock main** — the delta is exactly the 10 new tests plus test-order shuffle; the "failures" in both runs are hardware skips implemented as panics (`SKIPPED: no RDMA devices available`, CUDA-unavailable) and the failing-name sets diff clean of any regression (every differing test passes in isolation on this branch).
- 10 new tests cover the loopback eligibility matrix (incl. the case that matters most: a GPU remote view must **not** take the copy path — on main a dmabuf MR maps at iova 0, so an address-based `is_device_ptr` probe would pass for device memory and memcpy to near-null; the port carries `MemoryLocation` on the wire instead) and flush-vs-root-cause attribution in both orderings, mutation-tested.

Two review promises resolved differently than announced in the #3391 plan comment, for cause:
- The `signaled` plumb-through turned out to be real plumbing, not a comment — the parameter already existed end-to-end and only the EFA branch dropped it (hardcoding `IBV_SEND_SIGNALED`); with `sq_sig_all = 0` that flag alone decides CQE generation. All call sites still pass `true`, so behavior is preserved; flipping any to `false` is deliberately left as a separate change because the new send-queue credit accounting assumes one CQE per WR.
- The adaptive-polling change from #3391 is **absorbed** by main's `PollSleepPolicy` + `RDMA_CQ_BUSY_POLL_WINDOW` and is not re-ported.

One #3391 hunk is dropped rather than ported: the `efa_nv_peermem` check in `validate_execution_context` is unreachable on the EFA path (its only consumer sits after the `is_efa` early-return that existed at merge-base too), and porting it process-wide would have made the **Mellanox** manager on a mixed host skip its own peer-mapping check.

Open review threads on #3391 that remain live design questions (delivery-complete semantics, `max_rdma_size`-driven chunking) apply unchanged to this branch.
