### PR TITLE
rdma benchmark: allow for configuring max nics per buffer (#4752)

### DIFF
--- a/python/benches/multihost_rdma/bench_stats.py
+++ b/python/benches/multihost_rdma/bench_stats.py
@@ -251,6 +251,7 @@ class ConfigColumns:
     local_only: int
     verify_mode: str
     rdma_runtime_threads: str
+    rdma_max_nics_per_buffer: str
     integrity_ok: str
     negative_control_ok: str
 

--- a/python/benches/multihost_rdma/benchmark_driver.py
+++ b/python/benches/multihost_rdma/benchmark_driver.py
@@ -150,6 +150,9 @@ class BenchConfig:
     max_host_gb_per_host: float
     # How many threads the RDMA runtime was configured to use.
     rdma_runtime_threads: int | None
+    # How many NICs a buffer is registered on, at most. `None` sets no limit,
+    # so every equally good NIC serves it.
+    rdma_max_nics_per_buffer: int | None
     # Path to the file where the output will live.
     output_csv: str
     # Batch or non-batch mode.
@@ -302,6 +305,16 @@ def _add_workload_args(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=None,
         help="How many threads the RDMA runtime should use (default: monarch's own).",
+    )
+
+    parser.add_argument(
+        "--rdma-max-nics-per-buffer",
+        type=int,
+        default=1,
+        help=(
+            "How many NICs a buffer is registered on, at most. Pass 0 for no "
+            "limit, which registers it on every equally good NIC (default: 1)."
+        ),
     )
 
     mode_group = parser.add_mutually_exclusive_group()
@@ -468,6 +481,7 @@ def config_from_args(args: argparse.Namespace) -> BenchConfig:
         max_device_gb_per_proc=float(args.max_device_gb_per_proc),
         max_host_gb_per_host=float(args.max_host_gb_per_host),
         rdma_runtime_threads=args.rdma_runtime_threads,
+        rdma_max_nics_per_buffer=args.rdma_max_nics_per_buffer or None,
         output_csv=args.output_csv,
         command=args.command,
         # These exist only on the `run` subparser.
@@ -484,6 +498,8 @@ def config_from_args(args: argparse.Namespace) -> BenchConfig:
         raise ValueError("--warm-iters-per-run must be at least 1")
     if cfg.runs < 1:
         raise ValueError("--runs must be at least 1")
+    if args.rdma_max_nics_per_buffer < 0:
+        raise ValueError("--rdma-max-nics-per-buffer cannot be negative")
     return cfg
 
 
@@ -496,6 +512,7 @@ def _rdma_settings(cfg: BenchConfig) -> dict[str, Any]:
     )
     if cfg.rdma_runtime_threads is not None:
         settings["rdma_runtime_worker_threads"] = cfg.rdma_runtime_threads
+    settings["rdma_max_nics_per_buffer"] = cfg.rdma_max_nics_per_buffer
     return settings
 
 
@@ -701,6 +718,7 @@ def _config_columns(cfg: BenchConfig, record: RunRecord) -> ConfigColumns:
         local_only=int(cfg.local_only),
         verify_mode=cfg.verify,
         rdma_runtime_threads=str(get_global_config()["rdma_runtime_worker_threads"]),
+        rdma_max_nics_per_buffer=str(get_global_config()["rdma_max_nics_per_buffer"]),
         integrity_ok=_flag(record.integrity_ok),
         negative_control_ok=_flag(record.negative_control_ok),
     )

--- a/python/tests/test_rdma_bench_driver.py
+++ b/python/tests/test_rdma_bench_driver.py
@@ -390,7 +390,7 @@ def test_reporting_writes_a_row_per_direction_and_phase(tmp_path, capsys) -> Non
     assert output_csv in printed
 
 
-def test_the_transport_and_thread_count_are_pinned_before_any_proc_starts(
+def test_the_config_is_pinned_before_any_proc_starts(
     monkeypatch,
 ) -> None:
     """The procs inherit this configuration, so it has to be set first."""
@@ -401,13 +401,19 @@ def test_the_transport_and_thread_count_are_pinned_before_any_proc_starts(
 
     bd._configure_rdma(_config("--transport", "ibverbs"))
     bd._configure_rdma(_config("--transport", "tcp", "--rdma-runtime-threads", "16"))
+    bd._configure_rdma(_config("--rdma-max-nics-per-buffer", "0"))
 
-    assert settings[0] == {"rdma_allow_tcp_fallback": False}
+    assert settings[0] == {
+        "rdma_allow_tcp_fallback": False,
+        "rdma_max_nics_per_buffer": 1,
+    }
     assert settings[1] == {
         "rdma_disable_ibverbs": True,
         "rdma_allow_tcp_fallback": True,
         "rdma_runtime_worker_threads": 16,
+        "rdma_max_nics_per_buffer": 1,
     }
+    assert settings[2]["rdma_max_nics_per_buffer"] is None
 
 
 def test_local_only_puts_every_host_on_this_machine(monkeypatch) -> None:
@@ -472,6 +478,7 @@ async def test_every_proc_must_have_the_configuration_the_client_pinned() -> Non
         "rdma_disable_ibverbs": True,
         "rdma_allow_tcp_fallback": True,
         "rdma_runtime_worker_threads": 16,
+        "rdma_max_nics_per_buffer": 1,
     }, "exactly what _configure_rdma pinned on the client"
 
 
@@ -494,7 +501,7 @@ async def test_the_run_is_told_every_proc_that_disagreed() -> None:
             _config("--transport", "ibverbs"), cast(bench_peer.Peer, peers)
         )
 
-    assert "{'rdma_allow_tcp_fallback': False}" in str(caught.value), (
+    assert "'rdma_allow_tcp_fallback': False" in str(caught.value), (
         "the message names what was expected as well as what was held"
     )
 
@@ -996,3 +1003,39 @@ def test_a_failing_run_kills_the_job_and_reraises(monkeypatch) -> None:
         bd.run(_config(), make_job=lambda c: cast(JobTrait, job), mesh_name="mesh0")
 
     assert job.killed
+
+
+@pytest.mark.parametrize(
+    ("flag", "configured"),
+    [
+        ((), 1),
+        (("--rdma-max-nics-per-buffer", "4"), 4),
+        (("--rdma-max-nics-per-buffer", "0"), None),
+    ],
+)
+def test_the_nic_limit_reaches_the_config_and_the_csv(
+    flag, configured, monkeypatch
+) -> None:
+    cfg = _config(*flag)
+
+    assert cfg.rdma_max_nics_per_buffer == configured
+    assert bd._rdma_settings(cfg)["rdma_max_nics_per_buffer"] == configured
+
+    # The column is read back from the live config rather than from the flag, so
+    # that it records what the procs were actually given.
+    monkeypatch.setattr(
+        bd,
+        "get_global_config",
+        lambda: {
+            "rdma_runtime_worker_threads": 16,
+            "rdma_max_nics_per_buffer": configured,
+        },
+    )
+    columns = bd._config_columns(cfg, _record())
+
+    assert columns.rdma_max_nics_per_buffer == str(configured)
+
+
+def test_a_negative_nic_limit_is_refused() -> None:
+    with pytest.raises(ValueError, match="--rdma-max-nics-per-buffer"):
+        _config("--rdma-max-nics-per-buffer", "-1")

--- a/python/tests/test_rdma_bench_e2e.py
+++ b/python/tests/test_rdma_bench_e2e.py
@@ -81,6 +81,7 @@ def _config(
         max_device_gb_per_proc=1.0,
         max_host_gb_per_host=1.0,
         rdma_runtime_threads=None,
+        rdma_max_nics_per_buffer=1,
         output_csv=output_csv,
         command=bd.RUN_COMMAND,
         local_only=True,

--- a/python/tests/test_rdma_bench_stats.py
+++ b/python/tests/test_rdma_bench_stats.py
@@ -273,6 +273,7 @@ def _columns() -> tuple[
             local_only=0,
             verify_mode="sampled",
             rdma_runtime_threads="16",
+            rdma_max_nics_per_buffer="1",
             integrity_ok="True",
             negative_control_ok="True",
         ),


### PR DESCRIPTION
Summary:

`rdma_max_nics_per_buffer` decides how many NICs a buffer is registered on. It trades one memory registration per NIC against the flexibility of having more than one NIC able to serve a transfer. The configuration value for a run is recorded in the CSV.

Reviewed By: zdevito

Differential Revision: D117435358


