### PR TITLE
Sanitize public bootstrap environment

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -1128,18 +1128,14 @@ When spawning processes, you can customize the bootstrap command used to launch 
 Pass a `BootstrapCommand` to use the same command for all spawned processes:
 
 ```python
-from monarch._rust_bindings.monarch_hyperactor.host_mesh import BootstrapCommand
-from monarch.actor import this_host
+from monarch.actor import default_bootstrap_cmd, this_host
 
 host = this_host()
 
 # Custom BootstrapCommand for all procs
-cmd = BootstrapCommand(
-    program="/custom/python",
-    arg0=None,
-    args=["-m", "monarch._src.actor.bootstrap_main"],
-    env={"CUDA_VISIBLE_DEVICES": "0,1,2,3", "MY_VAR": "value"},
-)
+cmd = default_bootstrap_cmd()
+cmd.program = "/custom/python"
+cmd = cmd.with_env({"CUDA_VISIBLE_DEVICES": "0,1,2,3", "MY_VAR": "value"})
 procs = host.spawn_procs(
     per_host={"gpus": 4},
     bootstrap_command=cmd
@@ -1151,19 +1147,14 @@ procs = host.spawn_procs(
 Pass a callable to customize the bootstrap command per process. The callable receives a `Point` representing the combined coordinate across host and per_host dimensions:
 
 ```python
-from monarch.actor import this_host
-from monarch._rust_bindings.monarch_hyperactor.host_mesh import BootstrapCommand
+from monarch.actor import default_bootstrap_cmd, this_host
 
 host = this_host()
+base = default_bootstrap_cmd()
 
 # Set CUDA_VISIBLE_DEVICES based on coordinate
 def make_bootstrap(point):
-    return BootstrapCommand(
-        program="/usr/bin/python3",
-        arg0=None,
-        args=["-m", "monarch._src.actor.bootstrap_main"],
-        env={"CUDA_VISIBLE_DEVICES": str(point["gpus"])},
-    )
+    return base.with_env({"CUDA_VISIBLE_DEVICES": str(point["gpus"])})
 
 procs = host.spawn_procs(
     per_host={"gpus": 4},
@@ -1182,7 +1173,7 @@ This is particularly useful for:
 
 ### Using with_env for Ergonomic Customization
 
-The `BootstrapCommand.with_env()` method makes it easy to create modified copies of a base command with additional environment variables. Use `default_bootstrap_cmd()` to get the default command for the current environment:
+The `BootstrapCommand.env` dictionary is the complete child environment; a raw `BootstrapCommand` does not inherit variables from its parent process. The `BootstrapCommand.with_env()` method makes it easy to create modified copies of a complete base command with additional environment variables. Use `default_bootstrap_cmd()` to get the default command for the current environment:
 
 ```python
 from monarch.actor import default_bootstrap_cmd, this_host
@@ -1231,16 +1222,15 @@ procs2 = host.spawn_procs(per_host={"gpus": 2})
 Bootstrap commands work with other HostMesh customization methods:
 
 ```python
+from monarch.actor import default_bootstrap_cmd
+
 host = this_host()
 
 # Customize Python executable and bootstrap command
 custom_host = host.with_python_executable("/path/to/python")
-cmd = BootstrapCommand(
-    program="/path/to/python",
-    arg0=None,
-    args=["-m", "monarch._src.actor.bootstrap_main"],
-    env={"CUDA_VISIBLE_DEVICES": "0,1,2,3"},
-)
+cmd = default_bootstrap_cmd()
+cmd.program = "/path/to/python"
+cmd = cmd.with_env({"CUDA_VISIBLE_DEVICES": "0,1,2,3"})
 procs = custom_host.spawn_procs(
     per_host={"gpus": 4},
     bootstrap_command=cmd

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -1545,6 +1545,8 @@ pub struct BootstrapCommand {
     pub program: PathBuf,
     pub arg0: Option<String>,
     pub args: Vec<String>,
+    /// The complete environment for the child process. No variables are
+    /// inherited from the spawning process.
     pub env: HashMap<String, String>,
 }
 wirevalue::register_type!(BootstrapCommand);
@@ -1596,6 +1598,9 @@ impl BootstrapCommand {
         for arg in &self.args {
             cmd.arg(arg);
         }
+        // `env` is authoritative, so disable `Command`'s implicit
+        // parent-environment inheritance before applying it.
+        cmd.env_clear();
         for (k, v) in &self.env {
             cmd.env(k, v);
         }
@@ -1615,7 +1620,7 @@ impl BootstrapCommand {
             program: crate::testresource::get("monarch/hyperactor_mesh/bootstrap"),
             arg0: None,
             args: vec![],
-            env: HashMap::new(),
+            env: std::env::vars().collect(),
         }
     }
 }
@@ -1627,7 +1632,7 @@ impl<T: Into<PathBuf>> From<T> for BootstrapCommand {
             program: s.into(),
             arg0: None,
             args: vec![],
-            env: HashMap::new(),
+            env: std::env::vars().collect(),
         }
     }
 }
@@ -2472,6 +2477,31 @@ mod tests {
     use hyperactor::testing::ids::test_proc_id_with_addr;
 
     use super::*;
+
+    #[tokio::test]
+    async fn bootstrap_command_uses_exact_environment() {
+        assert!(
+            std::env::var_os("PATH").is_some(),
+            "test runner should set PATH"
+        );
+
+        let output = BootstrapCommand {
+            program: PathBuf::from("/usr/bin/env"),
+            env: HashMap::from([("BOOTSTRAP_COMMAND_TEST".to_string(), "present".to_string())]),
+            ..Default::default()
+        }
+        .new()
+        .output()
+        .await
+        .expect("run env with the configured environment");
+        let stdout = String::from_utf8(output.stdout).expect("env output should be UTF-8");
+
+        assert_eq!(
+            stdout.lines().collect::<Vec<_>>(),
+            ["BOOTSTRAP_COMMAND_TEST=present"],
+            "bootstrap command should use only its configured environment"
+        );
+    }
 
     struct ShutdownFlushProbe {
         gateway: Gateway,

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -2515,8 +2515,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_basic() {
+        let bootstrap_command = BootstrapCommand::test();
+        let expected_bootstrap_command = bootstrap_command.clone();
         let host = Host::new(
-            BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
+            BootstrapProcManager::new(bootstrap_command).unwrap(),
             ChannelTransport::Unix.any(),
         )
         .await
@@ -2566,7 +2568,7 @@ mod tests {
                     // The mesh agent should run in the same proc, under the name
                     // "proc_agent".
                     mesh_agent,
-                    bootstrap_command,
+                    bootstrap_command: actual_bootstrap_command,
                     proc_status: Some(ProcStatus::Ready { started_at: _, addr: _, agent: proc_status_mesh_agent}),
                     ..
                 }),
@@ -2574,7 +2576,7 @@ mod tests {
             } if id == resource_id
               && proc_id == expected_proc_addr
               && mesh_agent == ActorRef::attest(expected_proc_addr.actor_addr(crate::proc_agent::PROC_AGENT_ACTOR_NAME))
-              && bootstrap_command == Some(BootstrapCommand::test())
+              && actual_bootstrap_command == Some(expected_bootstrap_command)
               && mesh_agent == proc_status_mesh_agent
         );
     }

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -1107,6 +1107,7 @@ while True:
         let command = BootstrapCommand {
             program: PathBuf::from("python3"),
             args: vec!["-u".into(), "-c".into(), python_script.trim().into()],
+            env: std::env::vars().collect(),
             ..Default::default()
         };
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
@@ -104,7 +104,8 @@ class BootstrapCommand:
         - `program`: The program to execute.
         - `arg0`: Optionally, the program's arg0. If not provided, the program's name will be used.
         - `args`: List of command line arguments.
-        - `env`: Environment variables as key-value pairs.
+        - `env`: The complete child environment as key-value pairs. Variables
+          are not inherited from the parent process.
         """
         ...
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/host_mesh.pyi
@@ -90,6 +90,8 @@ class HostMesh:
 
 @final
 class BootstrapCommand:
+    env: dict[str, str]
+
     def __init__(
         self,
         program: str,

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -991,15 +991,13 @@ _BOOTSTRAP_MAIN = "monarch._src.actor.bootstrap_main"
 
 
 def _get_bootstrap_args() -> tuple[str, Optional[list[str]], dict[str, str]]:
+    env = dict(os.environ)
     if IN_PAR:
         cmd = sys.argv[0]
         args = None
-        env = {
-            "PAR_MAIN_OVERRIDE": _BOOTSTRAP_MAIN,
-        }
+        env["PAR_MAIN_OVERRIDE"] = _BOOTSTRAP_MAIN
     else:
         cmd = sys.executable
         args = ["-m", _BOOTSTRAP_MAIN]
-        env = {}
 
     return cmd, args, env

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -636,6 +636,18 @@ class CudaVisibleDevicesActor(Actor):
         return os.environ.get("CUDA_VISIBLE_DEVICES", "")
 
 
+def test_get_bootstrap_args_includes_parent_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from monarch._src.actor.proc_mesh import _get_bootstrap_args
+
+    monkeypatch.setenv("MONARCH_BOOTSTRAP_ENV_TEST", "present")
+
+    _, _, env = _get_bootstrap_args()
+
+    assert env["MONARCH_BOOTSTRAP_ENV_TEST"] == "present"
+
+
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 def test_spawn_procs_with_bootstrap_command() -> None:


### PR DESCRIPTION
Summary:
Preserve D116656704’s public one-shot bootstrap command path while replacing its complete child environment with a sanitized copy. Remove launcher-host `/dev/shm` values for Triton and vLLM NCCL so remote hosts can resolve their own package-local paths.

Remove the obsolete private HostMesh reconstruction left by D115920195 and expose the existing writable `BootstrapCommand` fields in the Python stub.

Reviewed By: pzhan9

Differential Revision: D117251196


