### PR TITLE
characterize worker bootstrap task behavior (#4746)

### DIFF
--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -256,7 +256,29 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
 
 #[cfg(test)]
 mod tests {
+    use std::os::fd::AsFd;
+    use std::os::fd::AsRawFd;
+    use std::os::fd::IntoRawFd;
+    use std::os::fd::OwnedFd;
+    use std::os::fd::RawFd;
+
+    use nix::errno::Errno;
+    use nix::libc;
+    use nix::sys::socket::AddressFamily;
+    use nix::sys::socket::SockFlag;
+    use nix::sys::socket::SockType;
+    use nix::sys::socket::SockaddrIn;
+    use nix::sys::socket::bind;
+    use nix::sys::socket::getsockname;
+    use nix::sys::socket::getsockopt;
+    use nix::sys::socket::socket;
+    use nix::sys::socket::sockopt;
+    use nix::unistd::dup;
+    use pyo3::PyErr;
+    use pyo3::PyTypeInfo;
+
     use super::*;
+    use crate::runtime::monarch_with_gil_blocking;
 
     #[test]
     fn test_bare_worker_address_uses_legacy_service_proc() {
@@ -330,6 +352,220 @@ mod tests {
         assert_eq!(service_proc.id(), &legacy_service_proc_id());
         assert_eq!(service_proc.location().to_string(), "tcp://127.0.0.1:1234");
         assert!(listener.is_none());
+    }
+
+    /// A bound but deliberately not-yet-listening IPv4 socket, plus the address
+    /// it holds. Starting from a listening socket would make the
+    /// `SO_ACCEPTCONN` transition below vacuous.
+    fn bound_not_listening() -> (OwnedFd, SockaddrIn) {
+        let sock = socket(
+            AddressFamily::Inet,
+            SockType::Stream,
+            SockFlag::empty(),
+            None,
+        )
+        .expect("test socket should be creatable");
+        let wildcard = SockaddrIn::new(127, 0, 0, 1, 0);
+        bind(sock.as_raw_fd(), &wildcard).expect("binding an ephemeral port should succeed");
+        let bound = getsockname::<SockaddrIn>(sock.as_raw_fd()).expect("bound socket has a name");
+        (sock, bound)
+    }
+
+    /// What the kernel says when a fresh socket tries to take `addr`. A live
+    /// listener holds it; a released one does not. The error is preserved so a
+    /// caller can require the specific refusal rather than any failure.
+    fn rebind_result(addr: &SockaddrIn) -> nix::Result<()> {
+        let probe = socket(
+            AddressFamily::Inet,
+            SockType::Stream,
+            SockFlag::empty(),
+            None,
+        )
+        .expect("probe socket should be creatable");
+        bind(probe.as_raw_fd(), addr)
+    }
+
+    /// A non-alias TCP `host:fdN` location transfers descriptor ownership while
+    /// the binding is being called, and the returned task holds that listener.
+    ///
+    /// The test exercises two spellings of this same path, each with its own
+    /// freshly bound socket: a bare channel URL using the legacy service proc id
+    /// and an explicit `ProcId@location` using a generated instance id. The tls,
+    /// metatls, quic, and metaquic schemes use the same `host:fdN` parser but are
+    /// not exercised here. A TCP alias is different: its nested listener is
+    /// discarded and closed during parsing rather than retained by the task.
+    ///
+    /// The address is the durable ownership witness. Rebinding is checked on
+    /// both sides of the drop, because a rebind that succeeds afterwards proves
+    /// nothing unless it fails while the task still owns the listener.
+    #[test]
+    fn run_worker_loop_forever_retains_non_alias_tcp_fd_until_drop() {
+        pyo3::Python::initialize();
+
+        for build_address in [
+            (&|fd| format!("tcp://127.0.0.1:fd{fd}")) as &dyn Fn(RawFd) -> String,
+            &|fd| {
+                format!(
+                    "{}@tcp://127.0.0.1:fd{fd}",
+                    ProcId::instance(Label::strip("service"))
+                )
+            },
+        ] {
+            let (sock, bound) = bound_not_listening();
+            let observer = dup(sock.as_fd()).expect("duplicating for observation should succeed");
+            assert!(
+                !getsockopt(&observer, sockopt::AcceptConn).expect("SO_ACCEPTCONN is readable"),
+                "the fixture must hand over a bound socket that is not yet listening"
+            );
+
+            // Ownership leaves Rust here: the number is all that is passed, and
+            // the binding adopts it.
+            //
+            // If construction were to fail instead, this fixture cannot reclaim
+            // the descriptor. Whether it is still open depends on where the
+            // failure happened -- a parse failure leaves it untouched, while a
+            // failure after the listener is built has already closed it -- and
+            // the caller cannot tell those apart. Closing it here would risk a
+            // double close, which in a shared test process could take out an
+            // unrelated descriptor opened concurrently. Leaking one descriptor
+            // in a test that is failing anyway is the safer of the two.
+            let transferred = sock.into_raw_fd();
+            let address = build_address(transferred);
+
+            let task = monarch_with_gil_blocking(GilSite::Test, |py| {
+                run_worker_loop_forever(py, &address)
+            })
+            .expect("a valid descriptor address should construct a task");
+
+            // SAFETY: `F_GETFD` only reads the flags of a descriptor number and
+            // never closes it. A number that is not open is defined input here:
+            // the call returns -1 and sets EBADF, which is exactly the outcome
+            // this assertion rules out. Taking a `BorrowedFd` first would
+            // instead assume the validity being tested.
+            let flags = unsafe { libc::fcntl(transferred, libc::F_GETFD) };
+            assert_ne!(
+                flags, -1,
+                "construction must leave the transferred descriptor number open"
+            );
+            // Still open is not enough: the number could have been closed and
+            // handed back out by another thread. Requiring it to name the same
+            // socket rules that out.
+            assert_eq!(
+                getsockname::<SockaddrIn>(transferred)
+                    .expect("a retained descriptor names its socket"),
+                bound,
+                "the retained descriptor must still be the socket that was handed over"
+            );
+            assert!(
+                getsockopt(&observer, sockopt::AcceptConn).expect("SO_ACCEPTCONN is readable"),
+                "construction must call listen before it returns"
+            );
+
+            // The task must be the only owner left before the address can say
+            // anything about what the task holds.
+            drop(observer);
+            assert_eq!(
+                rebind_result(&bound),
+                Err(Errno::EADDRINUSE),
+                "the undriven task must still hold the listener"
+            );
+
+            monarch_with_gil_blocking(GilSite::Test, |_py| {
+                drop(task);
+                Ok::<_, PyErr>(())
+            })
+            .expect("dropping the task should not fail");
+
+            // Deliberately not probing `transferred` here: once released, that
+            // number may already belong to another thread's descriptor.
+            assert_eq!(
+                rebind_result(&bound),
+                Ok(()),
+                "dropping the undriven task must release the adopted listener"
+            );
+        }
+    }
+
+    /// An `fdN` on the bind side of a TCP alias is listened on during parsing,
+    /// but the alias parser discards that listener before the binding returns.
+    /// The returned task therefore retains no ownership of the bind socket.
+    #[test]
+    fn run_worker_loop_forever_alias_fd_listens_and_closes_during_construction() {
+        pyo3::Python::initialize();
+
+        let (sock, bound) = bound_not_listening();
+        let observer = dup(sock.as_fd()).expect("duplicating for observation should succeed");
+        assert!(
+            !getsockopt(&observer, sockopt::AcceptConn).expect("SO_ACCEPTCONN is readable"),
+            "the fixture must hand over a bound socket that is not yet listening"
+        );
+
+        let transferred = sock.into_raw_fd();
+        let address = format!("tcp://127.0.0.1:4444@tcp://127.0.0.1:fd{transferred}");
+        let task =
+            monarch_with_gil_blocking(GilSite::Test, |py| run_worker_loop_forever(py, &address))
+                .expect("a valid alias descriptor address should construct a task");
+
+        assert!(
+            getsockopt(&observer, sockopt::AcceptConn).expect("SO_ACCEPTCONN is readable"),
+            "alias parsing must call listen before discarding the adopted listener"
+        );
+        drop(observer);
+        assert_eq!(
+            rebind_result(&bound),
+            Ok(()),
+            "the returned task must not retain the alias bind listener"
+        );
+
+        monarch_with_gil_blocking(GilSite::Test, |_py| {
+            drop(task);
+            Ok::<_, PyErr>(())
+        })
+        .expect("dropping the task should not fail");
+    }
+
+    /// A textual address failure and a descriptor-syntax failure are both
+    /// raised by the call itself, so no task is created.
+    ///
+    /// Both are `ValueError`, as is the later bind failure when a task is
+    /// driven, so the type alone does not say which phase failed. What
+    /// distinguishes these is that there is no task to drive. This says nothing
+    /// about a numeric descriptor that is syntactically valid; that precondition
+    /// belongs to the caller and is not exercised here.
+    #[test]
+    fn run_worker_loop_forever_rejects_invalid_addresses_before_returning_task() {
+        pyo3::Python::initialize();
+
+        for (address, cause) in [
+            (
+                "tcp://127.0.0.1:fdnot-a-number",
+                "invalid file descriptor number: fdnot-a-number",
+            ),
+            ("zzz://127.0.0.1:1234", "unsupported ZMQ scheme: zzz"),
+        ] {
+            monarch_with_gil_blocking(GilSite::Test, |py| {
+                let error = match run_worker_loop_forever(py, address) {
+                    Ok(_) => panic!("{address} must not produce a task"),
+                    Err(error) => error,
+                };
+
+                assert!(
+                    error.get_type(py).is(PyValueError::type_object(py)),
+                    "an address failure must be exactly ValueError"
+                );
+                let message = error.value(py).to_string();
+                assert!(
+                    message.contains(&format!("invalid worker address {address:?}")),
+                    "the message must name the rejected address, got {message}"
+                );
+                assert!(
+                    message.contains(cause),
+                    "the message must retain the underlying cause, got {message}"
+                );
+                Ok::<_, PyErr>(())
+            })
+            .expect("assertions should not fail");
+        }
     }
 
     #[test]

--- a/python/tests/test_worker_loop_characterization.py
+++ b/python/tests/test_worker_loop_characterization.py
@@ -1,0 +1,195 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""When the occupied-address failure of ``run_worker_loop_forever`` is published.
+
+Constructing the raw binding against an address that is already taken succeeds;
+the failure is published when the returned task is driven. That is the claim
+here, and it is a claim about *publication*, not about attempt timing: this test
+cannot rule out an eager bind attempt whose error was withheld until the drive.
+That the bind is genuinely attempted inside the task is source-grounded instead,
+by ``host(...)`` living in the future the task owns.
+
+The drive runs in a child process under a deadline. A regression that makes the
+bind succeed starts a worker that owns its process lifetime, which would hang or
+exit the test process rather than fail it.
+"""
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+
+# Long enough for a child interpreter to import the bindings on a loaded host,
+# short enough that a worker which wrongly starts gets reported rather than
+# waited on.
+_CHILD_DEADLINE_SECONDS: int = 180
+_CHILD_CLEANUP_SECONDS: int = 10
+
+# An instance-form service proc id. The bare word "service" also parses, but
+# only as the legacy singleton the fallback already produces, so it would not
+# show that the "proc_id@location" split was taken.
+#
+# The uid is a known-valid literal so the child fixture remains deterministic.
+# It is not the value from the binding's address-format help: that example is a
+# placeholder and is rejected as an invalid base58 uid. This one was taken from
+# a generated id and round-trips. A parse failure here would surface loudly, as
+# construction raising before the child ever reaches its drive.
+_SERVICE_PROC_ID: str = "service<E4cgvRepadk>"
+
+# The child reports progress as tagged single-line records, so the parent can
+# require that construction succeeded *before* the drive failed and can read the
+# failure text out of its own record rather than out of merged output. It
+# imports only the raw bootstrap binding: reaching the same task through the
+# pytokio module would add a scanned module import to a test that changes no
+# production code.
+_CHILD_SOURCE: str = """
+import sys
+
+from monarch._rust_bindings.monarch_hyperactor.bootstrap import (
+    run_worker_loop_forever,
+)
+
+task = run_worker_loop_forever(sys.argv[1])
+print("CONSTRUCTED", flush=True)
+
+try:
+    task.block_on()
+except BaseException as err:
+    print("EXACT_VALUE_ERROR", type(err) is ValueError, flush=True)
+    print("MESSAGE", str(err).replace("\\n", " "), flush=True)
+    sys.exit(0)
+
+print("NO_RAISE", flush=True)
+sys.exit(1)
+"""
+
+
+def _records(output: str, tag: str) -> list[str]:
+    """The values of the child's ``tag`` records, ignoring any other output."""
+    prefix = f"{tag} "
+    return [
+        line.removeprefix(prefix)
+        for line in output.splitlines()
+        if line.startswith(prefix)
+    ]
+
+
+def _kill_group(child: "subprocess.Popen[str]") -> None:
+    """Signal the binding child's group; tolerate a group that is already gone."""
+    try:
+        os.killpg(child.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+
+def _kill_and_reap(child: "subprocess.Popen[str]") -> None:
+    """Bound cleanup without waiting for stdout held by worker descendants."""
+    if child.poll() is None:
+        _kill_group(child)
+
+    # Native-launched workers create their own process groups and may inherit
+    # this pipe. Closing our reader keeps their writers from delaying cleanup.
+    if child.stdout is not None:
+        child.stdout.close()
+
+    try:
+        child.wait(timeout=_CHILD_CLEANUP_SECONDS)
+    except subprocess.TimeoutExpired:
+        try:
+            child.kill()
+        except ProcessLookupError:
+            pass
+        try:
+            child.wait(timeout=_CHILD_CLEANUP_SECONDS)
+        except subprocess.TimeoutExpired as error:
+            raise AssertionError(
+                "the worker-loop test child could not be reaped within the cleanup deadline"
+            ) from error
+
+
+def test_occupied_numeric_address_fails_when_blocked_on() -> None:
+    occupied = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    child = None
+    try:
+        occupied.bind(("127.0.0.1", 0))
+        occupied.listen(1)
+        port = occupied.getsockname()[1]
+
+        env = {**os.environ}
+        if "FB_XAR_INVOKED_NAME" in os.environ:
+            env["PYTHONPATH"] = ":".join(sys.path)
+
+        # Its own session isolates the binding child's process group. Native
+        # worker children create their own groups, so cleanup below also closes
+        # the stdout reader and bounds every wait instead of relying on pipe EOF.
+        child = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                _CHILD_SOURCE,
+                f"{_SERVICE_PROC_ID}@tcp://127.0.0.1:{port}",
+            ],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+
+        try:
+            output = child.communicate(timeout=_CHILD_DEADLINE_SECONDS)[0]
+        except subprocess.TimeoutExpired as error:
+            partial_output = error.stdout
+            if isinstance(partial_output, bytes):
+                partial_output = partial_output.decode(errors="replace")
+            output = partial_output or ""
+            raise AssertionError(
+                "the occupied address must fail when the task is driven; a "
+                "child that keeps running means the failure is no longer "
+                f"published by the drive. child output:\n{output}"
+            ) from None
+
+        assert child.returncode == 0, f"child did not observe a failure:\n{output}"
+
+        lines = output.splitlines()
+        assert "CONSTRUCTED" in lines, (
+            "construction must succeed on an occupied address, which is what "
+            f"shows the failure is not published by the call. child output:\n{output}"
+        )
+        kinds = _records(output, "EXACT_VALUE_ERROR")
+        assert kinds == ["True"], (
+            f"the drive must raise exactly ValueError. child output:\n{output}"
+        )
+
+        messages = _records(output, "MESSAGE")
+        assert len(messages) == 1, (
+            f"the child must report exactly one failure. child output:\n{output}"
+        )
+        message = messages[0]
+        assert "listen:" in message, (
+            f"the failure must come from the host bind, got: {message}"
+        )
+        assert "in use" in message, (
+            f"the cause must be the occupied address, got: {message}"
+        )
+        assert f"127.0.0.1:{port}" in message, (
+            f"the failure must name the address under test, got: {message}"
+        )
+    finally:
+        # Reap before releasing the port, so a child that is still alive cannot
+        # take the address as it goes away. Signalling is guarded on the child
+        # still running: once it has been reaped its pid can be reused, and the
+        # group that number names may belong to somebody else. The nested
+        # finally keeps the listener from outliving a failure in that cleanup.
+        try:
+            if child is not None:
+                _kill_and_reap(child)
+        finally:
+            occupied.close()

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -2259,16 +2259,22 @@ state = "legacy"
 transition = "6.2"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from run_worker_loop_forever"
-consumer = "bootstrap_main, which blocks the worker's main thread on it"
-driver = "PythonTask.block_on on the calling thread"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "not reachable in practice; the caller blocks immediately after construction"
-eager_effect = "starts a side effect"
-drop_behavior = "the worker server loop never starts"
-unobserved_error = "propagated synchronously out of block_on"
+consumer = "monarch._src.actor.bootstrap.run_worker_loop_forever, which calls block_on immediately after its argument checks; bootstrap_main is the child command captured during construction, not the consumer"
+driver = "PythonTask.block_on consumes the task; on the Python main thread signal_safe_block_on spawns it onto the embedded runtime and blocks the caller while checking signals, while the non-main branch uses runtime.block_on"
+start_point = "source inspection places service-address parsing and child-command/environment capture in the call and host(...) in the returned task. The Rust ownership tests prove that a non-alias TCP host:fdN location calls listen and transfers its listener before return, while a TCP alias listens on and closes any nested fdN listener during parsing. The same parser handles non-alias tls, metatls, quic, and metaquic host:fdN locations"
+abandonment = "possible through the private native binding; the public wrapper offers no ordinary caller-controlled gap before block_on, while signal interruption follows the shared signal_safe_block_on policy"
+eager_effect = "a successful non-alias host:fdN construction for tcp, tls, metatls, quic, or metaquic calls listen and moves the adopted listener into the returned task; a TCP alias listens on and closes any nested fdN listener during the call, so the task retains none"
+drop_behavior = "source makes a successfully returned non-alias host:fdN task own the listener, so dropping it undriven closes that listener without entering host; the Rust oracle exercises the TCP forms and proves that their address is released. A TCP alias has no nested listener left for task drop to release because parsing closed it before return"
+unobserved_error = "textual address and descriptor-syntax errors raise as PyValueError before a task is returned. Source places host errors inside the returned task; the occupied-numeric-address oracle proves that construction returns a task and block_on publishes the listen failure as PyValueError. The phases are distinguished by whether a task was returned and driven, not by exception type"
 disposition = "replace with a direct blocking binding"
-semantic_class = "deferred_side_effect"
-oracle = "bootstrap worker-loop coverage"
+semantic_class = "sync_partial_effect_lazy_tail"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::bootstrap::tests::run_worker_loop_forever_retains_non_alias_tcp_fd_until_drop",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::bootstrap::tests::run_worker_loop_forever_alias_fd_listens_and_closes_during_construction",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::bootstrap::tests::run_worker_loop_forever_rejects_invalid_addresses_before_returning_task",
+  "fbcode//monarch/python/tests:test_worker_loop_characterization::test_occupied_numeric_address_fails_when_blocked_on",
+  "fbcode//monarch/python/tests:test_python_actors::test_fd_bootstrap",
+]
 
 [[site]]
 id = "np.context.PyInstance.stop_and_wait"


### PR DESCRIPTION
Summary:

`run_worker_loop_forever()` does part of its work before returning a `PythonTask`, and descriptor ownership depends on the address shape.

for a non-alias `host:fdN` address, parsing calls `listen()` and transfers the listener into the returned task. dropping that task releases the listener without starting the host. for an `fdN` on the bind side of a TCP alias, parsing also calls `listen()`, but the alias parser closes the nested listener before returning, so the task retains nothing. host startup remains deferred until the task is driven.

this adds direct Rust tests for both descriptor paths and for synchronous address errors. a bounded child-process test proves that an occupied numeric address returns a task and publishes its `ValueError` from `block_on()`. its timeout path closes the stdout reader and bounds every wait, so worker descendants in separate process groups cannot hang the test.

the Python target keeps `_rust_bindings` as a manual runtime dependency because the import is embedded in the child source and cannot be discovered by autodeps. the census records the split as `sync_partial_effect_lazy_tail` and links it to five exact tests.

no production behavior changes.

Differential Revision: D117373463


