### PR TITLE
(docs)[monarch][tools] Pin why the self-referential _fmt write is safe

### DIFF
--- a/python/monarch/_src/tools/commands.py
+++ b/python/monarch/_src/tools/commands.py
@@ -121,6 +121,8 @@ def create(
                 info = runner.dryrun(appdef, scheduler, cfg, str(workspace_out))
 
         if config.dryrun:
+            # every formatter returns a fresh function or the CURRENT `info._fmt`;
+            # one that read `info._fmt` lazily would make `repr(info)` recurse
             info._fmt = defaults.dryrun_info_formatter(info)
             return info
         else:


### PR DESCRIPTION
Summary:
`info._fmt = defaults.dryrun_info_formatter(info)` in `commands.create()` hands
the formatter the very object whose attribute it is assigning, which reads like
a bug on the way past.

It is safe only because every `dryrun_info_formatter` returns either a fresh
function or the *current* value of `info._fmt` — nothing captures `info` and
re-reads `_fmt` later. A variant that wrapped the existing formatter in a
closure reading `info._fmt` would make `repr(info)` recurse until the stack
blew, and that is exactly the shape someone extending the formatter would
reach for. A two-line comment pins the invariant at the one call site that
depends on it.

Differential Revision: D117452976
