### PR TITLE
mlx5dv: better handling when an expandable segment hits max_sge (#4756)

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -426,6 +426,10 @@ struct RegisteredSegmentState {
     mkey: Option<Mlx5dvMkey>,
     /// Bytes currently covered by `mkey`.
     size: usize,
+    /// Bytes the most recent scan reported for this segment. Equal to `size`
+    /// while the key spans the whole segment, and larger once growth is refused
+    /// because the segment needs more MRs than one key can bind.
+    scanned_size: usize,
 }
 
 /// A CUDA segment bound to the device via an indirect mlx5dv key, covering
@@ -472,28 +476,66 @@ impl RegisteredSegment {
                 stale_mkeys: Vec::new(),
                 mkey: None,
                 size: 0,
+                scanned_size: 0,
             }),
         }
     }
 
     /// Bytes currently covered by the segment's MRs and bound to its key.
+    #[cfg(test)]
     fn size(&self) -> usize {
         self.state.lock().expect("segment state lock poisoned").size
     }
 
-    /// True when `[addr, addr + size)` lies entirely within this segment.
+    /// True when `[addr, addr + size)` lies entirely within the extent bound to
+    /// this segment's key.
     fn covers(&self, addr: usize, size: usize) -> bool {
-        let end = self.base_virtual_addr + self.size();
+        let state = self.state.lock().expect("segment state lock poisoned");
+        if state.mkey.is_none() {
+            return false;
+        }
+        let end = self.base_virtual_addr + state.size;
         addr >= self.base_virtual_addr && addr <= end && size <= end - addr
     }
 
-    /// Grow the segment to `scanned_seg.size` (must exceed its current size):
-    /// register the new tail — the whole range on the first call from
-    /// [`Self::empty`] — bind the existing + new MRs to a fresh key, and retire
-    /// the prior key to `stale_mkeys` (rather than rebinding the in-use key,
-    /// which could race in-flight ops); the initial null key is not retired. On
-    /// any failure the freshly-registered tail MRs are deregistered and the
-    /// segment is left unchanged.
+    /// Bytes the most recent scan reported for this segment.
+    fn scanned_size(&self) -> usize {
+        self.state
+            .lock()
+            .expect("segment state lock poisoned")
+            .scanned_size
+    }
+
+    /// True when both conditions are true:
+    /// 1. The scanned size of the segment is larger than the registered
+    ///    size, which occurs only when the mkey for this segment cannot
+    ///    grow anymore.
+    /// 2. [addr, addr + size) overlaps the unregistered part of the scanned
+    ///    segment.
+    fn in_unregistered_tail(&self, addr: usize, size: usize) -> bool {
+        let state = self.state.lock().expect("segment state lock poisoned");
+        let registered_end = self.base_virtual_addr + state.size;
+        let scanned_end = self.base_virtual_addr + state.scanned_size;
+        addr >= self.base_virtual_addr
+            && addr <= scanned_end
+            && size <= scanned_end - addr
+            && addr + size > registered_end
+    }
+
+    /// Grow the segment towards `scanned_seg.size` (must not be below its
+    /// current size): register the new tail — the whole range on the first call
+    /// from [`Self::empty`] — bind the existing + new MRs to a fresh key, and
+    /// retire the prior key to `stale_mkeys` (rather than rebinding the in-use
+    /// key, which could race in-flight ops); the initial null key is not
+    /// retired. On any failure, any freshly registered tail MRs will be cleaned
+    /// up. However, the segment's `scanned_size` remains at the updated value.
+    /// This is necessary to prevent future registrations from repeatedly triggering
+    /// an expensive rescan only to fail again inside this function.
+    ///
+    /// A key binds at most `mkey_max_entries` MRs. When the tail needs more than
+    /// the key has room for, as much of it as fits is registered and the rest is
+    /// left out, so the segment still covers its prefix; [`Self::covers`] then
+    /// reports what was bound and [`Self::in_unregistered_tail`] the remainder.
     ///
     /// # Safety
     ///
@@ -528,6 +570,36 @@ impl RegisteredSegment {
         if scanned_seg.size == state.size {
             return Ok(());
         }
+        state.scanned_size = scanned_seg.size;
+
+        // `register_range` splits the tail into `MAX_MR_SIZE` chunks, so how many
+        // MRs it needs is known before any of it is registered. Take only as many
+        // chunks as the key has room for.
+        let bound = state.mkey.as_ref().map_or(0, |k| k.mrs().len());
+        let room = self
+            .mkey_max_entries
+            .saturating_sub(bound)
+            .saturating_mul(MAX_MR_SIZE);
+        let grew = scanned_seg.size - state.size;
+        let tail = grew.min(room);
+
+        if tail < grew {
+            tracing::warn!(
+                "CUDA segment at 0x{:x} grew from {} bytes to {} bytes, \
+            but its mkey only has room for {tail} more bytes. This segment's tail \
+            will remain unregistered, and some tensors inside it may use the dmabuf \
+            fallback.",
+                self.base_virtual_addr,
+                state.size,
+                state.scanned_size
+            );
+        }
+
+        // The key is full: the segment keeps the prefix it already covers.
+        if tail == 0 {
+            return Ok(());
+        }
+
         // SAFETY: per this function's contract `pd` is null or a live PD and
         // `qp` a valid QP; the tail MRs registered here belong to this segment.
         let new_tail = unsafe {
@@ -536,7 +608,7 @@ impl RegisteredSegment {
                 pd,
                 access,
                 self.base_virtual_addr + state.size,
-                scanned_seg.size - state.size,
+                tail,
             )
         }?;
 
@@ -550,18 +622,12 @@ impl RegisteredSegment {
             .map(|k| k.mrs().clone())
             .unwrap_or_default();
         all.extend(new_tail);
-        // A single indirect key binds at most `mkey_max_entries` MRs; exceeding
-        // it would fault at transfer time. Fail here instead; the caller falls
-        // back to per-region dmabuf registration. The freshly-registered tail
-        // drops as `all` unwinds, leaving the segment unchanged.
-        if all.len() > self.mkey_max_entries {
-            anyhow::bail!(
-                "segment at 0x{:x} needs {} MRs, exceeding mkey max entries {}",
-                self.base_virtual_addr,
-                all.len(),
-                self.mkey_max_entries
-            );
-        }
+        debug_assert!(
+            all.len() <= self.mkey_max_entries,
+            "mkey max entries is {}, but got {} MRs",
+            self.mkey_max_entries,
+            all.len()
+        );
         // SAFETY: same contract; `all` are this segment's live MRs.
         let new_mkey = unsafe {
             self.ops
@@ -573,7 +639,7 @@ impl RegisteredSegment {
         if let Some(prior) = state.mkey.replace(new_mkey) {
             state.stale_mkeys.push(prior);
         }
-        state.size = scanned_seg.size;
+        state.size += tail;
         Ok(())
     }
 
@@ -740,9 +806,11 @@ impl MlxDomain {
             .lock()
             .expect("mlx domain segments lock poisoned");
 
-        // Fast path: a current binding already covers the request.
-        if let Some(seg) = segments.values().find(|s| s.covers(addr, size)) {
-            return Ok(RegisteredSegment::view(seg, addr, size));
+        // Fast path: an existing scanned segment already fully covers the new
+        // range (`Ok` when the scanned segment's registered portion covers the
+        // range, `Err` when the range overlaps the segment's unregistered tail).
+        if let Some(result) = Self::lookup(&segments, addr, size) {
+            return result;
         }
 
         // Which ordinals this NIC serves, resolved now rather than at domain
@@ -767,8 +835,8 @@ impl MlxDomain {
             let key = (scanned_seg.address, scanned_seg.cuda_ordinal);
             snapshot.insert(key);
             match segments.get(&key) {
-                // Already bound at this extent: nothing to do.
-                Some(seg) if seg.size() == scanned_seg.size => {}
+                // Already grown against this extent: nothing to do.
+                Some(seg) if seg.scanned_size() == scanned_seg.size => {}
                 // Grew: extend the existing segment in place (reuses its MRs,
                 // retires its prior key internally).
                 // SAFETY: `pd`/`qp` satisfy this function's contract (live PD or
@@ -776,7 +844,11 @@ impl MlxDomain {
                 // segments lock held here serializes every use of the domain's
                 // one loopback QP, so nothing else polls its completion queue.
                 Some(seg) => unsafe { seg.grow(pd, qp, access, scanned_seg) }?,
-                // New: create an empty segment and grow it to the full range.
+                // New: create an empty segment and grow it towards the full
+                // range. It is kept even when the growth covers only part of
+                // that range, so the scanned extent is recorded and later
+                // requests past the covered prefix are answered without another
+                // scan.
                 None => {
                     let fresh = Arc::new(RegisteredSegment::empty(
                         self.ops.clone(),
@@ -796,18 +868,42 @@ impl MlxDomain {
         segments.retain(|key, _| snapshot.contains(key));
 
         // Serve the caller's view from a current segment that covers it.
-        segments
+        Self::lookup(&segments, addr, size).unwrap_or_else(|| {
+            Err(anyhow::anyhow!(
+                "CUDA address 0x{:x} + size {} is not covered by any scanned segment on the CUDA ordinals {:?} mapped to this NIC",
+                addr,
+                size,
+                cuda_ordinals,
+            ))
+        })
+    }
+
+    /// Look up how `[addr, addr + size)` relates to the already scanned
+    /// and registered segments. There are 3 possibilities:
+    /// 1. `[addr, addr + size)` does not fall within any scanned segment.
+    ///    Return `None`.
+    /// 2. `[addr, addr + size)` is fully covered by the registered portion
+    ///    of a scanned segment. Return `Some(Ok(IbvMemoryRegionView))`.
+    /// 3. `[addr, addr + size)` is fully covered by a scanned segment, but
+    ///    part of it extends into that scanned segment's unregistered tail.
+    ///    Return `Some(Err(anyhow::Error))`.
+    fn lookup(
+        segments: &HashMap<(usize, i32), Arc<RegisteredSegment>>,
+        addr: usize,
+        size: usize,
+    ) -> Option<anyhow::Result<IbvMemoryRegionView>> {
+        if let Some(seg) = segments.values().find(|s| s.covers(addr, size)) {
+            return Some(Ok(RegisteredSegment::view(seg, addr, size)));
+        }
+        let seg = segments
             .values()
-            .find(|s| s.covers(addr, size))
-            .map(|s| RegisteredSegment::view(s, addr, size))
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "CUDA address 0x{:x} + size {} is not covered by any scanned segment on the CUDA ordinals {:?} mapped to this NIC",
-                    addr,
-                    size,
-                    cuda_ordinals,
-                )
-            })
+            .find(|s| s.in_unregistered_tail(addr, size))?;
+        Some(Err(anyhow::anyhow!(
+            "CUDA address 0x{:x} + size {} is in the unregistered tail of the segment at 0x{:x}, whose key has no more room",
+            addr,
+            size,
+            seg.base_virtual_addr,
+        )))
     }
 }
 
@@ -1017,7 +1113,12 @@ mod tests {
     /// (and, through it, its context) is null (no-op `Drop`). Drive the strategy
     /// via [`IbvDomain::domain_impl`].
     fn domain(mock: Arc<MockOps>) -> Arc<IbvDomain<MlxDomain>> {
-        let mlx = MlxDomain::new_with_ops(mock, IbvConfig::default(), TEST_MKEY_MAX_ENTRIES);
+        domain_with_cap(mock, TEST_MKEY_MAX_ENTRIES)
+    }
+
+    /// A [`domain`] whose segments cap their keys at `mkey_max_entries` MRs.
+    fn domain_with_cap(mock: Arc<MockOps>, mkey_max_entries: usize) -> Arc<IbvDomain<MlxDomain>> {
+        let mlx = MlxDomain::new_with_ops(mock, IbvConfig::default(), mkey_max_entries);
         // SAFETY: `IbvPd::null()` holds a null PD (and, through it, a null
         // context) whose `Drop`s are no-ops.
         unsafe {
@@ -1337,23 +1438,118 @@ mod tests {
     }
 
     #[test]
-    fn test_grow_exceeding_mkey_max_entries_errors() {
+    fn test_grow_past_mkey_max_entries_covers_the_prefix_that_fits() {
         let ops = MockOps::new(SERVED_NIC, true, &[0]);
         let base = 0x10_0000_0000;
-        // Cap at one MR; a two-chunk segment needs two, so grow must reject it
-        // rather than bind an over-capacity (and silently truncated) key.
+        // Cap at one MR against a two-chunk segment: the first chunk binds and
+        // the second is left out rather than pushing the key over its cap.
         let segment = RegisteredSegment::empty(dyn_ops(&ops), base, 1);
         // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
         let result =
             unsafe { segment.grow(&null_pd(), &null_qp(), 0, &seg(base, MAX_MR_SIZE + MIB2, 0)) };
-        assert!(
-            result.is_err(),
-            "grow must reject a segment needing more MRs than mkey max entries"
+        assert!(result.is_ok(), "grow binds the chunks that fit the cap");
+        assert_eq!(segment.size(), MAX_MR_SIZE, "one chunk is bound");
+        assert_eq!(
+            segment.scanned_size(),
+            MAX_MR_SIZE + MIB2,
+            "the whole scanned extent is recorded"
         );
-        assert_eq!(segment.size(), 0, "the segment is left unchanged");
         assert!(
-            ops.lock().bind_calls.is_empty(),
-            "no bind attempted past the cap"
+            segment.in_unregistered_tail(base + MAX_MR_SIZE, MIB2),
+            "the chunk left out is reported as unregistered tail"
+        );
+        let s = ops.lock();
+        assert_eq!(s.dmabuf_calls.len(), 1, "only the fitting chunk registers");
+        assert_eq!(s.bind_calls.len(), 1, "the key binds that one chunk");
+    }
+
+    #[test]
+    fn test_grow_with_a_full_key_leaves_the_segment_bound() {
+        let ops = MockOps::new(SERVED_NIC, true, &[0]);
+        let base = 0x10_0000_0000;
+        let segment = RegisteredSegment::empty(dyn_ops(&ops), base, 1);
+        // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
+        unsafe { segment.grow(&null_pd(), &null_qp(), 0, &seg(base, MAX_MR_SIZE, 0)) }
+            .expect("the first chunk fills the one-MR key");
+        let registered = ops.lock().dmabuf_calls.len();
+
+        // SAFETY: as above.
+        let result =
+            unsafe { segment.grow(&null_pd(), &null_qp(), 0, &seg(base, MAX_MR_SIZE + MIB2, 0)) };
+        assert!(result.is_ok(), "a full key is not an error");
+        assert_eq!(segment.size(), MAX_MR_SIZE, "the bound prefix is unchanged");
+        assert_eq!(
+            segment.scanned_size(),
+            MAX_MR_SIZE + MIB2,
+            "the new scanned extent is recorded"
+        );
+        assert_eq!(
+            ops.lock().dmabuf_calls.len(),
+            registered,
+            "nothing registers once the key is full"
+        );
+    }
+
+    #[test]
+    fn test_segment_too_large_for_one_key_still_covers_its_prefix() {
+        let ops = MockOps::new(SERVED_NIC, true, &[0]);
+        let base = 0x10_0000_0000;
+        // Two chunks against a one-MR cap: the first binds, the second is left
+        // out.
+        ops.lock().scan = vec![seg(base, MAX_MR_SIZE + MIB2, 0)];
+        let domain = domain_with_cap(ops.clone(), 1);
+
+        assert!(
+            register_cuda(&domain, base, MIB2).is_ok(),
+            "a request inside the bound prefix is served by the key"
+        );
+        let scans = ops.lock().scan_calls;
+
+        let tail = base + MAX_MR_SIZE;
+        assert!(
+            register_cuda(&domain, tail, MIB2).is_err(),
+            "a request in the chunk left out cannot use the key"
+        );
+        assert_eq!(
+            ops.lock().scan_calls,
+            scans,
+            "the unregistered tail does not trigger another scan"
+        );
+    }
+
+    #[test]
+    fn test_growth_past_the_cap_refuses_the_new_tail_without_rescanning() {
+        let ops = MockOps::new(SERVED_NIC, true, &[0]);
+        let base = 0x10_0000_0000;
+        // One chunk binds under a one-MR cap; a second would not.
+        ops.lock().scan = vec![seg(base, MAX_MR_SIZE, 0)];
+        let domain = domain_with_cap(ops.clone(), 1);
+        assert!(
+            register_cuda(&domain, base, MIB2).is_ok(),
+            "the first chunk fits the cap"
+        );
+
+        ops.lock().scan = vec![seg(base, MAX_MR_SIZE + MIB2, 0)];
+        let tail = base + MAX_MR_SIZE;
+        assert!(
+            register_cuda(&domain, tail, MIB2).is_err(),
+            "growing into a second chunk would exceed the cap"
+        );
+        let (scans, dmabufs) = {
+            let s = ops.lock();
+            (s.scan_calls, s.dmabuf_calls.len())
+        };
+
+        assert!(
+            register_cuda(&domain, tail, MIB2).is_err(),
+            "the tail stays unservable"
+        );
+        let s = ops.lock();
+        assert_eq!(s.scan_calls, scans, "no rescan for a known tail");
+        assert_eq!(
+            s.dmabuf_calls.len(),
+            dmabufs,
+            "no registration attempted for a refused tail"
         );
     }
 

--- a/python/benches/multihost_rdma/bench_peer.py
+++ b/python/benches/multihost_rdma/bench_peer.py
@@ -39,7 +39,7 @@ can be given a plan by :py:meth:`Peer.wire`.
 from __future__ import annotations
 
 import time
-from typing import Any, Mapping
+from typing import Any, cast, Mapping
 
 import torch
 import xxhash
@@ -68,7 +68,10 @@ class Peer(Actor):
         # destination device.
         self.tensors: SlotValues[torch.Tensor] = _nothing()
         self.buffers: SlotValues[RDMABuffer] = _nothing()
-        self.plan: InitiatorPlan = InitiatorPlan()
+        # Built once by `wire` and submitted every iteration, so assembling
+        # it costs nothing on the timed path. `None` on a proc that
+        # initiates nothing.
+        self.action: RDMAAction | None = None
 
     @endpoint
     async def check_config(self, expected: Mapping[str, Any]) -> dict[str, Any]:
@@ -147,34 +150,36 @@ class Peer(Actor):
                 tensor.zero_()
 
     @endpoint
-    async def wire(self, plans: Mapping[Slot, InitiatorPlan]) -> None:
-        """Install the ops this slot will issue."""
-        self.plan = plans.get(self.slot, InitiatorPlan())
+    async def wire(self, plans: Mapping[Slot, InitiatorPlan]) -> float:
+        """Build the action carrying the ops this slot will issue, and return the
+        milliseconds that took.
+
+        An `RDMAAction` can be submitted more than once, so it is built here
+        rather than in every iteration.
+        """
+        plan = plans.get(self.slot, InitiatorPlan())
+        started = time.perf_counter()
+        action = RDMAAction()
+        for op in plan.push:
+            action.write_remote(op.remote, self.tensors.outgoing[op.outgoing_index])
+        for op in plan.pull:
+            action.read_remote(self.tensors.incoming[op.peer][op.op_index], op.remote)
+        ended = time.perf_counter()
+        self.action = action if plan.ops else None
+        return _ms(ended - started)
 
     @endpoint
     async def execute_iteration(self) -> Sample | None:
-        """Build one ``RDMAAction`` from the installed plan, submit it, and wait
-        for every op in it to complete.
+        """Submit this slot's action and wait for every op in it to complete.
 
         ``None`` on a proc that initiates nothing, so the driver can cast to
         every proc and keep only the measurements that mean something.
         """
-        if not self.plan.ops:
+        if self.action is None:
             return None
         started = time.perf_counter()
-        action = RDMAAction()
-        for op in self.plan.push:
-            action.write_remote(op.remote, self.tensors.outgoing[op.outgoing_index])
-        for op in self.plan.pull:
-            action.read_remote(self.tensors.incoming[op.peer][op.op_index], op.remote)
-        built = time.perf_counter()
-        await action.submit()
-        finished = time.perf_counter()
-        return Sample(
-            slot=self.slot,
-            build_ms=_ms(built - started),
-            submit_ms=_ms(finished - built),
-        )
+        await cast(RDMAAction, self.action).submit()
+        return Sample(slot=self.slot, submit_ms=_ms(time.perf_counter() - started))
 
     @endpoint
     async def digest(self, mode: str, window_bytes: int) -> SlotValues[str]:
@@ -199,7 +204,7 @@ class Peer(Actor):
             await buffer.drop()
         self.buffers = _nothing()
         self.tensors = _nothing()
-        self.plan = InitiatorPlan()
+        self.action = None
 
 
 def _nothing() -> SlotValues[Any]:

--- a/python/benches/multihost_rdma/bench_stats.py
+++ b/python/benches/multihost_rdma/bench_stats.py
@@ -61,24 +61,15 @@ def _gbs(num_bytes: int, milliseconds: float) -> float:
 class Sample:
     """One initiator's measurement of one iteration, on the initiator's clock.
 
-    ``build_ms`` is the Python-side cost of assembling the ``RDMAAction``: one
-    call per op, before any byte moves. ``submit_ms`` runs from handing that
-    action to the RDMA layer until every op in it has completed, so it is the
-    only part that measures the fabric. They are reported separately and only
-    ``submit_ms`` is ever a throughput denominator.
+    ``submit_ms`` runs from handing the action to the RDMA layer until every op
+    in it has completed.
 
     The slot travels with the measurement because how many bytes it stands for
     depends on how that slot fits into the topology of the run.
     """
 
     slot: Slot
-    build_ms: float
     submit_ms: float
-
-    @property
-    def total_ms(self) -> float:
-        """Everything the initiator spent, which the driver's span must cover."""
-        return self.build_ms + self.submit_ms
 
 
 def percentile(values: Sequence[float], pct: float) -> float:
@@ -134,12 +125,11 @@ class PhaseRecord:
     :py:func:`bench_topology.phase_of` is that mapping, and it is the only place
     the boundaries are decided.
 
-    ``build_ms`` and ``submit_ms`` hold one entry per initiator per iteration.
+    ``submit_ms`` holds one entry per initiator per iteration.
     ``span_ms``, ``overhead_ms``, and ``agg_gbs`` hold one entry per iteration,
     because one span covers every initiator at once.
     """
 
-    build_ms: list[float] = field(default_factory=list)
     submit_ms: list[float] = field(default_factory=list)
     initiator_gbs: list[float] = field(default_factory=list)
     span_ms: list[float] = field(default_factory=list)
@@ -149,7 +139,6 @@ class PhaseRecord:
     def add_sample(self, sample: Sample, initiator_bytes: int) -> None:
         """Record one initiator's iteration. ``initiator_bytes`` is what that
         initiator moved, which depends on its degree."""
-        self.build_ms.append(sample.build_ms)
         self.submit_ms.append(sample.submit_ms)
         if sample.submit_ms > 0:
             self.initiator_gbs.append(_gbs(initiator_bytes, sample.submit_ms))
@@ -159,7 +148,7 @@ class PhaseRecord:
     ) -> None:
         """Record the driver-clock span of one iteration.
 
-        ``slowest_ms`` is the largest ``Sample.total_ms`` in that iteration, so
+        ``slowest_ms`` is the largest ``Sample.submit_ms`` in that iteration, so
         the overhead is the part of the span no initiator was working during.
         """
         self.span_ms.append(span_ms)
@@ -190,6 +179,7 @@ class RunRecord:
     # actor, one entry per run per proc, so the spread across procs shows how
     # the cost tracks a proc's buffer count. Allocation itself is excluded.
     register_ms: list[float] = field(default_factory=list)
+    build_ms: list[float] = field(default_factory=list)
     phases: dict[str, PhaseRecord] = field(
         default_factory=lambda: {phase: PhaseRecord() for phase in PHASES}
     )
@@ -299,7 +289,7 @@ def metrics_for(phase: str, runs: RunRecord) -> MetricColumns:
     """
     record = runs.phases[phase]
     register = summarize(runs.register_ms)
-    build = summarize(record.build_ms)
+    build = summarize(runs.build_ms)
     submit = summarize(record.submit_ms)
     span = summarize(record.span_ms)
     overhead = summarize(record.overhead_ms)

--- a/python/benches/multihost_rdma/benchmark_driver.py
+++ b/python/benches/multihost_rdma/benchmark_driver.py
@@ -591,13 +591,12 @@ async def _iterate(
     reply."""
     phase = record.record(phase_of(run, iteration, cfg.warmup_iters_per_run))
     started = time.perf_counter()
-    samples = await peers.execute_iteration.call()
+    replies = await peers.execute_iteration.call()
     span_ms = (time.perf_counter() - started) * 1000.0
+    samples = [sample for _point, sample in replies.items() if sample is not None]
 
     slowest_ms = 0.0
-    for _point, sample in samples.items():
-        if sample is None:
-            continue
+    for sample in samples:
         phase.add_sample(
             sample,
             initiator_bytes(
@@ -608,7 +607,7 @@ async def _iterate(
                 payload_bytes=cfg.payload_bytes,
             ),
         )
-        slowest_ms = max(slowest_ms, sample.total_ms)
+        slowest_ms = max(slowest_ms, sample.submit_ms)
     phase.add_iteration(
         span_ms,
         bytes_per_iteration(
@@ -667,7 +666,11 @@ async def _run_direction(
         for run in range(cfg.runs):
             buffers = await _setup_run(cfg, peers, allocations, record, seed=run)
             plans = plan_for(topo, direction, buffers, ops=cfg.concurrent_ops)
-            await peers.wire.call(plans)
+            build_timing = await peers.wire.call(plans)
+            for point, build_ms in build_timing.items():
+                # Only record build time for slots with non-empty actions.
+                if slot_of(point) in plans:
+                    record.build_ms.append(build_ms)
             if verifying and run == 0:
                 record.negative_control_ok = await _check_control(cfg, topo, peers)
             for iteration in range(cfg.iterations_per_run):

--- a/python/tests/test_rdma_bench_driver.py
+++ b/python/tests/test_rdma_bench_driver.py
@@ -279,7 +279,7 @@ def _record(*, submit_ms: float = 200.0, spans: int = 4) -> bs.RunRecord:
         phase = bt.COLD_QP if index == 0 else bt.WARM
         into = runs.record(phase)
         into.add_sample(
-            bs.Sample(bt.Slot(0, 0), build_ms=1.0, submit_ms=submit_ms),
+            bs.Sample(bt.Slot(0, 0), submit_ms=submit_ms),
             initiator_bytes=_GB,
         )
         into.add_iteration(
@@ -647,7 +647,7 @@ async def _noop_drive(cfg, job, mesh_name, banner) -> None:
 
 
 def _sample(lane: int, submit_ms: float) -> bs.Sample:
-    return bs.Sample(bt.Slot(0, lane), build_ms=1.0, submit_ms=submit_ms)
+    return bs.Sample(bt.Slot(0, lane), submit_ms=submit_ms)
 
 
 async def test_an_iteration_lands_in_the_phase_it_belongs_to() -> None:
@@ -727,7 +727,7 @@ def _fake_peers_entire_direction(
     return _FakePeers(
         check_config=_FakeEndpoint(_value_mesh([{}] * lanes, lanes=lanes)),
         setup=_FakeEndpoint(_value_mesh(setup_replies, lanes=lanes)),
-        wire=_FakeEndpoint(_value_mesh([None] * lanes, lanes=lanes)),
+        wire=_FakeEndpoint(_value_mesh([3.0] * lanes, lanes=lanes)),
         execute_iteration=_FakeEndpoint(
             _value_mesh([_sample(s.lane, 100.0) for s in slots], lanes=lanes)
         ),
@@ -1039,3 +1039,14 @@ def test_the_nic_limit_reaches_the_config_and_the_csv(
 def test_a_negative_nic_limit_is_refused() -> None:
     with pytest.raises(ValueError, match="--rdma-max-nics-per-buffer"):
         _config("--rdma-max-nics-per-buffer", "-1")
+
+
+async def test_building_the_actions_is_measured_once_per_run() -> None:
+    topo = _self_edge_topology()
+    peers = _fake_peers_entire_direction(topo)
+
+    record = await bd._run_direction(
+        _config("--runs", "2"), topo, cast(bench_peer.Peer, peers), bt.READ
+    )
+
+    assert record.build_ms == [3.0] * 4, "one per proc per run, from wire"

--- a/python/tests/test_rdma_bench_stats.py
+++ b/python/tests/test_rdma_bench_stats.py
@@ -69,18 +69,15 @@ def test_summarize_handles_thin_sample_sets() -> None:
     assert two.maximum == 3.0
 
 
-def test_sample_total() -> None:
-    sample = bs.Sample(slot=bt.Slot(0, 0), build_ms=2.0, submit_ms=100.0)
-    assert sample.total_ms == pytest.approx(102.0)
+def _sample(slot: bt.Slot, submit_ms: float) -> bs.Sample:
+    return bs.Sample(slot=slot, submit_ms=submit_ms)
 
 
 def test_phase_record_derives_throughput_from_the_right_clock() -> None:
     record = bs.PhaseRecord()
+    record.add_sample(_sample(bt.Slot(0, 0), 500.0), initiator_bytes=GB)
     record.add_sample(
-        bs.Sample(bt.Slot(0, 0), build_ms=1.0, submit_ms=500.0), initiator_bytes=GB
-    )
-    record.add_sample(
-        bs.Sample(bt.Slot(1, 0), build_ms=1.0, submit_ms=1000.0),
+        _sample(bt.Slot(1, 0), 1000.0),
         initiator_bytes=2 * GB,
     )
     assert record.initiator_gbs == [2.0, 2.0], "each initiator's own bytes and clock"
@@ -100,12 +97,8 @@ def test_aggregate_throughput_is_measured_against_the_span() -> None:
     that the assertion pins which one is reported.
     """
     record = bs.PhaseRecord()
-    record.add_sample(
-        bs.Sample(bt.Slot(0, 0), build_ms=0.0, submit_ms=500.0), initiator_bytes=GB
-    )
-    record.add_sample(
-        bs.Sample(bt.Slot(1, 0), build_ms=0.0, submit_ms=1000.0), initiator_bytes=GB
-    )
+    record.add_sample(_sample(bt.Slot(0, 0), 500.0), initiator_bytes=GB)
+    record.add_sample(_sample(bt.Slot(1, 0), 1000.0), initiator_bytes=GB)
     record.add_iteration(span_ms=1000.0, iteration_bytes=2 * GB, slowest_ms=1000.0)
 
     assert record.agg_gbs == [2.0]
@@ -115,9 +108,7 @@ def test_aggregate_throughput_is_measured_against_the_span() -> None:
 
 def test_zero_durations_do_not_produce_infinite_throughput() -> None:
     record = bs.PhaseRecord()
-    record.add_sample(
-        bs.Sample(bt.Slot(0, 0), build_ms=0.0, submit_ms=0.0), initiator_bytes=GB
-    )
+    record.add_sample(_sample(bt.Slot(0, 0), 0.0), initiator_bytes=GB)
     record.add_iteration(span_ms=0.0, iteration_bytes=GB, slowest_ms=0.0)
     assert record.initiator_gbs == []
     assert record.agg_gbs == []
@@ -128,12 +119,8 @@ def test_run_record_discards_ramp_without_a_special_case() -> None:
     runs = bs.RunRecord()
     assert set(runs.phases) == set(bt.PHASES)
 
-    runs.record(bt.WARM).add_sample(
-        bs.Sample(bt.Slot(0, 0), 0.0, 500.0), initiator_bytes=GB
-    )
-    runs.record(bt.RAMP).add_sample(
-        bs.Sample(bt.Slot(0, 0), 0.0, 9000.0), initiator_bytes=GB
-    )
+    runs.record(bt.WARM).add_sample(_sample(bt.Slot(0, 0), 500.0), initiator_bytes=GB)
+    runs.record(bt.RAMP).add_sample(_sample(bt.Slot(0, 0), 9000.0), initiator_bytes=GB)
 
     assert runs.phases[bt.WARM].submit_ms == [500.0]
     assert bt.RAMP not in runs.phases, "the ramp record is a throwaway"
@@ -173,13 +160,14 @@ def _run_record() -> bs.RunRecord:
     for run in range(_RUNS):
         # One registration measurement per proc per run.
         runs.register_ms.extend(400.0 + 100.0 * run + 50.0 * i for i in range(2))
+        runs.build_ms.extend(2.0 for _ in range(2))
         for iteration in range(_WARMUP_ITERS + _WARM_ITERS):
             phase = bt.phase_of(run, iteration, _WARMUP_ITERS)
             record = runs.record(phase)
             submit_ms = _SUBMIT_MS[phase]
             for slot in _INITIATORS:
                 record.add_sample(
-                    bs.Sample(slot, build_ms=2.0, submit_ms=submit_ms),
+                    _sample(slot, submit_ms),
                     initiator_bytes=GB,
                 )
             record.add_iteration(


### PR DESCRIPTION
Summary:

Before this PR, we did something extremely inefficient if an expandable cuda segment grew so large that it could not fit in a single mlx5dv mkey due to the max_sge limit of 30.

Let's say a cuda segment covers a ~150GB address range (possible on e.g. GB200). With a max MR size of ~4GB and a max_sge limit of 30, one mlx5dv mkey can only cover 120GB of that range. So any time we wanted to register a tensor in the 30GB tail of this region, we would:
1. See that the tensor was not in a registered segment.
2. Trigger a python rescan of the pytorch cuda allocator.
3. See that the 150GB segment had 30GB at its tail unregistered.
4. Register that entire 30GB tail.
5. See that the mkey was already at its max sge limit.
6. Deregister the 30GB tail.
7. Fall back to the dmabuf path to register the tensor.

These steps introduced massive overhead. This PR addresses two of the major inefficiencies:
1. When we try to grow a segment's registration, we register as much as we can up to the max sge limit -- we never over-register only to deregister later when we see that max sge was exceeded. We then store the *scanned* size separately from the *registered* size.
2. When we register a cuda tensor, we check if it is already covered by the registered portion of any existing segment, and if so, return the MR immediately. We *additionally* check if the tensor spans an already-scanned-but-unregistered tail of an existing segment. In this case, we *do not trigger a rescan*: we immediately fall back to the dmabuf path.

Differential Revision: D117560225


