### PR TITLE
rdma benchmark: build a transfer's action once, not every iteration

### DIFF
--- a/python/benches/multihost_rdma/bench_peer.py
+++ b/python/benches/multihost_rdma/bench_peer.py
@@ -39,7 +39,7 @@ can be given a plan by :py:meth:`Peer.wire`.
 from __future__ import annotations
 
 import time
-from typing import Any, Mapping
+from typing import Any, cast, Mapping
 
 import torch
 import xxhash
@@ -68,7 +68,10 @@ class Peer(Actor):
         # destination device.
         self.tensors: SlotValues[torch.Tensor] = _nothing()
         self.buffers: SlotValues[RDMABuffer] = _nothing()
-        self.plan: InitiatorPlan = InitiatorPlan()
+        # Built once by `wire` and submitted every iteration, so assembling
+        # it costs nothing on the timed path. `None` on a proc that
+        # initiates nothing.
+        self.action: RDMAAction | None = None
 
     @endpoint
     async def check_config(self, expected: Mapping[str, Any]) -> dict[str, Any]:
@@ -147,34 +150,36 @@ class Peer(Actor):
                 tensor.zero_()
 
     @endpoint
-    async def wire(self, plans: Mapping[Slot, InitiatorPlan]) -> None:
-        """Install the ops this slot will issue."""
-        self.plan = plans.get(self.slot, InitiatorPlan())
+    async def wire(self, plans: Mapping[Slot, InitiatorPlan]) -> float:
+        """Build the action carrying the ops this slot will issue, and return the
+        milliseconds that took.
+
+        An `RDMAAction` can be submitted more than once, so it is built here
+        rather than in every iteration.
+        """
+        plan = plans.get(self.slot, InitiatorPlan())
+        started = time.perf_counter()
+        action = RDMAAction()
+        for op in plan.push:
+            action.write_remote(op.remote, self.tensors.outgoing[op.outgoing_index])
+        for op in plan.pull:
+            action.read_remote(self.tensors.incoming[op.peer][op.op_index], op.remote)
+        ended = time.perf_counter()
+        self.action = action if plan.ops else None
+        return _ms(ended - started)
 
     @endpoint
     async def execute_iteration(self) -> Sample | None:
-        """Build one ``RDMAAction`` from the installed plan, submit it, and wait
-        for every op in it to complete.
+        """Submit this slot's action and wait for every op in it to complete.
 
         ``None`` on a proc that initiates nothing, so the driver can cast to
         every proc and keep only the measurements that mean something.
         """
-        if not self.plan.ops:
+        if self.action is None:
             return None
         started = time.perf_counter()
-        action = RDMAAction()
-        for op in self.plan.push:
-            action.write_remote(op.remote, self.tensors.outgoing[op.outgoing_index])
-        for op in self.plan.pull:
-            action.read_remote(self.tensors.incoming[op.peer][op.op_index], op.remote)
-        built = time.perf_counter()
-        await action.submit()
-        finished = time.perf_counter()
-        return Sample(
-            slot=self.slot,
-            build_ms=_ms(built - started),
-            submit_ms=_ms(finished - built),
-        )
+        await cast(RDMAAction, self.action).submit()
+        return Sample(slot=self.slot, submit_ms=_ms(time.perf_counter() - started))
 
     @endpoint
     async def digest(self, mode: str, window_bytes: int) -> SlotValues[str]:
@@ -199,7 +204,7 @@ class Peer(Actor):
             await buffer.drop()
         self.buffers = _nothing()
         self.tensors = _nothing()
-        self.plan = InitiatorPlan()
+        self.action = None
 
 
 def _nothing() -> SlotValues[Any]:

--- a/python/benches/multihost_rdma/bench_stats.py
+++ b/python/benches/multihost_rdma/bench_stats.py
@@ -251,6 +251,7 @@ class ConfigColumns:
     local_only: int
     verify_mode: str
     rdma_runtime_threads: str
+    rdma_max_nics_per_buffer: str
     integrity_ok: str
     negative_control_ok: str
 

--- a/python/benches/multihost_rdma/bench_stats.py
+++ b/python/benches/multihost_rdma/bench_stats.py
@@ -61,24 +61,15 @@ def _gbs(num_bytes: int, milliseconds: float) -> float:
 class Sample:
     """One initiator's measurement of one iteration, on the initiator's clock.
 
-    ``build_ms`` is the Python-side cost of assembling the ``RDMAAction``: one
-    call per op, before any byte moves. ``submit_ms`` runs from handing that
-    action to the RDMA layer until every op in it has completed, so it is the
-    only part that measures the fabric. They are reported separately and only
-    ``submit_ms`` is ever a throughput denominator.
+    ``submit_ms`` runs from handing the action to the RDMA layer until every op
+    in it has completed.
 
     The slot travels with the measurement because how many bytes it stands for
     depends on how that slot fits into the topology of the run.
     """
 
     slot: Slot
-    build_ms: float
     submit_ms: float
-
-    @property
-    def total_ms(self) -> float:
-        """Everything the initiator spent, which the driver's span must cover."""
-        return self.build_ms + self.submit_ms
 
 
 def percentile(values: Sequence[float], pct: float) -> float:
@@ -134,12 +125,11 @@ class PhaseRecord:
     :py:func:`bench_topology.phase_of` is that mapping, and it is the only place
     the boundaries are decided.
 
-    ``build_ms`` and ``submit_ms`` hold one entry per initiator per iteration.
+    ``submit_ms`` holds one entry per initiator per iteration.
     ``span_ms``, ``overhead_ms``, and ``agg_gbs`` hold one entry per iteration,
     because one span covers every initiator at once.
     """
 
-    build_ms: list[float] = field(default_factory=list)
     submit_ms: list[float] = field(default_factory=list)
     initiator_gbs: list[float] = field(default_factory=list)
     span_ms: list[float] = field(default_factory=list)
@@ -149,7 +139,6 @@ class PhaseRecord:
     def add_sample(self, sample: Sample, initiator_bytes: int) -> None:
         """Record one initiator's iteration. ``initiator_bytes`` is what that
         initiator moved, which depends on its degree."""
-        self.build_ms.append(sample.build_ms)
         self.submit_ms.append(sample.submit_ms)
         if sample.submit_ms > 0:
             self.initiator_gbs.append(_gbs(initiator_bytes, sample.submit_ms))
@@ -159,7 +148,7 @@ class PhaseRecord:
     ) -> None:
         """Record the driver-clock span of one iteration.
 
-        ``slowest_ms`` is the largest ``Sample.total_ms`` in that iteration, so
+        ``slowest_ms`` is the largest ``Sample.submit_ms`` in that iteration, so
         the overhead is the part of the span no initiator was working during.
         """
         self.span_ms.append(span_ms)
@@ -190,6 +179,7 @@ class RunRecord:
     # actor, one entry per run per proc, so the spread across procs shows how
     # the cost tracks a proc's buffer count. Allocation itself is excluded.
     register_ms: list[float] = field(default_factory=list)
+    build_ms: list[float] = field(default_factory=list)
     phases: dict[str, PhaseRecord] = field(
         default_factory=lambda: {phase: PhaseRecord() for phase in PHASES}
     )
@@ -299,7 +289,7 @@ def metrics_for(phase: str, runs: RunRecord) -> MetricColumns:
     """
     record = runs.phases[phase]
     register = summarize(runs.register_ms)
-    build = summarize(record.build_ms)
+    build = summarize(runs.build_ms)
     submit = summarize(record.submit_ms)
     span = summarize(record.span_ms)
     overhead = summarize(record.overhead_ms)

--- a/python/benches/multihost_rdma/benchmark_driver.py
+++ b/python/benches/multihost_rdma/benchmark_driver.py
@@ -591,13 +591,12 @@ async def _iterate(
     reply."""
     phase = record.record(phase_of(run, iteration, cfg.warmup_iters_per_run))
     started = time.perf_counter()
-    samples = await peers.execute_iteration.call()
+    replies = await peers.execute_iteration.call()
     span_ms = (time.perf_counter() - started) * 1000.0
+    samples = [sample for _point, sample in replies.items() if sample is not None]
 
     slowest_ms = 0.0
-    for _point, sample in samples.items():
-        if sample is None:
-            continue
+    for sample in samples:
         phase.add_sample(
             sample,
             initiator_bytes(
@@ -608,7 +607,7 @@ async def _iterate(
                 payload_bytes=cfg.payload_bytes,
             ),
         )
-        slowest_ms = max(slowest_ms, sample.total_ms)
+        slowest_ms = max(slowest_ms, sample.submit_ms)
     phase.add_iteration(
         span_ms,
         bytes_per_iteration(
@@ -667,7 +666,11 @@ async def _run_direction(
         for run in range(cfg.runs):
             buffers = await _setup_run(cfg, peers, allocations, record, seed=run)
             plans = plan_for(topo, direction, buffers, ops=cfg.concurrent_ops)
-            await peers.wire.call(plans)
+            build_timing = await peers.wire.call(plans)
+            for point, build_ms in build_timing.items():
+                # Only record build time for slots with non-empty actions.
+                if slot_of(point) in plans:
+                    record.build_ms.append(build_ms)
             if verifying and run == 0:
                 record.negative_control_ok = await _check_control(cfg, topo, peers)
             for iteration in range(cfg.iterations_per_run):

--- a/python/benches/multihost_rdma/benchmark_driver.py
+++ b/python/benches/multihost_rdma/benchmark_driver.py
@@ -150,6 +150,9 @@ class BenchConfig:
     max_host_gb_per_host: float
     # How many threads the RDMA runtime was configured to use.
     rdma_runtime_threads: int | None
+    # How many NICs a buffer is registered on, at most. `None` sets no limit,
+    # so every equally good NIC serves it.
+    rdma_max_nics_per_buffer: int | None
     # Path to the file where the output will live.
     output_csv: str
     # Batch or non-batch mode.
@@ -302,6 +305,16 @@ def _add_workload_args(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=None,
         help="How many threads the RDMA runtime should use (default: monarch's own).",
+    )
+
+    parser.add_argument(
+        "--rdma-max-nics-per-buffer",
+        type=int,
+        default=1,
+        help=(
+            "How many NICs a buffer is registered on, at most. Pass 0 for no "
+            "limit, which registers it on every equally good NIC (default: 1)."
+        ),
     )
 
     mode_group = parser.add_mutually_exclusive_group()
@@ -468,6 +481,7 @@ def config_from_args(args: argparse.Namespace) -> BenchConfig:
         max_device_gb_per_proc=float(args.max_device_gb_per_proc),
         max_host_gb_per_host=float(args.max_host_gb_per_host),
         rdma_runtime_threads=args.rdma_runtime_threads,
+        rdma_max_nics_per_buffer=args.rdma_max_nics_per_buffer or None,
         output_csv=args.output_csv,
         command=args.command,
         # These exist only on the `run` subparser.
@@ -484,6 +498,8 @@ def config_from_args(args: argparse.Namespace) -> BenchConfig:
         raise ValueError("--warm-iters-per-run must be at least 1")
     if cfg.runs < 1:
         raise ValueError("--runs must be at least 1")
+    if args.rdma_max_nics_per_buffer < 0:
+        raise ValueError("--rdma-max-nics-per-buffer cannot be negative")
     return cfg
 
 
@@ -496,6 +512,7 @@ def _rdma_settings(cfg: BenchConfig) -> dict[str, Any]:
     )
     if cfg.rdma_runtime_threads is not None:
         settings["rdma_runtime_worker_threads"] = cfg.rdma_runtime_threads
+    settings["rdma_max_nics_per_buffer"] = cfg.rdma_max_nics_per_buffer
     return settings
 
 
@@ -701,6 +718,7 @@ def _config_columns(cfg: BenchConfig, record: RunRecord) -> ConfigColumns:
         local_only=int(cfg.local_only),
         verify_mode=cfg.verify,
         rdma_runtime_threads=str(get_global_config()["rdma_runtime_worker_threads"]),
+        rdma_max_nics_per_buffer=str(get_global_config()["rdma_max_nics_per_buffer"]),
         integrity_ok=_flag(record.integrity_ok),
         negative_control_ok=_flag(record.negative_control_ok),
     )

--- a/python/tests/test_rdma_bench_driver.py
+++ b/python/tests/test_rdma_bench_driver.py
@@ -390,7 +390,7 @@ def test_reporting_writes_a_row_per_direction_and_phase(tmp_path, capsys) -> Non
     assert output_csv in printed
 
 
-def test_the_transport_and_thread_count_are_pinned_before_any_proc_starts(
+def test_the_config_is_pinned_before_any_proc_starts(
     monkeypatch,
 ) -> None:
     """The procs inherit this configuration, so it has to be set first."""
@@ -401,13 +401,19 @@ def test_the_transport_and_thread_count_are_pinned_before_any_proc_starts(
 
     bd._configure_rdma(_config("--transport", "ibverbs"))
     bd._configure_rdma(_config("--transport", "tcp", "--rdma-runtime-threads", "16"))
+    bd._configure_rdma(_config("--rdma-max-nics-per-buffer", "0"))
 
-    assert settings[0] == {"rdma_allow_tcp_fallback": False}
+    assert settings[0] == {
+        "rdma_allow_tcp_fallback": False,
+        "rdma_max_nics_per_buffer": 1,
+    }
     assert settings[1] == {
         "rdma_disable_ibverbs": True,
         "rdma_allow_tcp_fallback": True,
         "rdma_runtime_worker_threads": 16,
+        "rdma_max_nics_per_buffer": 1,
     }
+    assert settings[2]["rdma_max_nics_per_buffer"] is None
 
 
 def test_local_only_puts_every_host_on_this_machine(monkeypatch) -> None:
@@ -472,6 +478,7 @@ async def test_every_proc_must_have_the_configuration_the_client_pinned() -> Non
         "rdma_disable_ibverbs": True,
         "rdma_allow_tcp_fallback": True,
         "rdma_runtime_worker_threads": 16,
+        "rdma_max_nics_per_buffer": 1,
     }, "exactly what _configure_rdma pinned on the client"
 
 
@@ -494,7 +501,7 @@ async def test_the_run_is_told_every_proc_that_disagreed() -> None:
             _config("--transport", "ibverbs"), cast(bench_peer.Peer, peers)
         )
 
-    assert "{'rdma_allow_tcp_fallback': False}" in str(caught.value), (
+    assert "'rdma_allow_tcp_fallback': False" in str(caught.value), (
         "the message names what was expected as well as what was held"
     )
 
@@ -996,3 +1003,39 @@ def test_a_failing_run_kills_the_job_and_reraises(monkeypatch) -> None:
         bd.run(_config(), make_job=lambda c: cast(JobTrait, job), mesh_name="mesh0")
 
     assert job.killed
+
+
+@pytest.mark.parametrize(
+    ("flag", "configured"),
+    [
+        ((), 1),
+        (("--rdma-max-nics-per-buffer", "4"), 4),
+        (("--rdma-max-nics-per-buffer", "0"), None),
+    ],
+)
+def test_the_nic_limit_reaches_the_config_and_the_csv(
+    flag, configured, monkeypatch
+) -> None:
+    cfg = _config(*flag)
+
+    assert cfg.rdma_max_nics_per_buffer == configured
+    assert bd._rdma_settings(cfg)["rdma_max_nics_per_buffer"] == configured
+
+    # The column is read back from the live config rather than from the flag, so
+    # that it records what the procs were actually given.
+    monkeypatch.setattr(
+        bd,
+        "get_global_config",
+        lambda: {
+            "rdma_runtime_worker_threads": 16,
+            "rdma_max_nics_per_buffer": configured,
+        },
+    )
+    columns = bd._config_columns(cfg, _record())
+
+    assert columns.rdma_max_nics_per_buffer == str(configured)
+
+
+def test_a_negative_nic_limit_is_refused() -> None:
+    with pytest.raises(ValueError, match="--rdma-max-nics-per-buffer"):
+        _config("--rdma-max-nics-per-buffer", "-1")

--- a/python/tests/test_rdma_bench_driver.py
+++ b/python/tests/test_rdma_bench_driver.py
@@ -279,7 +279,7 @@ def _record(*, submit_ms: float = 200.0, spans: int = 4) -> bs.RunRecord:
         phase = bt.COLD_QP if index == 0 else bt.WARM
         into = runs.record(phase)
         into.add_sample(
-            bs.Sample(bt.Slot(0, 0), build_ms=1.0, submit_ms=submit_ms),
+            bs.Sample(bt.Slot(0, 0), submit_ms=submit_ms),
             initiator_bytes=_GB,
         )
         into.add_iteration(
@@ -647,7 +647,7 @@ async def _noop_drive(cfg, job, mesh_name, banner) -> None:
 
 
 def _sample(lane: int, submit_ms: float) -> bs.Sample:
-    return bs.Sample(bt.Slot(0, lane), build_ms=1.0, submit_ms=submit_ms)
+    return bs.Sample(bt.Slot(0, lane), submit_ms=submit_ms)
 
 
 async def test_an_iteration_lands_in_the_phase_it_belongs_to() -> None:
@@ -727,7 +727,7 @@ def _fake_peers_entire_direction(
     return _FakePeers(
         check_config=_FakeEndpoint(_value_mesh([{}] * lanes, lanes=lanes)),
         setup=_FakeEndpoint(_value_mesh(setup_replies, lanes=lanes)),
-        wire=_FakeEndpoint(_value_mesh([None] * lanes, lanes=lanes)),
+        wire=_FakeEndpoint(_value_mesh([3.0] * lanes, lanes=lanes)),
         execute_iteration=_FakeEndpoint(
             _value_mesh([_sample(s.lane, 100.0) for s in slots], lanes=lanes)
         ),
@@ -1039,3 +1039,14 @@ def test_the_nic_limit_reaches_the_config_and_the_csv(
 def test_a_negative_nic_limit_is_refused() -> None:
     with pytest.raises(ValueError, match="--rdma-max-nics-per-buffer"):
         _config("--rdma-max-nics-per-buffer", "-1")
+
+
+async def test_building_the_actions_is_measured_once_per_run() -> None:
+    topo = _self_edge_topology()
+    peers = _fake_peers_entire_direction(topo)
+
+    record = await bd._run_direction(
+        _config("--runs", "2"), topo, cast(bench_peer.Peer, peers), bt.READ
+    )
+
+    assert record.build_ms == [3.0] * 4, "one per proc per run, from wire"

--- a/python/tests/test_rdma_bench_e2e.py
+++ b/python/tests/test_rdma_bench_e2e.py
@@ -81,6 +81,7 @@ def _config(
         max_device_gb_per_proc=1.0,
         max_host_gb_per_host=1.0,
         rdma_runtime_threads=None,
+        rdma_max_nics_per_buffer=1,
         output_csv=output_csv,
         command=bd.RUN_COMMAND,
         local_only=True,

--- a/python/tests/test_rdma_bench_stats.py
+++ b/python/tests/test_rdma_bench_stats.py
@@ -273,6 +273,7 @@ def _columns() -> tuple[
             local_only=0,
             verify_mode="sampled",
             rdma_runtime_threads="16",
+            rdma_max_nics_per_buffer="1",
             integrity_ok="True",
             negative_control_ok="True",
         ),

--- a/python/tests/test_rdma_bench_stats.py
+++ b/python/tests/test_rdma_bench_stats.py
@@ -69,18 +69,15 @@ def test_summarize_handles_thin_sample_sets() -> None:
     assert two.maximum == 3.0
 
 
-def test_sample_total() -> None:
-    sample = bs.Sample(slot=bt.Slot(0, 0), build_ms=2.0, submit_ms=100.0)
-    assert sample.total_ms == pytest.approx(102.0)
+def _sample(slot: bt.Slot, submit_ms: float) -> bs.Sample:
+    return bs.Sample(slot=slot, submit_ms=submit_ms)
 
 
 def test_phase_record_derives_throughput_from_the_right_clock() -> None:
     record = bs.PhaseRecord()
+    record.add_sample(_sample(bt.Slot(0, 0), 500.0), initiator_bytes=GB)
     record.add_sample(
-        bs.Sample(bt.Slot(0, 0), build_ms=1.0, submit_ms=500.0), initiator_bytes=GB
-    )
-    record.add_sample(
-        bs.Sample(bt.Slot(1, 0), build_ms=1.0, submit_ms=1000.0),
+        _sample(bt.Slot(1, 0), 1000.0),
         initiator_bytes=2 * GB,
     )
     assert record.initiator_gbs == [2.0, 2.0], "each initiator's own bytes and clock"
@@ -100,12 +97,8 @@ def test_aggregate_throughput_is_measured_against_the_span() -> None:
     that the assertion pins which one is reported.
     """
     record = bs.PhaseRecord()
-    record.add_sample(
-        bs.Sample(bt.Slot(0, 0), build_ms=0.0, submit_ms=500.0), initiator_bytes=GB
-    )
-    record.add_sample(
-        bs.Sample(bt.Slot(1, 0), build_ms=0.0, submit_ms=1000.0), initiator_bytes=GB
-    )
+    record.add_sample(_sample(bt.Slot(0, 0), 500.0), initiator_bytes=GB)
+    record.add_sample(_sample(bt.Slot(1, 0), 1000.0), initiator_bytes=GB)
     record.add_iteration(span_ms=1000.0, iteration_bytes=2 * GB, slowest_ms=1000.0)
 
     assert record.agg_gbs == [2.0]
@@ -115,9 +108,7 @@ def test_aggregate_throughput_is_measured_against_the_span() -> None:
 
 def test_zero_durations_do_not_produce_infinite_throughput() -> None:
     record = bs.PhaseRecord()
-    record.add_sample(
-        bs.Sample(bt.Slot(0, 0), build_ms=0.0, submit_ms=0.0), initiator_bytes=GB
-    )
+    record.add_sample(_sample(bt.Slot(0, 0), 0.0), initiator_bytes=GB)
     record.add_iteration(span_ms=0.0, iteration_bytes=GB, slowest_ms=0.0)
     assert record.initiator_gbs == []
     assert record.agg_gbs == []
@@ -128,12 +119,8 @@ def test_run_record_discards_ramp_without_a_special_case() -> None:
     runs = bs.RunRecord()
     assert set(runs.phases) == set(bt.PHASES)
 
-    runs.record(bt.WARM).add_sample(
-        bs.Sample(bt.Slot(0, 0), 0.0, 500.0), initiator_bytes=GB
-    )
-    runs.record(bt.RAMP).add_sample(
-        bs.Sample(bt.Slot(0, 0), 0.0, 9000.0), initiator_bytes=GB
-    )
+    runs.record(bt.WARM).add_sample(_sample(bt.Slot(0, 0), 500.0), initiator_bytes=GB)
+    runs.record(bt.RAMP).add_sample(_sample(bt.Slot(0, 0), 9000.0), initiator_bytes=GB)
 
     assert runs.phases[bt.WARM].submit_ms == [500.0]
     assert bt.RAMP not in runs.phases, "the ramp record is a throwaway"
@@ -173,13 +160,14 @@ def _run_record() -> bs.RunRecord:
     for run in range(_RUNS):
         # One registration measurement per proc per run.
         runs.register_ms.extend(400.0 + 100.0 * run + 50.0 * i for i in range(2))
+        runs.build_ms.extend(2.0 for _ in range(2))
         for iteration in range(_WARMUP_ITERS + _WARM_ITERS):
             phase = bt.phase_of(run, iteration, _WARMUP_ITERS)
             record = runs.record(phase)
             submit_ms = _SUBMIT_MS[phase]
             for slot in _INITIATORS:
                 record.add_sample(
-                    bs.Sample(slot, build_ms=2.0, submit_ms=submit_ms),
+                    _sample(slot, submit_ms),
                     initiator_bytes=GB,
                 )
             record.add_iteration(


### PR DESCRIPTION
Summary: Separate building the `RDMAAction` from submitting it by building it once at the start of a run. This way aggregate throughput no longer measures it.

Differential Revision: D117545606


