### PR TITLE
characterize pending message resolution (#4735)

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -2109,6 +2109,7 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
 
 #[cfg(test)]
 mod tests {
+    use futures::future::FutureExt;
     use hyperactor as reference;
     use hyperactor::accum::ReducerSpec;
     use hyperactor::accum::StreamingReducerOpts;
@@ -2120,6 +2121,8 @@ mod tests {
     use hyperactor_mesh::resource::Status;
     use hyperactor_mesh::resource::{self};
     use pyo3::PyTypeInfo;
+    use pyo3::ffi::c_str;
+    use pyo3::panic::PanicException;
 
     use super::*;
     use crate::actor::to_py_error;
@@ -2298,5 +2301,208 @@ mod tests {
             // 3) Starts with the expected prefix
             assert!(py_msg.starts_with(&expected_prefix));
         });
+    }
+
+    // -- ready response ports -------------------------------------------
+    //
+    // Both wrappers complete their effect synchronously inside
+    // `resolve_and_send` and hand back a `PyPythonTask` that only converts the
+    // result. The task is therefore not the operation: observing it cannot
+    // cause the effect, and dropping it cannot undo one. These pin that split
+    // directly on the two methods, because coverage that reaches them through
+    // `Port.send()` or an endpoint reply cannot separate the synchronous half
+    // from the returned task.
+    //
+    // Note what is deliberately NOT claimed: that the returned task is ready on
+    // its first poll. Result conversion can wait on the GIL, so these only
+    // establish that it completes successfully.
+
+    /// A real `LocalPort` over a live once port, plus its receiver.
+    ///
+    /// The proc is deliberately not returned: the `Instance` owns a clone of it
+    /// and the port owns the `Instance`, so the port keeps the proc alive by
+    /// itself. It is an isolated proc because delivery never leaves the process
+    /// -- posting to a once port hands the value to a oneshot sender -- so no
+    /// served channel is needed, and a direct proc would serve one from a
+    /// spawned task that outlives the `Proc`.
+    ///
+    /// `actor_instance` spawns detached introspect tasks, so callers must be
+    /// `#[tokio::test]`: cleanup is the per-test runtime being dropped. Driving
+    /// this fixture from the shared runtime would leak those tasks for the life
+    /// of the test binary.
+    fn local_port_fixture() -> (
+        LocalPort,
+        hyperactor::mailbox::OncePortReceiver<Result<Py<PyAny>, Py<PyAny>>>,
+    ) {
+        let proc = Proc::isolated();
+        let instance = proc
+            .actor_instance::<PythonActor>("resolve_and_send_client")
+            .unwrap()
+            .instance;
+        let (handle, receiver) = instance.open_once_port::<Result<Py<PyAny>, Py<PyAny>>>();
+        let port = LocalPort {
+            instance: PyInstance::from(instance),
+            inner: Some(handle),
+        };
+        (port, receiver)
+    }
+
+    // The post happens inside `resolve_and_send`, before anything observes the
+    // returned task, and dropping that task cannot undo it.
+    //
+    // The single non-yielding poll is what makes this precise. Awaiting the
+    // receiver would also accept a post made later by some other task, and
+    // would hang rather than fail if the value never arrived at all. Requiring
+    // the value to be there without ever yielding is the actual claim.
+    #[tokio::test]
+    async fn local_port_resolve_and_send_posts_before_the_task_is_observed() {
+        pyo3::Python::initialize();
+        let (mut port, receiver) = local_port_fixture();
+
+        let task = monarch_with_gil_blocking(GilSite::Test, |py| {
+            let value = 41i64.into_py_any(py).unwrap();
+            port.resolve_and_send(value).unwrap()
+        });
+
+        // Dropped without ever being driven.
+        drop(task);
+
+        let received = receiver
+            .recv()
+            .now_or_never()
+            .expect("the value must already be posted, with no further polling")
+            .unwrap();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            assert_eq!(
+                received.unwrap().extract::<i64>(py).unwrap(),
+                41,
+                "the value must already be posted when the task is discarded"
+            );
+        });
+    }
+
+    // The positive control for the case above: driving the returned task
+    // succeeds rather than erroring, and the value that arrives is the one the
+    // synchronous half already posted. A once port can carry only one value, so
+    // this also shows observation adds no second delivery.
+    #[tokio::test]
+    async fn local_port_resolve_and_send_task_completes_successfully() {
+        pyo3::Python::initialize();
+        let (mut port, receiver) = local_port_fixture();
+
+        let mut task = monarch_with_gil_blocking(GilSite::Test, |py| {
+            let value = 42i64.into_py_any(py).unwrap();
+            port.resolve_and_send(value).unwrap()
+        });
+
+        let driven = task.take_task().unwrap().await;
+        assert!(driven.is_ok(), "observing the wrapper must succeed");
+
+        let received = receiver
+            .recv()
+            .now_or_never()
+            .expect("driving the wrapper must not be what delivers the value")
+            .unwrap();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            assert_eq!(received.unwrap().extract::<i64>(py).unwrap(), 42);
+        });
+    }
+
+    // KNOWN-BAD CURRENT BEHAVIOR, recorded so a later conversion decides
+    // deliberately rather than by accident: a `LocalPort` is one-shot by panic,
+    // not by error. `send` unwraps the taken handle with
+    // `expect("use local port once")`, so a second call aborts the frame rather
+    // than returning `Err`. This is what the code does today; it is not a
+    // contract worth preserving on purpose.
+    //
+    // The first call sits outside the `try` so that only the second call can
+    // satisfy the assertions; a first-call failure surfaces as a test error
+    // instead of masquerading as the expected one. The rest runs inside Python
+    // because PyO3 maps the panic to `PanicException` at the boundary but
+    // resumes it as a Rust panic if it escapes back out, so catching it in
+    // Python is what makes the production-visible type observable. That type is
+    // compared by identity against PyO3's own `PanicException`, which derives
+    // from `BaseException` -- hence the `except BaseException`, and hence a
+    // caller's ordinary error handling never sees this.
+    #[tokio::test]
+    async fn local_port_second_resolve_and_send_raises_panic_exception() {
+        pyo3::Python::initialize();
+        let (port, _receiver) = local_port_fixture();
+
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let locals = PyDict::new(py);
+            locals.set_item("port", Py::new(py, port).unwrap()).unwrap();
+            py.run(
+                c_str!(
+                    r#"
+port.resolve_and_send(1)
+try:
+    port.resolve_and_send(2)
+except BaseException as err:
+    raised = type(err)
+    message = str(err)
+else:
+    raise AssertionError("a second resolve_and_send must fail")
+"#
+                ),
+                None,
+                Some(&locals),
+            )
+            .unwrap();
+
+            let raised = locals.get_item("raised").unwrap().unwrap();
+            let message: String = locals
+                .get_item("message")
+                .unwrap()
+                .unwrap()
+                .extract()
+                .unwrap();
+            assert!(
+                raised.is(PanicException::type_object(py)),
+                "a second send must surface as PanicException, got {raised}"
+            );
+            assert!(
+                message.contains("use local port once"),
+                "expected the one-shot panic message, got {message}"
+            );
+        });
+    }
+
+    // `DroppingPort` is stateless, so unlike `LocalPort` it is idempotent:
+    // repeated calls keep returning tasks that complete successfully, and a
+    // discarded task leaves nothing behind because there was never a deferred
+    // effect. This one is a plain `#[test]`: it needs no proc and no port, only
+    // a runtime to drive the returned wrapper.
+    #[test]
+    fn dropping_port_resolve_and_send_completes_and_is_idempotent() {
+        pyo3::Python::initialize();
+        let port = DroppingPort;
+
+        for _ in 0..3 {
+            let mut task = monarch_with_gil_blocking(GilSite::Test, |py| {
+                let value = 7i64.into_py_any(py).unwrap();
+                port.resolve_and_send(value).unwrap()
+            });
+            let driven = get_tokio_runtime().block_on(task.take_task().unwrap());
+            assert!(driven.is_ok(), "every DroppingPort task must complete");
+        }
+
+        // A task nobody observes is equally inert.
+        let discarded = monarch_with_gil_blocking(GilSite::Test, |py| {
+            let value = 8i64.into_py_any(py).unwrap();
+            port.resolve_and_send(value).unwrap()
+        });
+        drop(discarded);
+
+        let mut after = monarch_with_gil_blocking(GilSite::Test, |py| {
+            let value = 9i64.into_py_any(py).unwrap();
+            port.resolve_and_send(value).unwrap()
+        });
+        assert!(
+            get_tokio_runtime()
+                .block_on(after.take_task().unwrap())
+                .is_ok(),
+            "discarding a task must not disturb the next call"
+        );
     }
 }

--- a/monarch_hyperactor/src/pickle.rs
+++ b/monarch_hyperactor/src/pickle.rs
@@ -902,25 +902,76 @@ mod tests {
     use hyperactor_mesh::proc_agent::ProcAgent;
     use hyperactor_mesh::proc_mesh::ProcMeshRef;
     use hyperactor_mesh::proc_mesh::ProcRef;
+    use pyo3::IntoPyObjectExt;
+    use pyo3::PyTypeInfo;
 
     use super::*;
+    use crate::proc_mesh::PyProcMesh;
 
-    fn resolved_proc_mesh_ref() -> MeshRef {
+    /// A distinct resolved proc mesh per `(instance, mesh)` pair, so a test can
+    /// tell one filled slot from another.
+    fn proc_mesh_ref(instance: u64, mesh: &str) -> ProcMeshRef {
         let proc_id = ProcId::new(
-            Uid::Instance(1, None),
+            Uid::Instance(instance, None),
             Some(Label::new("local").expect("test label should be valid")),
         );
         let proc_addr = ProcAddr::new(proc_id, ChannelAddr::Local(1).into());
         let agent: ActorRef<ProcAgent> =
             ActorRef::attest(proc_addr.actor_addr(PROC_AGENT_ACTOR_NAME));
         let proc_ref = ProcRef::new(proc_addr, 0, agent);
-        MeshRef::Proc(Box::new(
-            ProcMeshRef::new_singleton(
-                ProcMeshId::singleton(Label::new("mesh").expect("test label should be valid")),
-                proc_ref,
-            )
-            .expect("test proc mesh should be valid"),
-        ))
+        ProcMeshRef::new_singleton(
+            ProcMeshId::singleton(Label::new(mesh).expect("test label should be valid")),
+            proc_ref,
+        )
+        .expect("test proc mesh should be valid")
+    }
+
+    fn resolved_proc_mesh_ref() -> MeshRef {
+        MeshRef::Proc(Box::new(proc_mesh_ref(1, "mesh")))
+    }
+
+    /// A `Shared` that is already completed with `value`.
+    ///
+    /// Built through the Python classmethod so nothing is spawned: the handle
+    /// is finished before any test looks at it, which keeps slot filling free
+    /// of scheduling order.
+    fn completed_shared(py: Python<'_>, value: Py<PyAny>) -> Py<PyShared> {
+        py.get_type::<PyShared>()
+            .call_method1("from_value", (value,))
+            .expect("Shared.from_value should accept any object")
+            .extract()
+            .expect("Shared.from_value should return a Shared")
+    }
+
+    /// The Python object a resolved pending mesh hands back: the wrapper type
+    /// the sender-side fill knows how to turn into a `MeshRef`.
+    fn mesh_value(py: Python<'_>, mesh: &ProcMeshRef) -> Py<PyAny> {
+        Py::new(py, PyProcMesh::new_ref(mesh.clone()))
+            .expect("PyProcMesh should construct")
+            .into_any()
+    }
+
+    /// `Result::expect_err` for a success type that is not `Debug`.
+    fn expect_error(result: PyResult<PyPythonTask>, context: &str) -> PyErr {
+        match result {
+            Ok(_) => panic!("{context}"),
+            Err(error) => error,
+        }
+    }
+
+    fn pickling_state(
+        buffer: Vec<u8>,
+        mesh_references: Vec<Option<MeshRef>>,
+        pending_mesh_fills: Vec<(usize, Py<PyShared>)>,
+    ) -> PicklingState {
+        PicklingState {
+            inner: Some(PicklingStateInner {
+                buffer: Part::from(buffer),
+                tensor_engine_references: VecDeque::new(),
+                mesh_references: mesh_references.into(),
+                pending_mesh_fills,
+            }),
+        }
     }
 
     fn pending_message(
@@ -1048,5 +1099,281 @@ mod tests {
                 "sync and async resolution should preserve kind, bytes, and refs"
             );
         }
+    }
+
+    /// `resolve` writes each pending mesh into the slot it reserved, leaving
+    /// the slots it did not reserve and the pickled bytes alone.
+    ///
+    /// The two pending slots are nonadjacent, with an already-resolved slot
+    /// between them, so filling them in the wrong order or appending instead of
+    /// writing in place both produce a different table.
+    #[tokio::test]
+    async fn resolve_fills_nonadjacent_slots_in_place_without_touching_the_payload() {
+        pyo3::Python::initialize();
+
+        let first = proc_mesh_ref(11, "first");
+        let already = proc_mesh_ref(22, "already");
+        let second = proc_mesh_ref(33, "second");
+        assert_ne!(
+            first, second,
+            "the two pending meshes must be distinguishable"
+        );
+        let payload: Vec<u8> = vec![0, 1, 2, 3, 127, 128, 254, 255];
+
+        let state = monarch_with_gil_blocking(GilSite::Test, |py| {
+            Ok::<_, PyErr>(pickling_state(
+                payload.clone(),
+                vec![None, Some(MeshRef::Proc(Box::new(already.clone()))), None],
+                // Deliberately out of index order: an implementation that
+                // ignored the index and filled successive empty slots would
+                // produce the reverse table.
+                vec![
+                    (2, completed_shared(py, mesh_value(py, &second))),
+                    (0, completed_shared(py, mesh_value(py, &first))),
+                ],
+            ))
+        })
+        .expect("building the pending state should succeed");
+
+        let resolved = state.resolve().await.expect("resolution should succeed");
+        let inner = resolved
+            .inner
+            .expect("a resolved state should still hold its inner");
+
+        assert_eq!(
+            inner.mesh_references,
+            VecDeque::from(vec![
+                Some(MeshRef::Proc(Box::new(first))),
+                Some(MeshRef::Proc(Box::new(already))),
+                Some(MeshRef::Proc(Box::new(second))),
+            ]),
+            "each pending mesh must land in the slot it reserved"
+        );
+        assert_eq!(
+            &inner.take_buffer().into_bytes()[..],
+            &payload[..],
+            "resolution must not re-pickle: the payload bytes are carried through"
+        );
+    }
+
+    /// `py_resolve` consumes its source in the call and defers the fill.
+    ///
+    /// The handle resolves to a value that is not a mesh, so filling its slot
+    /// must fail. `py_resolve` returning `Ok` therefore shows the fill did not
+    /// happen during the call, and
+    /// `py_resolve_task_surfaces_the_fill_error_and_leaves_the_source_consumed`
+    /// drives the same shape and collects that failure.
+    /// `py_resolve_retains_no_waiter_on_a_pending_handle` is what covers the
+    /// stronger timing claim, that the call retains no waiter on the handle.
+    #[tokio::test]
+    async fn py_resolve_consumes_the_source_before_returning_its_task() {
+        pyo3::Python::initialize();
+
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let not_a_mesh = 41i64.into_py_any(py)?;
+            let mut message = PendingMessage::new(
+                PythonMessageKind::Result { rank: Some(7) },
+                pickling_state(
+                    vec![1, 2, 3],
+                    vec![None],
+                    vec![(0, completed_shared(py, not_a_mesh))],
+                ),
+            );
+
+            let task = message
+                .py_resolve()
+                .expect("the fill is deferred, so construction must not perform it");
+
+            // Discarded without ever being driven: no fill runs and no
+            // `PythonMessage` is ever produced.
+            drop(task);
+
+            let second = expect_error(
+                message.py_resolve(),
+                "the source was consumed by the first call",
+            );
+            assert_eq!(
+                second.value(py).to_string(),
+                "PicklingState has already been consumed",
+                "a second resolution must report the consumed source"
+            );
+            Ok::<_, PyErr>(())
+        })
+        .expect("test body should not fail");
+    }
+
+    /// The control for the case above: the fill error the construction did not
+    /// raise surfaces when the returned task is driven, and the source stays
+    /// consumed afterwards.
+    #[tokio::test]
+    async fn py_resolve_task_surfaces_the_fill_error_and_leaves_the_source_consumed() {
+        pyo3::Python::initialize();
+
+        let (mut task, mut message) = monarch_with_gil_blocking(GilSite::Test, |py| {
+            let not_a_mesh = 41i64.into_py_any(py)?;
+            let mut message = PendingMessage::new(
+                PythonMessageKind::Result { rank: Some(7) },
+                pickling_state(
+                    vec![1, 2, 3],
+                    vec![None],
+                    vec![(0, completed_shared(py, not_a_mesh))],
+                ),
+            );
+            let task = message.py_resolve()?;
+            Ok::<_, PyErr>((task, message))
+        })
+        .expect("construction should succeed");
+
+        let error = task
+            .take_task()
+            .expect("the returned task should be takeable")
+            .await
+            .expect_err("driving the task must surface the fill failure");
+
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            assert!(
+                error
+                    .get_type(py)
+                    .is(pyo3::exceptions::PyRuntimeError::type_object(py)),
+                "the original exception type must survive the task boundary exactly, \
+                 not merely as a subclass"
+            );
+            assert_eq!(
+                error.value(py).to_string(),
+                "pending pickle did not resolve to a mesh reference",
+                "the original message must survive the task boundary"
+            );
+
+            let second = expect_error(
+                message.py_resolve(),
+                "a failed drive must not hand the source back",
+            );
+            assert_eq!(
+                second.value(py).to_string(),
+                "PicklingState has already been consumed",
+            );
+            Ok::<_, PyErr>(())
+        })
+        .expect("assertions should not fail");
+    }
+
+    /// A failure raised by the pending handle's own task, rather than by the
+    /// conversion that follows it, is what the outer task reports.
+    ///
+    /// The inner message reserves a slot with no fill for it, so its task fails
+    /// in assembly with a message the conversion path cannot produce. Spawning
+    /// that task backs the handle with a task that fails, so awaiting the handle
+    /// is the step that fails and the sibling conversion-error test cannot be
+    /// what this one is measuring.
+    #[tokio::test]
+    async fn py_resolve_task_surfaces_a_failed_pending_handle_error() {
+        pyo3::Python::initialize();
+
+        let (mut outer_task, mut outer) = monarch_with_gil_blocking(GilSite::Test, |py| {
+            let mut inner = PendingMessage::new(
+                PythonMessageKind::Result { rank: Some(1) },
+                pickling_state(vec![9], vec![None], vec![]),
+            );
+            let handle = Py::new(py, inner.py_resolve()?.spawn()?)?;
+
+            let mut outer = PendingMessage::new(
+                PythonMessageKind::Result { rank: Some(7) },
+                pickling_state(vec![1, 2, 3], vec![None], vec![(0, handle)]),
+            );
+            let task = outer.py_resolve()?;
+            Ok::<_, PyErr>((task, outer))
+        })
+        .expect("construction should succeed");
+
+        let error = outer_task
+            .take_task()
+            .expect("the returned task should be takeable")
+            .await
+            .expect_err("the failed handle must fail the outer resolution");
+
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            assert!(
+                error
+                    .get_type(py)
+                    .is(pyo3::exceptions::PyRuntimeError::type_object(py)),
+                "the producer's exception type must survive both task boundaries"
+            );
+            assert_eq!(
+                error.value(py).to_string(),
+                "mesh reference slot was never filled",
+                "the outer task must report the producer's own failure, not a \
+                 conversion failure raised after a successful await"
+            );
+
+            let second = expect_error(
+                outer.py_resolve(),
+                "a failed handle must not hand the source back",
+            );
+            assert_eq!(
+                second.value(py).to_string(),
+                "PicklingState has already been consumed",
+            );
+            Ok::<_, PyErr>(())
+        })
+        .expect("assertions should not fail");
+    }
+
+    /// `py_resolve` returns without retaining a waiter on a pending handle:
+    /// it consumes the source and leaves the waiting to the returned task.
+    ///
+    /// The witness is the sender's receiver count, because `Shared::task()`
+    /// clones the watch receiver and holds it for the life of the waiter. The
+    /// count is read before the returned task is dropped, since dropping it
+    /// would release any waiter it had retained and restore the baseline.
+    ///
+    /// Scope: this is about retaining a waiter, not about looking. `poll()`
+    /// reads the watch value through a borrow and clones nothing, so a count
+    /// that has not moved does not rule out a poll.
+    #[tokio::test]
+    async fn py_resolve_retains_no_waiter_on_a_pending_handle() {
+        pyo3::Python::initialize();
+
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let (sender, pending) = PyShared::pending();
+            let handle = Py::new(py, pending)?;
+            let baseline = sender.receiver_count();
+
+            let mut message = PendingMessage::new(
+                PythonMessageKind::Result { rank: Some(7) },
+                pickling_state(vec![1, 2, 3], vec![None], vec![(0, handle.clone_ref(py))]),
+            );
+
+            let task = message.py_resolve()?;
+            let retained = sender.receiver_count();
+            drop(task);
+
+            assert_eq!(
+                retained, baseline,
+                "py_resolve must return without retaining a waiter on the handle"
+            );
+
+            let waiter = handle.borrow(py).task()?;
+            assert_eq!(
+                sender.receiver_count(),
+                baseline + 1,
+                "one task() waiter must retain exactly one additional receiver"
+            );
+            drop(waiter);
+
+            let second = expect_error(
+                message.py_resolve(),
+                "the source was consumed by the first call",
+            );
+            assert_eq!(
+                second.value(py).to_string(),
+                "PicklingState has already been consumed",
+            );
+
+            // Nothing is parked on this handle, but publish rather than leave
+            // the fixture's sender to drop on a still-live receiver.
+            sender.send(Some(Ok(py.None()))).ok();
+            Ok::<_, PyErr>(())
+        })
+        .expect("test body should not fail");
     }
 }

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -773,6 +773,27 @@ impl PyShared {
     }
 }
 
+#[cfg(test)]
+impl PyShared {
+    /// A `Shared` that stays pending until the returned sender publishes.
+    ///
+    /// Handing back the sender lets a test both control completion and read
+    /// `receiver_count()`. `task()` and `wait_future()` clone the receiver
+    /// eagerly and hold it for the life of the waiter, so the count witnesses
+    /// waiter retention specifically. It is not a witness for observation in
+    /// general: `poll()` reads the watch value through a borrow and clones
+    /// nothing, so it leaves the count unmoved.
+    pub(crate) fn pending() -> (watch::Sender<Option<PyResult<Py<PyAny>>>>, Self) {
+        let (tx, rx) = watch::channel(None);
+        (
+            tx,
+            Self {
+                core: HandleCore::new(rx, None, None),
+            },
+        )
+    }
+}
+
 #[pymethods]
 impl PyShared {
     /// Convert this `Shared` handle into a `PythonTask` that waits

--- a/scripts/pytokio_removal_census.py
+++ b/scripts/pytokio_removal_census.py
@@ -244,6 +244,151 @@ REQUIRED_COROUTINE_ROOT_FIELDS = (
     "first_side_effect",
 )
 
+# An oracle reference names one test: a Buck target, then the test within it,
+# split at the first `::`. The target half allows the path and hyphen forms Buck
+# uses; the test half is identifier segments, which covers a Rust module path
+# and a class-qualified Python method equally.
+ORACLE_PREFIX = "fbcode//"
+
+# Buck's own target-name grammar, mirrored from buck2_core/src/target/name.rs
+# rather than guessed: a narrower class rejects legal targets like `foo+bar`,
+# a laxer one blesses names Buck reserves, and both failures are silent here
+# because the label is never resolved.
+#
+# The character list is taken from TARGET_NAME_VALID_CHARS, not from the
+# InvalidName error text, which omits the backslash the set actually contains.
+ORACLE_TARGET_NAME = re.compile(r"^[A-Za-z0-9,.=/~@!+$_\\-]+$")
+RESERVED_TARGET_NAME = "..."
+# Buck substitutes this for `=` in generated names and rejects it in a written
+# one.
+TARGET_NAME_SUBSTITUTION = "_eqsb_"
+# TargetName::MAX_NAME_LEN, which is u16::MAX.
+TARGET_NAME_MAX_LEN = 0xFFFF
+
+# Package path segments are a different grammar: a cell-relative path, so an
+# empty, `.` or `..` component is traversal rather than a name.
+ORACLE_PACKAGE_SEGMENT = re.compile(r"^[A-Za-z0-9_.-]+$")
+ORACLE_TEST = re.compile(r"^[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*$")
+
+
+def oracle_target_problem(target: str) -> str | None:
+    """Why ``target`` is not a well-formed Buck label, or ``None``.
+
+    The two halves have different grammars and are checked differently. The
+    package is a cell-relative path, so an empty, ``.`` or ``..`` segment is
+    traversal and is rejected. The target name is whatever Buck accepts, which
+    includes ``.``, ``..`` and a good deal of punctuation; it rejects the
+    reserved name ``...``, any name containing the substitution ``_eqsb_``, and
+    a name over ``u16::MAX`` characters. Neither half is resolved: the label is
+    checked for shape, never for existence.
+    """
+    if not target.startswith(ORACLE_PREFIX):
+        return f"has a malformed target {target!r}"
+    package, separator, name = target[len(ORACLE_PREFIX) :].partition(":")
+    if not separator:
+        return f"has a malformed target {target!r}"
+    # Same order Buck checks in, so the diagnostic names the first thing wrong.
+    if len(name) > TARGET_NAME_MAX_LEN:
+        return (
+            f"has a target name of {len(name)} characters, over the "
+            f"{TARGET_NAME_MAX_LEN} limit, in {target!r}"
+        )
+    if not ORACLE_TARGET_NAME.match(name):
+        return f"has a malformed target name in {target!r}"
+    if TARGET_NAME_SUBSTITUTION in name:
+        return (
+            f"has a target name containing the reserved substring "
+            f"{TARGET_NAME_SUBSTITUTION!r} in {target!r}"
+        )
+    if name == RESERVED_TARGET_NAME:
+        return f"uses the reserved target name {RESERVED_TARGET_NAME!r} in {target!r}"
+    segments = package.split("/")
+    if not package or any(
+        segment in ("", ".", "..") or not ORACLE_PACKAGE_SEGMENT.match(segment)
+        for segment in segments
+    ):
+        return f"has a malformed package path in {target!r}"
+    return None
+
+
+def oracle_reference_problem(reference: object) -> str | None:
+    """Why ``reference`` is not a well-formed oracle reference, or ``None``.
+
+    Structure only. Whether the named test exists, or exercises the row, is a
+    review question: resolving a Buck target or searching for a test function
+    would make the checker depend on the build graph to answer a question it
+    cannot settle anyway.
+    """
+    if not isinstance(reference, str):
+        return f"is {type(reference).__name__}, expected a string"
+    if any(character.isspace() for character in reference):
+        return "contains whitespace"
+    target, separator, test = reference.partition("::")
+    if not separator:
+        return "has no '::' between the Buck target and the test name"
+    target_problem = oracle_target_problem(target)
+    if target_problem is not None:
+        return target_problem
+    if not ORACLE_TEST.match(test):
+        return f"has a malformed test name {test!r}"
+    return None
+
+
+def oracle_problem(value: object) -> str | None:
+    """Why a present ``oracle`` value is unusable, or ``None``.
+
+    Two accepted shapes while rows are being converted: the canonical list of
+    references, and a legacy prose label. Any bare string that starts with the
+    Buck prefix is rejected rather than read as prose -- valid or malformed --
+    because it is a half-finished conversion wearing the old shape.
+    """
+    if isinstance(value, str):
+        if not value.strip():
+            return "oracle is empty"
+        if value.strip().startswith(ORACLE_PREFIX):
+            # Anything reaching for the canonical form is a half-finished
+            # conversion, whether or not it parses. Accepting a *malformed*
+            # attempt as prose would hide precisely the typo worth catching.
+            problem = oracle_reference_problem(value)
+            syntax = "" if problem is None else f", and it {problem}"
+            return (
+                f"oracle is a bare reference string{syntax}; canonical "
+                "references go in a list, as oracle = [...]"
+            )
+        return None
+    if not isinstance(value, list):
+        return (
+            f"oracle is {type(value).__name__}; expected a list of references "
+            "or a legacy label"
+        )
+    if not value:
+        return "oracle is an empty list; give at least one reference"
+    seen: set[str] = set()
+    for position, reference in enumerate(value):
+        if (
+            isinstance(reference, str)
+            and not reference.startswith(ORACLE_PREFIX)
+            and "::" not in reference
+        ):
+            # A legacy label typed into the new shape. Say so directly: the
+            # generic reference diagnostic would blame whatever the label
+            # happens to trip first, usually a space. Something carrying `::`
+            # is a botched reference rather than prose, so it falls through to
+            # the reference diagnostic, which can name the actual defect.
+            return (
+                f"oracle[{position}] {reference!r} is not a reference; a legacy "
+                "prose label stays a bare string, and list entries must be "
+                "canonical references"
+            )
+        problem = oracle_reference_problem(reference)
+        if problem is not None:
+            return f"oracle[{position}] {problem}"
+        if reference in seen:
+            return f"oracle[{position}] repeats {reference!r}"
+        seen.add(reference)
+    return None
+
+
 REQUIRED_MATRIX_FIELDS = ("id", "disposition", "execution_state")
 
 REVISION = re.compile(r"^D\d{6,}$")
@@ -1041,7 +1186,9 @@ def validate_rows(rows: list[dict], schema: dict, config: dict) -> list[str]:
 
     Enforces required fields, declared enum values, identifier uniqueness, and
     locator uniqueness across active rows *and* tombstones, so a completed
-    migration still reserves its identity. Behavior rows additionally must
+    migration still reserves its identity. A present ``oracle`` is shape-checked
+    before the required-field gate, so an empty or malformed one is reported as
+    such rather than as a missing field. Behavior rows additionally must
     carry the full field set, and coroutine-root rows the three root-only
     facts on top of it. The obligation to pin an import member set is derived
     from the row's *operation* -- whether it is a configured Python module
@@ -1094,6 +1241,18 @@ def validate_rows(rows: list[dict], schema: dict, config: dict) -> list[str]:
             )
         if row["category"] not in BEHAVIOR_KINDS:
             continue
+        if "oracle" in row:
+            # Shape first, for this field only. While rows are being converted
+            # `oracle` accepts two representations, so a present value can be
+            # structurally wrong rather than merely absent, and the truthiness
+            # gate below would misreport it as missing. The other required
+            # fields are single free-form values with nothing to check, so this
+            # is a local exception and not the start of a field-validation
+            # framework.
+            problem = oracle_problem(row["oracle"])
+            if problem is not None:
+                errors.append(f"{row['id']}: {problem}")
+                continue
         absent = [f for f in REQUIRED_BEHAVIOR_FIELDS if not row.get(f)]
         if absent:
             errors.append(

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -2000,16 +2000,18 @@ state = "legacy"
 transition = "6.2"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from DroppingPort::resolve_and_send"
-consumer = "_Actor.handle, through its isinstance(response, PythonTask) branch"
+consumer = "_Actor.handle, through its isinstance(response, PythonTask) branch; also handed directly to user endpoint code as the explicit port argument for MethodSpecifier::ExplicitPort"
 driver = "awaited on the actor loop by _Actor.handle"
-start_point = "already complete at construction"
-abandonment = "possible; _Actor.handle may return before awaiting the branch"
-eager_effect = "only wraps a ready value"
-drop_behavior = "no effect; the send is a no-op by construction"
+start_point = "the no-op send completes synchronously inside resolve_and_send, before the wrapper is returned; observing the wrapper only converts the result, which waits on the process-global GIL lock"
+abandonment = "possible through direct use of the port, and harmless; _Actor.handle itself does not abandon the wrapper, awaiting the branch with no suspension after resolve_and_send returns"
+eager_effect = "performs the no-op send synchronously; the returned task only wraps a ready value"
+drop_behavior = "no effect; dropping the wrapper cannot undo the no-op that already ran"
 unobserved_error = "none; the future resolves to Ok(())"
 disposition = "replace with a direct value"
 semantic_class = "ready_no_op_wrapper"
-oracle = "test_python_actors response-port coverage"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::actor::tests::dropping_port_resolve_and_send_completes_and_is_idempotent",
+]
 
 [[site]]
 id = "np.actor.LocalPort.resolve_and_send"
@@ -2023,16 +2025,20 @@ state = "legacy"
 transition = "6.2"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from LocalPort::resolve_and_send"
-consumer = "_Actor.handle, through its isinstance(response, PythonTask) branch"
+consumer = "_Actor.handle, through its isinstance(response, PythonTask) branch; also handed directly to user endpoint code as the explicit port argument for MethodSpecifier::ExplicitPort"
 driver = "awaited on the actor loop by _Actor.handle"
-start_point = "already complete at construction"
-abandonment = "possible; _Actor.handle may return before awaiting the branch"
-eager_effect = "only wraps a ready value"
-drop_behavior = "no effect; port.send already happened synchronously"
+start_point = "the post completes synchronously inside resolve_and_send, before the wrapper is returned; observing the wrapper only converts the result, which waits on the process-global GIL lock"
+abandonment = "possible through direct use of the port, and harmless; _Actor.handle itself does not abandon the wrapper, awaiting the branch with no suspension after resolve_and_send returns"
+eager_effect = "posts to the once port synchronously; the returned task only wraps the already-delivered result"
+drop_behavior = "no effect; dropping the wrapper cannot undo the post that already happened"
 unobserved_error = "none; the future resolves to Ok(())"
 disposition = "replace with a direct value"
 semantic_class = "ready_no_op_wrapper"
-oracle = "test_python_actors response-port coverage"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::actor::tests::local_port_resolve_and_send_posts_before_the_task_is_observed",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::actor::tests::local_port_resolve_and_send_task_completes_successfully",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::actor::tests::local_port_second_resolve_and_send_raises_panic_exception",
+]
 
 [[site]]
 id = "np.actor_mesh.ActorMeshRef_as_ActorMeshProtocol.name"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -2491,14 +2491,20 @@ constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PendingMessage::py_resolve"
 consumer = "Port.resolve_and_send, on the actor loop"
 driver = "awaited on the actor loop before the reply is sent"
-start_point = "self.take() consumes the PendingMessage synchronously at construction; only the slot fill in resolve() is deferred to the returned task"
-abandonment = "possible; the message has already been taken out of the PendingMessage, so the source cannot be reused"
-eager_effect = "starts a side effect"
+start_point = "self.take() consumes the PendingMessage synchronously at construction; the call returns without retaining a waiter on any pending handle, and the slot fill in resolve() is deferred to the returned task"
+abandonment = "possible; the message has already been taken out of the PendingMessage, so a second resolution reports PicklingState has already been consumed"
+eager_effect = "consumes the source; take() moves the kind and the pickling state out, so the PendingMessage is spent whether or not the returned task is ever driven"
 drop_behavior = "the taken message is lost: slots are never filled and no reply is sent"
-unobserved_error = "surfaced on observation"
+unobserved_error = "none until the returned task is driven; driving it reports either a pending handle's failure or the mesh conversion that follows, with the original exception type and message, and the source stays consumed either way. What a producer behind a pending handle does with its own failure is that producer's policy, not this task's"
 disposition = "preserve timing"
 semantic_class = "sync_partial_effect_lazy_tail"
-oracle = "PicklingState::resolve slot-order in-crate test (6.0c)"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::pickle::tests::py_resolve_consumes_the_source_before_returning_its_task",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::pickle::tests::py_resolve_retains_no_waiter_on_a_pending_handle",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::pickle::tests::py_resolve_task_surfaces_a_failed_pending_handle_error",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::pickle::tests::py_resolve_task_surfaces_the_fill_error_and_leaves_the_source_consumed",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::pickle::tests::resolve_fills_nonadjacent_slots_in_place_without_touching_the_payload",
+]
 
 [[site]]
 id = "np.proc_launcher_probe.probe_exit_port_via_mesh"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -171,7 +171,33 @@
 #   disposition      the intended target treatment, from schema.dispositions.
 #   semantic_class   the abandonment class, from schema.semantic_classes; it
 #                    selects the characterization test that covers the site.
-#   oracle           the named test pinning the current behavior.
+#   oracle           the tests pinning the current behavior, as a list of
+#                    references of the form
+#                    "fbcode//package:target::test_name". Several entries are
+#                    conjunctive: the row needs all of them. The test half may
+#                    be qualified, which is how a Rust module path or a Python
+#                    class method is named:
+#
+#                      "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest\
+#                       ::pickle::tests::resolve_fills_slots_in_order"
+#                      "fbcode//monarch/python/tests:test_job::TestJob::test_exec_command"
+#
+#                    A legacy label stays a *bare string*. Prose inside the list
+#                    is rejected: the list is the canonical form and every entry
+#                    in it must be a reference.
+#
+#                    A prose label on an *active* row is transitional: those
+#                    rows are being converted to exact references and the label
+#                    will be replaced. A historical tombstone may keep its prose
+#                    label permanently, because the path it described is gone
+#                    and there is no live test left to name.
+#
+#                    A bare string starting with "fbcode//" is rejected whether
+#                    or not it parses, because that is a half-finished
+#                    conversion rather than a label. The checker validates
+#                    reference shape only -- whether the named test exists, and
+#                    whether it actually exercises the row, is a review
+#                    question it cannot answer.
 #
 # coroutine_root rows add public_operation, caller_contexts, and
 # first_side_effect: the user-facing API, the calling contexts it supports,

--- a/scripts/test_pytokio_removal_census.py
+++ b/scripts/test_pytokio_removal_census.py
@@ -108,7 +108,7 @@ drop_behavior = "nothing runs"
 unobserved_error = "dropped"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "fixture"
+oracle = ["fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes"]
 """
 
 TRANSITION = """
@@ -699,7 +699,8 @@ class CensusCheckerTest(unittest.TestCase):
             'eager_effect = "starts a side effect"\n'
             'drop_behavior = "nothing runs"\nunobserved_error = "dropped"\n'
             'disposition = "intentionally become eager"\n'
-            'semantic_class = "deferred_side_effect"\noracle = "fixture"\n'
+            'semantic_class = "deferred_side_effect"\n'
+            'oracle = ["fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes"]\n'
         )
         manifest = self.fixture.manifest(row, totals={"py_python_task_new": 1})
         manifest["site"] = [r for r in manifest["site"] if r["id"] != "np.one"]
@@ -1198,7 +1199,7 @@ class CensusCheckerTest(unittest.TestCase):
             'drop_behavior = "n/a"\nunobserved_error = "kill signal"\n'
             'disposition = "replace with the bridge future directly"\n'
             'semantic_class = "already_started_lazy_observer"\n'
-            'oracle = "fixture"\n'
+            'oracle = ["fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes"]\n'
         )
         manifest = self.fixture.manifest(direct)
         manifest["transition"][0]["owns"].append("np.direct")
@@ -1304,6 +1305,241 @@ class CensusCheckerTest(unittest.TestCase):
         )
         manifest["schema"]["matrix_ids"] = ["fm.x"]
         self.assert_reports(self.fixture.check(manifest), "unknown execution state")
+
+    # -- oracle references ------------------------------------------------
+
+    def _behavior_row(self, manifest):
+        """The synthetic producer row, which is a behavior row."""
+        return manifest["site"][0]
+
+    def _tombstoned_producer(self, manifest, oracle):
+        """Append a tombstoned behavior row carrying ``oracle``.
+
+        Its locator names no source file, so reconciliation -- which skips
+        tombstones -- neither expects a hit nor reports an unknown one.
+        """
+        row = dict(manifest["site"][0])
+        row.update(
+            id="np.gone",
+            path="src/deleted.rs",
+            symbol="Gone::make",
+            state="removed_upstream",
+            transition_revision="D111111",
+            oracle=oracle,
+        )
+        manifest["site"].append(row)
+        manifest["transition"][0]["owns"].append("np.gone")
+        return manifest
+
+    def test_oracle_canonical_single_reference_passes(self) -> None:
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            "fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes"
+        ]
+        self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_oracle_multiple_qualified_references_pass(self) -> None:
+        """Conjunctive references, module-qualified and class-qualified."""
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest"
+            "::pickle::tests::resolve_fills_slots_in_order",
+            "fbcode//monarch/python/tests:test_job::TestJob::test_exec_command",
+        ]
+        self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_oracle_legacy_label_accepted_on_active_row(self) -> None:
+        """Prose is still accepted while rows are being converted."""
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = "endpoint reply coverage"
+        self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_oracle_legacy_label_accepted_on_tombstone(self) -> None:
+        """A deleted path has no live test to name, so its label stays."""
+        manifest = self._tombstoned_producer(
+            self.fixture.manifest(), "test_actor_driver_characterization"
+        )
+        self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_oracle_scalar_reference_attempts_fail(self) -> None:
+        """Any bare string reaching for the canonical form is a half-finished
+        conversion, valid or not.
+
+        Accepting a *malformed* attempt as prose would silently swallow the
+        typo, so the prefix alone decides, and the diagnostic names the syntax
+        problem as well as the shape."""
+        cases = [
+            ("fbcode//monarch/scripts:target::test_name", None),
+            ("fbcode//monarch/scripts:target::9bad", "malformed test name"),
+            ("fbcode//monarch/scripts:target", "no '::'"),
+            ("fbcode//monarch/scripts:target::test name", "whitespace"),
+            ("  fbcode//monarch/scripts:target::test_name", "whitespace"),
+        ]
+        for reference, syntax in cases:
+            with self.subTest(reference=reference):
+                manifest = self.fixture.manifest()
+                self._behavior_row(manifest)["oracle"] = reference
+                errors = self.fixture.check(manifest)
+                self.assert_reports(errors, "canonical references go in a list")
+                if syntax is not None:
+                    self.assert_reports(errors, syntax)
+
+    def test_oracle_target_names_follow_buck_grammar(self) -> None:
+        """Buck's grammar, not a guessed subset.
+
+        A narrower class silently rejects legal targets; a laxer one blesses
+        ``...``, which Buck reserves. Both failures are invisible here because
+        the checker never resolves the label.
+        """
+        for name in (
+            ".",
+            "..",
+            "foo+bar",
+            "a@b!c=d~e",
+            "with.dots-and_score",
+            "back\\slash",
+        ):
+            with self.subTest(name=name):
+                manifest = self.fixture.manifest()
+                self._behavior_row(manifest)["oracle"] = [
+                    f"fbcode//monarch/scripts:{name}::test_name"
+                ]
+                self.assertEqual(self.fixture.check(manifest), [])
+
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            "fbcode//monarch/scripts:...::test_name"
+        ]
+        self.assert_reports(self.fixture.check(manifest), "reserved target name")
+
+    def test_oracle_target_name_boundary_rules(self) -> None:
+        """The three rules Buck applies beyond its character set.
+
+        Each is a boundary rather than a shape, so none of them is caught by
+        the character class alone.
+        """
+        limit = census.TARGET_NAME_MAX_LEN
+
+        # `_eqsb_` is Buck's substitution for `=`; a written name may not carry it.
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            "fbcode//monarch/scripts:a_eqsb_b::test_name"
+        ]
+        self.assert_reports(self.fixture.check(manifest), "reserved substring")
+
+        # Exactly at the limit is legal; one over is not.
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            f"fbcode//monarch/scripts:{'x' * limit}::test_name"
+        ]
+        self.assertEqual(self.fixture.check(manifest), [])
+
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            f"fbcode//monarch/scripts:{'x' * (limit + 1)}::test_name"
+        ]
+        self.assert_reports(self.fixture.check(manifest), f"over the {limit} limit")
+
+    def test_oracle_prose_inside_list_is_named_directly(self) -> None:
+        """Prose in the list gets its own diagnostic.
+
+        Falling through to the reference check would blame whatever the label
+        trips first -- usually a space -- instead of the real mistake. An entry
+        carrying '::' is a botched reference, not prose, and still gets the
+        reference diagnostic.
+        """
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = ["endpoint reply coverage"]
+        self.assert_reports(
+            self.fixture.check(manifest), "a legacy prose label stays a bare string"
+        )
+
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [
+            "fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes",
+            "lifecycle_coverage",
+        ]
+        self.assert_reports(self.fixture.check(manifest), "oracle[1]")
+
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = ["//monarch/scripts:target::test_name"]
+        self.assert_reports(self.fixture.check(manifest), "malformed target")
+
+    def test_oracle_whitespace_only_label_fails(self) -> None:
+        """A blank label names nothing, and was passing because it is truthy."""
+        for blank in ("   ", "\t", " \n "):
+            with self.subTest(blank=repr(blank)):
+                manifest = self.fixture.manifest()
+                self._behavior_row(manifest)["oracle"] = blank
+                self.assert_reports(self.fixture.check(manifest), "oracle is empty")
+
+    def test_oracle_ordinary_prose_label_still_passes(self) -> None:
+        """The contrast case: prose that does not reach for the canonical form
+        is untouched by the prefix rule."""
+        for label in ("endpoint reply coverage", "lifecycle edge behavior"):
+            with self.subTest(label=label):
+                manifest = self.fixture.manifest()
+                self._behavior_row(manifest)["oracle"] = label
+                self.assertEqual(self.fixture.check(manifest), [])
+
+    def test_oracle_empty_list_reports_shape_not_missing_field(self) -> None:
+        """The empty list is present but unusable; the truthiness gate would
+        otherwise misreport it as an absent field."""
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = []
+        errors = self.fixture.check(manifest)
+        self.assert_reports(errors, "oracle is an empty list")
+        joined = "\n".join(errors)
+        self.assertNotIn("behavior row missing", joined)
+
+    def test_oracle_absent_still_reports_missing_field(self) -> None:
+        """Shape checking must not swallow the absent-field diagnostic."""
+        manifest = self.fixture.manifest()
+        del self._behavior_row(manifest)["oracle"]
+        self.assert_reports(self.fixture.check(manifest), "behavior row missing oracle")
+
+    def test_oracle_wrong_top_level_type_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = 7
+        self.assert_reports(self.fixture.check(manifest), "oracle is int")
+
+    def test_oracle_non_string_member_fails(self) -> None:
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [7]
+        self.assert_reports(self.fixture.check(manifest), "oracle[0] is int")
+
+    def test_oracle_duplicate_references_fail(self) -> None:
+        reference = (
+            "fbcode//monarch/scripts:test_pytokio_removal_census::test_baseline_passes"
+        )
+        manifest = self.fixture.manifest()
+        self._behavior_row(manifest)["oracle"] = [reference, reference]
+        self.assert_reports(self.fixture.check(manifest), "oracle[1] repeats")
+
+    def test_oracle_malformed_references_fail(self) -> None:
+        """Each malformed shape is rejected, and named in the diagnostic."""
+        cases = [
+            ("//monarch/scripts:target::test_name", "malformed target"),
+            ("fbcode//:target::test_name", "malformed package path"),
+            ("fbcode//monarch/scripts::test_name", "malformed target"),
+            ("fbcode//monarch/scripts:target", "no '::'"),
+            ("fbcode//monarch/scripts:target::", "malformed test name"),
+            ("fbcode//monarch/scripts:target::9test", "malformed test name"),
+            ("fbcode//monarch/scripts:target::test name", "whitespace"),
+            ("fbcode//monarch/scripts:tar get::test_name", "whitespace"),
+            ("fbcode///pkg:target::test", "malformed package path"),
+            ("fbcode//pkg//sub:target::test", "malformed package path"),
+            ("fbcode//pkg/../sub:target::test", "malformed package path"),
+            ("fbcode//pkg/./sub:target::test", "malformed package path"),
+            ("fbcode//pkg/:target::test", "malformed package path"),
+            ("fbcode//pkg:...::test", "reserved target name"),
+            ("fbcode//pkg:tar get::test", "whitespace"),
+        ]
+        for reference, expected in cases:
+            with self.subTest(reference=reference):
+                manifest = self.fixture.manifest()
+                self._behavior_row(manifest)["oracle"] = [reference]
+                self.assert_reports(self.fixture.check(manifest), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

when a reply contains a mesh that is still initializing, Monarch can serialize the payload immediately, but it must reserve a slot for the mesh reference and carry the pending mesh handle alongside it.

calling `PendingMessage.resolve()` moves the message state into a single-use task. the original `PendingMessage` is spent as soon as the call returns, although no waiter has been retained and no reply has been assembled yet. driving the task waits for each pending mesh, writes its reference into the reserved slot, and builds the final message from the original serialized bytes. discarding the task therefore discards the reply, and the original message cannot be resolved again.

this adds direct tests for that ownership and timing boundary, correct slot placement regardless of fill order, unchanged payload bytes, and exact propagation of failures from both the pending mesh and reference conversion. the census now points to those tests. no production behavior changes.

Reviewed By: mariusae

Differential Revision: D117214355


