### PR TITLE
rdma benchmark: add logic to drive all runs for a single direction (#4747)

### DIFF
--- a/python/benches/multihost_rdma/bench_peer.py
+++ b/python/benches/multihost_rdma/bench_peer.py
@@ -47,7 +47,7 @@ from bench_stats import Sample
 from bench_topology import InitiatorPlan, Slot, SlotAllocation, SlotValues
 from monarch.actor import Actor, context, endpoint, Point
 from monarch.config import get_global_config
-from monarch.rdma import is_ibverbs_available, RDMAAction, RDMABuffer
+from monarch.rdma import RDMAAction, RDMABuffer
 
 
 VERIFY_OFF: str = "off"
@@ -71,19 +71,15 @@ class Peer(Actor):
         self.plan: InitiatorPlan = InitiatorPlan()
 
     @endpoint
-    async def transport(self) -> str:
-        """Which transport this proc's configuration will actually use.
-
-        The driver checks this against what was asked for, so a silent
-        fallback fails loudly instead of showing up as a hundred-fold
-        outlier.
+    async def check_config(self, expected: Mapping[str, Any]) -> dict[str, Any]:
+        """Which of `expected` this proc's config disagrees with, and what it
+        holds instead. Empty when the proc has every one of them. Used to ensure
+        the client's config propagated properly.
         """
         config = get_global_config()
-        if not config["rdma_disable_ibverbs"] and is_ibverbs_available():
-            return "ibverbs"
-        if config["rdma_allow_tcp_fallback"]:
-            return "tcp"
-        return "none"
+        return {
+            key: config[key] for key, value in expected.items() if config[key] != value
+        }
 
     @endpoint
     async def setup(

--- a/python/benches/multihost_rdma/bench_stats.py
+++ b/python/benches/multihost_rdma/bench_stats.py
@@ -240,7 +240,6 @@ class ConfigColumns:
 
     schema_version: int
     transport: str
-    tcp_serialized: int
     source_device: str
     dest_device: str
     payload_size_mb: float
@@ -249,7 +248,7 @@ class ConfigColumns:
     runs: int
     warmup_iters_per_run: int
     warm_iters_per_run: int
-    local_sender: int
+    local_only: int
     verify_mode: str
     rdma_runtime_threads: str
     integrity_ok: str

--- a/python/benches/multihost_rdma/benchmark_driver.py
+++ b/python/benches/multihost_rdma/benchmark_driver.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+All of the scheduler-independent logic to configure and drive a multihost RDMA
+benchmark.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+from bench_peer import VERIFY_MODES, VERIFY_SAMPLED
+from bench_topology import PAIRINGS, PATTERNS, SAME
+
+
+RUN_COMMAND: str = "run"
+BATCH_COMMAND: str = "run-batch"
+
+# When to kill the job once the benchmark is done.
+TEARDOWN_NEVER: str = "never"
+TEARDOWN_ON_FAILURE: str = "on_failure"
+TEARDOWN_ALWAYS: str = "always"
+TEARDOWN_POLICIES: tuple[str, ...] = (
+    TEARDOWN_NEVER,
+    TEARDOWN_ON_FAILURE,
+    TEARDOWN_ALWAYS,
+)
+
+_MB: int = 1000**2
+
+
+@dataclass(frozen=True)
+class BenchConfig:
+    """Everything the benchmark needs that is not scheduler-specific."""
+
+    # ibverbs or tcp
+    transport: str
+    # Shape of the edges between hosts (see `PATTERNS`)
+    pattern: str
+    # How many hosts take part in the benchmark.
+    num_hosts: int
+    # How procs on each host are paired with each other:
+    # - same: proc i -> proc i
+    # - shifted: proc i -> proc (i + lane_shift) % num_lanes
+    # - all: proc i -> proc j for all i, j
+    lane_pairing: str
+    lane_shift: int
+    # Size of the payload per op per edge between lanes.
+    payload_size_mb: float
+    # Number of concurrent ops per edge between lanes.
+    concurrent_ops: int
+    # Number of times the benchmark will run on a set of
+    # freshly allocated buffers. Each run does
+    # `warmup_iters_per_run + warm_iters_per_run` total iterations.
+    runs: int
+    # Number of iterations at the beginning of a run whose timings
+    # will be discarded.
+    warmup_iters_per_run: int
+    # Number of iterations within a run whose timings will be counted.
+    warm_iters_per_run: int
+    procs_per_host: int
+    # Whether each proc's outgoing buffers reside on gpu.
+    source_on_gpu: bool
+    # Whether each proc's incoming buffers reside on gpu.
+    dest_on_gpu: bool
+    # Verification mode (see `VERIFY_MODES`): whether or not, and to what
+    # extent, to validate each tensor's value after each iteration.
+    verify: str
+    # In `VERIFY_SAMPLED` mode, instead of creating a hash digest of the
+    # entire tensor, we create hash digest from a window of size
+    # `verify_window_mb` at the front, middle and end of the tensor.
+    verify_window_mb: float
+    # How much gpu memory each proc is entitled to. Validated before
+    # launching.
+    max_device_gb_per_proc: float
+    # How much host memory each host is entitled to. Validated before
+    # launching.
+    max_host_gb_per_host: float
+    # How many threads the RDMA runtime was configured to use.
+    rdma_runtime_threads: int | None
+    # Path to the file where the output will live.
+    output_csv: str
+    # Batch or non-batch mode.
+    command: str
+    # Run the benchmark locally on the current host.
+    local_only: bool
+    # Path to the monarch job's cached state.
+    cached_path: str | None
+    # When to teardown the monarch job when the benchmark is done.
+    teardown_policy: str
+
+    @property
+    def payload_bytes(self) -> int:
+        return int(self.payload_size_mb * _MB)
+
+    @property
+    def iterations_per_run(self) -> int:
+        return self.warmup_iters_per_run + self.warm_iters_per_run
+
+    @property
+    def job_hosts(self) -> int:
+        """Hosts the job must provision. Zero under ``--local-only``, which puts
+        every host on this machine and so needs no job at all."""
+        return 0 if self.local_only else self.num_hosts
+
+    @property
+    def source_label(self) -> str:
+        return "gpu" if self.source_on_gpu else "cpu"
+
+    @property
+    def dest_label(self) -> str:
+        return "gpu" if self.dest_on_gpu else "cpu"
+
+
+def add_benchmark_args(parser: argparse.ArgumentParser, *, batch: bool = True) -> None:
+    """Add the scheduler-independent flags, then the subcommands.
+
+    Wrappers add their own flags on top; because those land on the parent parser
+    they are given before the subcommand, as in
+    ``slurm_benchmark.py --partition x run --teardown-policy on_failure``.
+
+    Set ``batch=False`` for a backend that cannot run the benchmark inside its
+    own allocation, which drops the ``run-batch`` subcommand entirely rather
+    than accepting it and failing later.
+    """
+    _add_shape_args(parser)
+    _add_workload_args(parser)
+    _add_reporting_args(parser)
+    _add_subcommands(parser, batch=batch)
+
+
+def _add_shape_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--pattern",
+        choices=PATTERNS,
+        default="p2p",
+        help="Shape of the edges between hosts (default: p2p).",
+    )
+    parser.add_argument(
+        "--num-hosts",
+        type=int,
+        default=2,
+        help=(
+            "How many hosts take part in the benchmark. Setting to 1 makes "
+            "every pattern the loopback self-edge (default: 2)."
+        ),
+    )
+    parser.add_argument(
+        "--lane-pairing",
+        choices=PAIRINGS,
+        default=SAME,
+        help=(
+            "How procs on each host are paired with each other: 'same' pairs "
+            "proc i with proc i, 'shifted' pairs proc i with proc "
+            "(i + --lane-shift) %% --procs-per-host, and 'all' pairs proc i "
+            "with proc j for all i, j (default: same)."
+        ),
+    )
+    parser.add_argument(
+        "--lane-shift",
+        type=int,
+        default=1,
+        help="Offset used by --lane-pairing shifted (default: 1).",
+    )
+    parser.add_argument(
+        "--procs-per-host",
+        type=int,
+        default=8,
+        help=(
+            "Procs to spawn per host. The local rank of a proc determines "
+            "which gpu ordinal it uses, when relevant (default: 8)."
+        ),
+    )
+
+
+def _add_workload_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--transport",
+        choices=["ibverbs", "tcp"],
+        default="ibverbs",
+        help="Transport every proc must use: ibverbs or tcp (default: ibverbs).",
+    )
+    parser.add_argument(
+        "--payload-size-mb",
+        type=float,
+        default=1024,
+        help=(
+            "Size of the payload per op per edge between lanes, in MB (default: 1024)."
+        ),
+    )
+    parser.add_argument(
+        "--concurrent-ops",
+        type=int,
+        default=1,
+        help=(
+            "Number of concurrent ops per edge between lanes. An initiator "
+            "batches every edge it drives and all of its ops into one "
+            "RDMAAction per iteration (default: 1)."
+        ),
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=3,
+        help=(
+            "Number of times to run against freshly allocated buffers. Each "
+            "run does --warmup-iters-per-run + --warm-iters-per-run "
+            "iterations (default: 3)."
+        ),
+    )
+    parser.add_argument(
+        "--warmup-iters-per-run",
+        type=int,
+        default=3,
+        help=(
+            "Number of iterations at the beginning of a run whose timings are "
+            "discarded (default: 3)."
+        ),
+    )
+    parser.add_argument(
+        "--warm-iters-per-run",
+        type=int,
+        default=10,
+        help=(
+            "Number of iterations within a run whose timings are counted (default: 10)."
+        ),
+    )
+    parser.add_argument(
+        "--rdma-runtime-threads",
+        type=int,
+        default=None,
+        help="How many threads the RDMA runtime should use (default: monarch's own).",
+    )
+
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--gpu",
+        action="store_true",
+        default=False,
+        help="Put both sides' buffers on gpu, which is the default.",
+    )
+    mode_group.add_argument(
+        "--cpu",
+        action="store_true",
+        default=False,
+        help="Put both sides' buffers on host memory.",
+    )
+    parser.add_argument(
+        "--source-device",
+        choices=["cpu", "gpu"],
+        default=None,
+        help=(
+            "Where each proc's outgoing buffers reside. Defaults to the "
+            "--gpu/--cpu setting, which sets both sides."
+        ),
+    )
+    parser.add_argument(
+        "--dest-device",
+        choices=["cpu", "gpu"],
+        default=None,
+        help=(
+            "Where each proc's incoming buffers reside. Defaults to the "
+            "--gpu/--cpu setting, which sets both sides."
+        ),
+    )
+
+
+def _add_reporting_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--verify",
+        choices=VERIFY_MODES,
+        default=VERIFY_SAMPLED,
+        help=(
+            "Whether, and to what extent, to validate each tensor's value "
+            "after each iteration (default: sampled)."
+        ),
+    )
+    parser.add_argument(
+        "--verify-window-mb",
+        type=float,
+        default=1.0,
+        help=(
+            "Under --verify sampled, the size of the window to check at the "
+            "front, middle and end of each tensor (default: 1.0)."
+        ),
+    )
+    parser.add_argument(
+        "--max-device-gb-per-proc",
+        type=float,
+        default=80.0,
+        help=(
+            "How much gpu memory each proc is entitled to. Validated before "
+            "launching (default: 80)."
+        ),
+    )
+    parser.add_argument(
+        "--max-host-gb-per-host",
+        type=float,
+        default=256.0,
+        help=(
+            "How much host memory each host is entitled to. Validated "
+            "before launching (default: 256)."
+        ),
+    )
+    parser.add_argument(
+        "--output-csv",
+        default="/tmp/rdma_benchmark_results.csv",
+        help=(
+            "Path to the file where the output will live, one row per "
+            "(pattern, direction, phase) (default: "
+            "/tmp/rdma_benchmark_results.csv). Override it per parallel run so "
+            "concurrent benchmarks do not clobber each other."
+        ),
+    )
+
+
+def _add_subcommands(parser: argparse.ArgumentParser, *, batch: bool) -> None:
+    """Attach the ``run`` / ``run-batch`` subcommands and their options."""
+
+    sub = parser.add_subparsers(dest="command", required=True, metavar="COMMAND")
+
+    run_parser = sub.add_parser(
+        RUN_COMMAND,
+        help="Drive the benchmark from this process, exiting non-zero on failure.",
+    )
+    run_parser.add_argument(
+        "--local-only",
+        action="store_true",
+        default=False,
+        help=(
+            "Run the benchmark locally on the current host, provisioning no "
+            "job. This uses a local proc mesh with a 'hosts' dimension whose "
+            "size is equal to the number of requested hosts."
+        ),
+    )
+    run_parser.add_argument(
+        "--teardown-policy",
+        choices=TEARDOWN_POLICIES,
+        default=TEARDOWN_ALWAYS,
+        help=(
+            "When to tear the monarch job down once the benchmark is done "
+            f"(default: {TEARDOWN_ALWAYS}). '{TEARDOWN_ON_FAILURE}' leaves a "
+            "fully successful run's job up so the next run can reuse it via "
+            "--cached-path, while still tearing down a failed one. "
+            f"'{TEARDOWN_NEVER}' always leaves it up."
+        ),
+    )
+    run_parser.add_argument(
+        "--cached-path",
+        default=None,
+        help=(
+            "Path to the monarch job's cached state, used to reconnect to a "
+            "job instead of creating one. When unset (default) no cache is "
+            "used and a fresh job is always created. Set it to a unique path "
+            "per parallel benchmark run so concurrent runs do not collide."
+        ),
+    )
+
+    if batch:
+        sub.add_parser(
+            BATCH_COMMAND,
+            help=(
+                "Submit the benchmark to run inside its own allocation and "
+                "return immediately. Exits 0 once submitted: the scheduler "
+                "exposes no completion status, so read the job's log or "
+                "--output-csv for the result. --output-csv is written by the "
+                "in-allocation client, so point it somewhere still visible "
+                "to the launching node."
+            ),
+        )
+
+
+def config_from_args(args: argparse.Namespace) -> BenchConfig:
+    """Build a :py:class:`BenchConfig` from :py:func:`add_benchmark_args` flags."""
+    # --gpu/--cpu set both sides; --source-device/--dest-device override
+    # each side independently.
+    default_on_gpu: bool = not args.cpu
+    cfg = BenchConfig(
+        transport=args.transport,
+        pattern=args.pattern,
+        num_hosts=int(args.num_hosts),
+        lane_pairing=args.lane_pairing,
+        lane_shift=int(args.lane_shift),
+        payload_size_mb=float(args.payload_size_mb),
+        concurrent_ops=int(args.concurrent_ops),
+        runs=int(args.runs),
+        warmup_iters_per_run=int(args.warmup_iters_per_run),
+        warm_iters_per_run=int(args.warm_iters_per_run),
+        procs_per_host=int(args.procs_per_host),
+        source_on_gpu=(
+            args.source_device == "gpu" if args.source_device else default_on_gpu
+        ),
+        dest_on_gpu=(args.dest_device == "gpu" if args.dest_device else default_on_gpu),
+        verify=args.verify,
+        verify_window_mb=float(args.verify_window_mb),
+        max_device_gb_per_proc=float(args.max_device_gb_per_proc),
+        max_host_gb_per_host=float(args.max_host_gb_per_host),
+        rdma_runtime_threads=args.rdma_runtime_threads,
+        output_csv=args.output_csv,
+        command=args.command,
+        # These exist only on the `run` subparser.
+        local_only=getattr(args, "local_only", False),
+        cached_path=getattr(args, "cached_path", None),
+        teardown_policy=getattr(args, "teardown_policy", TEARDOWN_ALWAYS),
+    )
+    if cfg.warmup_iters_per_run < 1:
+        raise ValueError(
+            "--warmup-iters-per-run must be at least 1, so that the cold "
+            "iteration takes a discarded slot rather than a warm one"
+        )
+    if cfg.warm_iters_per_run < 1:
+        raise ValueError("--warm-iters-per-run must be at least 1")
+    if cfg.runs < 1:
+        raise ValueError("--runs must be at least 1")
+    return cfg

--- a/python/benches/multihost_rdma/benchmark_driver.py
+++ b/python/benches/multihost_rdma/benchmark_driver.py
@@ -26,7 +26,7 @@ reported separately.
 from __future__ import annotations
 
 import argparse
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
 
@@ -47,6 +47,7 @@ from bench_stats import (
 )
 from bench_topology import (
     bytes_per_iteration,
+    compare_digests,
     describe,
     DIRECTIONS,
     max_ops_per_action,
@@ -55,11 +56,15 @@ from bench_topology import (
     PATTERNS,
     PHASES,
     SAME,
+    Slot,
+    SlotAllocation,
+    SlotValues,
     Topology,
     unused_hosts,
 )
 from monarch.actor import ProcMesh, this_host
 from monarch.config import get_global_config
+from monarch.rdma import RDMABuffer
 
 # `monarch.job` is only needed for the type of the object a wrapper hands us;
 # this module never constructs one.
@@ -521,6 +526,62 @@ async def _check_config(cfg: BenchConfig, peers: Peer) -> None:
         raise RuntimeError(
             f"the procs must be configured with {expected}, but {disagreed}"
         )
+
+
+async def _setup_run(
+    cfg: BenchConfig,
+    peers: Peer,
+    allocations: Mapping[Slot, SlotAllocation],
+    record: RunRecord,
+    seed: int,
+) -> dict[Slot, SlotValues[RDMABuffer]]:
+    """Allocate, fill and register everywhere; collect the buffers to route."""
+    results = await peers.setup.call(
+        allocations, cfg.payload_bytes, seed, cfg.source_on_gpu, cfg.dest_on_gpu
+    )
+    buffers: dict[Slot, SlotValues[RDMABuffer]] = {}
+    for point, (register_ms, values) in results.items():
+        slot = slot_of(point)
+        if slot not in allocations:
+            continue
+        record.register_ms.append(register_ms)
+        buffers[slot] = values
+    return buffers
+
+
+async def _mismatches(
+    cfg: BenchConfig, topo: Topology, peers: Peer
+) -> tuple[int, list[str]]:
+    window = max(int(cfg.verify_window_mb * _MB), 1)
+    results = await peers.digest.call(cfg.verify, window)
+    digests = {slot_of(point): values for point, values in results.items()}
+    return compare_digests(topo, digests)
+
+
+async def _check_control(cfg: BenchConfig, topo: Topology, peers: Peer) -> bool:
+    """Before any transfer every edge must disagree.
+
+    Freshly allocated destinations are zeroed, so this is what proves the
+    comparison can fail at all.
+    """
+    checked, mismatches = await _mismatches(cfg, topo, peers)
+    if checked and len(mismatches) == checked:
+        return True
+    raise RuntimeError(
+        f"negative control failed: {checked - len(mismatches)} of {checked} "
+        "pairs already matched before any transfer"
+    )
+
+
+async def _check_integrity(cfg: BenchConfig, topo: Topology, peers: Peer) -> bool:
+    """After a transfer every edge's destination must match what was sent."""
+    checked, mismatches = await _mismatches(cfg, topo, peers)
+    if not mismatches:
+        return True
+    raise RuntimeError(
+        f"data corruption: {len(mismatches)} of {checked} pairs differ; "
+        + "; ".join(mismatches[:5])
+    )
 
 
 def _shape_columns(

--- a/python/benches/multihost_rdma/benchmark_driver.py
+++ b/python/benches/multihost_rdma/benchmark_driver.py
@@ -10,15 +10,54 @@
 """
 All of the scheduler-independent logic to configure and drive a multihost RDMA
 benchmark.
+
+Each configuration is run in two directions. Both move the same bytes over the
+same edges; only the side that initiates the transfers changes, so ``write`` has
+the source pushing into the destination's buffers and ``read`` has the
+destination pulling from the source's. Each side's memory kind is set
+independently with ``--source-device`` and ``--dest-device``.
+
+A *run* allocates and registers fresh tensors and then iterates. Within a run, the
+first ``--warmup-iters-per-run`` iterations are discarded and the rest are warm.
+The very first iteration of all needs to establish QP connections and is therefore
+reported separately.
 """
 
 from __future__ import annotations
 
 import argparse
+from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any
 
 from bench_peer import VERIFY_MODES, VERIFY_SAMPLED
-from bench_topology import PAIRINGS, PATTERNS, SAME
+from bench_stats import (
+    ConfigColumns,
+    KeyColumns,
+    MetricColumns,
+    metrics_for,
+    phase_table,
+    RunRecord,
+    SCHEMA_VERSION,
+    ShapeColumns,
+    summary_header,
+    summary_row,
+    write_rows,
+)
+from bench_topology import (
+    bytes_per_iteration,
+    describe,
+    DIRECTIONS,
+    max_ops_per_action,
+    MemoryPlan,
+    PAIRINGS,
+    PATTERNS,
+    PHASES,
+    SAME,
+    Topology,
+    unused_hosts,
+)
+from monarch.config import get_global_config
 
 
 RUN_COMMAND: str = "run"
@@ -34,6 +73,7 @@ TEARDOWN_POLICIES: tuple[str, ...] = (
     TEARDOWN_ALWAYS,
 )
 
+_GB: int = 1000**3
 _MB: int = 1000**2
 
 
@@ -421,3 +461,116 @@ def config_from_args(args: argparse.Namespace) -> BenchConfig:
     if cfg.runs < 1:
         raise ValueError("--runs must be at least 1")
     return cfg
+
+
+def _shape_columns(
+    cfg: BenchConfig, topo: Topology, plan: MemoryPlan, direction: str
+) -> ShapeColumns:
+    return ShapeColumns(
+        num_hosts=topo.num_hosts,
+        procs_per_host=topo.procs_per_host,
+        lane_pairing=topo.pairing,
+        lane_shift=topo.shift,
+        num_edges=len(topo.edges),
+        num_initiators=len(topo.initiators(direction)),
+        max_degree=topo.max_degree(direction),
+        max_ops_per_action=max_ops_per_action(topo, direction, ops=cfg.concurrent_ops),
+        max_in_degree=max((topo.in_degree(s) for s in topo.slots()), default=0),
+        bytes_per_iteration=bytes_per_iteration(
+            topo, ops=cfg.concurrent_ops, payload_bytes=cfg.payload_bytes
+        ),
+        max_buffers_per_proc=max(plan.buffers.values(), default=0),
+        max_device_bytes_per_proc=max(plan.device_bytes.values(), default=0),
+        max_host_bytes_per_host=max(plan.host_bytes_per_host.values(), default=0),
+    )
+
+
+def _config_columns(cfg: BenchConfig, record: RunRecord) -> ConfigColumns:
+    return ConfigColumns(
+        schema_version=SCHEMA_VERSION,
+        transport=cfg.transport,
+        source_device=cfg.source_label,
+        dest_device=cfg.dest_label,
+        payload_size_mb=cfg.payload_size_mb,
+        concurrent_ops=cfg.concurrent_ops,
+        # One generation of procs, so `cold_qp` has exactly one iteration behind
+        # it however many runs there were.
+        cold_proc_runs=1,
+        runs=cfg.runs,
+        warmup_iters_per_run=cfg.warmup_iters_per_run,
+        warm_iters_per_run=cfg.warm_iters_per_run,
+        local_only=int(cfg.local_only),
+        verify_mode=cfg.verify,
+        rdma_runtime_threads=str(get_global_config()["rdma_runtime_worker_threads"]),
+        integrity_ok=_flag(record.integrity_ok),
+        negative_control_ok=_flag(record.negative_control_ok),
+    )
+
+
+def _flag(value: bool | None) -> str:
+    return "skipped" if value is None else str(value)
+
+
+def _report(
+    cfg: BenchConfig,
+    topo: Topology,
+    plan: MemoryPlan,
+    records: dict[str, RunRecord],
+) -> None:
+    """Write the CSV and print the per-phase digest."""
+    rows: list[Sequence[Any]] = []
+    table: list[tuple[KeyColumns, MetricColumns]] = []
+    for direction, record in records.items():
+        shape = _shape_columns(cfg, topo, plan, direction)
+        config = _config_columns(cfg, record)
+        for phase in PHASES:
+            key = KeyColumns(pattern=topo.pattern, direction=direction, phase=phase)
+            metrics = metrics_for(phase, record)
+            rows.append(summary_row(key, shape, config, metrics))
+            table.append((key, metrics))
+
+    with open(cfg.output_csv, "w") as stream:
+        write_rows(stream, summary_header(), rows)
+
+    print()
+    for line in phase_table(table):
+        print(line)
+    print(f"\nResults written to {cfg.output_csv}")
+
+
+def _print_banner(
+    cfg: BenchConfig, topo: Topology, plan: MemoryPlan, banner: Sequence[str]
+) -> None:
+    print("=" * 78)
+    print("RDMA Benchmark")
+    print("=" * 78)
+    for line in banner:
+        print(line)
+    for direction in DIRECTIONS:
+        print(
+            describe(
+                topo,
+                direction,
+                ops=cfg.concurrent_ops,
+                payload_bytes=cfg.payload_bytes,
+            )
+        )
+    idle = unused_hosts(topo)
+    if idle:
+        print(f"Hosts this pattern never touches: {list(idle)}")
+    print(
+        f"Memory: source={cfg.source_label} dest={cfg.dest_label}; "
+        f"up to {max(plan.buffers.values(), default=0)} buffers per proc, "
+        f"{_gb(max(plan.device_bytes.values(), default=0))} device per proc, "
+        f"{_gb(max(plan.host_bytes_per_host.values(), default=0))} host per host"
+    )
+    print(
+        f"Runs: {cfg.runs} x ({cfg.warmup_iters_per_run} ramp + "
+        f"{cfg.warm_iters_per_run} warm) iterations, first iteration "
+        f"cold; verify={cfg.verify}"
+    )
+    print(f"Transport: {cfg.transport}  |  Output: {cfg.output_csv}")
+
+
+def _gb(num_bytes: int) -> str:
+    return f"{num_bytes / _GB:.2f} GB"

--- a/python/benches/multihost_rdma/benchmark_driver.py
+++ b/python/benches/multihost_rdma/benchmark_driver.py
@@ -26,12 +26,13 @@ reported separately.
 from __future__ import annotations
 
 import argparse
+import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
 
 import monarch
-from bench_peer import Peer, slot_of, VERIFY_MODES, VERIFY_SAMPLED
+from bench_peer import Peer, slot_of, VERIFY_MODES, VERIFY_OFF, VERIFY_SAMPLED
 from bench_stats import (
     ConfigColumns,
     KeyColumns,
@@ -46,15 +47,19 @@ from bench_stats import (
     write_rows,
 )
 from bench_topology import (
+    allocation_for,
     bytes_per_iteration,
     compare_digests,
     describe,
     DIRECTIONS,
+    initiator_bytes,
     max_ops_per_action,
     MemoryPlan,
     PAIRINGS,
     PATTERNS,
+    phase_of,
     PHASES,
+    plan_for,
     SAME,
     Slot,
     SlotAllocation,
@@ -549,6 +554,46 @@ async def _setup_run(
     return buffers
 
 
+async def _iterate(
+    cfg: BenchConfig,
+    topo: Topology,
+    peers: Peer,
+    direction: str,
+    record: RunRecord,
+    run: int,
+    iteration: int,
+) -> None:
+    """One iteration, timed on this process's clock from the cast to the last
+    reply."""
+    phase = record.record(phase_of(run, iteration, cfg.warmup_iters_per_run))
+    started = time.perf_counter()
+    samples = await peers.execute_iteration.call()
+    span_ms = (time.perf_counter() - started) * 1000.0
+
+    slowest_ms = 0.0
+    for _point, sample in samples.items():
+        if sample is None:
+            continue
+        phase.add_sample(
+            sample,
+            initiator_bytes(
+                topo,
+                sample.slot,
+                direction,
+                ops=cfg.concurrent_ops,
+                payload_bytes=cfg.payload_bytes,
+            ),
+        )
+        slowest_ms = max(slowest_ms, sample.total_ms)
+    phase.add_iteration(
+        span_ms,
+        bytes_per_iteration(
+            topo, ops=cfg.concurrent_ops, payload_bytes=cfg.payload_bytes
+        ),
+        slowest_ms,
+    )
+
+
 async def _mismatches(
     cfg: BenchConfig, topo: Topology, peers: Peer
 ) -> tuple[int, list[str]]:
@@ -582,6 +627,32 @@ async def _check_integrity(cfg: BenchConfig, topo: Topology, peers: Peer) -> boo
         f"data corruption: {len(mismatches)} of {checked} pairs differ; "
         + "; ".join(mismatches[:5])
     )
+
+
+async def _run_direction(
+    cfg: BenchConfig, topo: Topology, peers: Peer, direction: str
+) -> RunRecord:
+    """Every run of one direction, leaving the peers in a clean state."""
+    record = RunRecord()
+    allocations = {
+        slot: allocation_for(topo, slot, ops=cfg.concurrent_ops)
+        for slot in topo.slots()
+    }
+    verifying = cfg.verify != VERIFY_OFF
+    try:
+        for run in range(cfg.runs):
+            buffers = await _setup_run(cfg, peers, allocations, record, seed=run)
+            plans = plan_for(topo, direction, buffers, ops=cfg.concurrent_ops)
+            await peers.wire.call(plans)
+            if verifying and run == 0:
+                record.negative_control_ok = await _check_control(cfg, topo, peers)
+            for iteration in range(cfg.iterations_per_run):
+                await _iterate(cfg, topo, peers, direction, record, run, iteration)
+            if verifying:
+                record.integrity_ok = await _check_integrity(cfg, topo, peers)
+    finally:
+        await peers.reset.call()
+    return record
 
 
 def _shape_columns(

--- a/python/benches/multihost_rdma/benchmark_driver.py
+++ b/python/benches/multihost_rdma/benchmark_driver.py
@@ -28,9 +28,10 @@ from __future__ import annotations
 import argparse
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
-from bench_peer import VERIFY_MODES, VERIFY_SAMPLED
+import monarch
+from bench_peer import Peer, slot_of, VERIFY_MODES, VERIFY_SAMPLED
 from bench_stats import (
     ConfigColumns,
     KeyColumns,
@@ -57,7 +58,13 @@ from bench_topology import (
     Topology,
     unused_hosts,
 )
+from monarch.actor import ProcMesh, this_host
 from monarch.config import get_global_config
+
+# `monarch.job` is only needed for the type of the object a wrapper hands us;
+# this module never constructs one.
+if TYPE_CHECKING:
+    from monarch.job import JobTrait
 
 
 RUN_COMMAND: str = "run"
@@ -461,6 +468,59 @@ def config_from_args(args: argparse.Namespace) -> BenchConfig:
     if cfg.runs < 1:
         raise ValueError("--runs must be at least 1")
     return cfg
+
+
+def _rdma_settings(cfg: BenchConfig) -> dict[str, Any]:
+    """The RDMA configuration this run needs, on the client and on every proc."""
+    settings: dict[str, Any] = (
+        {"rdma_allow_tcp_fallback": False}
+        if cfg.transport == "ibverbs"
+        else {"rdma_disable_ibverbs": True, "rdma_allow_tcp_fallback": True}
+    )
+    if cfg.rdma_runtime_threads is not None:
+        settings["rdma_runtime_worker_threads"] = cfg.rdma_runtime_threads
+    return settings
+
+
+def _configure_rdma(cfg: BenchConfig) -> None:
+    """Pin the transport and the runtime thread count."""
+    monarch.configure(**_rdma_settings(cfg))
+
+
+def _spawn_procs_and_actors(
+    cfg: BenchConfig, job: JobTrait | None, mesh_name: str
+) -> tuple[ProcMesh, Peer]:
+    """Spawn one proc per lane on each host, and spawn a `Peer` actor on
+    each proc."""
+    if cfg.local_only:
+        procs = this_host().spawn_procs(
+            per_host={"hosts": cfg.num_hosts, "lanes": cfg.procs_per_host}
+        )
+    else:
+        assert job is not None, "a job is required unless --local-only is specified"
+        hosts = getattr(job.state(cached_path=cfg.cached_path), mesh_name)
+        # `--cached-path` reconnects to whatever job is already there, which
+        # might not be the size this run asked for.
+        if hosts.size() != cfg.num_hosts:
+            raise RuntimeError(
+                f"--num-hosts {cfg.num_hosts} but the job provisioned {hosts.size()}"
+            )
+        procs = hosts.spawn_procs(per_host={"lanes": cfg.procs_per_host})
+    return procs, procs.spawn("rdma_bench_peer", Peer)
+
+
+async def _check_config(cfg: BenchConfig, peers: Peer) -> None:
+    """Fail unless every proc inherited the configuration the client pinned."""
+    expected = _rdma_settings(cfg)
+    results = await peers.check_config.call(expected)
+    wrong = {slot_of(point): held for point, held in results.items() if held}
+    if wrong:
+        disagreed = "; ".join(
+            f"{slot} has {held}" for slot, held in sorted(wrong.items())
+        )
+        raise RuntimeError(
+            f"the procs must be configured with {expected}, but {disagreed}"
+        )
 
 
 def _shape_columns(

--- a/python/tests/test_rdma_bench_driver.py
+++ b/python/tests/test_rdma_bench_driver.py
@@ -12,7 +12,10 @@ Unit tests for the multi-host RDMA benchmark's driver.
 """
 
 import argparse
+import csv
 
+import bench_stats as bs
+import bench_topology as bt
 import benchmark_driver as bd
 import pytest
 
@@ -147,3 +150,141 @@ def test_run_batch_gets_the_run_only_flags_defaulted() -> None:
     assert cfg.local_only is False
     assert cfg.cached_path is None
     assert cfg.teardown_policy == bd.TEARDOWN_ALWAYS
+
+
+_GB: int = 1000**3
+
+
+def _topology(cfg: bd.BenchConfig) -> bt.Topology:
+    return bt.build_topology(
+        cfg.pattern, cfg.num_hosts, cfg.procs_per_host, cfg.lane_pairing, cfg.lane_shift
+    )
+
+
+def _plan(cfg: bd.BenchConfig, topo: bt.Topology) -> bt.MemoryPlan:
+    return bt.plan_memory(
+        topo,
+        ops=cfg.concurrent_ops,
+        payload_bytes=cfg.payload_bytes,
+        source_on_gpu=cfg.source_on_gpu,
+        dest_on_gpu=cfg.dest_on_gpu,
+    )
+
+
+def _record(*, submit_ms: float = 200.0, spans: int = 4) -> bs.RunRecord:
+    """A record holding one cold iteration and ``spans`` warm ones."""
+    runs = bs.RunRecord()
+    runs.register_ms.append(5.0)
+    for index in range(spans + 1):
+        phase = bt.COLD_QP if index == 0 else bt.WARM
+        into = runs.record(phase)
+        into.add_sample(
+            bs.Sample(bt.Slot(0, 0), build_ms=1.0, submit_ms=submit_ms),
+            initiator_bytes=_GB,
+        )
+        into.add_iteration(
+            span_ms=submit_ms + 5.0, iteration_bytes=2 * _GB, slowest_ms=submit_ms
+        )
+    runs.integrity_ok = True
+    runs.negative_control_ok = True
+    return runs
+
+
+def test_the_banner_states_the_shape_before_anything_is_provisioned(capsys) -> None:
+    cfg = _config("--pattern", "ring", "--num-hosts", "4", "--procs-per-host", "2")
+    topo = _topology(cfg)
+
+    bd._print_banner(cfg, topo, _plan(cfg, topo), ["Mode: test"])
+
+    printed = capsys.readouterr().out
+    assert "Mode: test" in printed
+    # One line per direction, each naming the graph that direction will drive.
+    assert printed.count("ring: 4x2 procs, 8 edges, same lanes") == 2
+    assert "read;" in printed and "write;" in printed
+    assert "Memory: source=gpu dest=gpu" in printed
+    # One outgoing pool plus one incoming, at one op of 1024 MB each.
+    assert "up to 2 buffers per proc, 2.05 GB device per proc" in printed
+    assert "3 x (3 ramp + 10 warm) iterations" in printed
+    assert "Transport: ibverbs" in printed
+    assert cfg.output_csv in printed
+
+
+def test_the_banner_names_the_hosts_a_pattern_leaves_idle(capsys) -> None:
+    """A p2p run over an eight-host job uses two of them, which is worth saying
+    out loud before the other six sit there costing capacity."""
+    cfg = _config("--pattern", "p2p", "--num-hosts", "8")
+    topo = _topology(cfg)
+
+    bd._print_banner(cfg, topo, _plan(cfg, topo), [])
+
+    assert "never touches: [2, 3, 4, 5, 6, 7]" in capsys.readouterr().out
+
+
+def test_the_shape_columns_describe_the_graph() -> None:
+    cfg = _config(
+        "--pattern", "all-to-all", "--num-hosts", "4", "--procs-per-host", "2"
+    )
+    topo = _topology(cfg)
+
+    shape = bd._shape_columns(cfg, topo, _plan(cfg, topo), bt.READ)
+
+    assert (shape.num_hosts, shape.procs_per_host) == (4, 2)
+    assert shape.num_edges == 24, "4 hosts fully connected, 2 same-lane pairs each"
+    assert shape.num_initiators == 8, "every proc pulls under read"
+    assert shape.max_degree == 3
+    assert shape.max_in_degree == 3
+    assert shape.max_ops_per_action == 3, "one op per edge, three edges in"
+    assert shape.bytes_per_iteration == 24 * 1024 * 1000**2
+    assert shape.max_buffers_per_proc == 4, "one outgoing plus three incoming"
+
+
+def test_the_config_columns_record_what_was_asked_for() -> None:
+    cfg = _config("--cpu", "--pattern", "ring", "--verify", "off")
+
+    config = bd._config_columns(cfg, _record())
+
+    assert config.schema_version == bs.SCHEMA_VERSION
+    assert (config.source_device, config.dest_device) == ("cpu", "cpu")
+    assert config.verify_mode == "off"
+    assert config.local_only == 0
+    assert config.cold_proc_runs == 1, "one generation of procs, so one cold_qp"
+    assert config.integrity_ok == "True"
+
+
+def test_a_check_that_never_ran_is_neither_pass_nor_fail() -> None:
+    """`--verify off` leaves the flags unset, and reporting them as False would
+    read as a corrupted transfer."""
+    assert bd._flag(None) == "skipped"
+    assert bd._flag(True) == "True"
+    assert bd._flag(False) == "False"
+
+
+def test_reporting_writes_a_row_per_direction_and_phase(tmp_path, capsys) -> None:
+    output_csv = str(tmp_path / "results.csv")
+    cfg = _config("--pattern", "ring", "--num-hosts", "4", "--output-csv", output_csv)
+    topo = _topology(cfg)
+    records = {bt.READ: _record(submit_ms=400.0), bt.WRITE: _record(submit_ms=200.0)}
+
+    bd._report(cfg, topo, _plan(cfg, topo), records)
+
+    with open(output_csv) as stream:
+        rows = list(csv.DictReader(stream))
+    assert list(rows[0]) == list(bs.summary_header())
+    assert {(row["direction"], row["phase"]) for row in rows} == {
+        (direction, phase) for direction in bt.DIRECTIONS for phase in bt.PHASES
+    }
+    assert all(row["pattern"] == "ring" for row in rows)
+
+    warm = {row["direction"]: row for row in rows if row["phase"] == bt.WARM}
+    assert float(warm[bt.READ]["submit_ms_median"]) == 400.0
+    assert float(warm[bt.WRITE]["submit_ms_median"]) == 200.0
+    # Halving the time doubles the rate, and only warm rows carry one at all.
+    assert float(warm[bt.WRITE]["agg_gbs_median"]) > float(
+        warm[bt.READ]["agg_gbs_median"]
+    )
+    cold = [row for row in rows if row["phase"] == bt.COLD_QP]
+    assert all(row["agg_gbs_median"] == "" for row in cold)
+
+    printed = capsys.readouterr().out
+    assert "build p50 (ms)" in printed
+    assert output_csv in printed

--- a/python/tests/test_rdma_bench_driver.py
+++ b/python/tests/test_rdma_bench_driver.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Unit tests for the multi-host RDMA benchmark's driver.
+"""
+
+import argparse
+
+import benchmark_driver as bd
+import pytest
+
+
+def _parse(*flags: str, batch: bool = True, command: str = bd.RUN_COMMAND):
+    """The namespace the CLI would build for ``flags`` plus a subcommand."""
+    parser = argparse.ArgumentParser()
+    bd.add_benchmark_args(parser, batch=batch)
+    return parser.parse_args([*flags, command])
+
+
+def _config(*flags: str, **kwargs) -> bd.BenchConfig:
+    return bd.config_from_args(_parse(*flags, **kwargs))
+
+
+def test_the_defaults_describe_a_two_host_gpu_run() -> None:
+    cfg = _config()
+
+    assert cfg.pattern == "p2p"
+    assert cfg.num_hosts == 2
+    assert cfg.procs_per_host == 8
+    assert cfg.lane_pairing == "same"
+    assert cfg.transport == "ibverbs"
+    assert cfg.payload_size_mb == 1024
+    assert cfg.concurrent_ops == 1
+    assert cfg.runs == 3
+    assert (cfg.source_on_gpu, cfg.dest_on_gpu) == (True, True)
+    assert cfg.verify == "sampled"
+    assert cfg.command == bd.RUN_COMMAND
+    assert cfg.local_only is False
+    assert cfg.cached_path is None
+    assert cfg.teardown_policy == bd.TEARDOWN_ALWAYS
+
+
+def test_every_shape_flag_reaches_the_config() -> None:
+    cfg = _config(
+        "--pattern",
+        "all-to-all",
+        "--num-hosts",
+        "8",
+        "--procs-per-host",
+        "4",
+        "--lane-pairing",
+        "shifted",
+        "--lane-shift",
+        "3",
+    )
+
+    assert (cfg.pattern, cfg.num_hosts, cfg.procs_per_host) == ("all-to-all", 8, 4)
+    assert (cfg.lane_pairing, cfg.lane_shift) == ("shifted", 3)
+
+
+@pytest.mark.parametrize(
+    ("flags", "source_on_gpu", "dest_on_gpu"),
+    [
+        ((), True, True),
+        (("--cpu",), False, False),
+        (("--gpu",), True, True),
+        (("--cpu", "--dest-device", "gpu"), False, True),
+        (("--gpu", "--dest-device", "cpu"), True, False),
+        (("--source-device", "cpu"), False, True),
+        (("--gpu", "--source-device", "cpu"), False, True),
+        (("--cpu", "--source-device", "gpu"), True, False),
+    ],
+)
+def test_each_sides_memory_kind_can_be_set_on_its_own(
+    flags, source_on_gpu, dest_on_gpu
+) -> None:
+    """``--gpu``/``--cpu`` set both sides; either side then overrides it."""
+    cfg = _config(*flags)
+
+    assert (cfg.source_on_gpu, cfg.dest_on_gpu) == (source_on_gpu, dest_on_gpu)
+    assert (cfg.source_label, cfg.dest_label) == (
+        "gpu" if source_on_gpu else "cpu",
+        "gpu" if dest_on_gpu else "cpu",
+    )
+
+
+def test_gpu_and_cpu_cannot_both_be_given() -> None:
+    with pytest.raises(SystemExit):
+        _parse("--gpu", "--cpu")
+
+
+def test_a_payload_is_counted_in_decimal_megabytes() -> None:
+    assert _config("--payload-size-mb", "1024").payload_bytes == 1024 * 1000**2
+    assert _config("--payload-size-mb", "0.5").payload_bytes == 500_000
+
+
+def test_a_run_is_its_ramp_plus_its_warm_iterations() -> None:
+    cfg = _config("--warmup-iters-per-run", "4", "--warm-iters-per-run", "10")
+
+    assert cfg.iterations_per_run == 14
+
+
+def test_local_only_provisions_nothing() -> None:
+    parser = argparse.ArgumentParser()
+    bd.add_benchmark_args(parser)
+    local = bd.config_from_args(
+        parser.parse_args(["--num-hosts", "8", "run", "--local-only"])
+    )
+
+    assert local.num_hosts == 8
+    assert local.local_only is True
+    assert local.job_hosts == 0, "no job at all, however many hosts take part"
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["--warmup-iters-per-run", "--warm-iters-per-run", "--runs"],
+)
+def test_a_run_shape_that_reports_nothing_is_refused(flag) -> None:
+    """Each of these at zero leaves a phase with no samples, or spends the cold
+    iteration on a warm slot, so the CLI rejects it before provisioning."""
+    with pytest.raises(ValueError, match=flag):
+        _config(flag, "0")
+
+    assert _config(flag, "1") is not None
+
+
+def test_run_batch_is_offered_only_to_schedulers_that_have_it() -> None:
+    assert _config(command=bd.BATCH_COMMAND).command == bd.BATCH_COMMAND
+
+    with pytest.raises(SystemExit):
+        _parse(batch=False, command=bd.BATCH_COMMAND)
+
+
+def test_run_batch_gets_the_run_only_flags_defaulted() -> None:
+    """They live on the ``run`` subparser, so the namespace lacks them entirely
+    and the config has to supply the same values ``run`` would have."""
+    cfg = _config(command=bd.BATCH_COMMAND)
+
+    assert cfg.local_only is False
+    assert cfg.cached_path is None
+    assert cfg.teardown_policy == bd.TEARDOWN_ALWAYS

--- a/python/tests/test_rdma_bench_driver.py
+++ b/python/tests/test_rdma_bench_driver.py
@@ -476,3 +476,139 @@ async def test_the_run_is_told_every_proc_that_disagreed() -> None:
     assert "{'rdma_allow_tcp_fallback': False}" in str(caught.value), (
         "the message names what was expected as well as what was held"
     )
+
+
+def _self_edge_topology() -> bt.Topology:
+    """Two procs on one host, each its own peer."""
+    return bt.build_topology("p2p", 1, 2, bt.SAME, 1)
+
+
+def _digests(slots, *, sent, received) -> dict:
+    return {
+        slot: bt.SlotValues(outgoing=(sent(slot),), incoming={slot: (received(slot),)})
+        for slot in slots
+    }
+
+
+async def test_setup_records_registration_and_collects_every_buffer() -> None:
+    topo = _self_edge_topology()
+    allocations = {slot: bt.allocation_for(topo, slot, ops=1) for slot in topo.slots()}
+    replies = [
+        (4.0, bt.SlotValues(outgoing=("buf-0",), incoming={})),
+        (6.0, bt.SlotValues(outgoing=("buf-1",), incoming={})),
+    ]
+    peers = _FakePeers(setup=_FakeEndpoint(_value_mesh(replies, lanes=2)))
+    record = bs.RunRecord()
+
+    buffers = await bd._setup_run(
+        _config(), cast(bench_peer.Peer, peers), allocations, record, seed=3
+    )
+
+    assert set(buffers) == {bt.Slot(0, 0), bt.Slot(0, 1)}
+    assert buffers[bt.Slot(0, 0)].outgoing == ("buf-0",)
+    assert buffers[bt.Slot(0, 1)].outgoing == ("buf-1",)
+    assert record.register_ms == [4.0, 6.0]
+
+
+async def test_setup_ignores_a_proc_the_pattern_never_touches() -> None:
+    """A pattern that leaves a proc idle still casts to it, and it answers with
+    nothing registered; counting that as a registration would skew the median."""
+    topo = _self_edge_topology()
+    allocations = {slot: bt.allocation_for(topo, slot, ops=1) for slot in topo.slots()}
+    replies = [
+        (4.0, bt.SlotValues(outgoing=("buf-0",), incoming={})),
+        (6.0, bt.SlotValues(outgoing=("buf-1",), incoming={})),
+        (0.0, bt.SlotValues(outgoing=(), incoming={})),
+    ]
+    peers = _FakePeers(setup=_FakeEndpoint(_value_mesh(replies, lanes=3)))
+    record = bs.RunRecord()
+
+    buffers = await bd._setup_run(
+        _config(), cast(bench_peer.Peer, peers), allocations, record, seed=0
+    )
+
+    assert bt.Slot(0, 2) not in buffers
+    assert record.register_ms == [4.0, 6.0]
+
+
+async def test_setup_passes_the_run_seed_and_memory_kinds_to_every_proc() -> None:
+    topo = _self_edge_topology()
+    allocations = {slot: bt.allocation_for(topo, slot, ops=1) for slot in topo.slots()}
+    replies = [(1.0, bt.SlotValues(outgoing=(), incoming={}))] * 2
+    setup = _FakeEndpoint(_value_mesh(replies, lanes=2))
+    cfg = _config("--payload-size-mb", "2", "--source-device", "cpu")
+
+    await bd._setup_run(
+        cfg,
+        cast(bench_peer.Peer, _FakePeers(setup=setup)),
+        allocations,
+        bs.RunRecord(),
+        7,
+    )
+
+    ((cast_allocations, payload_bytes, seed, source_on_gpu, dest_on_gpu),) = setup.casts
+    assert cast_allocations == allocations
+    assert (payload_bytes, seed) == (2 * 1000**2, 7)
+    assert (source_on_gpu, dest_on_gpu) == (False, True)
+
+
+async def test_matching_digests_pass_the_integrity_check() -> None:
+    topo = _self_edge_topology()
+    digests = _digests(
+        topo.slots(), sent=lambda s: f"h{s.lane}", received=lambda s: f"h{s.lane}"
+    )
+    peers = _FakePeers(
+        digest=_FakeEndpoint(_value_mesh(list(digests.values()), lanes=2))
+    )
+    cfg = _config()
+
+    assert await bd._check_integrity(cfg, topo, cast(bench_peer.Peer, peers)) is True
+    with pytest.raises(RuntimeError, match="negative control failed"):
+        await bd._check_control(cfg, topo, cast(bench_peer.Peer, peers))
+
+
+async def test_zeroed_destinations_pass_the_negative_control() -> None:
+    """Every edge must disagree before a transfer, which is what proves the
+    comparison is able to fail at all."""
+    topo = _self_edge_topology()
+    digests = _digests(
+        topo.slots(), sent=lambda s: f"h{s.lane}", received=lambda s: "zero"
+    )
+    peers = _FakePeers(
+        digest=_FakeEndpoint(_value_mesh(list(digests.values()), lanes=2))
+    )
+    cfg = _config()
+
+    assert await bd._check_control(cfg, topo, cast(bench_peer.Peer, peers)) is True
+    with pytest.raises(RuntimeError, match="data corruption: 2 of 2 pairs differ"):
+        await bd._check_integrity(cfg, topo, cast(bench_peer.Peer, peers))
+
+
+async def test_one_wrongly_routed_edge_is_caught_and_named() -> None:
+    topo = _self_edge_topology()
+    digests = _digests(
+        topo.slots(),
+        sent=lambda s: f"h{s.lane}",
+        received=lambda s: "h0" if s.lane == 0 else "wrong",
+    )
+    peers = _FakePeers(
+        digest=_FakeEndpoint(_value_mesh(list(digests.values()), lanes=2))
+    )
+
+    with pytest.raises(RuntimeError, match="1 of 2 pairs differ") as caught:
+        await bd._check_integrity(_config(), topo, cast(bench_peer.Peer, peers))
+
+    assert "h1" in str(caught.value) and "wrong" in str(caught.value)
+
+
+async def test_the_digest_window_is_at_least_one_byte() -> None:
+    """`--verify-window-mb` is a float, so a small enough one rounds to zero and
+    would digest nothing at all."""
+    topo = _self_edge_topology()
+    digests = _digests(topo.slots(), sent=lambda s: "x", received=lambda s: "x")
+    digest = _FakeEndpoint(_value_mesh(list(digests.values()), lanes=2))
+    cfg = _config("--verify-window-mb", "0.0000001")
+
+    await bd._mismatches(cfg, topo, cast(bench_peer.Peer, _FakePeers(digest=digest)))
+
+    assert digest.casts == [("sampled", 1)]

--- a/python/tests/test_rdma_bench_driver.py
+++ b/python/tests/test_rdma_bench_driver.py
@@ -13,11 +13,90 @@ Unit tests for the multi-host RDMA benchmark's driver.
 
 import argparse
 import csv
+from typing import cast
 
+import bench_peer
 import bench_stats as bs
 import bench_topology as bt
 import benchmark_driver as bd
 import pytest
+from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
+from monarch.actor import ValueMesh
+from monarch.job import JobTrait
+
+
+def _value_mesh(values, *, hosts: int | None = None, lanes: int = 1) -> ValueMesh:
+    """A real ``ValueMesh`` over ``hosts`` x ``lanes``, in rank order."""
+    labels = ["lanes"] if hosts is None else ["hosts", "lanes"]
+    sizes = [lanes] if hosts is None else [hosts, lanes]
+    return ValueMesh(Shape(labels, Slice.new_row_major(sizes)), list(values))
+
+
+class _FakeEndpoint:
+    """One actor endpoint, recording its casts and replying from ``replies``."""
+
+    def __init__(self, replies) -> None:
+        self._replies = replies
+        self.casts: list[tuple] = []
+
+    async def call(self, *args, **kwargs) -> ValueMesh:
+        self.casts.append(args)
+        replies = (
+            self._replies(*args, **kwargs) if callable(self._replies) else self._replies
+        )
+        return cast(ValueMesh, replies)
+
+
+class _FakePeers:
+    """Stands in for the peer actor mesh."""
+
+    def __init__(self, **endpoints: _FakeEndpoint) -> None:
+        for name, endpoint in endpoints.items():
+            setattr(self, name, endpoint)
+
+
+class _FakeProcs:
+    def __init__(self, peers=None) -> None:
+        self.peers = peers
+        self.spawned: list[tuple] = []
+        self.stopped = False
+
+    def spawn(self, name, actor_class):
+        self.spawned.append((name, actor_class))
+        return self.peers
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class _FakeHost:
+    """A host mesh that hands out one proc mesh and remembers the request."""
+
+    def __init__(self, procs: _FakeProcs, hosts: int = 1) -> None:
+        self.procs = procs
+        self.per_host = None
+        self._hosts = hosts
+
+    def size(self) -> int:
+        return self._hosts
+
+    def spawn_procs(self, per_host):
+        self.per_host = per_host
+        return self.procs
+
+
+class _FakeJob:
+    def __init__(self, mesh_name: str, host: _FakeHost) -> None:
+        self._state = type("State", (), {mesh_name: host})()
+        self.cached_paths: list = []
+        self.killed = False
+
+    def state(self, cached_path=None):
+        self.cached_paths.append(cached_path)
+        return self._state
+
+    def kill(self) -> None:
+        self.killed = True
 
 
 def _parse(*flags: str, batch: bool = True, command: str = bd.RUN_COMMAND):
@@ -288,3 +367,112 @@ def test_reporting_writes_a_row_per_direction_and_phase(tmp_path, capsys) -> Non
     printed = capsys.readouterr().out
     assert "build p50 (ms)" in printed
     assert output_csv in printed
+
+
+def test_the_transport_and_thread_count_are_pinned_before_any_proc_starts(
+    monkeypatch,
+) -> None:
+    """The procs inherit this configuration, so it has to be set first."""
+    settings: list[dict] = []
+    monkeypatch.setattr(
+        bd.monarch, "configure", lambda **kw: settings.append(kw), raising=False
+    )
+
+    bd._configure_rdma(_config("--transport", "ibverbs"))
+    bd._configure_rdma(_config("--transport", "tcp", "--rdma-runtime-threads", "16"))
+
+    assert settings[0] == {"rdma_allow_tcp_fallback": False}
+    assert settings[1] == {
+        "rdma_disable_ibverbs": True,
+        "rdma_allow_tcp_fallback": True,
+        "rdma_runtime_worker_threads": 16,
+    }
+
+
+def test_local_only_puts_every_host_on_this_machine(monkeypatch) -> None:
+    peers = _FakePeers()
+    host = _FakeHost(_FakeProcs(peers))
+    monkeypatch.setattr(bd, "this_host", lambda: host)
+    parser = argparse.ArgumentParser()
+    bd.add_benchmark_args(parser)
+    cfg = bd.config_from_args(
+        parser.parse_args(
+            ["--num-hosts", "4", "--procs-per-host", "2", "run", "--local-only"]
+        )
+    )
+
+    procs, spawned = bd._spawn_procs_and_actors(cfg, None, "unused")
+
+    assert host.per_host == {"hosts": 4, "lanes": 2}, "both dimensions, one machine"
+    assert procs is host.procs
+    assert spawned is peers
+    assert procs.spawned == [("rdma_bench_peer", bench_peer.Peer)]
+
+
+def test_a_scheduled_run_takes_its_hosts_from_the_job() -> None:
+    """The job supplies the hosts dimension, so the driver asks only for lanes."""
+    peers = _FakePeers()
+    host = _FakeHost(_FakeProcs(peers), hosts=4)
+    job = _FakeJob("mesh0", host)
+    cfg = _config("--num-hosts", "4", "--procs-per-host", "2")
+
+    procs, spawned = bd._spawn_procs_and_actors(cfg, cast(JobTrait, job), "mesh0")
+
+    assert job.cached_paths == [None]
+    assert host.per_host == {"lanes": 2}
+    assert (procs, spawned) == (host.procs, peers)
+
+
+def test_a_job_of_the_wrong_size_is_refused() -> None:
+    host = _FakeHost(_FakeProcs(_FakePeers()), hosts=2)
+    job = _FakeJob("mesh0", host)
+
+    with pytest.raises(RuntimeError, match="--num-hosts 4 but the job provisioned 2"):
+        bd._spawn_procs_and_actors(
+            _config("--num-hosts", "4"), cast(JobTrait, job), "mesh0"
+        )
+
+    assert host.per_host is None, "nothing is spawned onto the wrong job"
+
+
+def test_a_scheduled_run_without_a_job_is_a_bug_not_a_local_run() -> None:
+    with pytest.raises(AssertionError, match="--local-only"):
+        bd._spawn_procs_and_actors(_config(), None, "mesh0")
+
+
+async def test_every_proc_must_have_the_configuration_the_client_pinned() -> None:
+    check = _FakeEndpoint(_value_mesh([{}] * 4, lanes=4))
+    cfg = _config("--transport", "tcp", "--rdma-runtime-threads", "16")
+
+    await bd._check_config(cfg, cast(bench_peer.Peer, _FakePeers(check_config=check)))
+
+    ((expected,),) = check.casts
+    assert expected == {
+        "rdma_disable_ibverbs": True,
+        "rdma_allow_tcp_fallback": True,
+        "rdma_runtime_worker_threads": 16,
+    }, "exactly what _configure_rdma pinned on the client"
+
+
+async def test_a_proc_that_did_not_inherit_the_configuration_fails_the_run() -> None:
+    held = [{}, {"rdma_allow_tcp_fallback": True}, {}, {}]
+    peers = _FakePeers(check_config=_FakeEndpoint(_value_mesh(held, lanes=4)))
+
+    with pytest.raises(RuntimeError, match=r"h0/l1 has \{'rdma_allow_tcp_fallback'"):
+        await bd._check_config(
+            _config("--transport", "ibverbs"), cast(bench_peer.Peer, peers)
+        )
+
+
+async def test_the_run_is_told_every_proc_that_disagreed() -> None:
+    held = [{"rdma_allow_tcp_fallback": True}] * 2
+    peers = _FakePeers(check_config=_FakeEndpoint(_value_mesh(held, lanes=2)))
+
+    with pytest.raises(RuntimeError, match="h0/l0 .*; h0/l1 ") as caught:
+        await bd._check_config(
+            _config("--transport", "ibverbs"), cast(bench_peer.Peer, peers)
+        )
+
+    assert "{'rdma_allow_tcp_fallback': False}" in str(caught.value), (
+        "the message names what was expected as well as what was held"
+    )

--- a/python/tests/test_rdma_bench_driver.py
+++ b/python/tests/test_rdma_bench_driver.py
@@ -41,14 +41,29 @@ class _FakeEndpoint:
 
     async def call(self, *args, **kwargs) -> ValueMesh:
         self.casts.append(args)
-        replies = (
-            self._replies(*args, **kwargs) if callable(self._replies) else self._replies
-        )
-        return cast(ValueMesh, replies)
+        if callable(self._replies):
+            return cast(ValueMesh, self._replies(*args, **kwargs))
+        if isinstance(self._replies, list):
+            return cast(
+                ValueMesh,
+                self._replies[min(len(self.casts) - 1, len(self._replies) - 1)],
+            )
+        return self._replies
 
 
 class _FakePeers:
-    """Stands in for the peer actor mesh."""
+    """Stands in for the peer actor mesh, one endpoint per keyword.
+
+    The endpoints are declared but not assigned: a test supplies only the ones
+    its subject casts to, and the rest stay missing.
+    """
+
+    check_config: _FakeEndpoint
+    setup: _FakeEndpoint
+    wire: _FakeEndpoint
+    execute_iteration: _FakeEndpoint
+    digest: _FakeEndpoint
+    reset: _FakeEndpoint
 
     def __init__(self, **endpoints: _FakeEndpoint) -> None:
         for name, endpoint in endpoints.items():
@@ -612,3 +627,155 @@ async def test_the_digest_window_is_at_least_one_byte() -> None:
     await bd._mismatches(cfg, topo, cast(bench_peer.Peer, _FakePeers(digest=digest)))
 
     assert digest.casts == [("sampled", 1)]
+
+
+def _sample(lane: int, submit_ms: float) -> bs.Sample:
+    return bs.Sample(bt.Slot(0, lane), build_ms=1.0, submit_ms=submit_ms)
+
+
+async def test_an_iteration_lands_in_the_phase_it_belongs_to() -> None:
+    topo = _self_edge_topology()
+    samples = _value_mesh([_sample(0, 100.0), _sample(1, 200.0)], lanes=2)
+    peers = _FakePeers(execute_iteration=_FakeEndpoint(samples))
+    cfg = _config("--warmup-iters-per-run", "1")
+    record = bs.RunRecord()
+
+    await bd._iterate(
+        cfg, topo, cast(bench_peer.Peer, peers), bt.READ, record, run=0, iteration=0
+    )
+    await bd._iterate(
+        cfg, topo, cast(bench_peer.Peer, peers), bt.READ, record, run=0, iteration=1
+    )
+
+    assert set(record.phases) == {bt.COLD_QP, bt.WARM}, "the ramp is discarded"
+    assert len(record.phases[bt.COLD_QP].span_ms) == 1
+    assert len(record.phases[bt.WARM].span_ms) == 1
+    # Two initiators answered, so one span carries two samples.
+    assert record.phases[bt.WARM].submit_ms == [100.0, 200.0]
+    assert record.phases[bt.WARM].span_ms[0] > 0.0
+
+
+async def test_a_proc_that_initiates_nothing_contributes_no_sample() -> None:
+    """It is still cast to, and answers `None`; counting that as a measurement
+    would drag every percentile toward zero."""
+    topo = _self_edge_topology()
+    samples = _value_mesh([_sample(0, 100.0), None], lanes=2)
+    peers = _FakePeers(execute_iteration=_FakeEndpoint(samples))
+    record = bs.RunRecord()
+
+    await bd._iterate(
+        _config(),
+        topo,
+        cast(bench_peer.Peer, peers),
+        bt.READ,
+        record,
+        run=0,
+        iteration=0,
+    )
+
+    assert record.phases[bt.COLD_QP].submit_ms == [100.0]
+    assert len(record.phases[bt.COLD_QP].span_ms) == 1, "the iteration still happened"
+
+
+def _fake_peers_entire_direction(topo, *, transferred: bool = True) -> _FakePeers:
+    """Construct and return a `_FakePeers` with responses covering an entire direction.
+    Assumes the input `topo` is the result of `_self_edge_topology()`.
+
+    `transferred = False` means the digests after an iteration will appear as though
+    the transfer never happened, and the integrity check should fail.
+    """
+    slots = topo.slots()
+    lanes = len(slots)
+    setup_replies = [
+        (
+            5.0 + slot.lane,
+            bt.SlotValues(
+                outgoing=(f"out-{slot.lane}",), incoming={slot: (f"in-{slot.lane}",)}
+            ),
+        )
+        for slot in slots
+    ]
+    before = [
+        bt.SlotValues(outgoing=(f"h{s.lane}",), incoming={s: ("zero",)}) for s in slots
+    ]
+    after = [
+        bt.SlotValues(
+            outgoing=(f"h{s.lane}",),
+            incoming={s: (f"h{s.lane}" if transferred else "zero",)},
+        )
+        for s in slots
+    ]
+    return _FakePeers(
+        setup=_FakeEndpoint(_value_mesh(setup_replies, lanes=lanes)),
+        wire=_FakeEndpoint(_value_mesh([None] * lanes, lanes=lanes)),
+        execute_iteration=_FakeEndpoint(
+            _value_mesh([_sample(s.lane, 100.0) for s in slots], lanes=lanes)
+        ),
+        digest=_FakeEndpoint(
+            [_value_mesh(before, lanes=lanes), _value_mesh(after, lanes=lanes)]
+        ),
+        reset=_FakeEndpoint(_value_mesh([None] * lanes, lanes=lanes)),
+    )
+
+
+async def test_a_direction_runs_every_iteration_of_every_run() -> None:
+    topo = _self_edge_topology()
+    peers = _fake_peers_entire_direction(topo)
+    cfg = _config(
+        "--runs", "2", "--warmup-iters-per-run", "1", "--warm-iters-per-run", "2"
+    )
+
+    record = await bd._run_direction(cfg, topo, cast(bench_peer.Peer, peers), bt.READ)
+
+    assert len(peers.setup.casts) == 2, "fresh tensors once per run"
+    assert len(peers.execute_iteration.casts) == 6, "2 runs x (1 ramp + 2 warm)"
+    assert len(record.register_ms) == 4, "one per proc per run"
+    assert len(record.phases[bt.COLD_QP].span_ms) == 1
+    assert len(record.phases[bt.WARM].span_ms) == 4
+    assert record.integrity_ok is True
+    assert record.negative_control_ok is True
+
+
+async def test_a_direction_wires_each_proc_the_ops_it_will_issue() -> None:
+    topo = _self_edge_topology()
+    peers = _fake_peers_entire_direction(topo)
+
+    await bd._run_direction(
+        _config("--runs", "1"), topo, cast(bench_peer.Peer, peers), bt.WRITE
+    )
+
+    ((plans,),) = peers.wire.casts
+    assert set(plans) == set(topo.slots())
+    # For the write direction, each slot pushes into its peer's incoming buffer.
+    pushed = plans[bt.Slot(0, 1)].push
+    assert [op.remote for op in pushed] == ["in-1"]
+    assert not plans[bt.Slot(0, 1)].pull
+
+
+async def test_a_direction_releases_its_buffers_even_when_it_fails() -> None:
+    """Leaving them registered would leak into the next direction's run."""
+    topo = _self_edge_topology()
+    peers = _fake_peers_entire_direction(topo, transferred=False)
+
+    with pytest.raises(RuntimeError, match="data corruption"):
+        await bd._run_direction(
+            _config("--runs", "1"), topo, cast(bench_peer.Peer, peers), bt.READ
+        )
+
+    assert len(peers.reset.casts) == 1
+
+
+async def test_verify_off_skips_both_checks() -> None:
+    topo = _self_edge_topology()
+    peers = _fake_peers_entire_direction(topo)
+
+    record = await bd._run_direction(
+        _config("--runs", "1", "--verify", "off"),
+        topo,
+        cast(bench_peer.Peer, peers),
+        bt.READ,
+    )
+
+    assert peers.digest.casts == []
+    assert record.integrity_ok is None, "not run is not the same as failed"
+    assert record.negative_control_ok is None

--- a/python/tests/test_rdma_bench_peer.py
+++ b/python/tests/test_rdma_bench_peer.py
@@ -83,16 +83,19 @@ def _skip_without_enough_cuda_devices(source_on_gpu: bool, dest_on_gpu: bool) ->
 
 
 @rdma_backends
-async def test_a_peer_reports_the_transport_its_configuration_selects() -> None:
-    # The rdma_backends decorator skips the test if rdma_disable_ibverbs == False
-    # and ibverbs is unavailable, and always enables tcp fallback when ibverbs is
-    # disabled, so this computation for `expected` is correct.
-    expected = "tcp" if get_global_config()["rdma_disable_ibverbs"] else "ibverbs"
+async def test_a_peer_reports_the_settings_its_configuration_disagrees_with() -> None:
+    disable_ibverbs = get_global_config()["rdma_disable_ibverbs"]
     peers = _spawn(lanes=1)
 
-    reported = {value for _point, value in (await peers.transport.call()).items()}
+    agreed = await peers.check_config.call({"rdma_disable_ibverbs": disable_ibverbs})
+    disagreed = await peers.check_config.call(
+        {"rdma_disable_ibverbs": not disable_ibverbs}
+    )
 
-    assert reported == {expected}
+    assert [held for _point, held in agreed.items()] == [{}]
+    assert [held for _point, held in disagreed.items()] == [
+        {"rdma_disable_ibverbs": disable_ibverbs}
+    ]
 
 
 @rdma_backends

--- a/python/tests/test_rdma_bench_stats.py
+++ b/python/tests/test_rdma_bench_stats.py
@@ -262,7 +262,6 @@ def _columns() -> tuple[
         bs.ConfigColumns(
             schema_version=bs.SCHEMA_VERSION,
             transport="ibverbs",
-            tcp_serialized=0,
             source_device="gpu",
             dest_device="gpu",
             payload_size_mb=1024.0,
@@ -271,7 +270,7 @@ def _columns() -> tuple[
             runs=3,
             warmup_iters_per_run=3,
             warm_iters_per_run=10,
-            local_sender=0,
+            local_only=0,
             verify_mode="sampled",
             rdma_runtime_threads="16",
             integrity_ok="True",


### PR DESCRIPTION
Summary:

Add `_run_direction`, which orchestrates the entire control flow to do every iteration of every run for a single direction.

Differential Revision: D117398804


