### PR TITLE
remove worker barrier Pyre suppression

### DIFF
--- a/python/monarch/common/remote.py
+++ b/python/monarch/common/remote.py
@@ -248,7 +248,10 @@ remote_identity = Remote(RemoteImpl(None, lambda x: x))
 
 
 def call_on_shard_and_fetch(
-    remote: Endpoint[P, R], *args, shard: Dict[str, int] | None = None, **kwargs
+    remote: Remote[P, R] | Endpoint[P, R],
+    *args,
+    shard: Dict[str, int] | None = None,
+    **kwargs,
 ) -> Future[R]:
     # We have to flatten the tensors twice: first to discover
     # which mesh we are working on to shard it, and then again when doing the
@@ -274,7 +277,7 @@ def call_on_shard_and_fetch(
         selected_slice = checker.mesh._process(shard)
         shard_mesh = checker.mesh._new_with_shape(Shape(["_"], selected_slice))
         with shard_mesh.activate():
-            return remote.call_one(*args, **kwargs)
+            return cast("Future[R]", remote.call_one(*args, **kwargs))
 
 
 def _old_call_on_shard_and_fetch(
@@ -407,7 +410,6 @@ def _cached_propagation(_cache, rfunction: ResolvableFunction, args, kwargs):
         _miss += 1
         args_no_pg, kwargs_no_pg = tree_map(_mock_pgs, (args, kwargs))
         result_with_placeholders, output_pattern = call_on_shard_and_fetch(
-            # pyre-fixme[6]: Remote with concrete types doesn't match Endpoint[P, R] variance
             _propagate,
             function=rfunction,
             args=args_no_pg,

--- a/python/monarch/worker/_testing_function.py
+++ b/python/monarch/worker/_testing_function.py
@@ -29,6 +29,8 @@ from torch.utils.data import DataLoader, TensorDataset
 
 logger = logging.getLogger(__name__)
 
+_barrier: threading.Barrier | None = None
+
 """
 Collection of worker-side remote functions that are used in unit tests
 """
@@ -78,15 +80,16 @@ def has_nan(t):
 
 
 def new_barrier_hackery(threads):
-    # pyrefly: ignore [unknown-name]
     global _barrier
     _barrier = threading.Barrier(threads)
     return torch.zeros(1)
 
 
 def wait_barrier_hackery(t: torch.Tensor):
-    # pyre-fixme[10]: Name `_barrier` is used but not defined.
-    _barrier.wait()
+    barrier = _barrier
+    if barrier is None:
+        raise RuntimeError("barrier has not been initialized")
+    barrier.wait()
 
 
 def all_reduce_prop(tensor, *args, **kwargs):

--- a/python/monarch_supervisor/worker/tests/test_worker_env.py
+++ b/python/monarch_supervisor/worker/tests/test_worker_env.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+import unittest
+from unittest.mock import patch
+
+from monarch_supervisor.worker import worker_env
+
+
+class WorkerEnvTest(unittest.TestCase):
+    def test_main_runs_requested_module_with_forwarded_arguments(self) -> None:
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["worker_env", "-m", "example.worker", "--rank", "3"],
+            ),
+            patch.object(
+                worker_env.runpy,
+                "_run_module_as_main",
+            ) as run_module_as_main,
+        ):
+            worker_env.main()
+
+            self.assertEqual(sys.argv, ["worker_env", "--rank", "3"])
+
+        run_module_as_main.assert_called_once_with("example.worker", False)

--- a/python/monarch_supervisor/worker/worker_env.py
+++ b/python/monarch_supervisor/worker/worker_env.py
@@ -7,6 +7,8 @@
 # pyre-unsafe
 import runpy
 import sys
+from collections.abc import Callable
+from typing import cast
 
 __MONARCH_TENSOR_WORKER_ENV__ = True
 
@@ -18,8 +20,14 @@ def main() -> None:
     # Remove the -m and the main module from the command line arguments before
     # forwarding
     sys.argv[1:] = sys.argv[3:]
-    # pyre-fixme[16]: Module `runpy` has no attribute `_run_module_as_main`.
-    runpy._run_module_as_main(main_module, alter_argv=False)
+
+    # The public run_module() uses a fresh namespace instead of preserving the
+    # existing __main__ namespace required by Python's -m behavior.
+    run_module_as_main = cast(
+        Callable[[str, bool], object],
+        vars(runpy)["_run_module_as_main"],
+    )
+    run_module_as_main(main_module, False)
 
 
 if __name__ == "__main__":

--- a/python/tests/test_coalescing.py
+++ b/python/tests/test_coalescing.py
@@ -9,7 +9,7 @@
 import itertools
 from contextlib import contextmanager
 from enum import Enum
-from typing import ContextManager, List
+from typing import ContextManager, List, Literal
 from unittest.mock import patch
 
 import monarch
@@ -37,15 +37,19 @@ def inspect(x):
     return fetch_shard(x).result().item()
 
 
+local: TestingContext | None = None
+
+
 @pytest.fixture(scope="module", autouse=True)
 def testing_context():
-    # pyrefly: ignore [unknown-name]
     global local
     with TestingContext() as local:
         yield
 
 
 class BackendType(Enum):
+    value: Literal["py", "rs", "mesh"]
+
     PY = "py"
     RS = "rs"
     MESH = "mesh"
@@ -67,7 +71,7 @@ class TestCoalescing:
         backend_type: BackendType,
         activate: bool = True,
     ) -> ContextManager[DeviceMesh]:
-        # pyre-fixme[10]: pytest defines this fixture.
+        assert local is not None
         return local.local_device_mesh(
             num_hosts,
             gpu_per_host,
@@ -167,7 +171,7 @@ class TestCoalescing:
 
             @compile(verify=False)
             def fn():
-                nonlocal a, b
+                nonlocal a
                 c, borrow = get_active_stream().borrow(b)
                 with borrow:
                     a += c
@@ -381,7 +385,6 @@ class TestCoalescing:
 
             @compile(verify=True)
             def add_broken(b):
-                nonlocal c
                 if c:
                     a = torch.zeros(3, 4)
                 else:


### PR DESCRIPTION
Summary:
the worker test helpers create a shared barrier in `new_barrier_hackery` and wait on it later in `wait_barrier_hackery`. declare the barrier before either function runs and report a direct error if wait is called before setup. this makes the required call ordering explicit and removes the Pyre and Pyrefly suppressions.

accept the Torch dependency update generated by autodeps for the touched worker target.

Differential Revision: D117371552


