### PR TITLE
Enable SQLite session support in rusqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,6 +4360,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
+ "bindgen",
  "cc",
  "pkg-config",
  "vcpkg",

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -22,7 +22,7 @@ opentelemetry-otlp = { version = "0.31.1", features = ["grpc-tonic", "http-proto
 opentelemetry_sdk = { version = "0.31", features = ["experimental_metrics_custom_reader", "metrics", "rt-tokio"] }
 prost = { version = "0.14.4", default-features = false }
 rand = "0.10.2"
-rusqlite = { version = "0.37.0", features = ["backup", "blob", "bundled", "column_decltype", "functions", "limits", "modern_sqlite", "serde_json", "vtab"] }
+rusqlite = { version = "0.37.0", features = ["backup", "blob", "bundled", "column_decltype", "functions", "limits", "modern_sqlite", "serde_json", "session", "vtab"] }
 serde = { version = "1.0.229", features = ["derive", "rc"] }
 serde_json = { version = "1.0.151", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_rusqlite = "0.40.1"


### PR DESCRIPTION
Summary: Enable rusqlite’s `session` feature in the shared third-party configuration. Regenerate Reindeer outputs so bundled `libsqlite3` enables the session and pre-update-hook APIs and rusqlite exposes `rusqlite::session`.

Reviewed By: dtolnay

Differential Revision: D117460707


