### PR TITLE
stop actor event loops before Python exits (#4757)

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -84,6 +84,7 @@ use crate::pympsc;
 use crate::pytokio::PyPythonTask;
 use crate::runtime::GilSite;
 use crate::runtime::get_tokio_runtime;
+use crate::runtime::mark_actor_event_loop_thread;
 use crate::runtime::monarch_with_gil;
 use crate::runtime::monarch_with_gil_blocking;
 use crate::supervision::PyMeshFailure;
@@ -1681,11 +1682,16 @@ fn create_task_locals() -> pyo3_async_runtimes::TaskLocals {
         kwargs.set_item("target", target).unwrap();
         // Need to make this a daemon thread, otherwise shutdown will hang.
         kwargs.set_item("daemon", true).unwrap();
+        kwargs
+            .set_item("name", "monarch-actor-event-loop")
+            .expect("thread name should be accepted");
         let thread = py
             .import("threading")
             .unwrap()
             .call_method("Thread", (), Some(&kwargs))
             .unwrap();
+        mark_actor_event_loop_thread(&thread, &event_loop)
+            .expect("actor event loop should attach to its owning thread");
         thread.call_method0("start").unwrap();
         task_locals
     })

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -13,7 +13,9 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::thread;
 use std::time::Duration;
+use std::time::Instant;
 
 use anyhow::Result;
 use hyperactor::runtime_identity::RuntimeKind;
@@ -35,6 +37,13 @@ use tokio::runtime::Handle;
 use tokio::task;
 
 use crate::config::TOKIO_WORKER_THREADS;
+
+/// Attribute holding an actor's event loop on the `threading.Thread` running
+/// it. `threading` already tracks every live thread, so this needs no second
+/// registry and takes no lock on the actor-spawn path.
+const ACTOR_EVENT_LOOP_ATTRIBUTE: &str = "_monarch_actor_event_loop";
+const ACTOR_EVENT_LOOP_POLL_INTERVAL: Duration = Duration::from_millis(1);
+const ACTOR_EVENT_LOOP_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// Global tokio runtime container.
 ///
@@ -84,6 +93,113 @@ pub fn get_tokio_runtime() -> Handle {
     global_runtime().handle.clone()
 }
 
+/// Record an actor's event loop on the `threading.Thread` running it, so the
+/// interpreter-exit reaper can find it again.
+///
+/// This does not keep the loop alive any longer than it already lives:
+/// `TaskLocals` holds it for the life of the `PythonActor` regardless. What it
+/// buys is that no separate process-lifetime registry exists.
+pub(crate) fn mark_actor_event_loop_thread(
+    thread: &Bound<'_, PyAny>,
+    event_loop: &Bound<'_, PyAny>,
+) -> PyResult<()> {
+    thread.setattr(ACTOR_EVENT_LOOP_ATTRIBUTE, event_loop)
+}
+
+fn actor_event_loops(py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
+    let threading = py.import("threading")?;
+    let mut loops = Vec::new();
+    for thread in threading.call_method0("enumerate")?.try_iter()? {
+        let thread = thread?;
+        let Ok(event_loop) = thread.getattr(ACTOR_EVENT_LOOP_ATTRIBUTE) else {
+            continue;
+        };
+        loops.push(event_loop.unbind());
+    }
+    Ok(loops)
+}
+
+/// Stop every marked actor loop, polling until they exit or `timeout` elapses.
+/// Returns how many were still enumerable when the pass ended.
+///
+/// Scope: this covers loops enumerable *during* the pass. The first empty
+/// snapshot returns, so a loop created after that observation is missed.
+/// That residual is deliberate -- closing it would mean proving actor-loop
+/// creation had quiesced first, which is a process-wide gate this guard
+/// intentionally does not have. Actor-owned teardown is what will make late
+/// creation safe; this is only the interpreter-exit backstop.
+///
+/// Latency: the deadline is checked once per pass, after a full enumeration
+/// and one `call_soon_threadsafe` per loop, so the bound is `timeout` plus one
+/// pass rather than exactly `timeout`.
+///
+/// Every wait is bounded and there are no thread joins: the pass only sleeps.
+/// `Thread.join()` and `Thread.is_alive()` are both avoided because on CPython
+/// 3.14 `is_alive()` can enter an unbounded OS-thread join once
+/// `thread_is_exiting` is set.
+fn stop_and_wait_actor_event_loops(py: Python<'_>, timeout: Duration) -> PyResult<usize> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let loops = actor_event_loops(py)?;
+        if loops.is_empty() {
+            return Ok(0);
+        }
+        for event_loop in &loops {
+            let event_loop = event_loop.bind(py);
+            // `stop` must run on the loop's own thread, so schedule it rather
+            // than call it. A closed loop raises, which is the normal state
+            // for an actor that already drained.
+            let stop_result = event_loop
+                .getattr("stop")
+                .and_then(|stop| event_loop.call_method1("call_soon_threadsafe", (stop,)));
+            if let Err(err) = stop_result {
+                tracing::warn!(error = %err, "failed to stop actor event loop at interpreter exit");
+            }
+        }
+        if Instant::now() >= deadline {
+            // Re-enumerate: threads may have exited while this pass issued its
+            // stops, and the survivor count is what the caller reports.
+            return Ok(actor_event_loops(py)?.len());
+        }
+
+        // Releasing the GIL is what lets the loop threads run the scheduled stop.
+        let sleep_for =
+            ACTOR_EVENT_LOOP_POLL_INTERVAL.min(deadline.saturating_duration_since(Instant::now()));
+        py.detach(move || thread::sleep(sleep_for));
+    }
+}
+
+/// Reap actor event-loop threads before the interpreter finalizes.
+///
+/// `Py_FinalizeEx` runs Python `atexit` handlers *before* it publishes the
+/// finalizing thread state, so while this runs every loop thread can still
+/// take the GIL, run the scheduled `stop`, return from `run_forever` and exit.
+/// After that point a surviving daemon thread that asks for the GIL is
+/// force-exited with `pthread_exit`, and that unwind through pyo3's
+/// `catch_unwind` aborts the process.
+///
+/// This is an interpreter-exit guard, not the lifecycle repair: actor cleanup
+/// still returns before its thread terminates, and the root client still
+/// publishes `Stopped` without running cleanup.
+fn shutdown_actor_event_loops(py: Python<'_>, timeout: Duration) {
+    let remaining = match stop_and_wait_actor_event_loops(py, timeout) {
+        Ok(remaining) => remaining,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to stop actor event-loop threads at interpreter exit");
+            return;
+        }
+    };
+    if remaining > 0 {
+        // Only reachable if a callback on that loop never yields, which is a
+        // bug of its own. Naming it turns a bare SIGABRT into something
+        // diagnosable rather than hanging the exit path.
+        tracing::warn!(
+            remaining,
+            "actor event-loop threads survived interpreter-exit shutdown"
+        );
+    }
+}
+
 /// atexit handler that tears down the data-plane runtimes and the global Tokio runtime.
 ///
 /// Callers obtain a cloned `Handle` from `get_tokio_runtime()` rather
@@ -111,6 +227,11 @@ pub fn shutdown_tokio_runtime(py: Python<'_>) {
         };
         rt.shutdown_timeout(Duration::from_secs(1));
     });
+
+    // Reaping runs unconditionally. The field intervention that took this
+    // failure from 6/60 to 0/60 was an unconditional stop-and-join, and the
+    // bounded deadline caps the worst case.
+    shutdown_actor_event_loops(py, ACTOR_EVENT_LOOP_SHUTDOWN_TIMEOUT);
 }
 
 /// Stores the native thread ID of the main Python thread.
@@ -251,6 +372,22 @@ pub fn sleep_indefinitely_for_unit_tests(py: Python) -> PyResult<()> {
     signal_safe_block_on(py, future)
 }
 
+/// Test hook for the interpreter-exit regression test.
+///
+/// `threading.Event.wait()` releases the GIL, so keeping this PyO3 frame on
+/// the stack while it waits is what puts a `catch_unwind` trampoline in the
+/// path of CPython's finalization unwind. Test-only; not part of any API.
+#[pyfunction]
+#[pyo3(name = "_wait_on_event_for_exit_test")]
+fn wait_on_event_for_exit_test(
+    entered: &Bound<'_, PyAny>,
+    release: &Bound<'_, PyAny>,
+) -> PyResult<()> {
+    entered.call_method0("set")?;
+    release.call_method0("wait")?;
+    Ok(())
+}
+
 /// Initialize the runtime module and expose Python functions
 pub fn register_python_bindings(runtime_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     let sleep_indefinitely_fn =
@@ -260,6 +397,14 @@ pub fn register_python_bindings(runtime_mod: &Bound<'_, PyModule>) -> PyResult<(
         "monarch._rust_bindings.monarch_hyperactor.runtime",
     )?;
     runtime_mod.add_function(sleep_indefinitely_fn)?;
+
+    let wait_on_event_for_exit_test_fn =
+        wrap_pyfunction!(wait_on_event_for_exit_test, runtime_mod.py())?;
+    wait_on_event_for_exit_test_fn.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.runtime",
+    )?;
+    runtime_mod.add_function(wait_on_event_for_exit_test_fn)?;
 
     let get_gil_on_control_plane_fn = wrap_pyfunction!(get_gil_on_control_plane, runtime_mod.py())?;
     get_gil_on_control_plane_fn.setattr(
@@ -342,10 +487,197 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use hyperactor::runtime_identity::RuntimeKind;
     use hyperactor::runtime_identity::current_runtime_kind;
+    use pyo3::types::PyDict;
 
     use super::*;
+
+    // The reaper is process-wide over `threading.enumerate()`, so two of these
+    // running concurrently would see each other's threads. A test-only static
+    // is fine; the no-new-global-state rule is about production code.
+    static ACTOR_EVENT_LOOP_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn start_marked_thread(
+        py: Python<'_>,
+        target: &Bound<'_, PyAny>,
+        event_loop: &Bound<'_, PyAny>,
+    ) {
+        let kwargs = PyDict::new(py);
+        kwargs
+            .set_item("target", target)
+            .expect("thread target should be set");
+        kwargs
+            .set_item("daemon", true)
+            .expect("thread should be made a daemon");
+        let thread = py
+            .import("threading")
+            .expect("threading should import")
+            .call_method("Thread", (), Some(&kwargs))
+            .expect("thread should be created");
+        mark_actor_event_loop_thread(&thread, event_loop)
+            .expect("actor event loop should attach to its owning thread");
+        thread.call_method0("start").expect("thread should start");
+    }
+
+    /// A marked thread actually running `run_forever`, so a scheduled `stop`
+    /// reaches it and the thread exits.
+    fn new_actor_event_loop(py: Python<'_>) -> Py<PyAny> {
+        let event_loop = py
+            .import("asyncio")
+            .expect("asyncio should import")
+            .call_method0("new_event_loop")
+            .expect("event loop should be created");
+        let target = event_loop
+            .getattr("run_forever")
+            .expect("event loop should have run_forever");
+        start_marked_thread(py, &target, &event_loop);
+        event_loop.unbind()
+    }
+
+    /// A marked thread wedged on `Event.wait()`, carrying a loop that never
+    /// runs, so the scheduled `stop` can never execute and the thread outlives
+    /// any deadline.
+    fn new_wedged_actor_event_loop(py: Python<'_>) -> (Py<PyAny>, Py<PyAny>) {
+        let event_loop = py
+            .import("asyncio")
+            .expect("asyncio should import")
+            .call_method0("new_event_loop")
+            .expect("event loop should be created");
+        let release = py
+            .import("threading")
+            .expect("threading should import")
+            .call_method0("Event")
+            .expect("release event should be created");
+        let target = release.getattr("wait").expect("event should have wait");
+        start_marked_thread(py, &target, &event_loop);
+        (event_loop.unbind(), release.unbind())
+    }
+
+    fn marked_loop_count(py: Python<'_>) -> usize {
+        actor_event_loops(py)
+            .expect("actor event-loop threads should enumerate")
+            .len()
+    }
+
+    #[test]
+    fn stop_and_wait_actor_event_loops_reaps_every_thread() {
+        let _guard = ACTOR_EVENT_LOOP_TEST_LOCK
+            .lock()
+            .expect("actor event-loop tests should not poison their lock");
+        pyo3::Python::initialize();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let loops = [new_actor_event_loop(py), new_actor_event_loop(py)];
+
+            assert_eq!(
+                stop_and_wait_actor_event_loops(py, Duration::from_secs(1))
+                    .expect("actor event-loop shutdown should succeed"),
+                0,
+                "all marked actor event-loop threads should exit before the deadline"
+            );
+            assert_eq!(
+                marked_loop_count(py),
+                0,
+                "stopped actor event-loop threads should leave threading.enumerate()"
+            );
+            for event_loop in loops {
+                event_loop
+                    .bind(py)
+                    .call_method0("close")
+                    .expect("stopped event loop should close");
+            }
+        });
+    }
+
+    #[test]
+    fn stop_and_wait_actor_event_loops_returns_at_deadline() {
+        let _guard = ACTOR_EVENT_LOOP_TEST_LOCK
+            .lock()
+            .expect("actor event-loop tests should not poison their lock");
+        pyo3::Python::initialize();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let (event_loop, release) = new_wedged_actor_event_loop(py);
+            let started = Instant::now();
+
+            assert_eq!(
+                stop_and_wait_actor_event_loops(py, Duration::from_millis(10))
+                    .expect("actor event-loop timeout should be observed"),
+                1,
+                "a wedged marked thread should survive the shutdown deadline"
+            );
+            assert!(
+                started.elapsed() < Duration::from_secs(1),
+                "actor event-loop shutdown should return near its deadline"
+            );
+
+            release
+                .bind(py)
+                .call_method0("set")
+                .expect("wedged thread should be released");
+            assert_eq!(
+                stop_and_wait_actor_event_loops(py, Duration::from_secs(1))
+                    .expect("released actor event-loop thread should be observed"),
+                0,
+                "released marked thread should exit"
+            );
+            event_loop
+                .bind(py)
+                .call_method0("close")
+                .expect("unused event loop should close");
+        });
+    }
+
+    // The documented bound is `timeout + one pass`. Measure the one-pass term
+    // with many loops so it is a behaviour rather than a claim, and so a
+    // regression to per-thread timeouts (N * timeout) would be caught.
+    #[test]
+    fn stop_and_wait_actor_event_loops_pass_cost_is_bounded_with_many_loops() {
+        const LOOPS: usize = 32;
+        let _guard = ACTOR_EVENT_LOOP_TEST_LOCK
+            .lock()
+            .expect("actor event-loop tests should not poison their lock");
+        pyo3::Python::initialize();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let wedged: Vec<_> = (0..LOOPS)
+                .map(|_| new_wedged_actor_event_loop(py))
+                .collect();
+            let started = Instant::now();
+
+            assert_eq!(
+                stop_and_wait_actor_event_loops(py, Duration::from_millis(50))
+                    .expect("actor event-loop timeout should be observed"),
+                LOOPS,
+                "every wedged marked thread should survive the shutdown deadline"
+            );
+            // Per-thread timeouts would cost LOOPS * 50ms = 1.6s here.
+            assert!(
+                started.elapsed() < Duration::from_secs(1),
+                "one pass over {LOOPS} loops should be small next to the deadline, got {:?}",
+                started.elapsed()
+            );
+
+            for (_, release) in &wedged {
+                release
+                    .bind(py)
+                    .call_method0("set")
+                    .expect("wedged thread should be released");
+            }
+            assert_eq!(
+                stop_and_wait_actor_event_loops(py, Duration::from_secs(5))
+                    .expect("released actor event-loop threads should be observed"),
+                0,
+                "released marked threads should exit"
+            );
+            for (event_loop, _) in wedged {
+                event_loop
+                    .bind(py)
+                    .call_method0("close")
+                    .expect("unused event loop should close");
+            }
+        });
+    }
 
     // The shared control-plane runtime stamps its worker threads ControlPlane.
     #[test]

--- a/python/monarch/_rust_bindings/monarch_hyperactor/runtime.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/runtime.pyi
@@ -21,6 +21,10 @@ def sleep_indefinitely_for_unit_tests() -> None:
     """
     ...
 
+def _wait_on_event_for_exit_test(entered: object, release: object) -> None:
+    """Block inside a PyO3 call for the interpreter-exit regression test."""
+    ...
+
 def _get_gil_on_control_plane() -> int:
     """
     Number of unsanctioned GIL acquisitions seen on the control-plane runtime.

--- a/python/tests/actor_loop_finalization_model.py
+++ b/python/tests/actor_loop_finalization_model.py
@@ -1,0 +1,245 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Constructed reproduction of the interpreter-exit actor-loop abort.
+
+Run by ``test_actor_loop_finalization``. Two arms:
+
+``unmitigated``
+    suppress the loop marker so the production reaper cannot see the loops,
+    then hold one of them inside a PyO3 call across interpreter finalization.
+    CPython <= 3.12 force-exits that daemon thread with ``pthread_exit``; the
+    forced unwind crosses PyO3's ``catch_unwind`` and glibc aborts.
+
+``fixed``
+    leave the marker in place and let the reaper run. Version-independent.
+
+Neither arm uses ``Thread.join()`` or ``Thread.is_alive()``: on CPython 3.14
+``is_alive()`` can enter an unbounded OS-thread join once ``thread_is_exiting``
+is set, and this module runs on 3.14. Thread liveness is observed by membership
+in ``threading.enumerate()`` and waited for by bounded polling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import importlib
+import os
+import resource
+import sys
+import threading
+import time
+
+from monarch.python.tests import actor_loop_finalization_timeouts as timeouts
+
+
+_ACTOR_EVENT_LOOP_ATTRIBUTE = "_monarch_actor_event_loop"
+
+# `context()` bootstraps the root client actor and the `controller_controller`
+# actor, and each `PythonActor` gets one asyncio loop on its own thread.
+_EXPECTED_ACTOR_LOOPS = 2
+
+# Deadlines live in a side-effect-free module so the test can assert they nest
+# inside its own subprocess timeout without importing this one.
+_LOOP_DISCOVERY_TIMEOUT_S = timeouts.LOOP_DISCOVERY_TIMEOUT_S
+_LOOP_DISCOVERY_SETTLE_S = timeouts.LOOP_DISCOVERY_SETTLE_S
+_LOOP_DISCOVERY_POLL_S = timeouts.LOOP_DISCOVERY_POLL_S
+_MODEL_ARM_TIMEOUT_S = timeouts.MODEL_ARM_TIMEOUT_S
+_THREAD_EXIT_POLL_S = timeouts.THREAD_EXIT_POLL_S
+_FINALIZATION_SWITCH_INTERVAL_S = timeouts.FINALIZATION_SWITCH_INTERVAL_S
+
+_actor_loops: list[tuple[asyncio.AbstractEventLoop, threading.Thread]] = []
+_model_mode = "fixed"
+
+
+def _note(message: str) -> None:
+    # Unbuffered: the unmitigated arm ends in an abort that discards anything
+    # still sitting in a Python-level stderr buffer.
+    os.write(2, f"{message}\n".encode())
+
+
+def _fail_model(message: str, exit_code: int) -> None:
+    _note(f"finalization model failed: {message}")
+    os._exit(exit_code)
+
+
+def _gil_enabled() -> bool:
+    # `sys._is_gil_enabled` exists on 3.13+; earlier versions always have it.
+    probe = getattr(sys, "_is_gil_enabled", None)
+    return True if probe is None else bool(probe())
+
+
+def _actor_event_loops() -> list[tuple[asyncio.AbstractEventLoop, threading.Thread]]:
+    loops = []
+    for thread in threading.enumerate():
+        target = getattr(thread, "_target", None)
+        loop = getattr(target, "__self__", None)
+        if getattr(target, "__name__", None) == "run_forever" and isinstance(
+            loop, asyncio.AbstractEventLoop
+        ):
+            loops.append((loop, thread))
+    return loops
+
+
+def _live(
+    actor_loops: list[tuple[asyncio.AbstractEventLoop, threading.Thread]],
+) -> list[tuple[asyncio.AbstractEventLoop, threading.Thread]]:
+    """Those whose thread is still enumerable.
+
+    Deliberately not `thread.is_alive()`: that can enter an unbounded OS-thread
+    join on CPython 3.14, and every wait at this boundary must be bounded.
+    """
+    running = set(map(id, threading.enumerate()))
+    return [(loop, thread) for loop, thread in actor_loops if id(thread) in running]
+
+
+def _wait_for_actor_event_loops(
+    expected: int,
+) -> list[tuple[asyncio.AbstractEventLoop, threading.Thread]]:
+    """Block until exactly `expected` actor loops have been steady for a settle window.
+
+    `context()` returns before `controller_controller` finishes spawning, so an
+    immediate snapshot can miss its loop and the model would then arm the
+    finalization boundary while a loop it does not control is still arriving.
+    """
+    deadline = time.monotonic() + _LOOP_DISCOVERY_TIMEOUT_S
+    steady_since: float | None = None
+    while True:
+        loops = _actor_event_loops()
+        if len(loops) > expected:
+            raise RuntimeError(
+                f"expected {expected} actor event-loop threads, observed {len(loops)}; "
+                "the model's topology assumption is stale"
+            )
+        if len(loops) == expected:
+            now = time.monotonic()
+            if steady_since is None:
+                steady_since = now
+            elif now - steady_since >= _LOOP_DISCOVERY_SETTLE_S:
+                return loops
+        else:
+            steady_since = None
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"expected {expected} actor event-loop threads, observed {len(loops)} "
+                f"after {_LOOP_DISCOVERY_TIMEOUT_S}s"
+            )
+        time.sleep(_LOOP_DISCOVERY_POLL_S)
+
+
+def _stop_actor_event_loops(
+    actor_loops: list[tuple[asyncio.AbstractEventLoop, threading.Thread]],
+) -> None:
+    """Stop each loop and poll until its thread leaves `threading.enumerate()`."""
+    for loop, _thread in actor_loops:
+        try:
+            loop.call_soon_threadsafe(loop.stop)
+        except RuntimeError as error:
+            _fail_model(f"actor loop rejected stop: {error}", 72)
+
+    deadline = time.monotonic() + _MODEL_ARM_TIMEOUT_S
+    while True:
+        survivors = _live(actor_loops)
+        if not survivors:
+            return
+        if time.monotonic() >= deadline:
+            _fail_model(
+                f"actor loops survived stop: {[t.name for _l, t in survivors]}", 73
+            )
+        time.sleep(_THREAD_EXIT_POLL_S)
+
+
+def _exercise_finalization_boundary() -> None:
+    alive = _live(_actor_loops)
+    # The survivor count is what separates the arms: the reaper ran and emptied
+    # the set, or it was suppressed and did not. Report it in every arm so both
+    # assert on the same observable, and write it before anything can redirect
+    # fd 2 (`closeStdPipesAtExit` points it at /dev/null during `exit()`).
+    _note(f"{_model_mode} observed {len(alive)} actor loops after runtime shutdown")
+
+    if _model_mode == "fixed":
+        if alive:
+            _fail_model(f"reaper left {len(alive)} actor loops alive", 75)
+        return
+
+    if not alive:
+        _fail_model(f"no actor loop survived in {_model_mode} mode", 74)
+
+    entered = threading.Event()
+    release = threading.Event()
+    loop, _thread = alive[0]
+    _stop_actor_event_loops(alive[1:])
+    try:
+        loop.call_soon_threadsafe(_wait_on_event_for_exit_test, entered, release)
+    except RuntimeError as error:
+        _fail_model(f"surviving loop rejected callback: {error}", 70)
+
+    if not entered.wait(timeout=_MODEL_ARM_TIMEOUT_S):
+        _fail_model("actor loop did not enter the PyO3 callback", 71)
+
+    # The actor thread is now waiting inside the PyO3 call with the GIL
+    # released. Releasing it must let that thread reach its next GIL attach
+    # while `Py_FinalizeEx` is still running.
+    #
+    # Do NOT starve the switch interval here. glibc writes the fatal message to
+    # fd 2, and `facebook::contextprop::cli::closeStdPipesAtExit` -- a libc
+    # `atexit` handler, so it runs after `Py_FinalizeEx` returns -- points fd 2
+    # at /dev/null. A long switch interval keeps the GIL on the main thread
+    # until the very end of finalization, so the woken thread aborts after that
+    # redirect and its diagnostic is discarded. Measured: 9/30 runs kept the
+    # message at 60s, 30/30 at the default.
+    sys.setswitchinterval(_FINALIZATION_SWITCH_INTERVAL_S)
+    release.set()
+
+
+# Register before importing Monarch. atexit is LIFO, so this runs after
+# shutdown_context and shutdown_tokio_runtime at the final pre-finalization
+# boundary that the production failure races.
+atexit.register(_exercise_finalization_boundary)
+
+_runtime = importlib.import_module("monarch._rust_bindings.monarch_hyperactor.runtime")
+_wait_on_event_for_exit_test = _runtime._wait_on_event_for_exit_test
+_actor = importlib.import_module("monarch.actor")
+context = _actor.context
+
+
+def main() -> None:
+    global _model_mode
+
+    resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+    mode = sys.argv[1] if len(sys.argv) == 2 else "fixed"
+    if mode not in {"fixed", "unmitigated"}:
+        raise ValueError(f"unknown model mode: {mode}")
+    _model_mode = mode
+
+    # The parent checks these: a 3.14 test target whose model resource was
+    # built at the default version would otherwise report false coverage.
+    _note(
+        f"{mode} python {sys.version_info.major}.{sys.version_info.minor} "
+        f"gil={'enabled' if _gil_enabled() else 'disabled'}"
+    )
+
+    context()
+    _actor_loops.extend(_wait_for_actor_event_loops(_EXPECTED_ACTOR_LOOPS))
+    _note(f"{mode} captured {len(_actor_loops)} actor loops")
+
+    if mode == "unmitigated":
+        for _loop, thread in _actor_loops:
+            # Strict: if production stopped marking actor-loop threads, this
+            # arm would silently become a second copy of `fixed`.
+            if not hasattr(thread, _ACTOR_EVENT_LOOP_ATTRIBUTE):
+                raise RuntimeError(
+                    f"actor loop thread {thread.name!r} carries no "
+                    f"{_ACTOR_EVENT_LOOP_ATTRIBUTE} marker to suppress"
+                )
+            delattr(thread, _ACTOR_EVENT_LOOP_ATTRIBUTE)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/actor_loop_finalization_timeouts.py
+++ b/python/tests/actor_loop_finalization_timeouts.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Deadlines shared by the finalization model and the test that drives it.
+
+Separate from both so the test can assert the nesting without importing the
+model, which imports Monarch and registers an ``atexit`` handler at module
+scope. Nothing here may import anything.
+
+They must nest strictly: the parent's subprocess timeout is a backstop, and if
+it is shorter than what the child can legitimately wait on then the child's own
+topology error is replaced by a generic parent timeout.
+"""
+
+# Child (model).
+LOOP_DISCOVERY_TIMEOUT_S = 20.0
+LOOP_DISCOVERY_SETTLE_S = 1.0
+LOOP_DISCOVERY_POLL_S = 0.01
+MODEL_ARM_TIMEOUT_S = 5.0
+THREAD_EXIT_POLL_S = 0.01
+
+# CPython's default switch interval. Pinned because the unmitigated arm depends
+# on it; see `actor_loop_finalization_model._exercise_finalization_boundary`.
+FINALIZATION_SWITCH_INTERVAL_S = 0.005
+
+# Parent (test).
+SUBPROCESS_TIMEOUT_S = 90.0
+
+# The child can wait on discovery, its settle window, and two arming waits.
+CHILD_WORST_CASE_S = (
+    LOOP_DISCOVERY_TIMEOUT_S + LOOP_DISCOVERY_SETTLE_S + MODEL_ARM_TIMEOUT_S * 2
+)

--- a/python/tests/test_actor_loop_finalization.py
+++ b/python/tests/test_actor_loop_finalization.py
@@ -1,0 +1,124 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Interpreter-exit actor-loop regression test.
+
+Two arms, gated separately:
+
+``unmitigated``
+    the `SIGABRT` oracle. CPython 3.13 changed daemon-thread finalization from
+    forced exit to a hang (gh-87135), so this arm only runs below 3.13.
+
+``fixed``
+    "zero actor-loop threads survive shutdown". Version-independent, and most
+    informative on 3.14 where the unfixed symptom would be a hang rather than
+    an abort. Runs on every supported version.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import signal
+import subprocess
+import sys
+import unittest
+
+import pytest
+
+try:
+    # Buck synthesizes `monarch.python.tests` from the target path.
+    from monarch.python.tests import actor_loop_finalization_timeouts as timeouts
+except ImportError:
+    # OSS: there is no `__init__.py` under python/tests, so pytest's prepend
+    # import mode puts this directory on sys.path and the module is top-level.
+    # Without this fallback the module raises during collection, which yields a
+    # JUnit <error> shape and crashes pytest-results-action.
+    import actor_loop_finalization_timeouts as timeouts  # type: ignore[no-redef]
+
+
+_SUBPROCESS_TIMEOUT_S = timeouts.SUBPROCESS_TIMEOUT_S
+
+
+class ActorLoopFinalizationTest(unittest.TestCase):
+    def test_subprocess_timeout_exceeds_every_child_deadline(self) -> None:
+        """A later edit to one constant must not silently re-invert the nesting."""
+        self.assertGreater(
+            _SUBPROCESS_TIMEOUT_S,
+            timeouts.CHILD_WORST_CASE_S,
+            "the parent timeout must be a backstop, not the usual failure mode",
+        )
+
+    def run_model(self, mode: str) -> subprocess.CompletedProcess[str]:
+        test_bin = importlib.resources.files("monarch.python.tests").joinpath(
+            "test_bin"
+        )
+        completed = subprocess.run(
+            [str(test_bin), mode],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_S,
+            check=False,
+        )
+        self.assert_child_interpreter_matches(completed)
+        return completed
+
+    def assert_child_interpreter_matches(
+        self, completed: subprocess.CompletedProcess[str]
+    ) -> None:
+        """The model resource must be built at this target's `py_version`.
+
+        Without this a 3.14 test target whose resource was built at the default
+        version would report false 3.14 coverage.
+        """
+        expected = (
+            f"python {sys.version_info.major}.{sys.version_info.minor} gil=enabled"
+        )
+        self.assertIn(
+            expected,
+            completed.stderr,
+            f"child interpreter does not match the parent, stderr:\n{completed.stderr}",
+        )
+
+    def assert_survivors(
+        self, completed: subprocess.CompletedProcess[str], mode: str, count: int
+    ) -> None:
+        self.assertIn(
+            f"{mode} observed {count} actor loops after runtime shutdown",
+            completed.stderr,
+        )
+
+    # oss_skip: drives the Buck-provided `test_bin` resource, which the OSS
+    # layout does not have; same reason as test_actor_error.py's resource tests.
+    @pytest.mark.oss_skip
+    @unittest.skipUnless(
+        sys.version_info < (3, 13),
+        "CPython 3.13 changed daemon-thread finalization from forced exit to hang",
+    )
+    def test_unmitigated_actor_loop_aborts_during_finalization(self) -> None:
+        completed = self.run_model("unmitigated")
+        self.assertEqual(
+            -signal.SIGABRT,
+            completed.returncode,
+            f"expected SIGABRT, stderr:\n{completed.stderr}",
+        )
+        self.assertIn("FATAL: exception not rethrown", completed.stderr)
+        self.assert_survivors(completed, "unmitigated", 2)
+
+    # oss_skip: drives the Buck-provided `test_bin` resource.
+    @pytest.mark.oss_skip
+    def test_actor_loop_reaper_prevents_finalization_abort(self) -> None:
+        completed = self.run_model("fixed")
+        self.assertEqual(
+            0,
+            completed.returncode,
+            f"mitigated process did not exit normally:\n{completed.stderr}",
+        )
+        self.assertNotIn("FATAL: exception not rethrown", completed.stderr)
+        # The reaper ran and emptied the set. Exit status alone would also be 0
+        # if no actor loop had ever been created.
+        self.assert_survivors(completed, "fixed", 0)


### PR DESCRIPTION
Summary:

GitHub issue: https://github.com/meta-pytorch/monarch/issues/4749
GitHub pull request: https://github.com/meta-pytorch/monarch/pull/4757

each `PythonActor` instance has its own asyncio event loop running on a dedicated daemon OS thread, created through Python's `threading.Thread`. today Python can begin exiting while one of those threads is still alive, which can crash the whole process. specifically, CPython can force an actor thread to exit while it still has Rust/PyO3 calls on its stack. that forced unwind aborts the process with `FATAL: exception not rethrown`.

cpuhrsch's core dumps establish this exact failure path, and D117279357 identified and field-tested the key mitigation: stop actor event loops before Python finalizes. this diff builds on that idea and refines how the loops are found and stopped:

- each actor-loop thread is marked with its loop before it starts, allowing shutdown to use Python's existing list of live threads instead of adding another global registry or lock;
- the existing `shutdown_tokio_runtime` handler performs the work, so no second production `atexit` handler is added;
- shutdown asks every marked loop to stop, releases the GIL so the threads can run, and polls Python's live-thread list until the shared deadline. this keeps shutdown bounded even on Python 3.14, where `Thread.is_alive()` can itself block;
- every loop shares one 250 ms deadline instead of receiving its own timeout. the actual bound is 250 ms plus one final scan.

the guard is deliberately best effort. it covers loops visible while it is scanning, but it can miss a loop created after it has scanned and found none.

together with this fix, a deterministic subprocess test is added that follows the real shutdown path and reproduces precisely the observed failure: without the markers, Python 3.12 aborts during shutdown; with them, every actor loop stops before exit on Python 3.12 and GIL-enabled Python 3.14. focused Rust tests cover multiple loops and the deadline path.

this is a temporary mitigation. it stops leftover actor loops just before Python exits, but it does not fix why they are still running. today actor cleanup can return before its loop thread ends, and the root client can report `Stopped` without running that cleanup. the pytokio-removal work will provide the lifecycle fix. once every actor owns and waits for its loop thread on every shutdown path, this mitigation and its marker can be removed.

the Jobs API creates a simple process tree: it provisions worker host processes with `run_worker_loop_forever()`, and those worker hosts launch actor processes through `bootstrap_main`. a worker host hands control to Rust and ends with `process::exit(0)`, so it never runs Python finalization. the client and actor processes return through Python and do run `Py_FinalizeEx`; those are the processes this mitigation protects.

Differential Revision: D117568016


