### PR TITLE
remove worker environment Pyre suppression

### DIFF
--- a/python/monarch_supervisor/worker/tests/test_worker_env.py
+++ b/python/monarch_supervisor/worker/tests/test_worker_env.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+import unittest
+from unittest.mock import patch
+
+from monarch_supervisor.worker import worker_env
+
+
+class WorkerEnvTest(unittest.TestCase):
+    def test_main_runs_requested_module_with_forwarded_arguments(self) -> None:
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["worker_env", "-m", "example.worker", "--rank", "3"],
+            ),
+            patch.object(
+                worker_env.runpy,
+                "_run_module_as_main",
+            ) as run_module_as_main,
+        ):
+            worker_env.main()
+
+            self.assertEqual(sys.argv, ["worker_env", "--rank", "3"])
+
+        run_module_as_main.assert_called_once_with("example.worker", False)

--- a/python/monarch_supervisor/worker/worker_env.py
+++ b/python/monarch_supervisor/worker/worker_env.py
@@ -7,6 +7,8 @@
 # pyre-unsafe
 import runpy
 import sys
+from collections.abc import Callable
+from typing import cast
 
 __MONARCH_TENSOR_WORKER_ENV__ = True
 
@@ -18,8 +20,14 @@ def main() -> None:
     # Remove the -m and the main module from the command line arguments before
     # forwarding
     sys.argv[1:] = sys.argv[3:]
-    # pyre-fixme[16]: Module `runpy` has no attribute `_run_module_as_main`.
-    runpy._run_module_as_main(main_module, alter_argv=False)
+
+    # The public run_module() uses a fresh namespace instead of preserving the
+    # existing __main__ namespace required by Python's -m behavior.
+    run_module_as_main = cast(
+        Callable[[str, bool], object],
+        vars(runpy)["_run_module_as_main"],
+    )
+    run_module_as_main(main_module, False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
`worker_env.py` uses CPython’s private `_run_module_as_main()` because it needs the same behavior as `python -m`: the requested module must run inside the existing `__main__` namespace.

the function exists at runtime, but Python’s type declarations omit private functions. read it from `runpy`’s module dictionary and tell Pyre its callable shape. the cast changes nothing at runtime; it only describes the function to the type checker.

this also adds the first focused unit test for `worker_env.main()`. it verifies that the wrapper removes `-m <module>` from `sys.argv`, forwards the remaining arguments, and invokes the requested module without replacing `argv[0]`.

Reviewed By: manav-a

Differential Revision: D117362754


