### PR TITLE
Probe wildcard address when selecting TCPStore port

### DIFF
--- a/python/monarch/_src/spmd/actor.py
+++ b/python/monarch/_src/spmd/actor.py
@@ -20,10 +20,8 @@ from monarch.tools.network import AddrType, get_ipaddr
 
 def _find_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("localhost", 0))
-        addr = s.getsockname()
-        port = addr[1]
-        return port
+        s.bind(("", 0))
+        return s.getsockname()[1]
 
 
 class SPMDActor(Actor):


### PR DESCRIPTION
Summary:
TCPStore listens on wildcard addresses: https://fburl.com/iicz2ka6

but Monarch selected a port by probing only localhost. A port can therefore appear free to Monarch while TCPStore cannot bind it. Probe the IPv4 wildcard address so the selected port is usable by TCPStore's IPv4 fallback. This is a pattern that has been used widely:

https://fburl.com/code/vet01oai

Differential Revision: D117296213


