### PR TITLE
Poll completion queues in CompletionQueueActor, not QueuePairActor (#4738)

### DIFF
--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -12,6 +12,7 @@ use hyperactor::ActorRef;
 use hyperactor::actor::Referable;
 use typeuri::Named;
 
+mod cq_actor;
 mod cq_pool;
 pub mod device;
 pub mod device_selection;

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -16,6 +16,19 @@
 //! A CQ is polled only while a queue pair on it has CQEs outstanding. Nothing
 //! here decides that a CQ has stopped working: noticing that completions have
 //! stopped arriving is the queue pair's responsibility.
+//!
+//! When a QP actor stops, the safest approach is to wait for all pending WRs
+//! to drain before actually destroying it. In order to not introduce an async
+//! dependency into a QP's teardown, we instead hand the underlying resources
+//! and CQ lease to the CQ actor via [`Detach`] when the QP actor drops. The
+//! CQ actor keeps the QP's resources and lease alive until all pending WRs
+//! have drained. This is important for correctness: we do not want the dead
+//! QP's qp_num to be reassigned until we are sure it will produce no more
+//! CQEs; similarly, we cannot safely drop its CQ lease until we are sure
+//! it will produce no more CQEs. It is also useful for reasoning about
+//! behavior: different RDMA providers treat pending WRs and their CQEs
+//! differently when the associated QP is destroyed. Keeping the QP alive
+//! until all CQEs have drained means we can have one uniform implementation.
 
 // Nothing outside the tests below uses this module.
 #![allow(dead_code)]
@@ -33,6 +46,7 @@ use hyperactor::Instance;
 use hyperactor::OncePortHandle;
 use hyperactor::PortHandle;
 
+use super::cq_pool::CqLease;
 use super::primitives::IbvCq;
 use super::primitives::IbvWc;
 use super::queue_pair::PollCompletionError;
@@ -146,6 +160,29 @@ pub(super) struct Attach<Cq: IbvCompletionQueue> {
 #[derive(Debug)]
 pub(super) struct Posted;
 
+/// Notifies the CQ actor that the QP with `qp_num` will post no more work.
+/// The CQ actor drops the QP and its associated lease on CQ capacity only once
+/// no more pending work remains for that QP.
+#[derive(Debug)]
+pub(super) struct Detach {
+    pub(super) cq_id: CqId,
+    pub(super) qp_num: u32,
+    pub(super) qp: DetachedQueuePair,
+    pub(super) lease: CqLease,
+}
+
+/// A queue pair the poller has taken responsibility for destroying, which happens
+/// when this is dropped. Opaque: the poller never operates on it, it only decides
+/// when it goes away.
+#[derive(Debug)]
+pub(super) struct DetachedQueuePair(Box<dyn std::fmt::Debug + Send + Sync>);
+
+impl DetachedQueuePair {
+    pub(super) fn new<Qp: std::fmt::Debug + Send + Sync + 'static>(qp: Qp) -> Self {
+        Self(Box::new(qp))
+    }
+}
+
 /// Self-message that drives one polling round.
 #[derive(Debug)]
 struct Poll;
@@ -153,12 +190,20 @@ struct Poll;
 /// One queue pair reporting on a CQ.
 #[derive(Debug)]
 struct QpSlot {
-    /// Where the QP's completions go.
-    port: PortHandle<CompletionBatch>,
+    /// Where the QP's completions go, and `None` once the QP has detached.
+    port: Option<PortHandle<CompletionBatch>>,
     /// The QP's [`Attach::posted`] counter, which stops moving when it stops posting.
     posted: Arc<AtomicU64>,
     /// CQEs consumed for this queue pair.
     consumed: u64,
+    /// The queue pair itself, set once its actor has stopped and sent
+    /// [`Detach`] to the CQ actor. Held here so the QP's resources aren't
+    /// destroyed until all pending work has drained.
+    qp: Option<DetachedQueuePair>,
+    /// The CQ capacity reservation associated with the detached QP. Dropped
+    /// after [`Detach`] once all pending work has drained -- until then,
+    /// the detached QP still uses capacity on the CQ.
+    _lease: Option<CqLease>,
 }
 
 impl QpSlot {
@@ -167,6 +212,12 @@ impl QpSlot {
     /// produced it.
     fn outstanding(&self) -> i64 {
         self.posted.load(Ordering::Relaxed) as i64 - self.consumed as i64
+    }
+
+    /// True as long as this QP has pending work *or* the QP is still
+    /// attached.
+    fn is_live(&self) -> bool {
+        self.port.is_some() || self.outstanding() > 0
     }
 }
 
@@ -184,7 +235,9 @@ impl<Cq: IbvCompletionQueue> CqSlot<Cq> {
         self.queue_pairs.values().any(|qp| qp.outstanding() > 0)
     }
 
-    /// Hands each of `consumed` to the queue pair that produced it.
+    /// Hands each of `consumed` to the queue pair that produced it. Completions
+    /// for detached QPs are discarded, and a detached QP with no more pending work
+    /// is dropped here, along with its lease on CQ capacity.
     fn route(
         &mut self,
         cq_id: CqId,
@@ -200,7 +253,9 @@ impl<Cq: IbvCompletionQueue> CqSlot<Cq> {
             });
             qp.consumed += completions.len() as u64;
 
-            if let Err(error) = qp.port.try_post(cx, CompletionBatch { completions }) {
+            if let Some(port) = &qp.port
+                && let Err(error) = port.try_post(cx, CompletionBatch { completions })
+            {
                 // It's okay to just log and do nothing here. It won't mess up the QP's internal credit
                 // accounting, because the delivery should only be able to fail once the QP is
                 // already dead
@@ -210,6 +265,10 @@ impl<Cq: IbvCompletionQueue> CqSlot<Cq> {
                     %error,
                     "delivering completions to a queue pair failed",
                 );
+            }
+
+            if !qp.is_live() {
+                self.queue_pairs.remove(&qp_num);
             }
         }
     }
@@ -231,7 +290,8 @@ fn group_by_queue_pair(
 /// produced it.
 ///
 /// Generic over the CQ type `Cq` so unit tests run without RDMA hardware. A
-/// poller starts empty: CQs arrive with the queue pairs that attach to them.
+/// poller starts empty: CQs arrive with the queue pairs that attach to them, and
+/// leave with the last queue pair on them.
 #[derive(Debug)]
 pub(super) struct CompletionQueueActor<Cq: IbvCompletionQueue> {
     completion_queues: HashMap<CqId, CqSlot<Cq>>,
@@ -240,6 +300,28 @@ pub(super) struct CompletionQueueActor<Cq: IbvCompletionQueue> {
     /// `true` while a `Poll` self-message is already in flight; the flag
     /// prevents stacking redundant rounds.
     poll_armed: bool,
+}
+
+impl<Cq: IbvCompletionQueue> Drop for CompletionQueueActor<Cq> {
+    fn drop(&mut self) {
+        let attached: usize = self
+            .completion_queues
+            .values()
+            .map(|slot| {
+                slot.queue_pairs
+                    .values()
+                    .filter(|qp| qp.port.is_some())
+                    .count()
+            })
+            .sum();
+        if attached > 0 {
+            tracing::error!(
+                attached,
+                completion_queues = self.completion_queues.len(),
+                "a CQ poller is going away with queue pairs attached to it",
+            );
+        }
+    }
 }
 
 impl<Cq: IbvCompletionQueue> CompletionQueueActor<Cq> {
@@ -284,9 +366,9 @@ impl<Cq: IbvCompletionQueue> CompletionQueueActor<Cq> {
             consumed,
             ..
         } = self;
-        for (cq_id, slot) in completion_queues {
+        completion_queues.retain(|cq_id, slot| {
             if !slot.expects_completions() {
-                continue;
+                return true;
             }
             consumed.clear();
             // SAFETY: a CQ stays live or null while a queue pair is attached to
@@ -298,10 +380,12 @@ impl<Cq: IbvCompletionQueue> CompletionQueueActor<Cq> {
                 // The failing entry is consumed either way, so the CQ can still
                 // make progress next round.
                 tracing::warn!(?cq_id, %error, "consuming from a CQ failed");
-                continue;
+                return true;
             }
             slot.route(*cq_id, cx, consumed);
-        }
+            // The last queue pair to be destroyed takes its CQ with it.
+            !slot.queue_pairs.is_empty()
+        });
         self.arm(cx)
     }
 }
@@ -345,9 +429,11 @@ impl<Cq: IbvCompletionQueue> Handler<Attach<Cq>> for CompletionQueueActor<Cq> {
         slot.queue_pairs.insert(
             qp_num,
             QpSlot {
-                port,
+                port: Some(port),
                 posted,
                 consumed: 0,
+                qp: None,
+                _lease: None,
             },
         );
         // The route is in place whether or not anyone is left to hear that, and
@@ -367,6 +453,41 @@ impl<Cq: IbvCompletionQueue> Handler<Posted> for CompletionQueueActor<Cq> {
 }
 
 #[async_trait]
+impl<Cq: IbvCompletionQueue> Handler<Detach> for CompletionQueueActor<Cq> {
+    async fn handle(&mut self, cx: &Context<Self>, msg: Detach) -> Result<(), anyhow::Error> {
+        let Detach {
+            cq_id,
+            qp_num,
+            qp,
+            lease,
+        } = msg;
+        let slot = self.completion_queues.get_mut(&cq_id).unwrap_or_else(|| {
+            panic!(
+                "detach for queue pair {qp_num} on CQ {cq_id:?}, which this poller does not hold"
+            )
+        });
+        let route = slot.queue_pairs.get_mut(&qp_num).unwrap_or_else(|| {
+            // A queue pair detaches only after its attach was acknowledged.
+            panic!("detach for queue pair {qp_num}, which is not attached to CQ {cq_id:?}")
+        });
+        // Nothing will read its completions or post to it again; what it still
+        // has outstanding is consumed and discarded.
+        route.port = None;
+        route.qp = Some(qp);
+        route._lease = Some(lease);
+        if !route.is_live() {
+            slot.queue_pairs.remove(&qp_num);
+        }
+        if slot.queue_pairs.is_empty() {
+            self.completion_queues.remove(&cq_id);
+        }
+        // It may have posted for completions nothing else will wake the poller
+        // for, its own actor being gone.
+        self.arm(cx)
+    }
+}
+
+#[async_trait]
 impl<Cq: IbvCompletionQueue> Handler<Poll> for CompletionQueueActor<Cq> {
     async fn handle(&mut self, cx: &Context<Self>, _msg: Poll) -> Result<(), anyhow::Error> {
         self.poll_armed = false;
@@ -378,6 +499,8 @@ impl<Cq: IbvCompletionQueue> Handler<Poll> for CompletionQueueActor<Cq> {
 mod tests {
     use std::collections::VecDeque;
     use std::sync::Mutex;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::AtomicU32;
     use std::time::Duration;
 
     use anyhow::Result;
@@ -471,11 +594,53 @@ mod tests {
         }
     }
 
+    /// Stands in for a queue pair handed over on detach: sets `destroyed` when the
+    /// poller drops it, and records the reservations outstanding as of then.
+    #[derive(Debug)]
+    struct TestQp {
+        destroyed: Arc<AtomicBool>,
+        leases: Arc<AtomicU32>,
+        leases_at_destroy: Arc<AtomicU32>,
+    }
+
+    impl Drop for TestQp {
+        fn drop(&mut self) {
+            self.leases_at_destroy
+                .store(self.leases.load(Ordering::SeqCst), Ordering::SeqCst);
+            self.destroyed.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// A queue pair to hand over, the flag reporting its destruction, and the
+    /// reservations outstanding when that happened -- which is how a test sees that
+    /// the queue pair went away before its reservation did.
+    fn test_qp(leases: &Arc<AtomicU32>) -> (DetachedQueuePair, Arc<AtomicBool>, Arc<AtomicU32>) {
+        let destroyed = Arc::new(AtomicBool::new(false));
+        let leases_at_destroy = Arc::new(AtomicU32::new(u32::MAX));
+        let qp = DetachedQueuePair::new(TestQp {
+            destroyed: Arc::clone(&destroyed),
+            leases: Arc::clone(leases),
+            leases_at_destroy: Arc::clone(&leases_at_destroy),
+        });
+        (qp, destroyed, leases_at_destroy)
+    }
+
     /// One attached queue pair, from the test's side: where its completions
-    /// arrive, and the counter it posts against.
+    /// arrive, the counter it posts against, and the reservation it holds.
     struct TestRoute {
         completions: PortReceiver<CompletionBatch>,
         posted: Arc<AtomicU64>,
+        leases: Arc<AtomicU32>,
+        lease: Option<CqLease>,
+    }
+
+    impl TestRoute {
+        /// The reservation this queue pair holds, to hand over on detach.
+        fn lease(&mut self) -> CqLease {
+            self.lease
+                .take()
+                .expect("the queue pair still holds its reservation")
+        }
     }
 
     /// Parent of the actor under test, so its supervision events land here and
@@ -510,8 +675,7 @@ mod tests {
     #[async_trait]
     impl Handler<SpawnPoller> for MockParent {
         async fn handle(&mut self, cx: &Context<Self>, msg: SpawnPoller) -> Result<()> {
-            let actor = CompletionQueueActor::<MockCq>::new();
-            let handle = cx.spawn(actor);
+            let handle = cx.spawn(CompletionQueueActor::<MockCq>::new());
             msg.reply.try_post(cx, handle)?;
             Ok(())
         }
@@ -561,6 +725,8 @@ mod tests {
         ) -> Result<TestRoute> {
             let (port, completions) = self.client.mailbox().open_port::<CompletionBatch>();
             let (reply, rx) = self.client.mailbox().open_once_port();
+            let leases = Arc::new(AtomicU32::new(0));
+            let lease = CqLease::for_test_counted(Arc::clone(&leases));
             let posted = Arc::new(AtomicU64::new(0));
             poller.handle.try_post(
                 &self.client,
@@ -576,6 +742,8 @@ mod tests {
             Ok(TestRoute {
                 completions,
                 posted,
+                leases,
+                lease: Some(lease),
             })
         }
 
@@ -591,6 +759,27 @@ mod tests {
         /// wake-up was lost does.
         fn post_without_wake(&self, route: &TestRoute, n: u64) {
             route.posted.fetch_add(n, Ordering::Relaxed);
+        }
+
+        /// Hand `qp` and its reservation over.
+        fn detach(
+            &self,
+            poller: &Poller,
+            cq_id: CqId,
+            qp_num: u32,
+            qp: DetachedQueuePair,
+            lease: CqLease,
+        ) -> Result<()> {
+            poller.handle.try_post(
+                &self.client,
+                Detach {
+                    cq_id,
+                    qp_num,
+                    qp,
+                    lease,
+                },
+            )?;
+            Ok(())
         }
 
         /// Await the next forwarded child-error supervision event.
@@ -656,6 +845,45 @@ mod tests {
     async fn assert_no_batch(rx: &mut PortReceiver<CompletionBatch>, wait: Duration) {
         if let Ok(Ok(batch)) = tokio::time::timeout(wait, rx.recv()).await {
             panic!("unexpected completions: {batch:?}");
+        }
+    }
+
+    /// Await `flag` becoming true; panics on timeout with `whose` named.
+    async fn await_flag(flag: &AtomicBool, whose: &str) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !flag.load(Ordering::SeqCst) {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for {whose}",
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// Await `count` clones of `cq` remaining, which is how a test sees the poller
+    /// let go of a CQ; panics on timeout.
+    async fn await_strong_count(cq: &Arc<MockCq>, count: usize) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while Arc::strong_count(cq) != count {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "the poller still holds {} clones of the CQ",
+                Arc::strong_count(cq) - 1,
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// Await `leases` reaching `expected`; panics on timeout.
+    async fn await_leases(leases: &AtomicU32, expected: u32) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while leases.load(Ordering::Relaxed) != expected {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "reservations settled at {} rather than {expected}",
+                leases.load(Ordering::Relaxed),
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
 
@@ -894,6 +1122,159 @@ mod tests {
             cq.polls() > 3,
             "the failures were retried, not fatal: {} polls",
             cq.polls(),
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_destroys_a_detached_queue_pair_once_it_drains() -> Result<()> {
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut qp7 = harness.attach(&poller, &cq, 7).await?;
+
+        harness.post(&poller, &qp7, 2)?;
+        let (qp, destroyed, leases_at_destroy) = test_qp(&qp7.leases);
+        harness.detach(&poller, cq.cq_id(), 7, qp, qp7.lease())?;
+
+        // Attaching another queue pair and awaiting its reply lands after the
+        // detach, so what is read below is the settled state.
+        let other = MockCq::new(2, CQES_PER_POLL);
+        let _qp9 = harness.attach(&poller, &other, 9).await?;
+        assert!(
+            !destroyed.load(Ordering::SeqCst),
+            "two completions are still to come, so the queue pair must live",
+        );
+        assert_eq!(qp7.leases.load(Ordering::Relaxed), 1);
+
+        cq.queue_completion(7, 100);
+        cq.queue_completion(7, 101);
+        await_flag(&destroyed, "the detached queue pair to be destroyed").await;
+        await_leases(&qp7.leases, 0).await;
+        assert_eq!(
+            leases_at_destroy.load(Ordering::SeqCst),
+            1,
+            "the reservation must outlive the queue pair, not the other way round",
+        );
+        assert_no_batch(&mut qp7.completions, Duration::from_millis(100)).await;
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_destroys_a_drained_queue_pair_on_detach() -> Result<()> {
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut qp7 = harness.attach(&poller, &cq, 7).await?;
+        assert_eq!(qp7.leases.load(Ordering::Relaxed), 1);
+
+        let (qp, destroyed, _leases_at_destroy) = test_qp(&qp7.leases);
+        harness.detach(&poller, cq.cq_id(), 7, qp, qp7.lease())?;
+        await_flag(&destroyed, "the detached queue pair to be destroyed").await;
+        await_leases(&qp7.leases, 0).await;
+
+        // The last queue pair to be destroyed takes its CQ with it: the poller
+        // lets go of its clone, and nothing polls it even once CQEs appear.
+        await_strong_count(&cq, 1).await;
+
+        // And a fresh attach on the same CQ still works afterwards.
+        let mut again = harness.attach(&poller, &cq, 7).await?;
+        cq.queue_completion(7, 100);
+        harness.post(&poller, &again, 1)?;
+        assert_eq!(recv_wr_ids(&mut again.completions, 1).await, vec![100]);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    /// A queue pair can die between posting work and waking the poller, so what
+    /// its counter says -- not what a message said -- is what decides when it can
+    /// be destroyed.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_detach_wakes_the_poller() -> Result<()> {
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut qp7 = harness.attach(&poller, &cq, 7).await?;
+
+        // Counted but never announced: the queue pair died before waking anyone.
+        harness.post_without_wake(&qp7, 1);
+        let (qp, destroyed, _leases_at_destroy) = test_qp(&qp7.leases);
+        // Detach should wake the poller.
+        harness.detach(&poller, cq.cq_id(), 7, qp, qp7.lease())?;
+
+        let other = MockCq::new(2, CQES_PER_POLL);
+        let _qp9 = harness.attach(&poller, &other, 9).await?;
+        assert!(
+            !destroyed.load(Ordering::SeqCst),
+            "a completion is still to come, so the queue pair must live",
+        );
+
+        cq.queue_completion(7, 100);
+        await_flag(&destroyed, "the detached queue pair to be destroyed").await;
+        await_leases(&qp7.leases, 0).await;
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_fails_on_a_detach_for_an_unattached_queue_pair() -> Result<()> {
+        let mut harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let _qp7 = harness.attach(&poller, &cq, 7).await?;
+
+        let leases = Arc::new(AtomicU32::new(0));
+        let (qp, destroyed, _leases_at_destroy) = test_qp(&leases);
+        harness.detach(
+            &poller,
+            cq.cq_id(),
+            404,
+            qp,
+            CqLease::for_test_counted(Arc::clone(&leases)),
+        )?;
+
+        let event = harness.next_supervision_failure().await;
+        assert_eq!(&event.actor_id, poller.handle.actor_addr());
+        let report = event.failure_report().expect("event should be a failure");
+        assert!(
+            report.contains("panic"),
+            "supervision report should say the poller panicked: {report}",
+        );
+        assert!(
+            destroyed.load(Ordering::SeqCst),
+            "the queue pair goes with the message that carried it",
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    /// Destroying one queue pair on a shared CQ must leave its neighbor's route
+    /// and reservation alone.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_leaves_a_sibling_working_when_one_queue_pair_detaches() -> Result<()> {
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut first = harness.attach(&poller, &cq, 7).await?;
+        let mut second = harness.attach(&poller, &cq, 9).await?;
+
+        cq.queue_completion(7, 100);
+        harness.post(&poller, &first, 1)?;
+        assert_eq!(recv_wr_ids(&mut first.completions, 1).await, vec![100]);
+
+        let (qp, destroyed, _leases_at_destroy) = test_qp(&first.leases);
+        harness.detach(&poller, cq.cq_id(), 7, qp, first.lease())?;
+        await_flag(&destroyed, "the detached queue pair to be destroyed").await;
+        await_leases(&first.leases, 0).await;
+
+        cq.queue_completion(9, 200);
+        harness.post(&poller, &second, 1)?;
+        assert_eq!(
+            recv_wr_ids(&mut second.completions, 1).await,
+            vec![200],
+            "the surviving queue pair keeps its route",
         );
         harness.teardown().await;
         Ok(())

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -6,13 +6,32 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Consuming completions from a completion queue (CQ).
+//! One poller for many CQs: the actor that polls them, and the routes it holds
+//! from each queue pair's completions back to that queue pair.
 //!
-//! [`IbvCompletionQueue`] is what a CQ offers a consumer: one call hands back a
-//! bounded batch, each completion naming the queue pair it completed on.
+//! A queue pair attaches to the CQ it reports on ([`Attach`]) and receives its
+//! completions as [`CompletionBatch`] messages. Many queue pairs share one
+//! [`CompletionQueueActor`] and one actor polls many CQs.
+//!
+//! A CQ is polled only while a queue pair on it has CQEs outstanding. Nothing
+//! here decides that a CQ has stopped working: noticing that completions have
+//! stopped arriving is the queue pair's responsibility.
 
 // Nothing outside the tests below uses this module.
 #![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::Context;
+use hyperactor::Handler;
+use hyperactor::Instance;
+use hyperactor::OncePortHandle;
+use hyperactor::PortHandle;
 
 use super::primitives::IbvCq;
 use super::primitives::IbvWc;
@@ -23,7 +42,7 @@ use super::queue_pair::WorkRequestError;
 const CQES_PER_POLL: usize = 64;
 
 /// Identifies one CQ, distinct from every other live one.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) struct CqId(usize);
 
 /// One completion a poll consumed: the queue pair it completed on, and either the
@@ -45,8 +64,8 @@ pub(super) trait IbvCompletionQueue: std::fmt::Debug + Send + Sync + 'static {
     ///
     /// # Safety
     ///
-    /// The CQ must be live -- a null `ibv_cq` does not qualify -- and no other
-    /// thread may poll it for the duration.
+    /// The CQ must be live or null, never a dangling `ibv_cq`, and no other
+    /// thread may poll it for the duration. Polling a null CQ consumes nothing.
     unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError>;
 }
 
@@ -57,9 +76,13 @@ impl IbvCompletionQueue for IbvCq {
 
     unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError> {
         let cq = self.as_ptr();
-        // SAFETY: `cq` is a live `ibv_cq` (caller contract), which holds its device
-        // context alive; we invoke that context's `poll_cq` verb through the ops
-        // table.
+        // A placeholder holds no CQ, so nothing can complete on one.
+        if cq.is_null() {
+            return Ok(());
+        }
+        // SAFETY: `cq` is non-null and so a live `ibv_cq` (caller contract), which
+        // holds its device context alive; we invoke that context's `poll_cq` verb
+        // through the ops table.
         let poll_cq = unsafe {
             (*(*cq).context)
                 .ops
@@ -95,13 +118,786 @@ impl IbvCompletionQueue for IbvCq {
     }
 }
 
+/// The completions consumed for one queue pair, in the order its CQ produced
+/// them. Each is either a work completion or the failure its work
+/// request reported.
+#[derive(Debug)]
+pub(super) struct CompletionBatch {
+    pub(super) completions: Vec<Result<IbvWc, WorkRequestError>>,
+}
+
+/// Route the completions `qp_num` produces on `cq` to `port`.
+#[derive(Debug)]
+pub(super) struct Attach<Cq: IbvCompletionQueue> {
+    pub(super) cq: Arc<Cq>,
+    /// Local number of the attaching queue pair, carried by every completion it
+    /// produces.
+    pub(super) qp_num: u32,
+    pub(super) port: PortHandle<CompletionBatch>,
+    /// Number of pending, posted WRs associated with this queue pair. Incremented
+    /// inside `QueuePairActor` whenever it posts new WRs. The `CompletionQueueActor`
+    /// stores this and uses it to determine if it is done processing work for this
+    /// QP.
+    pub(super) posted: Arc<AtomicU64>,
+    pub(super) reply: OncePortHandle<()>,
+}
+
+/// Wakes the poller: some queue pair has posted.
+#[derive(Debug)]
+pub(super) struct Posted;
+
+/// Self-message that drives one polling round.
+#[derive(Debug)]
+struct Poll;
+
+/// One queue pair reporting on a CQ.
+#[derive(Debug)]
+struct QpSlot {
+    /// Where the QP's completions go.
+    port: PortHandle<CompletionBatch>,
+    /// The QP's [`Attach::posted`] counter, which stops moving when it stops posting.
+    posted: Arc<AtomicU64>,
+    /// CQEs consumed for this queue pair.
+    consumed: u64,
+}
+
+impl QpSlot {
+    /// WRs the queue pair has posted for and the poller has yet to consume.
+    /// Negative between consuming a completion and observing the post that
+    /// produced it.
+    fn outstanding(&self) -> i64 {
+        self.posted.load(Ordering::Relaxed) as i64 - self.consumed as i64
+    }
+}
+
+/// One CQ, with the queue pairs reporting on it.
+#[derive(Debug)]
+struct CqSlot<Cq> {
+    cq: Arc<Cq>,
+    queue_pairs: HashMap<u32, QpSlot>,
+}
+
+impl<Cq: IbvCompletionQueue> CqSlot<Cq> {
+    /// Whether any queue pair here awaits a completion, and so whether the CQ is
+    /// worth polling.
+    fn expects_completions(&self) -> bool {
+        self.queue_pairs.values().any(|qp| qp.outstanding() > 0)
+    }
+
+    /// Hands each of `consumed` to the queue pair that produced it.
+    fn route(
+        &mut self,
+        cq_id: CqId,
+        cx: &Instance<CompletionQueueActor<Cq>>,
+        consumed: &mut Vec<Completion>,
+    ) {
+        for (qp_num, completions) in group_by_queue_pair(consumed) {
+            let qp = self.queue_pairs.get_mut(&qp_num).unwrap_or_else(|| {
+                // When a `QueuePairActor` terminates, we hold its `QpSlot` alive
+                // until all its pending CQEs have drained, so it should be impossible
+                // to observe a `qp_num` without a corresponding `QpSlot`.
+                panic!("CQ {cq_id:?} completed for unattached queue pair {qp_num}")
+            });
+            qp.consumed += completions.len() as u64;
+
+            if let Err(error) = qp.port.try_post(cx, CompletionBatch { completions }) {
+                // It's okay to just log and do nothing here. It won't mess up the QP's internal credit
+                // accounting, because the delivery should only be able to fail once the QP is
+                // already dead
+                tracing::error!(
+                    qp_num,
+                    ?cq_id,
+                    %error,
+                    "delivering completions to a queue pair failed",
+                );
+            }
+        }
+    }
+}
+
+/// Groups `consumed` by the queue pair each completion came from, keeping the
+/// order the CQ produced them in.
+fn group_by_queue_pair(
+    consumed: &mut Vec<Completion>,
+) -> HashMap<u32, Vec<Result<IbvWc, WorkRequestError>>> {
+    let mut batches: HashMap<u32, Vec<Result<IbvWc, WorkRequestError>>> = HashMap::new();
+    for Completion { qp_num, result } in consumed.drain(..) {
+        batches.entry(qp_num).or_default().push(result);
+    }
+    batches
+}
+
+/// Polls a set of CQs and delivers every completion to the queue pair that
+/// produced it.
+///
+/// Generic over the CQ type `Cq` so unit tests run without RDMA hardware. A
+/// poller starts empty: CQs arrive with the queue pairs that attach to them.
+#[derive(Debug)]
+pub(super) struct CompletionQueueActor<Cq: IbvCompletionQueue> {
+    completion_queues: HashMap<CqId, CqSlot<Cq>>,
+    /// The completions one poll consumes, reused by every round.
+    consumed: Vec<Completion>,
+    /// `true` while a `Poll` self-message is already in flight; the flag
+    /// prevents stacking redundant rounds.
+    poll_armed: bool,
+}
+
+impl<Cq: IbvCompletionQueue> CompletionQueueActor<Cq> {
+    pub(super) fn new() -> Self {
+        Self {
+            completion_queues: HashMap::new(),
+            consumed: Vec::with_capacity(CQES_PER_POLL),
+            poll_armed: false,
+        }
+    }
+
+    /// Arms a polling round, unless one is already armed or no queue pair awaits
+    /// a completion.
+    fn arm(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
+        if self.poll_armed
+            || !self
+                .completion_queues
+                .values()
+                .any(|slot| slot.expects_completions())
+        {
+            return Ok(());
+        }
+        self.poll_armed = true;
+        if let Err(error) = cx.handle().try_post(cx, Poll) {
+            self.poll_armed = false;
+            return Err(error.into());
+        }
+        Ok(())
+    }
+
+    /// One polling round: consumes a batch from every CQ with completions expected,
+    /// routes what comes back, and arms the next round if anything is still
+    /// expected.
+    ///
+    /// Returns `Err` if arming the next round fails, which the surrounding
+    /// handler propagates so supervision tears the actor down. A poll that fails
+    /// does not bring down the actor, since it does not mean that the CQ is
+    /// poisoned.
+    fn poll_round(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
+        let Self {
+            completion_queues,
+            consumed,
+            ..
+        } = self;
+        for (cq_id, slot) in completion_queues {
+            if !slot.expects_completions() {
+                continue;
+            }
+            consumed.clear();
+            // SAFETY: a CQ stays live or null while a queue pair is attached to
+            // it, and every `Arc` of it reaches this one poller, whose loop is
+            // single-threaded -- so nothing else polls it here. Both are
+            // obligations on the wiring that sends `Attach`, which does not exist
+            // yet.
+            if let Err(error) = unsafe { slot.cq.poll(consumed) } {
+                // The failing entry is consumed either way, so the CQ can still
+                // make progress next round.
+                tracing::warn!(?cq_id, %error, "consuming from a CQ failed");
+                continue;
+            }
+            slot.route(*cq_id, cx, consumed);
+        }
+        self.arm(cx)
+    }
+}
+
+#[async_trait]
+impl<Cq: IbvCompletionQueue> Actor for CompletionQueueActor<Cq> {
+    // Polling is data-plane work that runs for as long as transfers do. Run its
+    // loop on the dedicated rdma runtime rather than the shared control-plane
+    // runtime; see `crate::rdma_runtime`.
+    fn spawn_server_task<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        crate::rdma_runtime::spawn_on_rdma_runtime(future)
+    }
+}
+
+#[async_trait]
+impl<Cq: IbvCompletionQueue> Handler<Attach<Cq>> for CompletionQueueActor<Cq> {
+    async fn handle(&mut self, cx: &Context<Self>, msg: Attach<Cq>) -> Result<(), anyhow::Error> {
+        let Attach {
+            cq,
+            qp_num,
+            port,
+            posted,
+            reply,
+        } = msg;
+        let cq_id = cq.cq_id();
+        let slot = self
+            .completion_queues
+            .entry(cq_id)
+            .or_insert_with(|| CqSlot {
+                cq,
+                queue_pairs: HashMap::new(),
+            });
+        assert!(
+            !slot.queue_pairs.contains_key(&qp_num),
+            "queue pair {qp_num} is already attached to CQ {cq_id:?}",
+        );
+        slot.queue_pairs.insert(
+            qp_num,
+            QpSlot {
+                port,
+                posted,
+                consumed: 0,
+            },
+        );
+        // The route is in place whether or not anyone is left to hear that, and
+        // failing here would take every other queue pair on this poller with it.
+        if let Err(error) = reply.try_post(cx, ()) {
+            tracing::warn!(qp_num, ?cq_id, %error, "failed to deliver Attach reply");
+        }
+        self.arm(cx)
+    }
+}
+
+#[async_trait]
+impl<Cq: IbvCompletionQueue> Handler<Posted> for CompletionQueueActor<Cq> {
+    async fn handle(&mut self, cx: &Context<Self>, _msg: Posted) -> Result<(), anyhow::Error> {
+        self.arm(cx)
+    }
+}
+
+#[async_trait]
+impl<Cq: IbvCompletionQueue> Handler<Poll> for CompletionQueueActor<Cq> {
+    async fn handle(&mut self, cx: &Context<Self>, _msg: Poll) -> Result<(), anyhow::Error> {
+        self.poll_armed = false;
+        self.poll_round(cx)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use anyhow::Result;
+    use hyperactor::ActorHandle;
+    use hyperactor::context::Mailbox;
+    use hyperactor::mailbox::PortReceiver;
+    use hyperactor::proc::Proc;
+
     use super::*;
     use crate::backend::ibverbs::device::IbvDevice;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
     use crate::backend::ibverbs::primitives::IbvDeviceInfo;
+
+    /// [`IbvCompletionQueue`] mock: hands back scripted completions in FIFO
+    /// order, at most `batch` of them per poll, and counts the polls it serves.
+    /// The test and the actor share one through an `Arc`.
+    #[derive(Debug)]
+    struct MockCq {
+        cq_id: CqId,
+        batch: usize,
+        inner: Mutex<MockCqInner>,
+    }
+
+    #[derive(Debug, Default)]
+    struct MockCqInner {
+        queued: VecDeque<Completion>,
+        /// Failures the next polls return, one each, before any completion.
+        poll_errors: VecDeque<PollCompletionError>,
+        polls: usize,
+    }
+
+    impl MockCq {
+        fn new(cq_id: usize, batch: usize) -> Arc<Self> {
+            Arc::new(Self {
+                cq_id: CqId(cq_id),
+                batch,
+                inner: Mutex::new(MockCqInner::default()),
+            })
+        }
+
+        /// Queue a successful completion for `wr_id` on `qp_num`.
+        fn queue_completion(&self, qp_num: u32, wr_id: u64) {
+            self.queue(Completion {
+                qp_num,
+                result: Ok(IbvWc::for_test(wr_id, true)),
+            });
+        }
+
+        /// Queue a completion reporting that `wr_id` failed.
+        fn queue_wr_error(&self, qp_num: u32, wr_id: u64, message: &str) {
+            self.queue(Completion {
+                qp_num,
+                result: Err(WorkRequestError::for_test(wr_id, message)),
+            });
+        }
+
+        fn queue(&self, completion: Completion) {
+            self.inner.lock().unwrap().queued.push_back(completion);
+        }
+
+        /// Make each of the next `count` polls fail.
+        fn queue_poll_errors(&self, count: usize, message: &str) {
+            let mut inner = self.inner.lock().unwrap();
+            for _ in 0..count {
+                inner
+                    .poll_errors
+                    .push_back(PollCompletionError::new(message.to_string()));
+            }
+        }
+
+        fn polls(&self) -> usize {
+            self.inner.lock().unwrap().polls
+        }
+    }
+
+    impl IbvCompletionQueue for MockCq {
+        fn cq_id(&self) -> CqId {
+            self.cq_id
+        }
+
+        unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError> {
+            let mut inner = self.inner.lock().unwrap();
+            inner.polls += 1;
+            if let Some(error) = inner.poll_errors.pop_front() {
+                return Err(error);
+            }
+            let consumed = inner.queued.len().min(self.batch);
+            out.extend(inner.queued.drain(..consumed));
+            Ok(())
+        }
+    }
+
+    /// One attached queue pair, from the test's side: where its completions
+    /// arrive, and the counter it posts against.
+    struct TestRoute {
+        completions: PortReceiver<CompletionBatch>,
+        posted: Arc<AtomicU64>,
+    }
+
+    /// Parent of the actor under test, so its supervision events land here and
+    /// the test can await them.
+    #[derive(Debug)]
+    struct MockParent {
+        supervision_tx:
+            tokio::sync::mpsc::UnboundedSender<hyperactor::supervision::ActorSupervisionEvent>,
+    }
+
+    #[async_trait]
+    impl Actor for MockParent {
+        async fn handle_supervision_event(
+            &mut self,
+            _this: &Instance<Self>,
+            event: &hyperactor::supervision::ActorSupervisionEvent,
+        ) -> Result<bool> {
+            self.supervision_tx
+                .send(event.clone())
+                .map_err(|e| anyhow::anyhow!("supervision_tx send failed: {e}"))?;
+            Ok(true)
+        }
+    }
+
+    /// Local message that spawns the poller as a child of this parent. The reply
+    /// carries its handle so the test can drive it and watch its status.
+    #[derive(Debug)]
+    struct SpawnPoller {
+        reply: OncePortHandle<ActorHandle<CompletionQueueActor<MockCq>>>,
+    }
+
+    #[async_trait]
+    impl Handler<SpawnPoller> for MockParent {
+        async fn handle(&mut self, cx: &Context<Self>, msg: SpawnPoller) -> Result<()> {
+            let actor = CompletionQueueActor::<MockCq>::new();
+            let handle = cx.spawn(actor);
+            msg.reply.try_post(cx, handle)?;
+            Ok(())
+        }
+    }
+
+    /// The poller under test.
+    struct Poller {
+        handle: ActorHandle<CompletionQueueActor<MockCq>>,
+    }
+
+    struct CqaHarness {
+        proc: Proc,
+        parent: ActorHandle<MockParent>,
+        client: hyperactor::Client,
+        supervision_rx:
+            tokio::sync::mpsc::UnboundedReceiver<hyperactor::supervision::ActorSupervisionEvent>,
+    }
+
+    impl CqaHarness {
+        fn build() -> Self {
+            let proc = Proc::anonymous();
+            let (supervision_tx, supervision_rx) = tokio::sync::mpsc::unbounded_channel();
+            let parent = proc.spawn_with_label("parent", MockParent { supervision_tx });
+            let client = proc.client("client");
+            Self {
+                proc,
+                parent,
+                client,
+                supervision_rx,
+            }
+        }
+
+        async fn spawn_poller(&self) -> Result<Poller> {
+            let (reply, handle_rx) = self.client.mailbox().open_once_port();
+            self.parent.try_post(&self.client, SpawnPoller { reply })?;
+            Ok(Poller {
+                handle: handle_rx.recv().await?,
+            })
+        }
+
+        /// Attach `qp_num` on `cq`.
+        async fn attach(
+            &self,
+            poller: &Poller,
+            cq: &Arc<MockCq>,
+            qp_num: u32,
+        ) -> Result<TestRoute> {
+            let (port, completions) = self.client.mailbox().open_port::<CompletionBatch>();
+            let (reply, rx) = self.client.mailbox().open_once_port();
+            let posted = Arc::new(AtomicU64::new(0));
+            poller.handle.try_post(
+                &self.client,
+                Attach {
+                    cq: Arc::clone(cq),
+                    qp_num,
+                    port,
+                    posted: Arc::clone(&posted),
+                    reply,
+                },
+            )?;
+            rx.recv().await?;
+            Ok(TestRoute {
+                completions,
+                posted,
+            })
+        }
+
+        /// Post for `n` further completions, as a queue pair does: count them,
+        /// then wake the poller.
+        fn post(&self, poller: &Poller, route: &TestRoute, n: u64) -> Result<()> {
+            self.post_without_wake(route, n);
+            poller.handle.try_post(&self.client, Posted)?;
+            Ok(())
+        }
+
+        /// Count `n` completions without waking the poller, as a queue pair whose
+        /// wake-up was lost does.
+        fn post_without_wake(&self, route: &TestRoute, n: u64) {
+            route.posted.fetch_add(n, Ordering::Relaxed);
+        }
+
+        /// Await the next forwarded child-error supervision event.
+        async fn next_supervision_failure(
+            &mut self,
+        ) -> hyperactor::supervision::ActorSupervisionEvent {
+            tokio::time::timeout(Duration::from_secs(5), self.supervision_rx.recv())
+                .await
+                .expect("timed out waiting for child failure event")
+                .expect("supervision channel closed")
+        }
+
+        /// Destroys the proc, closes the supervision channel, drains every
+        /// remaining event, and asserts none are unexpected.
+        async fn teardown(mut self) {
+            self.proc
+                .destroy_and_wait(Duration::from_secs(30), "test teardown")
+                .await
+                .expect("destroy_and_wait failed");
+            self.supervision_rx.close();
+            let mut leftover = Vec::new();
+            while let Some(event) = self.supervision_rx.recv().await {
+                leftover.push(event);
+            }
+            assert!(
+                leftover.is_empty(),
+                "unexpected supervision events at teardown: {leftover:?}",
+            );
+        }
+    }
+
+    /// Await the next batch of completions, each rendered as its `wr_id` or the
+    /// message of the failure it reported; panics on timeout.
+    async fn recv_batch(rx: &mut PortReceiver<CompletionBatch>) -> Vec<Result<u64, String>> {
+        let batch = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("timed out waiting for a completion batch")
+            .expect("completion port closed");
+        batch
+            .completions
+            .into_iter()
+            .map(|completion| {
+                completion
+                    .map(|wc| wc.wr_id())
+                    .map_err(|error| error.to_string())
+            })
+            .collect()
+    }
+
+    /// The `wr_id`s of `n` successful completions, however many batches they
+    /// arrive in.
+    async fn recv_wr_ids(rx: &mut PortReceiver<CompletionBatch>, n: usize) -> Vec<u64> {
+        let mut wr_ids = Vec::with_capacity(n);
+        while wr_ids.len() < n {
+            for completion in recv_batch(rx).await {
+                wr_ids.push(completion.expect("completion should be successful"));
+            }
+        }
+        wr_ids
+    }
+
+    /// Assert no batch arrives within `wait`.
+    async fn assert_no_batch(rx: &mut PortReceiver<CompletionBatch>, wait: Duration) {
+        if let Ok(Ok(batch)) = tokio::time::timeout(wait, rx.recv()).await {
+            panic!("unexpected completions: {batch:?}");
+        }
+    }
+
+    #[test]
+    fn grouping_keeps_each_queue_pairs_completions_in_order() {
+        let mut consumed = vec![
+            Completion {
+                qp_num: 7,
+                result: Ok(IbvWc::for_test(100, true)),
+            },
+            Completion {
+                qp_num: 9,
+                result: Ok(IbvWc::for_test(200, true)),
+            },
+            Completion {
+                qp_num: 7,
+                result: Err(WorkRequestError::for_test(101, "failed")),
+            },
+            Completion {
+                qp_num: 7,
+                result: Ok(IbvWc::for_test(102, true)),
+            },
+        ];
+        let batches = group_by_queue_pair(&mut consumed);
+        assert!(consumed.is_empty(), "grouping consumes what it groups");
+        assert_eq!(batches.len(), 2, "two queue pairs completed: {batches:?}");
+
+        let wr_ids = |qp_num: u32| -> Vec<u64> {
+            batches[&qp_num]
+                .iter()
+                .map(|completion| match completion {
+                    Ok(wc) => wc.wr_id(),
+                    Err(error) => error.wr_id,
+                })
+                .collect()
+        };
+        assert_eq!(wr_ids(7), vec![100, 101, 102]);
+        assert_eq!(wr_ids(9), vec![200]);
+    }
+
+    /// A CQ nobody is waiting on is left alone, however much it holds: what
+    /// drives a poll is a queue pair expecting completions.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_leaves_an_idle_cq_alone() -> Result<()> {
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut qp = harness.attach(&poller, &cq, 7).await?;
+        cq.queue_completion(7, 100);
+
+        assert_no_batch(&mut qp.completions, Duration::from_millis(200)).await;
+        assert_eq!(cq.polls(), 0, "an attach alone must not start polling");
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_routes_completions_to_the_queue_pair_that_posted_them() -> Result<()> {
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut qp = harness.attach(&poller, &cq, 7).await?;
+
+        cq.queue_completion(7, 100);
+        cq.queue_wr_error(7, 101, "simulated WR fail");
+        harness.post(&poller, &qp, 2)?;
+
+        let batch = recv_batch(&mut qp.completions).await;
+        let [first, second] = batch.as_slice() else {
+            panic!("expected two completions, got: {batch:?}");
+        };
+        assert_eq!(
+            *first.as_ref().expect("wr 100 succeeded"),
+            100,
+            "a successful completion arrives as `Ok`",
+        );
+        let error = second.as_ref().expect_err("wr 101 failed");
+        assert!(
+            error.contains("simulated WR fail"),
+            "a failed work request arrives as its own error: {error}",
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    /// Once everything posted for has been consumed, polling stops rather than
+    /// spinning on an idle CQ.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_stops_polling_once_everything_posted_for_is_consumed() -> Result<()> {
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut qp = harness.attach(&poller, &cq, 7).await?;
+
+        cq.queue_completion(7, 100);
+        harness.post(&poller, &qp, 1)?;
+        assert_eq!(recv_wr_ids(&mut qp.completions, 1).await, vec![100]);
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let settled = cq.polls();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            cq.polls(),
+            settled,
+            "nothing is outstanding, so the CQ is no longer polled",
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    /// Queue pairs sharing a CQ each see only their own completions, which is
+    /// what lets one poller serve several of them.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_splits_a_shared_cq_between_its_queue_pairs() -> Result<()> {
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut first = harness.attach(&poller, &cq, 7).await?;
+        let mut second = harness.attach(&poller, &cq, 9).await?;
+
+        cq.queue_completion(7, 100);
+        cq.queue_completion(9, 200);
+        cq.queue_completion(7, 101);
+        harness.post(&poller, &first, 2)?;
+        harness.post(&poller, &second, 1)?;
+
+        assert_eq!(recv_wr_ids(&mut first.completions, 2).await, vec![100, 101]);
+        assert_eq!(recv_wr_ids(&mut second.completions, 1).await, vec![200]);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    /// A queue pair with more outstanding than one poll consumes gets the rest in
+    /// later batches.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_delivers_more_completions_than_a_batch_holds() -> Result<()> {
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, 2);
+        let mut qp = harness.attach(&poller, &cq, 7).await?;
+
+        for wr_id in 0..5 {
+            cq.queue_completion(7, wr_id);
+        }
+        harness.post(&poller, &qp, 5)?;
+
+        let mut wr_ids = Vec::new();
+        while wr_ids.len() < 5 {
+            let batch = recv_batch(&mut qp.completions).await;
+            assert!(
+                batch.len() <= 2,
+                "a batch is bounded: {} consumed",
+                batch.len(),
+            );
+            wr_ids.extend(
+                batch
+                    .into_iter()
+                    .map(|completion| completion.expect("completion should be successful")),
+            );
+        }
+        assert_eq!(wr_ids, vec![0, 1, 2, 3, 4]);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    /// A shared CQ is polled on any queue pair's behalf, so a completion can be
+    /// consumed before the post that produced it has been counted.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_tolerates_a_completion_consumed_before_its_post_is_counted() -> Result<()> {
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut first = harness.attach(&poller, &cq, 7).await?;
+        let mut second = harness.attach(&poller, &cq, 9).await?;
+
+        // Only queue pair 9 has counted anything, and the round it drives consumes
+        // queue pair 7's completion too.
+        cq.queue_completion(7, 100);
+        cq.queue_completion(9, 200);
+        harness.post(&poller, &second, 1)?;
+
+        assert_eq!(recv_wr_ids(&mut first.completions, 1).await, vec![100]);
+        assert_eq!(recv_wr_ids(&mut second.completions, 1).await, vec![200]);
+
+        // Queue pair 7 is owed nothing now, so counting its post afterwards
+        // leaves it expecting nothing rather than a second entry.
+        harness.post(&poller, &first, 1)?;
+        assert_no_batch(&mut first.completions, Duration::from_millis(100)).await;
+        harness.teardown().await;
+        Ok(())
+    }
+
+    /// Every queue pair on a CQ has a route, so a completion for one that does
+    /// not is the device attributing an entry to a queue pair that never existed
+    /// here -- unroutable, and not something to carry on through.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_fails_on_a_completion_for_an_unattached_queue_pair() -> Result<()> {
+        let mut harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let qp7 = harness.attach(&poller, &cq, 7).await?;
+
+        cq.queue_completion(404, 900);
+        harness.post(&poller, &qp7, 1)?;
+
+        let event = harness.next_supervision_failure().await;
+        assert_eq!(&event.actor_id, poller.handle.actor_addr());
+
+        let report = event.failure_report().expect("event should be a failure");
+        assert!(
+            report.contains("panic"),
+            "supervision report should say the poller panicked: {report}",
+        );
+        let mut status = poller.handle.status();
+        status
+            .wait_for(|s| matches!(s, hyperactor::actor::ActorStatus::Failed(_)))
+            .await?;
+        harness.teardown().await;
+        Ok(())
+    }
+
+    /// A failed poll is retried, not fatal.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_survives_a_failed_poll() -> Result<()> {
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut qp7 = harness.attach(&poller, &cq, 7).await?;
+
+        cq.queue_poll_errors(3, "simulated stale entry");
+        cq.queue_completion(7, 100);
+        harness.post(&poller, &qp7, 1)?;
+
+        assert_eq!(recv_wr_ids(&mut qp7.completions, 1).await, vec![100]);
+        assert!(
+            cq.polls() > 3,
+            "the failures were retried, not fatal: {} polls",
+            cq.polls(),
+        );
+        harness.teardown().await;
+        Ok(())
+    }
 
     /// Polling a real, empty CQ consumes nothing, and distinct CQs have distinct ids.
     #[test]

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Consuming completions from a completion queue (CQ).
+//!
+//! [`IbvCompletionQueue`] is what a CQ offers a consumer: one call hands back a
+//! bounded batch, each completion naming the queue pair it completed on.
+
+// Nothing outside the tests below uses this module.
+#![allow(dead_code)]
+
+use super::primitives::IbvCq;
+use super::primitives::IbvWc;
+use super::queue_pair::PollCompletionError;
+use super::queue_pair::WorkRequestError;
+
+/// The number of CQEs requested in each `ibv_poll_cq` call.
+const CQES_PER_POLL: usize = 64;
+
+/// Identifies one CQ, distinct from every other live one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct CqId(usize);
+
+/// One completion a poll consumed: the queue pair it completed on, and either the
+/// work completion or the failure its work request reported.
+#[derive(Debug)]
+pub(super) struct Completion {
+    qp_num: u32,
+    result: Result<IbvWc, WorkRequestError>,
+}
+
+/// A CQ that hands back completions in bounded batches.
+pub(super) trait IbvCompletionQueue: std::fmt::Debug + Send + Sync + 'static {
+    /// This CQ's [`CqId`].
+    fn cq_id(&self) -> CqId;
+
+    /// Consumes a batch of completions, appending each to `out`. A batch is
+    /// bounded, so appending nothing means the CQ was empty, while a full batch
+    /// says nothing about what is left in it. A failure appends nothing.
+    ///
+    /// # Safety
+    ///
+    /// The CQ must be live -- a null `ibv_cq` does not qualify -- and no other
+    /// thread may poll it for the duration.
+    unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError>;
+}
+
+impl IbvCompletionQueue for IbvCq {
+    fn cq_id(&self) -> CqId {
+        CqId(self.as_ptr().addr())
+    }
+
+    unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError> {
+        let cq = self.as_ptr();
+        // SAFETY: `cq` is a live `ibv_cq` (caller contract), which holds its device
+        // context alive; we invoke that context's `poll_cq` verb through the ops
+        // table.
+        let poll_cq = unsafe {
+            (*(*cq).context)
+                .ops
+                .poll_cq
+                .expect("poll_cq verb missing from ibv_context ops")
+        };
+        let mut wcs = [rdmaxcel_sys::ibv_wc::default(); CQES_PER_POLL];
+        // SAFETY: `cq` is live and no other thread is polling it (caller
+        // contract); `wcs` holds the `CQES_PER_POLL` entries requested, of which
+        // `poll_cq` overwrites the first `consumed` entries whenever it returns a
+        // positive count.
+        let consumed = unsafe { poll_cq(cq, CQES_PER_POLL as i32, wcs.as_mut_ptr()) };
+        if consumed < 0 {
+            return Err(PollCompletionError::new(format!(
+                "CQ poll failed (ibv_poll_cq returned {consumed})"
+            )));
+        }
+        for wc in &wcs[..consumed as usize] {
+            // `error()` is `Some` exactly when the status is not `IBV_WC_SUCCESS`.
+            out.push(Completion {
+                qp_num: wc.qp_num,
+                result: match wc.error() {
+                    Some((status, vendor_err)) => Err(WorkRequestError::from_status(
+                        wc.wr_id(),
+                        status,
+                        vendor_err,
+                    )),
+                    None => Ok(IbvWc::from(*wc)),
+                },
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::ibverbs::device::IbvDevice;
+    use crate::backend::ibverbs::mlx_device::MlxDevice;
+    use crate::backend::ibverbs::primitives::IbvConfig;
+    use crate::backend::ibverbs::primitives::IbvDeviceInfo;
+
+    /// Polling a real, empty CQ consumes nothing, and distinct CQs have distinct ids.
+    #[test]
+    fn polling_an_empty_cq_consumes_nothing() {
+        let info = IbvDeviceInfo::first_available().expect("a device is available");
+        let device = IbvDevice::<MlxDevice>::try_open(info.name(), IbvConfig::default())
+            .expect("the first available device should open");
+        // SAFETY: the device holds its `ibv_context` open for its own lifetime.
+        let cq = unsafe { IbvCq::create(device.context(), 16) }.expect("creating a CQ should work");
+        // SAFETY: as above.
+        let other =
+            unsafe { IbvCq::create(device.context(), 16) }.expect("creating a CQ should work");
+        assert_ne!(cq.cq_id(), other.cq_id());
+
+        let mut consumed = Vec::new();
+        // SAFETY: `cq` is the live CQ created above, which nothing else has been
+        // handed and so nothing else polls.
+        unsafe { cq.poll(&mut consumed) }.expect("polling an empty CQ should succeed");
+        assert!(consumed.is_empty());
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -30,9 +30,6 @@
 //! differently when the associated QP is destroyed. Keeping the QP alive
 //! until all CQEs have drained means we can have one uniform implementation.
 
-// Nothing outside the tests below uses this module.
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
@@ -180,6 +177,7 @@ pub(super) struct Detach {
 /// when this is dropped. Opaque: the poller never operates on it, it only decides
 /// when it goes away.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub(super) struct DetachedQueuePair(Box<dyn std::fmt::Debug + Send + Sync>);
 
 impl DetachedQueuePair {

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -37,8 +37,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
+use std::time::Instant;
 
 use async_trait::async_trait;
+use backoff::ExponentialBackoff;
+use backoff::ExponentialBackoffBuilder;
+use backoff::backoff::Backoff;
 use hyperactor::Actor;
 use hyperactor::Context;
 use hyperactor::Handler;
@@ -286,6 +291,62 @@ fn group_by_queue_pair(
     batches
 }
 
+/// How long to wait before the next polling round. Ask
+/// [`Self::next_interval`] for the delay; call [`Self::reset`] whenever a poll
+/// consumed something.
+///
+/// Within `yield_window` of the first call to [`Self::next_interval`] since
+/// construction/the last reset, the round the delay is `Duration::ZERO`,
+/// which keeps latency tight while completions are expected. Passed the
+/// yield window, the policy walks an exponential backoff (1ms initial, doubling,
+/// capped at 10ms) rather than keep a core busy. A `yield_window` of `None` --
+/// the default of [`crate::config::RDMA_CQ_BUSY_POLL_WINDOW`] -- always returns
+/// `Duration::ZERO`.
+#[derive(Debug)]
+pub(super) struct PollSleepPolicy {
+    yield_window: Option<Duration>,
+    started_at: Option<Instant>,
+    backoff: Option<ExponentialBackoff>,
+}
+
+impl PollSleepPolicy {
+    pub(super) fn new() -> Self {
+        let yield_window = hyperactor_config::global::get(crate::config::RDMA_CQ_BUSY_POLL_WINDOW);
+        Self {
+            yield_window,
+            started_at: None,
+            backoff: None,
+        }
+    }
+
+    /// Forget all accumulated backoff state.
+    pub(super) fn reset(&mut self) {
+        self.started_at = None;
+        self.backoff = None;
+    }
+
+    /// Delay before the next round. `Duration::ZERO` means "now".
+    pub(super) fn next_interval(&mut self) -> Duration {
+        let Some(window) = self.yield_window else {
+            return Duration::ZERO;
+        };
+        let started = *self.started_at.get_or_insert_with(Instant::now);
+        if started.elapsed() < window {
+            return Duration::ZERO;
+        }
+        let backoff = self.backoff.get_or_insert_with(|| {
+            ExponentialBackoffBuilder::new()
+                .with_initial_interval(Duration::from_millis(1))
+                .with_max_interval(Duration::from_millis(10))
+                .with_multiplier(2.0)
+                .with_randomization_factor(0.0)
+                .with_max_elapsed_time(None)
+                .build()
+        });
+        backoff.next_backoff().unwrap_or(Duration::ZERO)
+    }
+}
+
 /// Polls a set of CQs and delivers every completion to the queue pair that
 /// produced it.
 ///
@@ -297,6 +358,9 @@ pub(super) struct CompletionQueueActor<Cq: IbvCompletionQueue> {
     completion_queues: HashMap<CqId, CqSlot<Cq>>,
     /// The completions one poll consumes, reused by every round.
     consumed: Vec<Completion>,
+    /// Controls polling frequency when no completions are being generated;
+    /// see [`PollSleepPolicy`].
+    poll_policy: PollSleepPolicy,
     /// `true` while a `Poll` self-message is already in flight; the flag
     /// prevents stacking redundant rounds.
     poll_armed: bool,
@@ -329,12 +393,14 @@ impl<Cq: IbvCompletionQueue> CompletionQueueActor<Cq> {
         Self {
             completion_queues: HashMap::new(),
             consumed: Vec::with_capacity(CQES_PER_POLL),
+            poll_policy: PollSleepPolicy::new(),
             poll_armed: false,
         }
     }
 
     /// Arms a polling round, unless one is already armed or no queue pair awaits
-    /// a completion.
+    /// a completion. A round that found nothing arms the next after the delay
+    /// [`PollSleepPolicy`] asks for.
     fn arm(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
         if self.poll_armed
             || !self
@@ -345,9 +411,14 @@ impl<Cq: IbvCompletionQueue> CompletionQueueActor<Cq> {
             return Ok(());
         }
         self.poll_armed = true;
-        if let Err(error) = cx.handle().try_post(cx, Poll) {
-            self.poll_armed = false;
-            return Err(error.into());
+        let delay = self.poll_policy.next_interval();
+        if delay.is_zero() {
+            if let Err(error) = cx.handle().try_post(cx, Poll) {
+                self.poll_armed = false;
+                return Err(error.into());
+            }
+        } else {
+            cx.post_after(cx, Poll, delay);
         }
         Ok(())
     }
@@ -361,6 +432,7 @@ impl<Cq: IbvCompletionQueue> CompletionQueueActor<Cq> {
     /// does not bring down the actor, since it does not mean that the CQ is
     /// poisoned.
     fn poll_round(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
+        let mut progressed = false;
         let Self {
             completion_queues,
             consumed,
@@ -382,10 +454,14 @@ impl<Cq: IbvCompletionQueue> CompletionQueueActor<Cq> {
                 tracing::warn!(?cq_id, %error, "consuming from a CQ failed");
                 return true;
             }
+            progressed |= !consumed.is_empty();
             slot.route(*cq_id, cx, consumed);
             // The last queue pair to be destroyed takes its CQ with it.
             !slot.queue_pairs.is_empty()
         });
+        if progressed {
+            self.poll_policy.reset();
+        }
         self.arm(cx)
     }
 }
@@ -448,6 +524,7 @@ impl<Cq: IbvCompletionQueue> Handler<Attach<Cq>> for CompletionQueueActor<Cq> {
 #[async_trait]
 impl<Cq: IbvCompletionQueue> Handler<Posted> for CompletionQueueActor<Cq> {
     async fn handle(&mut self, cx: &Context<Self>, _msg: Posted) -> Result<(), anyhow::Error> {
+        self.poll_policy.reset();
         self.arm(cx)
     }
 }
@@ -482,7 +559,8 @@ impl<Cq: IbvCompletionQueue> Handler<Detach> for CompletionQueueActor<Cq> {
             self.completion_queues.remove(&cq_id);
         }
         // It may have posted for completions nothing else will wake the poller
-        // for, its own actor being gone.
+        // for.
+        self.poll_policy.reset();
         self.arm(cx)
     }
 }
@@ -965,6 +1043,40 @@ mod tests {
             error.contains("simulated WR fail"),
             "a failed work request arrives as its own error: {error}",
         );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    /// A CQ that keeps coming back empty is polled on a backoff rather than in a
+    /// spin, and a completion that arrives during one still lands.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn cqa_backs_off_on_a_quiet_cq() -> Result<()> {
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(
+            crate::config::RDMA_CQ_BUSY_POLL_WINDOW,
+            Some(Duration::from_millis(1)),
+        );
+
+        let harness = CqaHarness::build();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut qp7 = harness.attach(&poller, &cq, 7).await?;
+
+        // Outstanding, with nothing to consume: the poller runs out its yield
+        // window and starts sleeping between rounds.
+        harness.post(&poller, &qp7, 1)?;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        // By now, it should have reached the maximum backoff of 10ms.
+        let polls = cq.polls();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let polls = cq.polls() - polls;
+        assert!(
+            polls <= 15,
+            "a quiet CQ is polled on a backoff, not spun: expected <= 15 polls, got {polls}"
+        );
+
+        cq.queue_completion(7, 100);
+        assert_eq!(recv_wr_ids(&mut qp7.completions, 1).await, vec![100]);
         harness.teardown().await;
         Ok(())
     }

--- a/monarch_rdma/src/backend/ibverbs/cq_pool.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_pool.rs
@@ -156,15 +156,6 @@ impl CqPool {
     ) -> anyhow::Result<Self> {
         let configured: usize =
             hyperactor_config::global::get(crate::config::RDMA_QPS_PER_CQ).into();
-        // Each queue pair polls its own completion queue, so two of them sharing
-        // one would give it two pollers, splitting its completions between them.
-        // The cap is temporary while each queue pair is responsible for polling
-        // its CQ.
-        anyhow::ensure!(
-            configured == 1,
-            "rdma_qps_per_cq is {configured}, but only 1 queue pair per completion \
-             queue is supported: each polls its own",
-        );
         let queue_pairs_per_cq = u32::try_from(configured)
             .map_err(|_| anyhow::anyhow!("rdma_qps_per_cq {configured} does not fit a u32"))?;
         let cq_entries = cq_entries_for(queue_pairs_per_cq, max_send_wr, device_info.max_cqe())?;
@@ -240,8 +231,7 @@ impl CqPool {
     /// Such a queue pair still needs a completion queue to be created against,
     /// but produces no entries, so it consumes no capacity and takes no lease:
     /// it shares whichever queue is already there rather than pinning one of its
-    /// own. It must not poll that queue either, which is what leaves the
-    /// leaseholder as the only poller.
+    /// own.
     pub(super) fn cq_without_lease(&mut self) -> anyhow::Result<Arc<IbvCq>> {
         if let Some(entry) = self.completion_queues.first() {
             return Ok(Arc::clone(&entry.cq));
@@ -321,27 +311,6 @@ mod tests {
         assert_eq!(leases.load(Ordering::Relaxed), 1);
         drop(lease);
         assert_eq!(leases.load(Ordering::Relaxed), 0);
-    }
-
-    /// The configured value is held at 1 while each queue pair polls its own
-    /// completion queue.
-    #[test]
-    fn pool_refuses_a_configured_value_above_one() {
-        let info =
-            IbvDeviceInfo::first_available().expect("test runs on machines with RDMA devices");
-        let lock = hyperactor_config::global::lock();
-        let _guard = lock.override_key(
-            crate::config::RDMA_QPS_PER_CQ,
-            std::num::NonZeroUsize::new(2)
-                .expect("2 is non-zero")
-                .into(),
-        );
-        let err = CqPool::new(Arc::new(IbvContext::null()), &info, 512)
-            .expect_err("two queue pairs per completion queue is not supported");
-        assert!(
-            err.to_string().contains("rdma_qps_per_cq"),
-            "the error should name the knob: {err}",
-        );
     }
 
     /// Queue pairs share a completion queue up to `queue_pairs_per_cq`, the next

--- a/monarch_rdma/src/backend/ibverbs/cq_pool.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_pool.rs
@@ -107,9 +107,17 @@ impl CqLease {
     /// a device.
     #[cfg(test)]
     pub(super) fn for_test() -> Self {
+        Self::for_test_counted(Arc::new(AtomicU32::new(0)))
+    }
+
+    /// A lease on no completion queue that counts against `leases`, for tests
+    /// that observe when it is released.
+    #[cfg(test)]
+    pub(super) fn for_test_counted(leases: Arc<AtomicU32>) -> Self {
+        leases.fetch_add(1, Ordering::Relaxed);
         Self {
             cq: Arc::new(IbvCq::null()),
-            leases: Arc::new(AtomicU32::new(1)),
+            leases,
         }
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/efa_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_queue_pair.rs
@@ -23,11 +23,7 @@ use super::primitives::IbvConfig;
 use super::primitives::IbvCq;
 use super::primitives::IbvQp;
 use super::primitives::IbvQpInfo;
-use super::primitives::IbvWc;
 use super::queue_pair::IbvQueuePair;
-use super::queue_pair::PollCompletionError;
-use super::queue_pair::PollTarget;
-use super::queue_pair::WorkRequestError;
 
 /// Queue key for EFA SRD traffic. Both peers must present the same value or the
 /// responder drops the traffic silently; [`IbvQpInfo`] carries no queue key, so
@@ -655,18 +651,6 @@ impl IbvQueuePair for EfaQueuePair {
             remote_src.rkey,
             remote_src.size,
         )
-    }
-
-    fn poll_completion(
-        &mut self,
-        target: PollTarget,
-    ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-        // SAFETY: `self.qp` owns the live queue pair built in `new`, along with
-        // its completion queues and device context, all non-null and alive for
-        // `self`'s lifetime. `&mut self` excludes another poll through this queue
-        // pair, and its lease leaves it the only queue pair polling that
-        // completion queue, so no other thread is polling it.
-        unsafe { super::queue_pair::poll_one(&self.qp, target) }
     }
 }
 

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -41,6 +41,7 @@ use serde::Serialize;
 use typeuri::Named;
 
 use super::IbvOp;
+use super::cq_actor::CompletionQueueActor;
 use super::device::IbvDevice;
 use super::device::IbvDeviceImpl;
 use super::device_selection::PeerDeviceAffinityPolicy;
@@ -54,6 +55,7 @@ use super::memory_region::IbvMemoryRegionView;
 use super::memory_region::IbvRemoteMemoryRegionView;
 use super::mlx_device::MlxDevice;
 use super::primitives::IbvConfig;
+use super::primitives::IbvCq;
 use super::primitives::IbvQpInfo;
 use super::primitives::ibverbs_supported;
 use super::queue_pair::IbvQueuePair;
@@ -188,6 +190,14 @@ pub struct IbvManagerActor<I: IbvDeviceImpl> {
     /// Read once, when the manager starts.
     peer_device_affinity: PeerDeviceAffinityPolicy,
 
+    /// The actors responsible for polling completion queues. When
+    /// [`crate::config::RDMA_CQ_POLLER_PER_DEVICE`] is true (default), there
+    /// is a one-to-one mapping from CQ actors to NICs: one CQ actor polls
+    /// all of the CQs for a specific NIC and no others. When the config value
+    /// is false, there is one CQ actor responsible for polling all CQs for
+    /// all NICs, and this map is keyed by the empty string only.
+    cq_pollers: HashMap<String, ActorHandle<CompletionQueueActor<IbvCq>>>,
+
     config: IbvConfig,
 }
 
@@ -226,6 +236,10 @@ impl<I: IbvDeviceImpl> Drop for IbvManagerActor<I> {
         // own `Drop`.
         for (_key, handle) in self.qp_handles.drain() {
             let _ = handle.drain_and_stop("IbvManagerActor dropped");
+        }
+
+        for (_key, poller) in self.cq_pollers.drain() {
+            let _ = poller.drain_and_stop("IbvManagerActor dropped");
         }
 
         // The remaining fields (`peer_created_qps`, `devices`) free their FFI
@@ -282,6 +296,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             peer_created_qps: HashMap::new(),
             devices: HashMap::new(),
             peer_device_affinity: configured_peer_device_affinity()?,
+            cq_pollers: HashMap::new(),
             config,
         };
 
@@ -491,6 +506,25 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         Ok(local_info)
     }
 
+    /// The poller that serves `device`, spawned on first request.
+    /// One per device, or one for all of them; see
+    /// [`crate::config::RDMA_CQ_POLLER_PER_DEVICE`].
+    fn ensure_cq_poller(
+        &mut self,
+        cx: &Context<'_, Self>,
+        device: &str,
+    ) -> ActorHandle<CompletionQueueActor<IbvCq>> {
+        let key = if hyperactor_config::global::get(crate::config::RDMA_CQ_POLLER_PER_DEVICE) {
+            device.to_string()
+        } else {
+            String::new()
+        };
+        self.cq_pollers
+            .entry(key)
+            .or_insert_with(|| cx.spawn(CompletionQueueActor::new()))
+            .clone()
+    }
+
     /// Lazy active-side QP actor: if `qp_key` is absent from
     /// [`Self::qp_handles`], create an [`IbvQueuePair`] on the
     /// requested device and spawn a [`QueuePairActor`] to drive its
@@ -509,6 +543,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         }
         let self_device = qp_key.self_device.clone();
         let config = self.config.clone();
+        let cq_poller = self.ensure_cq_poller(cx, &self_device);
         let (qp, cq_lease) = self
             .get_or_create_device(&self_device)?
             .create_queue_pair(DEFAULT_DOMAIN, &config)
@@ -521,6 +556,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             local_manager,
             peer_manager,
             qp,
+            cq_poller,
             cq_lease,
             is_loopback,
             config.max_send_wr,

--- a/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
@@ -22,12 +22,8 @@ use super::primitives::IbvConfig;
 use super::primitives::IbvCq;
 use super::primitives::IbvQp;
 use super::primitives::IbvQpInfo;
-use super::primitives::IbvWc;
 use super::queue_pair::IbvQueuePair;
-use super::queue_pair::PollCompletionError;
-use super::queue_pair::PollTarget;
 use super::queue_pair::RCQueuePair;
-use super::queue_pair::WorkRequestError;
 
 /// An mlx5 RC queue pair created through `mlx5dv_create_qp`, so it carries the
 /// mlx5dv send-ops flags that arm a direct-WQE/doorbell data path.
@@ -162,12 +158,5 @@ impl IbvQueuePair for MlxQueuePair {
         remote_src: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         self.0.get(local_dst, remote_src)
-    }
-
-    fn poll_completion(
-        &mut self,
-        target: PollTarget,
-    ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-        self.0.poll_completion(target)
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -1261,8 +1261,9 @@ impl Drop for IbvCq {
 #[derive(Debug)]
 pub(super) struct IbvQp {
     qp: *mut rdmaxcel_sys::ibv_qp,
-    send_cq: Arc<IbvCq>,
-    recv_cq: Arc<IbvCq>,
+    /// Kept alive for the QP's lifetime. Never read.
+    _send_cq: Arc<IbvCq>,
+    _recv_cq: Arc<IbvCq>,
     /// Keeps the PD alive for the QP's lifetime and is the source of the QP's
     /// device context (via [`IbvPd::context`]).
     pd: Arc<IbvPd>,
@@ -1294,8 +1295,8 @@ impl IbvQp {
     ) -> Self {
         Self {
             qp,
-            send_cq,
-            recv_cq,
+            _send_cq: send_cq,
+            _recv_cq: recv_cq,
             pd,
         }
     }
@@ -1303,16 +1304,6 @@ impl IbvQp {
     /// The raw `ibv_qp`; null for a placeholder that holds no queue pair.
     pub(super) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_qp {
         self.qp
-    }
-
-    /// The send completion queue.
-    pub(super) fn send_cq(&self) -> &IbvCq {
-        &self.send_cq
-    }
-
-    /// The receive completion queue.
-    pub(super) fn recv_cq(&self) -> &IbvCq {
-        &self.recv_cq
     }
 
     /// The protection domain this QP was created against, shareable as a
@@ -1332,8 +1323,8 @@ impl IbvQp {
     pub(super) fn null() -> Self {
         Self {
             qp: std::ptr::null_mut(),
-            send_cq: Arc::new(IbvCq::null()),
-            recv_cq: Arc::new(IbvCq::null()),
+            _send_cq: Arc::new(IbvCq::null()),
+            _recv_cq: Arc::new(IbvCq::null()),
             pd: Arc::new(IbvPd::null()),
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -91,6 +91,23 @@ impl WorkRequestError {
         self.status == rdmaxcel_sys::ibv_wc_status::IBV_WC_WR_FLUSH_ERR
     }
 
+    /// Builds the failure a work completion reported, formatting its message from
+    /// the status fields.
+    pub(super) fn from_status(
+        wr_id: u64,
+        status: rdmaxcel_sys::ibv_wc_status::Type,
+        vendor_err: u32,
+    ) -> Self {
+        Self {
+            wr_id,
+            status,
+            vendor_err,
+            message: format!(
+                "completion failed for wr_id={wr_id}: status={status:?}, vendor_err={vendor_err}"
+            ),
+        }
+    }
+
     #[cfg(test)]
     pub(super) fn for_test(wr_id: u64, message: &str) -> Self {
         Self {
@@ -102,9 +119,9 @@ impl WorkRequestError {
     }
 }
 
-/// A CQ-level poll failure from [`IbvQueuePair::poll_completion`]:
-/// `ibv_poll_cq` itself failed and the completion queue is no longer
-/// usable. The owning QP should be treated as poisoned.
+/// A CQ-level poll failure: `ibv_poll_cq` itself failed, naming no work request.
+/// The entry that caused it, if any, has been consumed.
+/// [`IbvQueuePair::poll_completion`] treats it as poisoning its queue pair.
 #[derive(Debug)]
 pub struct PollCompletionError {
     message: String,
@@ -119,11 +136,9 @@ impl std::fmt::Display for PollCompletionError {
 impl std::error::Error for PollCompletionError {}
 
 impl PollCompletionError {
-    #[cfg(test)]
-    pub(super) fn for_test(message: &str) -> Self {
-        Self {
-            message: message.to_string(),
-        }
+    /// A poll that failed, described by `message`.
+    pub(super) fn new(message: String) -> Self {
+        Self { message }
     }
 }
 
@@ -2656,7 +2671,7 @@ mod tests {
         let items = vec![make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
         let _rx = submit_ops(&harness, &actor, items)?;
         let _ = recv_posted(&mut posted_rx).await;
-        qp.queue_poll_error(PollCompletionError::for_test("simulated CQ poison"));
+        qp.queue_poll_error(PollCompletionError::new("simulated CQ poison".to_string()));
 
         let event = harness.next_supervision_failure().await;
         assert_eq!(&event.actor_id, actor.actor_addr());

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -22,12 +22,8 @@ use std::io::Error;
 use std::result::Result;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
 
 use async_trait::async_trait;
-use backoff::ExponentialBackoff;
-use backoff::ExponentialBackoffBuilder;
-use backoff::backoff::Backoff;
 use hyperactor::Actor;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
@@ -43,6 +39,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
+use super::cq_actor::PollSleepPolicy;
 use super::cq_pool::CqLease;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
@@ -772,68 +769,6 @@ impl IbvQueuePair for RCQueuePair {
         // this queue pair, and its lease leaves it the only queue pair polling
         // that completion queue, so no other thread is polling it.
         unsafe { poll_one(&self.qp, target) }
-    }
-}
-
-/// Adaptive backoff for the scheduler's `Tick` self-message. Use
-/// [`Self::next_interval`] to ask "how long should I wait before the
-/// next poll attempt?"; call [`Self::reset`] whenever the previous
-/// poll observed completions (so the actor stays tight while work
-/// is making progress).
-///
-/// While the elapsed time since the first non-zero interval is below
-/// `yield_window`, the policy returns `Duration::ZERO` so the actor
-/// just re-sends `Tick` to itself with no delay — keeping latency
-/// tight when WRs are about to complete. Past the window, it walks
-/// an exponential backoff (1ms initial, doubling, capped at 10ms)
-/// so a long-running op doesn't keep the runtime spinning. When
-/// `yield_window` is `None` (the default for
-/// `RDMA_CQ_BUSY_POLL_WINDOW`) the policy always returns
-/// `Duration::ZERO`.
-#[derive(Debug)]
-struct PollSleepPolicy {
-    yield_window: Option<Duration>,
-    started_at: Option<Instant>,
-    backoff: Option<ExponentialBackoff>,
-}
-
-impl PollSleepPolicy {
-    fn new() -> Self {
-        let yield_window = hyperactor_config::global::get(crate::config::RDMA_CQ_BUSY_POLL_WINDOW);
-        Self {
-            yield_window,
-            started_at: None,
-            backoff: None,
-        }
-    }
-
-    /// Forget all accumulated backoff state. Called after a poll
-    /// returns completions, so the next idle stretch starts fresh.
-    fn reset(&mut self) {
-        self.started_at = None;
-        self.backoff = None;
-    }
-
-    /// Suggested delay before the next `Tick`. `Duration::ZERO`
-    /// means "send `Tick` immediately".
-    fn next_interval(&mut self) -> Duration {
-        let Some(window) = self.yield_window else {
-            return Duration::ZERO;
-        };
-        let started = *self.started_at.get_or_insert_with(Instant::now);
-        if started.elapsed() < window {
-            return Duration::ZERO;
-        }
-        let backoff = self.backoff.get_or_insert_with(|| {
-            ExponentialBackoffBuilder::new()
-                .with_initial_interval(Duration::from_millis(1))
-                .with_max_interval(Duration::from_millis(10))
-                .with_multiplier(2.0)
-                .with_randomization_factor(0.0)
-                .with_max_elapsed_time(None)
-                .build()
-        });
-        backoff.next_backoff().unwrap_or(Duration::ZERO)
     }
 }
 

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -21,10 +21,13 @@ use std::collections::VecDeque;
 use std::io::Error;
 use std::result::Result;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
+use hyperactor::ActorHandle;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Context;
@@ -39,7 +42,14 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-use super::cq_actor::PollSleepPolicy;
+use super::cq_actor::Attach;
+use super::cq_actor::CompletionBatch;
+use super::cq_actor::CompletionQueueActor;
+use super::cq_actor::CqId;
+use super::cq_actor::Detach;
+use super::cq_actor::DetachedQueuePair;
+use super::cq_actor::IbvCompletionQueue as _;
+use super::cq_actor::Posted;
 use super::cq_pool::CqLease;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
@@ -118,7 +128,6 @@ impl WorkRequestError {
 
 /// A CQ-level poll failure: `ibv_poll_cq` itself failed, naming no work request.
 /// The entry that caused it, if any, has been consumed.
-/// [`IbvQueuePair::poll_completion`] treats it as poisoning its queue pair.
 #[derive(Debug)]
 pub struct PollCompletionError {
     message: String,
@@ -248,21 +257,6 @@ pub trait IbvQueuePair: std::fmt::Debug + Send + Sync + 'static + Sized {
         local_dst: IbvMemoryRegionView,
         remote_src: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error>;
-
-    /// Poll `target`'s completion queue for a single work completion.
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(None)` — the CQ is currently empty.
-    /// * `Ok(Some(Ok(wc)))` — a completion landed with success status.
-    /// * `Ok(Some(Err(_)))` — a completion landed with a non-success
-    ///   status; the [`WorkRequestError`] names the failed request.
-    /// * `Err(_)` — `ibv_poll_cq` itself failed; the QP should be treated
-    ///   as poisoned.
-    fn poll_completion(
-        &mut self,
-        target: PollTarget,
-    ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError>;
 }
 
 /// Queries the local endpoint info for `qp`, whose device `context` and the QP
@@ -433,70 +427,6 @@ pub(super) unsafe fn connect(
         ));
     }
     Ok(())
-}
-
-/// Polls `target`'s completion queue on `qp` for a single work completion,
-/// through the device context's `poll_cq` verb. Shared by every queue-pair
-/// implementation built on an [`IbvQp`]; see
-/// [`IbvQueuePair::poll_completion`] for the meaning of the return value.
-///
-/// # Safety
-///
-/// `qp` must hold a non-null, live `ibv_qp` whose send and receive completion
-/// queues and device context are likewise non-null and live: this invokes the
-/// `poll_cq` verb through them without re-checking. A placeholder [`IbvQp`]
-/// built from null handles does not qualify.
-///
-/// No other thread may be polling `target`'s completion queue for the duration.
-pub(super) unsafe fn poll_one(
-    qp: &IbvQp,
-    target: PollTarget,
-) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-    let (cq, cq_type) = match target {
-        PollTarget::Send => (qp.send_cq().as_ptr(), "send"),
-        PollTarget::Recv => (qp.recv_cq().as_ptr(), "recv"),
-    };
-    let context = qp.context().as_ptr();
-    // SAFETY: `context` is `qp`'s live device context (caller contract); we
-    // invoke its `poll_cq` verb through the ops table.
-    let poll_cq = unsafe {
-        (*context)
-            .ops
-            .poll_cq
-            .expect("poll_cq verb missing from ibv_context ops")
-    };
-    let mut wc = rdmaxcel_sys::ibv_wc::default();
-    // SAFETY: `cq` is a live `ibv_cq` belonging to `qp` (caller contract);
-    // `&mut wc` has room for the single entry requested, and `poll_cq`
-    // overwrites it whenever it returns a completion (`ret >= 1`).
-    let ret = unsafe { poll_cq(cq, 1, &mut wc) };
-
-    if ret < 0 {
-        return Err(PollCompletionError {
-            message: format!("{} CQ poll failed (ibv_poll_cq returned {})", cq_type, ret),
-        });
-    }
-    if ret == 0 {
-        return Ok(None);
-    }
-
-    // `ret >= 1`: a single entry was requested, so `wc` holds one completion.
-    // `error()` is `Some` exactly when the status is not `IBV_WC_SUCCESS`.
-    if let Some((status, vendor_err)) = wc.error() {
-        return Ok(Some(Err(WorkRequestError {
-            wr_id: wc.wr_id(),
-            status,
-            vendor_err,
-            message: format!(
-                "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
-                cq_type,
-                wc.wr_id(),
-                status,
-                vendor_err,
-            ),
-        })));
-    }
-    Ok(Some(Ok(IbvWc::from(wc))))
 }
 
 /// An RDMA reliable-connected (RC) queue pair built on plain ibverbs
@@ -758,18 +688,6 @@ impl IbvQueuePair for RCQueuePair {
             remote_src.size,
         )
     }
-
-    fn poll_completion(
-        &mut self,
-        target: PollTarget,
-    ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-        // SAFETY: `self.qp` wraps a live, fully non-null `ibv_qp` — everything
-        // reached through it included — per `from_qp`'s contract, and it stays
-        // alive for `self`'s lifetime. `&mut self` excludes another poll through
-        // this queue pair, and its lease leaves it the only queue pair polling
-        // that completion queue, so no other thread is polling it.
-        unsafe { poll_one(&self.qp, target) }
-    }
 }
 
 /// Bundle of trait bounds for an actor type that can serve as the
@@ -819,10 +737,6 @@ pub(super) struct ProcessOps {
     pub(super) reply: PortHandle<OpResult>,
 }
 
-/// Local-only self-message that drives one round of the scheduler.
-#[derive(Debug)]
-struct Tick;
-
 /// An op accepted by the actor but not yet posted to the QP.
 #[derive(Debug)]
 struct PendingOp {
@@ -866,7 +780,17 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     local_manager: ActorRef<M>,
     /// Recipient of [`CreatePeerQueuePair`].
     peer_manager: ActorRef<M>,
-    qp: Qp,
+    /// The queue pair itself. `None` only once [`Drop`] has handed it to the
+    /// poller, which destroys it when the CQ is clear of its work.
+    qp: Option<Qp>,
+    /// The poller this queue pair's completions come back from.
+    cq_poller: ActorHandle<CompletionQueueActor<IbvCq>>,
+    /// Work requests this queue pair has posted, shared with the poller: see
+    /// [`Attach::posted`]. Only ever incremented, and only here.
+    posted_wrs: Arc<AtomicU64>,
+    /// What a [`Detach`] must name, set once the poller has acknowledged the
+    /// [`Attach`].
+    attached: Option<(CqId, u32)>,
     /// `true` when the peer QP is colocated with this actor's QP —
     /// i.e. both endpoints live in the same `IbvManagerActor` *and*
     /// target the same RDMA device. In that case `init` connects
@@ -893,26 +817,30 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// WRs posted to the send queue and not yet reaped:
     /// what `max_send_wr` gates against.
     in_flight: u32,
-    /// `true` while a `Tick` self-message is already in flight; the
-    /// flag prevents stacking redundant ticks.
-    tick_armed: bool,
-    poll_policy: PollSleepPolicy,
-    /// This queue pair's lease on the device's completion queue. Never read: it
-    /// is held so the lease -- and the completion queue itself -- outlive the
-    /// queue pair, which drops with this actor. This placement is temporary and
-    /// works now only because each queue pair still gets its own unique CQ. Once
-    /// multiple QPs share a CQ (and polling is handled elsewhere), the CQ's poller
-    /// will own the lease, ensuring it isn't dropped until all of a QP's pending
-    /// work requests have been drained.
-    _cq_lease: CqLease,
+    /// This queue pair's claim on its completion queue's capacity, handed to the
+    /// poller with the queue pair itself on [`Detach`] so that both remain
+    /// alive until the poller has processed all of the QP's outstanding
+    /// work requests. `None` only after the lease is passed to the poller.
+    cq_lease: Option<CqLease>,
 }
 
 impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
+    /// The queue pair this actor owns, which it holds until [`Drop`] hands it
+    /// over.
+    fn qp(&self) -> &Qp {
+        self.qp.as_ref().expect("the queue pair this actor owns")
+    }
+
+    fn qp_mut(&mut self) -> &mut Qp {
+        self.qp.as_mut().expect("the queue pair this actor owns")
+    }
+
     pub(super) fn new(
         qp_key: QpKey,
         local_manager: ActorRef<M>,
         peer_manager: ActorRef<M>,
         qp: Qp,
+        cq_poller: ActorHandle<CompletionQueueActor<IbvCq>>,
         cq_lease: CqLease,
         is_loopback: bool,
         max_send_wr: u32,
@@ -922,7 +850,10 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
             qp_key,
             local_manager,
             peer_manager,
-            qp,
+            qp: Some(qp),
+            cq_poller,
+            posted_wrs: Arc::new(AtomicU64::new(0)),
+            attached: None,
             is_loopback,
             init_timeout,
             max_send_wr,
@@ -931,9 +862,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
             wr_to_op: HashMap::new(),
             next_op_id: 0,
             in_flight: 0,
-            tick_armed: false,
-            poll_policy: PollSleepPolicy::new(),
-            _cq_lease: cq_lease,
+            cq_lease: Some(cq_lease),
         }
     }
 
@@ -942,7 +871,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
     /// [`IbvQueuePair::max_msg_size`]-bound chunks; a zero-byte op still
     /// consumes one WR.
     fn wr_count(&self, local_size: usize) -> u32 {
-        local_size.div_ceil(self.qp.max_msg_size()).max(1) as u32
+        local_size.div_ceil(self.qp().max_msg_size()).max(1) as u32
     }
 
     /// Try to post the head of `queue`.
@@ -988,8 +917,8 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         // 3. Post.
         let local = op.local;
         let post_result = match op.op_type {
-            RdmaOpType::WriteFromLocal => self.qp.put(op.remote.clone(), local.clone()),
-            RdmaOpType::ReadIntoLocal => self.qp.get(local.clone(), op.remote.clone()),
+            RdmaOpType::WriteFromLocal => self.qp_mut().put(op.remote.clone(), local.clone()),
+            RdmaOpType::ReadIntoLocal => self.qp_mut().get(local.clone(), op.remote.clone()),
         };
         let wr_ids = post_result.map_err(|e| {
             anyhow::anyhow!(
@@ -1003,6 +932,16 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 self.qp_key,
                 local,
                 op.remote,
+            )
+        })?;
+
+        // Make the new WRs visible to the CQ poller.
+        self.posted_wrs
+            .fetch_add(wr_ids.len() as u64, Ordering::Relaxed);
+        self.cq_poller.try_post(cx, Posted).map_err(|e| {
+            anyhow::anyhow!(
+                "could not wake the completion queue poller [qp_key={:?}]: {e}",
+                self.qp_key,
             )
         })?;
 
@@ -1029,88 +968,91 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         Ok(true)
     }
 
-    /// One scheduler round: post everything that fits, poll for
-    /// completions, emit replies for finished ops, and re-arm
-    /// `Tick` if work remains. Returns `Err` for fatal QP-level
-    /// failures; the surrounding handler propagates the error so
-    /// supervision tears the actor down.
+    /// Posts everything the send queue has room for. Completions arrive as
+    /// [`CompletionBatch`] messages, which frees space on the send queue.
+    ///
+    /// Returns `Err` for fatal QP-level failures; the surrounding handler
+    /// propagates the error so supervision tears the actor down.
     fn advance(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
-        // 1. Post from the queue head until either it's empty or
-        //    the head is credit-blocked.
         while !self.queue.is_empty() {
             if !self.try_post_head(cx)? {
                 break;
             }
         }
+        Ok(())
+    }
 
-        // 2. Drain the send CQ. Each completion identifies its WR by
-        //    `wr_id`; we correlate it back to its op and, once every WR
-        //    for an op has reported, emit the op's reply. Polling only
-        //    while WRs are outstanding keeps the loop from spinning on an
-        //    empty queue, and draining to `None` ensures no completion is
-        //    left behind.
-        let mut progressed = false;
-        while !self.wr_to_op.is_empty() {
-            let completion = self
-                .qp
-                .poll_completion(PollTarget::Send)
-                .map_err(|e| anyhow::anyhow!("CQ poll failed for qp_key={:?}: {e}", self.qp_key))?;
-            let Some(wc_result) = completion else {
-                break;
-            };
-            progressed = true;
-
-            let (wr_id, wr_error) = match wc_result {
-                Ok(wc) => (wc.wr_id(), None),
-                Err(per_wr) => (per_wr.wr_id, Some(per_wr.to_string())),
-            };
-
-            let op_id = self
-                .wr_to_op
-                .remove(&wr_id)
-                .expect("completed wr_id missing from wr_to_op");
-            let entry = self
-                .posted
-                .get_mut(&op_id)
-                .expect("op_id missing from posted");
-            entry.pending_wrs.remove(&wr_id);
-            self.in_flight -= 1;
-            if let Some(err) = wr_error
-                && entry.first_error.is_none()
-            {
-                entry.first_error = Some(err);
-            }
-            if entry.pending_wrs.is_empty() {
-                let entry = self.posted.remove(&op_id).expect("just verified");
-                let result = match entry.first_error {
-                    Some(err) => Err(err),
-                    None => Ok(()),
-                };
-                entry.reply.try_post(
-                    cx,
-                    OpResult {
-                        op_idx: entry.op_idx,
-                        result,
-                    },
-                )?;
-            }
+    /// Retires one work request: drops it from its op, and replies for that op
+    /// once its last work request has reported. `error` is what that work request
+    /// reported, if it failed.
+    fn complete_wr(
+        &mut self,
+        cx: &Instance<Self>,
+        wr_id: u64,
+        error: Option<String>,
+    ) -> Result<(), anyhow::Error> {
+        let op_id = self
+            .wr_to_op
+            .remove(&wr_id)
+            .expect("completed wr_id missing from wr_to_op");
+        let entry = self
+            .posted
+            .get_mut(&op_id)
+            .expect("op_id missing from posted");
+        entry.pending_wrs.remove(&wr_id);
+        self.in_flight -= 1;
+        if let Some(err) = error
+            && entry.first_error.is_none()
+        {
+            entry.first_error = Some(err);
         }
-        if progressed {
-            self.poll_policy.reset();
-        }
-
-        // 3. Re-arm Tick if any work remains.
-        let pending_work = !self.queue.is_empty() || !self.posted.is_empty();
-        if pending_work && !self.tick_armed {
-            self.tick_armed = true;
-            let interval = self.poll_policy.next_interval();
-            if interval.is_zero() {
-                cx.handle().try_post(cx, Tick)?;
-            } else {
-                cx.post_after(cx, Tick, interval);
-            }
+        if entry.pending_wrs.is_empty() {
+            let entry = self.posted.remove(&op_id).expect("just verified");
+            let result = match entry.first_error {
+                Some(err) => Err(err),
+                None => Ok(()),
+            };
+            entry.reply.try_post(
+                cx,
+                OpResult {
+                    op_idx: entry.op_idx,
+                    result,
+                },
+            )?;
         }
         Ok(())
+    }
+}
+
+impl<M: Manager, Qp: IbvQueuePair> Drop for QueuePairActor<M, Qp> {
+    fn drop(&mut self) {
+        let Some((cq_id, qp_num)) = self.attached else {
+            // Never attached, so nothing was ever posted: the queue pair and its
+            // claim on the CQ go away here.
+            return;
+        };
+        let (Some(qp), Some(lease)) = (self.qp.take(), self.cq_lease.take()) else {
+            return;
+        };
+        if let Err(error) = self.cq_poller.try_post(
+            Instance::<Self>::self_client(),
+            Detach {
+                cq_id,
+                qp_num,
+                qp: DetachedQueuePair::new(qp),
+                lease,
+            },
+        ) {
+            // The poller is gone, so nothing is polling that CQ and the queue
+            // pair the message carried is destroyed with it.
+            tracing::warn!(
+                qp_key = ?self.qp_key,
+                qp_num,
+                ?cq_id,
+                %error,
+                "handing the queue pair to its poller failed",
+            );
+        }
     }
 }
 
@@ -1118,10 +1060,51 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
 impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         this.set_system();
-        let local_info = self.qp.get_qp_info().map_err(|e| {
+        let local_info = self.qp_mut().get_qp_info().map_err(|e| {
             tracing::error!(qp_key = ?self.qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
             anyhow::anyhow!("could not extract local QP info: {e}")
         })?;
+
+        // Attach the queue pair and its completion queue to the
+        // completion queue actor that will be responsible for polling.
+        let qp_num = local_info.qp_num;
+        let cq = self
+            .cq_lease
+            .as_ref()
+            .expect("the lease this actor was built with")
+            .cq()
+            .clone();
+        let cq_id = cq.cq_id();
+        let (reply, attached) = this.mailbox().open_once_port::<()>();
+        self.cq_poller
+            .try_post(
+                // This message needs to come from the static client, because
+                // `Attach` must be ordered before `Detach`, and `Detach` is
+                // called from `Drop` (which requires the static client).
+                Instance::<Self>::self_client(),
+                Attach {
+                    cq,
+                    qp_num,
+                    port: this.handle().port::<CompletionBatch>(),
+                    posted: Arc::clone(&self.posted_wrs),
+                    reply,
+                },
+            )
+            .map_err(|e| anyhow::anyhow!("could not reach the completion queue poller: {e}"))?;
+        // The poller holds the reply port until it answers, so a poller that
+        // goes away -- with the message still queued or not -- drops it and wakes
+        // this rather than leaving it to wait.
+        match attached.recv().await {
+            Ok(()) => self.attached = Some((cq_id, qp_num)),
+            Err(e) => {
+                tracing::error!(
+                    qp_key = ?self.qp_key,
+                    error = %e,
+                    "QueuePairActor init: poller went away before attaching",
+                );
+                return Err(anyhow::anyhow!("poller went away before attaching: {e}"));
+            }
+        }
 
         let peer_info = if self.is_loopback {
             // The "peer" is ourselves; skip the round-trip and
@@ -1174,7 +1157,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
             }
         };
 
-        self.qp.connect(&peer_info).map_err(|e| {
+        self.qp_mut().connect(&peer_info).map_err(|e| {
             tracing::error!(
                 qp_key = ?self.qp_key,
                 peer_info = ?peer_info,
@@ -1209,21 +1192,27 @@ impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps> for QueuePairActor<M, Qp>
                 wrs,
             });
         }
-        // If a tick is already armed it will pick up the new ops on
-        // its next round; advancing here would just duplicate work.
-        if !self.tick_armed {
-            self.advance(cx)?;
-        }
-        Ok(())
+        self.advance(cx)
     }
 }
 
 #[async_trait]
-impl<M: Manager, Qp: IbvQueuePair> Handler<Tick> for QueuePairActor<M, Qp> {
-    async fn handle(&mut self, cx: &Context<Self>, _msg: Tick) -> Result<(), anyhow::Error> {
-        self.tick_armed = false;
-        self.advance(cx)?;
-        Ok(())
+impl<M: Manager, Qp: IbvQueuePair> Handler<CompletionBatch> for QueuePairActor<M, Qp> {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: CompletionBatch,
+    ) -> Result<(), anyhow::Error> {
+        for completion in msg.completions {
+            let (wr_id, error) = match completion {
+                Ok(wc) => (wc.wr_id(), None),
+                Err(per_wr) => (per_wr.wr_id, Some(per_wr.to_string())),
+            };
+            self.complete_wr(cx, wr_id, error)?;
+        }
+        // Retiring work requests frees send-queue slots for whatever is queued
+        // behind them.
+        self.advance(cx)
     }
 }
 
@@ -1419,11 +1408,13 @@ mod tests {
     impl Handler<SpawnQpaChild> for QpaMockManager {
         async fn handle(&mut self, cx: &Context<Self>, msg: SpawnQpaChild) -> Result<()> {
             let local_manager = cx.bind::<QpaMockManager>();
+            let cq_poller = cx.spawn(CompletionQueueActor::<IbvCq>::new());
             let actor = QueuePairActor::new(
                 msg.qp_key,
                 local_manager,
                 msg.peer_manager,
                 msg.qp,
+                cq_poller,
                 CqLease::for_test(),
                 msg.is_loopback,
                 msg.max_send_wr,
@@ -1457,12 +1448,6 @@ mod tests {
         /// Every `put`/`get` call is forwarded here in order, so the
         /// test body can `await` rather than poll.
         posted_tx: tokio::sync::mpsc::UnboundedSender<PostedOp>,
-        /// FIFO of completions the next `poll_completion` calls hand
-        /// back, one per call. Each entry is either `Ok(IbvWc)`
-        /// (success) or `Err(...)` (per-WR completion failure).
-        pending_completions: VecDeque<std::result::Result<IbvWc, WorkRequestError>>,
-        /// One-shot CQ-level error; cleared after the next poll consumes it.
-        poll_error: Option<PollCompletionError>,
         /// One-shot error for the next `put` or `get` call.
         post_error: Option<String>,
     }
@@ -1493,8 +1478,6 @@ mod tests {
                     connect_calls: Vec::new(),
                     next_wr_id: 0,
                     posted_tx,
-                    pending_completions: VecDeque::new(),
-                    poll_error: None,
                     post_error: None,
                 })),
             };
@@ -1503,33 +1486,6 @@ mod tests {
 
         fn connect_calls(&self) -> Vec<IbvQpInfo> {
             self.inner.lock().unwrap().connect_calls.clone()
-        }
-
-        /// Queue a successful WC for `wr_id`. A subsequent
-        /// `poll_completion` call returns it in FIFO order.
-        fn queue_completion(&self, wr_id: u64) {
-            self.inner
-                .lock()
-                .unwrap()
-                .pending_completions
-                .push_back(Ok(IbvWc::for_test(wr_id, true)));
-        }
-
-        /// Queue a per-WR completion failure for `wr_id` — the actor
-        /// receives it as the inner `Err` from `poll_completion` and
-        /// should fail just that op (not poison the QP).
-        fn queue_per_wr_error(&self, wr_id: u64, message: &str) {
-            self.inner
-                .lock()
-                .unwrap()
-                .pending_completions
-                .push_back(Err(WorkRequestError::for_test(wr_id, message)));
-        }
-
-        /// Queue a CQ-level poll error (one-shot). The next poll
-        /// returns this as the outer `Err`, simulating a poisoned QP.
-        fn queue_poll_error(&self, err: PollCompletionError) {
-            self.inner.lock().unwrap().poll_error = Some(err);
         }
 
         /// Make the next `put`/`get` return this error (one-shot).
@@ -1607,20 +1563,6 @@ mod tests {
                 wr_ids: wr_ids.clone(),
             });
             Ok(wr_ids)
-        }
-
-        fn poll_completion(
-            &mut self,
-            _target: PollTarget,
-        ) -> std::result::Result<
-            Option<std::result::Result<IbvWc, WorkRequestError>>,
-            PollCompletionError,
-        > {
-            let mut inner = self.inner.lock().unwrap();
-            if let Some(err) = inner.poll_error.take() {
-                return Err(err);
-            }
-            Ok(inner.pending_completions.pop_front())
         }
     }
 
@@ -2136,6 +2078,37 @@ mod tests {
         Ok(rx)
     }
 
+    /// Deliver successful completions for `wr_ids` to `actor`, as its poller
+    /// would.
+    fn complete(
+        harness: &QpaHarness,
+        actor: &ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
+        wr_ids: impl IntoIterator<Item = u64>,
+    ) -> Result<()> {
+        let completions = wr_ids
+            .into_iter()
+            .map(|wr_id| Ok(IbvWc::for_test(wr_id, true)))
+            .collect();
+        actor.try_post(&harness.client, CompletionBatch { completions })?;
+        Ok(())
+    }
+
+    /// Deliver a completion reporting that `wr_id` failed.
+    fn complete_err(
+        harness: &QpaHarness,
+        actor: &ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
+        wr_id: u64,
+        message: &str,
+    ) -> Result<()> {
+        actor.try_post(
+            &harness.client,
+            CompletionBatch {
+                completions: vec![Err(WorkRequestError::for_test(wr_id, message))],
+            },
+        )?;
+        Ok(())
+    }
+
     /// Collect exactly `n` replies with a per-recv timeout, sorted
     /// by op_idx for deterministic comparison.
     async fn collect_replies(
@@ -2170,7 +2143,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn qpa_processes_single_write() -> Result<()> {
         let harness = QpaHarness::build()?;
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
 
         let items = vec![make_op(7, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
         let mut rx = submit_ops(&harness, &actor, items)?;
@@ -2187,7 +2160,7 @@ mod tests {
         assert_eq!(rhandle.size, 4096);
         assert_eq!(rhandle.device_name, PEER_DEVICE);
 
-        qp.queue_completion(0);
+        complete(&harness, &actor, [0])?;
         let replies = collect_replies(&mut rx, 1).await;
         assert_eq!(replies, vec![(7, Ok(()))]);
         harness.teardown().await;
@@ -2197,7 +2170,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn qpa_posted_op_pins_local_memory() -> Result<()> {
         let harness = QpaHarness::build()?;
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
 
         // Two ops: the second exists only to prove the first has left
         // `try_post_head`, which is where the `QueuePairOp` — the batch's own
@@ -2227,11 +2200,11 @@ mod tests {
         // The pin lasts exactly as long as the op: retiring op 0 alone
         // releases it, which would not hold if the entry that pinned the
         // allocation were some other op's.
-        qp.queue_completion(wr_ids[0]);
+        complete(&harness, &actor, [wr_ids[0]])?;
         await_dropped(&dropped).await;
 
         // Retire op 1 too, so no op is left in flight at teardown.
-        qp.queue_completion(other_wr_ids[0]);
+        complete(&harness, &actor, [other_wr_ids[0]])?;
         assert_eq!(
             collect_replies(&mut rx, 2).await,
             vec![(0, Ok(())), (1, Ok(()))]
@@ -2243,7 +2216,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn qpa_posted_op_pins_local_registration() -> Result<()> {
         let harness = QpaHarness::build()?;
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
 
         // As above, op 1 only proves op 0 has left `try_post_head`.
         let dropped = Arc::new(AtomicBool::new(false));
@@ -2266,10 +2239,10 @@ mod tests {
             "the registration must stay alive while a WR that touches it is in flight"
         );
 
-        qp.queue_completion(wr_ids[0]);
+        complete(&harness, &actor, [wr_ids[0]])?;
         await_dropped(&dropped).await;
 
-        qp.queue_completion(other_wr_ids[0]);
+        complete(&harness, &actor, [other_wr_ids[0]])?;
         assert_eq!(
             collect_replies(&mut rx, 2).await,
             vec![(0, Ok(())), (1, Ok(()))]
@@ -2281,7 +2254,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn qpa_chunked_op_waits_for_all_wrs() -> Result<()> {
         let harness = QpaHarness::build()?;
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(8).await?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(8).await?;
 
         // A 3-chunk write (3 * MAX_RDMA_MSG_SIZE) splits into 3 WRs;
         // the op's reply must be held back until all 3 complete.
@@ -2297,8 +2270,8 @@ mod tests {
         assert_eq!(wr_ids, vec![0, 1, 2]);
 
         // Complete the first two — no reply yet.
-        qp.queue_completion(wr_ids[0]);
-        qp.queue_completion(wr_ids[1]);
+        complete(&harness, &actor, [wr_ids[0]])?;
+        complete(&harness, &actor, [wr_ids[1]])?;
         assert!(
             try_recv(&mut rx, Duration::from_millis(100))
                 .await
@@ -2307,7 +2280,7 @@ mod tests {
         );
 
         // Complete the third — now the op resolves.
-        qp.queue_completion(wr_ids[2]);
+        complete(&harness, &actor, [wr_ids[2]])?;
         let replies = collect_replies(&mut rx, 1).await;
         assert_eq!(replies, vec![(11, Ok(()))]);
         harness.teardown().await;
@@ -2317,7 +2290,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn qpa_per_wr_error_held_until_all_wrs_complete() -> Result<()> {
         let harness = QpaHarness::build()?;
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(8).await?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(8).await?;
 
         // 3-WR write: simulate the second WR failing first; the op's
         // Err must not fire until the other 2 WRs have also reported
@@ -2334,7 +2307,7 @@ mod tests {
         assert_eq!(wr_ids.len(), 3);
 
         // Deliver the per-WR error first.
-        qp.queue_per_wr_error(wr_ids[1], "simulated WR fail");
+        complete_err(&harness, &actor, wr_ids[1], "simulated WR fail")?;
         assert!(
             try_recv(&mut rx, Duration::from_millis(100))
                 .await
@@ -2344,8 +2317,8 @@ mod tests {
 
         // The remaining WRs complete (flush-style or otherwise) and
         // finally the op's Err is reported.
-        qp.queue_completion(wr_ids[0]);
-        qp.queue_completion(wr_ids[2]);
+        complete(&harness, &actor, [wr_ids[0]])?;
+        complete(&harness, &actor, [wr_ids[2]])?;
 
         let replies = collect_replies(&mut rx, 1).await;
         assert_eq!(replies.len(), 1);
@@ -2365,7 +2338,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn qpa_per_wr_error_isolates_to_failing_op() -> Result<()> {
         let harness = QpaHarness::build()?;
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(8).await?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(8).await?;
 
         // Two writes share a batch: op_idx 0 is multi-WR (3 chunks),
         // op_idx 1 is single-WR. One of op_idx 0's WRs fails;
@@ -2382,11 +2355,11 @@ mod tests {
         assert_eq!(small_wrs, vec![3]);
 
         // op_idx 1 completes successfully on its own.
-        qp.queue_completion(small_wrs[0]);
+        complete(&harness, &actor, [small_wrs[0]])?;
         // op_idx 0: middle WR fails, others succeed.
-        qp.queue_per_wr_error(big_wrs[1], "isolated per-WR fail");
-        qp.queue_completion(big_wrs[0]);
-        qp.queue_completion(big_wrs[2]);
+        complete_err(&harness, &actor, big_wrs[1], "isolated per-WR fail")?;
+        complete(&harness, &actor, [big_wrs[0]])?;
+        complete(&harness, &actor, [big_wrs[2]])?;
 
         let replies = collect_replies(&mut rx, 2).await;
         assert_eq!(replies.len(), 2);
@@ -2410,7 +2383,7 @@ mod tests {
         let harness = QpaHarness::build()?;
         // Reads hold no credit of their own: three of them against
         // max_send_wr=2 gate on send-queue slots, just as writes would.
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(2).await?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(2).await?;
 
         let items = (0..3usize)
             .map(|i| make_op(i, RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096))
@@ -2425,12 +2398,12 @@ mod tests {
         assert_no_post(&mut posted_rx, Duration::from_millis(50)).await;
 
         // Freeing one slot lets the third read post.
-        qp.queue_completion(r0_wrs[0]);
+        complete(&harness, &actor, [r0_wrs[0]])?;
         let (_, _, r2_wrs) = expect_get(recv_posted(&mut posted_rx).await);
         assert_eq!(r2_wrs, vec![2]);
 
-        qp.queue_completion(r1_wrs[0]);
-        qp.queue_completion(r2_wrs[0]);
+        complete(&harness, &actor, [r1_wrs[0]])?;
+        complete(&harness, &actor, [r2_wrs[0]])?;
         let replies = collect_replies(&mut rx, 3).await;
         assert_eq!(replies, vec![(0, Ok(())), (1, Ok(())), (2, Ok(()))]);
         harness.teardown().await;
@@ -2441,7 +2414,7 @@ mod tests {
     async fn qpa_write_slot_gating() -> Result<()> {
         let harness = QpaHarness::build()?;
         // max_send_wr=2 caps total in-flight WRs; submit 4 writes.
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(2).await?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(2).await?;
 
         let items = (0..4usize)
             .map(|i| make_op(i, RdmaOpType::WriteFromLocal, 0x1000 + i * 0x1000, 4096))
@@ -2455,18 +2428,18 @@ mod tests {
         assert_no_post(&mut posted_rx, Duration::from_millis(50)).await;
 
         // Complete one — the third write should post; one slot still busy.
-        qp.queue_completion(w0_wrs[0]);
+        complete(&harness, &actor, [w0_wrs[0]])?;
         let (_, _, w2_wrs) = expect_put(recv_posted(&mut posted_rx).await);
         assert_eq!(w2_wrs, vec![2]);
         assert_no_post(&mut posted_rx, Duration::from_millis(50)).await;
 
         // Complete another — the fourth write posts.
-        qp.queue_completion(w1_wrs[0]);
+        complete(&harness, &actor, [w1_wrs[0]])?;
         let (_, _, w3_wrs) = expect_put(recv_posted(&mut posted_rx).await);
         assert_eq!(w3_wrs, vec![3]);
 
-        qp.queue_completion(w2_wrs[0]);
-        qp.queue_completion(w3_wrs[0]);
+        complete(&harness, &actor, [w2_wrs[0]])?;
+        complete(&harness, &actor, [w3_wrs[0]])?;
         let replies = collect_replies(&mut rx, 4).await;
         assert_eq!(
             replies,
@@ -2481,7 +2454,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn qpa_reads_and_writes_share_send_slots() -> Result<()> {
         let harness = QpaHarness::build()?;
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
 
         let items = vec![
             make_op(0, RdmaOpType::ReadIntoLocal, 0x1000, 4096),
@@ -2505,22 +2478,22 @@ mod tests {
         assert_no_post(&mut posted_rx, Duration::from_millis(50)).await;
 
         // One completion frees one slot: still one short.
-        qp.queue_completion(r0_wrs[0]);
+        complete(&harness, &actor, [r0_wrs[0]])?;
         assert_eq!(collect_replies(&mut rx, 1).await, vec![(0, Ok(()))]);
         assert_no_post(&mut posted_rx, Duration::from_millis(50)).await;
 
         // The second completion -- a write this time -- frees the slot the
         // read was waiting for, so it posts.
-        qp.queue_completion(w1_wrs[0]);
+        complete(&harness, &actor, [w1_wrs[0]])?;
         assert_eq!(collect_replies(&mut rx, 1).await, vec![(1, Ok(()))]);
         let (_, _, r4_wrs) = expect_get(recv_posted(&mut posted_rx).await);
         assert_eq!(r4_wrs, vec![4, 5]);
 
         // Drain everything else.
-        qp.queue_completion(w2_wrs[0]);
-        qp.queue_completion(w3_wrs[0]);
+        complete(&harness, &actor, [w2_wrs[0]])?;
+        complete(&harness, &actor, [w3_wrs[0]])?;
         for &id in &r4_wrs {
-            qp.queue_completion(id);
+            complete(&harness, &actor, [id])?;
         }
         let rest = collect_replies(&mut rx, 3).await;
         assert_eq!(rest, vec![(2, Ok(())), (3, Ok(())), (4, Ok(()))]);
@@ -2531,7 +2504,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn qpa_multiple_batches_share_credit() -> Result<()> {
         let harness = QpaHarness::build()?;
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
 
         // Batch A: 2 writes with op_idx 10, 11.
         let batch_a = vec![
@@ -2555,7 +2528,7 @@ mod tests {
             all_wr_ids.extend(wrs);
         }
         for &id in &all_wr_ids {
-            qp.queue_completion(id);
+            complete(&harness, &actor, [id])?;
         }
 
         let replies_a = collect_replies(&mut rx_a, 2).await;
@@ -2570,7 +2543,7 @@ mod tests {
     async fn qpa_op_too_large_for_qp() -> Result<()> {
         let harness = QpaHarness::build()?;
         // max_send_wr=1 with a 2-chunk write → can never fit.
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(1).await?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(1).await?;
 
         let items = vec![
             make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 2 * MAX_RDMA_MSG_SIZE),
@@ -2581,7 +2554,7 @@ mod tests {
         // Only op_idx 1 reaches the wire (op_idx 0 was rejected).
         let (_, _, wrs) = expect_put(recv_posted(&mut posted_rx).await);
         assert_eq!(wrs, vec![0]);
-        qp.queue_completion(0);
+        complete(&harness, &actor, [0])?;
 
         let replies = collect_replies(&mut rx, 2).await;
         // op_idx 0 must report a "too large" error; op_idx 1 succeeds.
@@ -2593,32 +2566,6 @@ mod tests {
             .expect_err("op_idx 0 should fail as too large");
         assert!(err.contains("too large"), "expected too-large error: {err}");
         assert_eq!(replies[1], (1usize, Ok(())));
-        harness.teardown().await;
-        Ok(())
-    }
-
-    #[timed_test::async_timed_test(timeout_secs = 60)]
-    async fn qpa_poll_error_kills_actor_via_supervision() -> Result<()> {
-        let mut harness = QpaHarness::build()?;
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
-
-        // Post one op so the next poll has something to look at.
-        let items = vec![make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
-        let _rx = submit_ops(&harness, &actor, items)?;
-        let _ = recv_posted(&mut posted_rx).await;
-        qp.queue_poll_error(PollCompletionError::new("simulated CQ poison".to_string()));
-
-        let event = harness.next_supervision_failure().await;
-        assert_eq!(&event.actor_id, actor.actor_addr());
-        let report = event.failure_report().expect("event should be a failure");
-        assert!(
-            report.contains("CQ poll failed") && report.contains("simulated CQ poison"),
-            "supervision report should name the poll failure: {report}",
-        );
-        await_status(&actor, |s| {
-            matches!(s, hyperactor::actor::ActorStatus::Failed(_))
-        })
-        .await;
         harness.teardown().await;
         Ok(())
     }

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -57,12 +57,12 @@ declare_attrs! {
     ))
     pub attr RDMA_TCP_FALLBACK_PARALLELISM: usize = 1;
 
-    /// Cooperative-yield window for the ibverbs CQ poll loop. While
-    /// the policy is within this window it calls
-    /// `tokio::task::yield_now` between polls; past it, polls fall
-    /// into an exponential backoff sleep (1ms initial, x2, capped at
-    /// 10ms). `None` (the default) disables the cutoff entirely:
-    /// the loop only ever yields, never sleeps.
+    /// How long a `CompletionQueueActor` keeps polling a completion queue that
+    /// comes back empty before it starts sleeping between rounds. Within the
+    /// window it arms the next round immediately; past it, rounds fall into an
+    /// exponential backoff (1ms initial, x2, capped at 10ms). `None` (the
+    /// default) disables the cutoff entirely: the loop only ever yields, never
+    /// sleeps.
     @meta(CONFIG = ConfigAttr::new(
         Some("MONARCH_RDMA_CQ_BUSY_POLL_WINDOW".to_string()),
         Some("rdma_cq_busy_poll_window".to_string()),
@@ -144,9 +144,6 @@ declare_attrs! {
     /// (`rdma_qps_per_cq * max_send_wr` entries), so raising this trades
     /// completion-queue memory for fewer completion queues to poll. Opening a
     /// device fails outright if it cannot hold a completion queue that large.
-    ///
-    /// Only 1 is accepted for now: each queue pair polls its own completion
-    /// queue, so sharing one would give it several pollers.
     @meta(CONFIG = ConfigAttr::new(
         Some("MONARCH_RDMA_QPS_PER_CQ".to_string()),
         Some("rdma_qps_per_cq".to_string()),
@@ -154,8 +151,21 @@ declare_attrs! {
     pub attr RDMA_QPS_PER_CQ: NonZeroUsize =
         NonZeroUsize::new(1).expect("1 is non-zero");
 
-    /// Worker-thread count for the shared rdma data-plane runtime, which
-    /// every `QueuePairActor` poll loop runs on.
+    /// Whether each device gets its own completion-queue poller.
+    ///
+    /// When true (the default) the manager spawns one `CompletionQueueActor` per
+    /// RDMA device, on demand, so each device's completions are polled
+    /// independently of every other device's and a poller that fails takes down
+    /// only that device's queue pairs. When false, one poller serves every device
+    /// in the process.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_CQ_POLLER_PER_DEVICE".to_string()),
+        Some("rdma_cq_poller_per_device".to_string()),
+    ))
+    pub attr RDMA_CQ_POLLER_PER_DEVICE: bool = true;
+
+    /// Worker-thread count for the shared rdma data-plane runtime, which every
+    /// `CompletionQueueActor` and `QueuePairActor` runs on.
     ///
     /// The runtime is built once, lazily, so this value is latched at the
     /// first RDMA use in a process and later changes have no effect.


### PR DESCRIPTION
Summary:

Wire `CompletionQueueActor` in and take the poll loop out of `QueuePairActor`. There are two shapes for the new polling setup, depending on the value of `MONARCH_RDMA_CQ_POLLER_PER_DEVICE`:
- True (default): `IbvManagerActor` spawns one `CompletionQueueActor` per NIC. Every queue pair on a specific NIC attaches to the corresponding `CompletionQueueActor`. The number of polling actors is O(# of NICs).
- False: `IbvManagerActor` spawns one `CompletionQueueActor` that every queue pair attaches to, regardless of NIC. The number of polling actors is 1.

Notably, `MONARCH_RDMA_QPS_PER_CQ` still defaults to 1, which means that regardless of `MONARCH_RDMA_CQ_POLLER_PER_DEVICE`, every queue pair still gets a dedicated CQ for now.

`QueuePairActor` no longer has any polling loop. During `init`, it attaches to its assigned `CompletionQueueActor`. When it posts work requests, it notifies the CQ actor that it should expect completions. When the CQ actor observes completions for that queue pair, it routes them back to the QP actor with the `CompletionBatch` message. This updates the QP actor's send queue credit accounting and makes space for new WRs to be posted if necessary. It also triggers replies to user requests.

When `QueuePairActor` drops, it sends `Detach` to the CQ actor, which keeps the real QP and its CQ lease alive until all work for the QP has been drained from the CQ. This ensures that the CQ cannot become oversubscribed, and that the queue pair number cannot be reused until all pending work is complete.

Reviewed By: zdevito

Differential Revision: D117284390


