### PR TITLE
Vendor WeightBridge library under examples/

### DIFF
--- a/examples/weightbridge/.gitignore
+++ b/examples/weightbridge/.gitignore
@@ -1,0 +1,34 @@
+# Byte-compiled
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution
+*.egg-info/
+*.egg
+dist/
+build/
+eggs/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# pytest / coverage
+.pytest_cache/
+.coverage
+htmlcov/
+
+# mypy
+.mypy_cache/
+
+# logs
+logs/

--- a/examples/weightbridge/README.md
+++ b/examples/weightbridge/README.md
@@ -1,0 +1,104 @@
+# WeightBridge
+
+WeightBridge is a reusable RL weight-transfer library. It moves updated policy weights from **Trainer
+Workers** (the training runtime) to **Rollout Workers** (the inference/generation runtime) when the two
+sides use different parameter names, tensor layouts, or parallelism strategies. It infers how each
+runtime maps to a common HuggingFace-checkpoint coordinate system, computes exactly which byte ranges
+each receiver needs, and moves only those bytes over one-sided RDMA.
+
+## Why WeightBridge?
+
+- **Bandwidth-efficient.** Replaces all-gather/broadcast weight sync with shard-routed, deduplicated,
+  one-sided RDMA transfer — each receiver gets only the slices it needs.
+- **Layout- and framework-agnostic.** Trainer and rollout may use different names, tensor-parallel or
+  expert-parallel layouts, and merged tensors (QKV, gate/up). No model- or engine-specific mapping is
+  hard-coded; the layout is *inferred* by probing your existing `load_weights`.
+- **One integration surface** for collocated, disaggregated-sync, and disaggregated-async modes.
+- **Narrow scope.** It is the transfer layer only — not an RL framework, scheduler, or inference engine.
+
+## Installation
+
+From this directory:
+
+```bash
+pip install -e .
+```
+
+The base install provides the framework-independent package. Optional imports are grouped by use case:
+
+```bash
+pip install -e '.[examples]'          # runnable Ray examples
+pip install -e '.[mooncake,cuda]'     # WeightBridge transfer runtime
+pip install -e '.[checkpoints]'       # direct safetensors checkpoint loading
+pip install -e '.[test]'
+```
+
+The `mooncake` extra installs Mooncake `>= 0.3.12.post1`; EFA deployments may instead preinstall a
+compatible EFA-enabled wheel with the same distribution name.
+
+Monarch is deliberately not a package dependency. It is needed only when importing the Monarch
+backend/examples. Install the version supplied by the surrounding training or serving environment;
+WeightBridge's framework-independent imports do not load it.
+
+WeightBridge intentionally does not ship a paper- or cluster-specific deployment profile. Record exact
+model, topology, container, and transport settings with the experiment that uses them. The examples inherit
+the caller's loader environment and accept node/interface choices explicitly.
+
+## Tiny integration sketch
+
+WeightBridge never parses your model — you describe each runtime with an `AdapterContext` (HF weight
+factories, a fresh worker-state-dict snapshot, and your native `load_weights`), then poll from the
+rollout scheduler and send from the trainer.
+
+```python
+# --- Rollout engine: one coordinator process per engine ---
+from wbridge.backend import coordinator
+from wbridge.backend.control_channel import coordinator_ipc, coordinator_tcp_port
+ipc = coordinator_ipc(server_port)
+coordinator.spawn(ipc, coordinator_tcp_port(server_port))   # rank 0 only
+
+# --- Rollout worker: one per model-parallel rank; poll every scheduler tick, all ranks ---
+from wbridge.frontend.adapters import AdapterContext, ReceiverAdapter
+receiver = ReceiverAdapter(ctx, ipc, num_workers=TP * PP)
+updated = receiver.poll_requests(before_receive=quiesce_runtime)
+if updated:
+    record_consume_end()            # receive + load has completed on this rank
+
+# --- Trainer worker: connect once, send per update ---
+from wbridge.backend.sender import SenderArgs
+from wbridge.frontend.adapters import SenderAdapter
+sender = SenderAdapter(ctx, SenderArgs(world_size=N, receiver_urls=[f"tcp://{host}:{port}"],
+                                       master_addr=addr, master_port=pg_port,
+                                       protocol=rdma_protocol))  # e.g. "efa" or "monarch"
+sender.connect()                   # once
+ev = sender.send_weights()         # per update
+if ev is not None: ev.synchronize()
+```
+
+See the [Integration Guide](docs/integration.md) for the full contract and constraints,
+the [Environment Variables](docs/environment.md) reference for deployment tuning, and
+[`examples/`](docs/examples.md) for a complete runnable demo.
+
+## Documentation
+
+- [Motivation](docs/motivation.md) — why RL weight transfer needs a reusable, shard-routed layer.
+- [Architecture](docs/architecture.md) — the Control, Metadata, and Data planes, and the threading model.
+- [Integration Guide](docs/integration.md) — the framework-agnostic contract + step-by-step checklist.
+- [API Reference](docs/api.md) — the public classes and helpers.
+- [Examples](docs/examples.md) — the runnable 2-node Ray walkthrough.
+- [Environment Variables](docs/environment.md) — defaults, dependencies, transport tuning, and diagnostics.
+- [Assumptions, Limitations & Pitfalls](docs/limitations.md) — read before your first real run.
+
+## Development
+
+```bash
+python -m pytest tests/test_shard_compatibility.py     # overlap / ShardSpec math
+python -m pytest tests/test_query_receivers_metadata.py # receiver metadata routing
+python -m pytest tests/test_fuse_copy.py                # fused transpose-aware copy plans
+python -m pytest tests/test_arena_planner.py            # dedup arena layout
+python -m pytest tests/test_rdma_protocol.py            # flag ping-pong / one-sided protocol
+python -m pytest tests/test_receive_trigger.py          # data-driven KICK/GO state machine
+python -m pytest tests/test_control_channel.py          # ZMQ coordinator + hub
+python -m pytest tests/test_mooncake_engine.py          # Mooncake engine wrapper
+python -m pytest tests/test_local_staging.py            # CPU staging path
+```

--- a/examples/weightbridge/docs/api.md
+++ b/examples/weightbridge/docs/api.md
@@ -1,0 +1,161 @@
+# API Reference
+
+Practical reference for the classes and helpers an integrator uses. See the source modules for
+lower-level transport internals. Import the **frontend adapters** for the normal integration path;
+they don't pull in any framework dependency.
+
+API signatures are deployment-neutral. Select transport and buffer settings for your environment before
+starting workers; see [Environment Variables](environment.md) and the validation checklist in
+[Assumptions, Limitations & Pitfalls](limitations.md).
+
+```python
+from wbridge.frontend.adapters import AdapterContext, SenderAdapter, ReceiverAdapter
+from wbridge.backend.sender import SenderArgs
+from wbridge.backend import coordinator
+from wbridge.backend.control_channel import coordinator_ipc, coordinator_tcp_port
+from wbridge.utils.specgen import hf_weights_from_checkpoint
+```
+
+---
+
+## `AdapterContext`
+
+Framework-neutral inputs; the same dataclass is used on both sides. Fields (all required):
+
+| field | type | meaning |
+|---|---|---|
+| `hf_weights` | `dict[str, Callable[[], Tensor]]` | HF tensor name → zero-arg factory. Called many times; must be re-callable and side-effect-free. |
+| `hf_shapes` | `dict[str, tuple[int, ...]]` | HF tensor name → shape. |
+| `wksd_factory` | `Callable[[], dict[str, Tensor]]` | returns a **fresh** GPU worker-state-dict snapshot each call. |
+| `load_weights` | `Callable[[HFWeightFetcher], Any]` | your native loader, adapted to take the fetcher dict; pure bijective copy/scatter for same-dtype elements. |
+| `rank` | `int` | this adapter's rank. |
+
+See [integration.md](integration.md#the-integration-contract-adaptercontext) for the exact
+requirements. (Older docs mentioned `hf_iter_factory`, `wksd`, or `load_spec_path` — those no longer
+exist.)
+
+## `SenderArgs`
+
+Transport configuration for the sender.
+
+| field | type | meaning |
+|---|---|---|
+| `world_size` | `int` | number of trainer sender ranks in the connect group. |
+| `receiver_urls` | `list[str]` | `tcp://host:port` of each rollout engine's coordinator (one per engine). |
+| `master_addr` | `str` | trainer rank-0 host for the one-time Gloo metadata rendezvous. |
+| `master_port` | `int` | TCP port for that Gloo group. |
+| `protocol` | `str = "efa"` | RDMA backend: `"efa"` (Mooncake on an EFA cluster), `"tcp"` (Mooncake, local/toy runs), or `"monarch"` (libibverbs via Monarch; requires Monarch-actor workers and rules out staging). See [transport backends](architecture.md#transport-backends). |
+| `sender_staging` | `bool = False` | pack → CPU offload → RDMA-from-CPU pipeline; off = straight-from-GPU (validated default). |
+
+## `SenderAdapter`
+
+Trainer-side integration. Construction runs `LoadSpec` inference + verification and builds a
+`WeightSender`.
+
+```python
+adapter = SenderAdapter(ctx, sender_args)
+adapter.connect()                     # once, before the first update
+record_send_start()                   # optional application EWTT marker
+ev = adapter.send_weights()           # per update; returns a CUDA event (or None off-GPU)
+if ev is not None: ev.synchronize()   # weights safe to overwrite
+# Record the application's trainer block_end here, then:
+adapter.flush_profile_outputs()
+```
+
+- `connect() -> None` — queries each coordinator, joins the Gloo rendezvous, registers RDMA buffers,
+  starts the background RDMA thread. Call **once**; reuse for all updates.
+- `send_weights() -> torch.cuda.Event | None` — packs on the calling thread, hands RDMA to the
+  background thread, returns an event that fires when the packed weights are safe to overwrite. One
+  call = one update.
+- `wait_send_complete() -> None` — blocks until the last update is delivered and consumed by all
+  receivers. Only needed for debug/equality checks; production skips it so RDMA overlaps the next step.
+- `flush_profile_outputs() -> None` — release Gantt/control profiling output for the latest epoch. Call
+  only after recording the application's trainer `block_end`; it does not wait for background delivery.
+
+## `ReceiverAdapter`
+
+Rollout-side integration. Construction runs `LoadSpec` inference + verification and builds a
+`WeightReceiver` (eagerly, so it can handshake before transfer).
+
+```python
+adapter = ReceiverAdapter(ctx, controller_ipc_name, num_workers=TP*PP, receiver_staging=False)
+updated = adapter.poll_requests(before_receive=quiesce_runtime)
+if updated:
+    record_consume_end()              # optional application EWTT marker
+    # Record the application's rollout block_end here, then:
+    adapter.flush_profile_outputs()
+```
+
+- `poll_requests(before_receive: Callable[[int], None] | None = None) -> bool` — performs one control
+  round and services its action on the main thread, called every scheduler tick on all ranks. Rank 0
+  peeks its first-round CPU flag and broadcasts KICK/GO. For a real update, `before_receive(epoch)` runs
+  synchronously on every model-parallel rank after GO but before model weights are mutated, allowing the
+  runtime to quiesce inference and cancel admitted requests. The callback must preserve rank lockstep and
+  must not start asymmetric TP/EP work. Empty polls, staging KICKs, and deferred connection setup return
+  `False`; a completed receive+load returns `True`.
+- **EWTT timing hook:** record a trainer `send_start` immediately before `send_weights()` and a rollout
+  `consume_end` immediately after `poll_requests()` returns `True`. Across a distributed deployment,
+  EWTT is the earliest trainer `send_start` to the latest rollout-rank `consume_end`. Use a cross-host
+  wall clock for those endpoints; a process-local monotonic clock cannot be subtracted across nodes.
+- `flush_profile_outputs() -> None` — release Gantt JSONL, control-profile logs, and a requested receiver
+  chrome trace for the latest epoch. Call after recording rollout `block_end`.
+- `num_workers` = the engine's model-parallel process count (`TP × PP`); `receiver_staging` enables the
+  full-epoch CPU landing pipeline. KICK leaves generation running; GO follows rank 0's completed first-round
+  H2D, and every peer then waits for its own corresponding host-side flag.
+
+## Coordinator (control plane)
+
+A standalone ZMQ relay **process**, one per rollout engine. It is not HTTP and holds no torch.
+
+```python
+from wbridge.backend import coordinator
+from wbridge.backend.control_channel import coordinator_ipc, coordinator_tcp_port
+
+ipc = coordinator_ipc(port)                                   # rank0-facing IPC endpoint
+proc = coordinator.spawn(ipc, coordinator_tcp_port(port))     # detached subprocess (Popen)
+```
+
+- `coordinator.spawn(ipc_name, tcp_port) -> subprocess.Popen` — launches the coordinator; it self-exits
+  when the spawning process dies.
+- `coordinator_ipc(port)`, `coordinator_tcp_port(port)`, `hub_addr(port)` — derive the IPC path, the
+  trainer-facing TCP port, and the rank0↔peers hub endpoint deterministically from one per-engine
+  integer, so no address handoff is needed. The trainer connects to `tcp://{host}:{coordinator_tcp_port(port)}`.
+- `WeightReceiverController` — the class the coordinator process runs (`__init__(ipc_name, tcp_endpoint)`,
+  `serve()`, `close()`). You normally use `coordinator.spawn`, not this directly. There is **no**
+  `set_worker_num` and **no** HTTP route — rank 0 auto-registers the receiver count.
+
+## Backend endpoints
+
+`SenderAdapter`/`ReceiverAdapter` own these; use them directly only for a bespoke integration.
+
+- `WeightSender(args, rank, shard_spec, load_spec, wksd)` — `connect()`, `send()`, `wait_send_complete()`.
+- `WeightReceiver(controller_ipc_name, rank, shard_spec, dtype_spec, load_spec, wksd, *, num_workers, receiver_staging=False)`
+  — `poll_requests()`, `stop()`.
+
+## Metadata helpers
+
+From `wbridge.utils.specgen`:
+
+- `hf_weights_from_checkpoint(hf_path) -> (HFWeightFetcher, dict[str, shape])` — builds `hf_weights` +
+  `hf_shapes` from a safetensors (or single-`.bin`) checkpoint via a metadata-only scan.
+- `infer_load_spec(hf_weights, hf_shapes, wksd_factory, load_weights) -> LoadSpec` — probe-based layout
+  inference (run for you by the adapters).
+- `verify_load_spec(hf_weights, wksd_factory, load_spec) -> None` — reconstructs and asserts
+  byte-equality (also run by the adapters).
+- Type aliases: `HFWeightFetcher = dict[str, Callable[[], Tensor]]`, `LoadWeightsFn`, `WksdFactory`.
+
+`ShardSpec`, `BoundShardSpec`, `LoadSpec`, `CopyPlan` (in `wbridge.utils.data`) are the internal
+data-plane types; the adapters produce and consume them — integrators rarely touch them directly.
+
+## Reference adapters
+
+These are **concrete examples** of the adapter pattern, not part of the framework-agnostic API. Read
+them as copy-me templates when writing an adapter for your own runtime; import them directly so
+environments without those dependencies don't import them.
+
+WeightBridge does not declare any inference or training framework as a package dependency. A framework
+adapter subclasses `SenderAdapter` or `ReceiverAdapter` and supplies `hf_weights`, `wksd_factory`, and
+`load_weights` for that runtime.
+
+Each shows the same pattern: wrap an existing `load_weights`, expose HF factories + a state-dict
+snapshot, then defer to `SenderAdapter`/`ReceiverAdapter`.

--- a/examples/weightbridge/docs/architecture.md
+++ b/examples/weightbridge/docs/architecture.md
@@ -1,0 +1,303 @@
+# Architecture
+
+WeightBridge moves updated policy weights from **Trainer Workers** (the training runtime) to
+**Rollout Workers** (the inference/generation runtime) when the two sides use different parameter
+names, tensor layouts, or parallelism. It is organized as three planes:
+
+- **Control Plane** — establishes the connection and keeps rollout ranks in lockstep. ZMQ plus the
+  CPU-resident data-ready sequence flags that trigger each update.
+- **Metadata Plane** — describes *how* each runtime's local tensors map to a common coordinate
+  system (the HuggingFace checkpoint), and computes who must send which bytes to whom. Gloo,
+  used once at connect.
+- **Data Plane** — moves the bytes. One-sided RDMA writes across nodes, with direct CUDA IPC for
+  supported same-node paths.
+
+Weight bytes never travel over the Control or Metadata planes; those planes only carry small
+JSON/metadata messages. The Data Plane is a passive, one-sided design: the receiver never issues a
+collective to pull weights — the sender *writes* into the receiver's registered memory and flips a
+flag the receiver polls. This is the central design choice (see [Threading model](#threading-model)).
+
+```mermaid
+flowchart LR
+    subgraph TrainerEngine["Trainer Engine (one process per shard-owning rank)"]
+        T0["Trainer Worker 0<br/>SenderAdapter → WeightSender"]
+        TN["Trainer Worker N<br/>SenderAdapter → WeightSender"]
+    end
+
+    subgraph Coord["Coordinator (separate process, one per Rollout Engine)"]
+        CO["ZMQ relay<br/>TCP (trainer-facing) ⇄ IPC (rank0-facing)"]
+    end
+
+    subgraph RolloutEngine["Rollout Engine (one process per model-parallel rank)"]
+        R0["Rollout Worker 0<br/>ReceiverAdapter → WeightReceiver"]
+        RM["Rollout Worker M<br/>ReceiverAdapter → WeightReceiver"]
+    end
+
+    T0 -- "ZMQ world_query / connect (rank 0)" --> CO
+    CO -- "IPC connect_request" --> R0
+    R0 -- "hub KICK / GO broadcast (per tick, lockstep)" --> RM
+    T0 -- "one-time Gloo all_gather (specs, buffer addrs)" --> R0
+    T0 == "one-sided RDMA writes + flag ping-pong (bytes)" ==> R0
+    TN == "one-sided RDMA writes + flag ping-pong (bytes)" ==> RM
+```
+
+The system **connects once** and then **streams many updates**. Every buffer, process group, and RDMA
+registration is created at connect and reused for every subsequent update; per-update work is just
+pack → write → flag → consume.
+
+---
+
+## Control Plane (flags + ZMQ lockstep)
+
+Each Rollout Engine runs one standalone **coordinator process** — a thin ZMQ relay with no torch and
+no HTTP. It binds a trainer-facing TCP `ROUTER` and a rank0-facing IPC `ROUTER`. Trainer rank 0 uses it
+for `world_query` and the one-time `connect`; per-update notification normally comes from the sender's
+data-before-flag sequence itself. The old `receive` relay remains only as a fallback when an engine rank 0
+has no trainer input and therefore cannot observe a data flag.
+
+Endpoints are **derived deterministically** from a single per-engine integer (in practice the
+inference server's port), so every process — the coordinator, all Rollout Workers, and the trainer —
+computes the same addresses with no handshake or environment handoff:
+
+- coordinator IPC (rank0-facing): `coordinator_ipc(port)`
+- coordinator TCP (trainer-facing): `coordinator_tcp_port(port)`
+- rank0 ⇄ peers hub: `hub_addr(port)`
+
+Inside a Rollout Engine, rank 0 owns a **hub** (a ZMQ star) to the other model-parallel ranks. Every
+scheduler tick, rank 0 turns its local input flag state into one decision and **broadcasts it to all
+peers, which block for it**. RS uses two decisions: KICK wakes CPU receive workers without stopping
+generation; GO quiesces every TP rank after rank 0's first GPU ingress round is ready. This per-tick
+lockstep keeps all model-parallel ranks entering blocking steps together — see
+[Threading model](#threading-model).
+
+After GO, a peer may still be waiting for its own GPU ingress flag. There is no engine-wide exchange
+barrier: each rank starts external exchange after its own A+R. Before reusing a peer's parity-selected
+`grecv` destination it waits only for that peer's OFFLOAD generation from `D` rounds ago. OFFLOAD means the
+target completed GRECV→DOFF, not that downstream readers finished. Each external DATA flag is published as
+soon as that peer's individual bulk write completes, so one slow destination cannot hold back every peer.
+
+The fused same-node process is called **internal consume**. Each receiver owns a non-RDMA DOFF arena with a
+fixed depth (default one): every generation contains one SEND/PREP shadow plus one exclusive, maximum-sized
+region for each possible external source. There is no common chunk pool, so substantially different receive
+sizes do not fragment or contend for an allocation. After A+R, SEND is copied to the self DOFF region. After
+external DATA, GRECV is copied to that source's DOFF region and OFFLOAD immediately frees GRECV.
+
+The exchange/consume host worker scans every `(column owner, source, DOFF slot)` shared-memory READY sequence
+and dispatches whichever lanes are ready. A peer descriptor kernel reads the owner's DOFF CUDA-IPC mapping
+over NVLink and writes the corresponding model slices directly. DONE from the self kernel and every local
+reader releases only the DOFF slot. Thus reader stragglers may delay reuse at depth one, but cannot extend the
+registered GRECV lifetime after offload.
+
+One endpoint-lifetime waiter per external destination publishes completed writes in sequence; a cross-round
+dispatcher keeps both registered parities live. At depth 2, round `r+1` writes the other GRECV parity without
+waiting for `r`, while `r+2` waits only for `r` OFFLOAD. DOFF reuse has its own cyclic predecessor at
+`round % WBRIDGE_DOFF` and waits for local DONE. These two lifetimes are deliberately independent.
+
+There is **no** `set_worker_num` and **no** HTTP route. Rank 0 auto-registers the engine's receiver
+count with the coordinator at startup, and that is how the coordinator answers the trainer's
+`world_query`.
+
+## Metadata Plane (Gloo, once)
+
+The Metadata Plane makes routing configuration-agnostic. It answers: *given my local sharded
+parameters and yours, which byte ranges do I need to send you?*
+
+- **`LoadSpec`** records how HuggingFace checkpoint tensors map into a runtime's local worker tensors.
+  It can represent the transformations mainstream loaders perform: QKV merge, gate/up merge,
+  row/column-parallel slices, vocab slices, expert stacking, and transpose.
+- WeightBridge **infers** a `LoadSpec` by *symbolically probing the runtime's own `load_weights`
+  function* (see [`specgen`](api.md#metadata-helpers)): it feeds structured index-placeholder tensors
+  through the loader, observes which worker elements they land in, and recovers axis-aligned shard
+  boxes. This relies on `load_weights` being a **pure, bijective copy/scatter** for same-dtype
+  elements — no arithmetic on values (see [limitations](limitations.md#loadspec-inference)).
+- **`ShardSpec`** is the storage-free view derived from `LoadSpec`: which HF-coordinate regions a
+  process owns (sender) or needs (receiver).
+
+At connect, all ranks `all_gather_object` their `ShardSpec`s, dtypes, and registered buffer addresses
+over a **one-time Gloo group**. The `WeightRouter` then compares sender and receiver `ShardSpec`s,
+computes overlaps, and schedules balanced **communication rounds** under a per-rank byte cap. The Gloo
+group carries only this metadata — never weights — and is created without eager device binding to
+avoid deadlocking against the many communicators an inference/training runtime already holds.
+
+## Data Plane (one-sided RDMA)
+
+The Data Plane is a staged pipeline whose only cross-node bulk primitive is a one-sided RDMA **write**:
+
+```text
+Pack(translate) → RDMA write → Fused prepare → External exchange → Internal consume(translate)
+```
+
+- **Pack** copies live trainer parameters into a wire buffer laid out in HF coordinates, applying the
+  sender `LoadSpec` in reverse (worker → HF). Packing runs as a fused, transpose-aware `CopyPlan` in
+  O(1) kernel launches.
+- **RDMA write** transfers the wire buffer directly into the receiver's registered arena. There is no
+  send/recv and no notify: "done" and "consumed" are themselves tiny **flag** writes the peer polls.
+- **Fused prepare / external exchange** prepares each receiver's local de-duplicated column. One copy plan maps RECV
+  directly into canonical `own` plus any unique partial peer payloads; full peer payloads alias `own`,
+  so there is no assemble-then-repack intermediate. Cross-node columns land once in exact compact GRECV
+  slots (see [de-duplication](#de-duplication)).
+- **Internal consume** applies the receiver `LoadSpec` (HF → worker) while reading self or peer DOFF bytes
+  directly into live rollout parameters. One descriptor kernel per independently-ready owner/source slot
+  fuses NVLink transfer, transpose/reshard, and consume.
+
+Transport selection is per destination, and is the same whichever RDMA backend is in use:
+
+- **same-node** device→device bulk → direct CUDA-IPC access over NVLink that bypasses the RDMA engine.
+  Trainer→rollout still uses a peer copy. Receiver internal consume opens the owner's DOFF allocation in the consumer
+  GPU's address space and issues ordinary kernel loads from that mapped address, gated by an exported CUDA
+  event so data and its completion signal share one GPU ordering domain.
+- **cross-node** bulk → the RDMA engine over the fabric (the "bulk" NIC),
+- **cross-node and trainer/rollout flags** (tiny writes) → the RDMA engine; a separate NIC when staging,
+  so a saturating bulk write never starves the concurrent flag handshake.
+- **same-node replica READY/DONE sequences** → a node-local shared CPU bank. The ready sequence only
+  establishes that the producer recorded this generation; the imported CUDA event remains the GPU
+  visibility fence before a peer pulls the bytes.
+
+### Transport backends
+
+The transport is pluggable behind one small ABC, `RdmaEngine` (`backend/rdma/base.py`):
+`init` / `register` / `write` / `write_async` / `write_batch` / `wait` / `close`. Everything above that
+line — routing, dedup, arena management, the flag protocol — is backend-agnostic. `SenderArgs.protocol`
+picks the implementation at connect, and the choice travels to the receivers in the connect payload so
+both sides always agree.
+
+| `protocol` | engine | |
+|---|---|---|
+| `"efa"` | `DualMooncakeEngine` | default; Mooncake over EFA, plus `nvlink_intra` for same-node pairs |
+| `"tcp"` | `DualMooncakeEngine` (`MC_FORCE_TCP=1`) | local/toy runs, no RDMA fabric required |
+| `"monarch"` | `MonarchEngine` | one-sided libibverbs via [Monarch](https://github.com/meta-pytorch/monarch); the workers must themselves be Monarch actors |
+
+(`LocalStagingEngine` is not selectable — it is the in-process GPU↔CPU engine that a staging endpoint
+runs *alongside* its network engine.)
+
+**Mooncake.** Its intra-node transport (`nvlink_intra`, in `DualMooncakeEngine`) is the fallback for
+same-node pairs the IPC bypass cannot cover: a staging endpoint (host DRAM is not IPC-mappable) or an
+allocator that cannot export IPC handles (`expandable_segments`). A Mooncake wheel without that
+transport is not fatal — those writes take the configured Mooncake network transport instead. Because
+EFA round-robins **one NIC per transfer
+request**, each large write is **striped** into configured contiguous sub-transfers in one batch, so a
+single write fans out across all NICs. This turns a single-path transfer into a full-fabric transfer.
+(Native Mooncake RC-QP RDMA does *not* work on EFA; the EFA build is required — see
+[limitations](limitations.md#3-mooncake-on-efa).)
+
+**Monarch.** Addressing is the one real impedance mismatch. A Monarch `RDMABuffer` has **no remote
+offset** — a write always lands at the buffer's base — while the ABC writes to arbitrary remote
+addresses. But every region WeightBridge ever writes into is fixed and enumerable at connect
+(per-`(sender, round)` RECV slots, flag slots, per-peer `grecv` slots), so the owner publishes **one
+buffer per exact `(addr, size)` region** through the optional `publish_regions` hook and the writer looks
+the region up. Publisher and writer tile regions through the same deterministic function
+(`WBRIDGE_MONARCH_CHUNK_BYTES`, default 64 MiB) so lookups match exactly; tiling is what makes an offset
+addressable at all, and the tile size is only a tuning knob — it trades connect time (fewer published
+handles) against nothing measurable in steady state. Monarch binds **one NIC per GPU** by design (device
+memory takes the NIC co-located with its GPU), so it has no equivalent of Mooncake's sub-slicing: at
+equal NIC count it is moderately *faster* than Mooncake, and slower once Mooncake stripes across the
+fabric. Its constraints on the surrounding process are sharp enough to have their own
+[pitfall section](limitations.md#4-monarch-transport).
+
+**Peer-progressive sender bulk.** A receiver's exact prior parity slot is the dependency for a trainer
+write—not the slowest slot among every receiver touched by that round. The Stage-2 sender therefore scans
+the pinned ACK words without blocking, calls `write_async` as soon as each destination becomes eligible,
+and hands the resulting handle to one endpoint-lifetime waiter for that destination. That waiter publishes
+DATA-ready immediately after its own completion. This removes both round-level head-of-line barriers:
+another receiver's late ACK cannot postpone submission, and another transfer's late completion cannot
+postpone DATA-ready. Exact `rdma_peer_<receiver-rank>` Gantt records span the sender's real submission
+timestamp through observed completion, so receiver timelines do not infer ingress start from a local poll.
+
+`write_batch` remains in the backend API for callers whose whole fan-out genuinely shares a dependency and
+completion boundary. That distinction matters for Monarch: coalescing destinations into one action
+materially improved its slowest-rank throughput in the ladder benchmark. WeightSender intentionally gives
+up that cross-destination completion boundary because it cannot both fuse the action and publish a truthful
+per-destination DATA-ready flag. The control plane likewise uses one `write_async` per flag.
+
+### De-duplication
+
+When trainer or rollout parallelism replicates a tensor across ranks, naive routing sends the same
+bytes many times. WeightBridge deduplicates:
+
+- **Senders** send only a disjoint sub-slice of any tensor replicated across senders (the receiver
+  reconstructs by union — no sender-side coordination needed).
+- **Receivers** in an `m`-member replica class each receive only their `1/m` per-tensor slice, then
+  reconstruct the full shard with a per-tensor receiver↔receiver all-to-all over a single packed
+  **arena**. Its `D` parity slots contain only RECV and fused-prepare (`own`/`send`) bytes. A compact
+  `grecv` bank sits after those slots and contains one parity slot per active exact cross-node ingress column. Same-node
+  columns are internally consumed from their owners and allocate no destination slot. Per-source consumed
+  flags prevent an external writer from overwriting a slot still read by any local kernel, including the
+  epoch boundary via a cyclic final-round → first-use dependency. The generic non-topology fallback retains
+  its full peer-partitioned GRECV bank.
+
+Dedup is keyed on canonical, deterministically-sorted shard identities so every rank independently
+agrees on which sub-shard is whose — required because the flag ping-pong is lockstep per pair.
+
+**Group consolidation (`WBRIDGE_DEDUP_PAIR_BYTES`).** A *small* tensor replicated *widely*
+(norms, MoE gates held on every rank) becomes a wide all-gather that costs many per-pair flag handshakes
+while saving almost no RDMA. A deterministic planning-layer pass scans the exchange plan and, for any
+receiver pair whose crossing traffic is below a threshold (`WBRIDGE_DEDUP_PAIR_BYTES`, default `inf`),
+decomposes that wide class into a *partition* of smaller sub-groups — each either an existing smaller
+group it can piggyback on (whose sync edges are already paid) or a singleton (a direct full send from the
+trainer, no exchange). It only rewrites the per-tensor grouping; the arena, exchange, and consume machinery
+are unchanged, so it stays byte-exact. On the representative multi-engine run this collapsed most of each
+receiver's distinct exchange peers (the widely-replicated tensors fold onto existing cross-engine pairs)
+for negligible additional sender RDMA, materially reducing transfer time at high round counts. Aggressive consolidation
+is the library default because it also gives topology-aware exchange one uniform group per
+worker; set the threshold to `0` to retain the natural replica classes.
+
+## Threading model
+
+This is the crux of a correct integration, so it is worth stating precisely.
+
+- The **receiver is an in-process object living inside each Rollout Worker process** — one per
+  model-parallel rank — **not** a separate process. The only separate process is the coordinator.
+- **Readiness decisions and weight consumption run on the Rollout Worker's main (scheduler) thread**,
+  synchronously, inside `poll_requests()`. Every tick, rank 0 non-blockingly peeks
+  its CPU-resident first-round sequence, decides, and broadcasts over the hub; every peer observes the
+  same decision. The coordinator intake thread remains for connect and the zero-input fallback.
+- This **per-tick, rank0-broadcast lockstep is mandatory**: it guarantees all model-parallel ranks
+  enter any blocking step together. A decentralized, per-rank, self-scheduled receiver deadlocks —
+  one rank enters WeightBridge's step while another is still inside the inference runtime's *own* TP/EP
+  collective, and two communicators get entered in opposite order across ranks (a silent circular
+  wait). The one-sided data plane exists for the same reason: the receiver is a passive RDMA *target*
+  and never issues a collective to fetch weights.
+- On the receiver, prepare runs in round order, while the topology-aware 3-stage dispatcher keeps both
+  registered parities active. An exact cyclic OFFLOAD protects each GRECV parity; an independent READY/DONE
+  generation protects each DOFF slot. Same-parity prepare waits only for outbound RDMA reads and its own
+  SEND→DOFF copy, not internal readers. The fixed-DOFF topology path requires 3-stage dispatch.
+- The **sender** runs its RDMA on a persistent background daemon thread, so `send_weights()` returns
+  after packing while the transfer overlaps the next training step.
+- Optional CPU **staging** (sender or receiver) adds background threads that offload/land bytes through
+  host memory; it trades bandwidth for HBM headroom and is off by default. With receiver staging, the
+  first CPU-landed round triggers KICK, the worker receives the complete epoch without stopping SGLang,
+  and only then preloads the first GPU ingress round and publishes the host-side flag that triggers GO.
+
+## Latency tuning (enabled by default)
+
+The wire is chunked into **rounds** under a per-rank byte cap (`WBRIDGE_ROUND_CAP_BYTES`): fewer, larger
+rounds saturate the fabric better and pay less per-round overhead, but need a larger arena. At a fixed
+(small) cap the round count is high, and a depth-1 receiver pays, *per round*, a full
+sender↔receiver round-trip (the sender waits on the receiver's ack before writing the next round) plus a
+serial control-plane handshake. The default library configuration combines the two scheduling features with
+direct asynchronous flag publication:
+
+- **Depth-2 RECV pipeline (`WBRIDGE_RECV_PIPELINE=1`).** Two RECV/SEND/GRECV parity slots let the sender
+  **stream two rounds ahead** instead of blocking on each ack, removing the backpressure round-trip that
+  dominates the per-round wait. External round `r+1` uses the other GRECV parity immediately; only round
+  `r+2` waits for round `r` OFFLOAD.
+- **Topology-aware three-stage receive (`WBRIDGE_TOPO_EXCHANGE=1`, `WBRIDGE_RECV_3STAGE=1`).** Cross-node
+  exchange is reduced to one worker per node; a cross-round worker overlaps independently-gated external
+  exchange + internal consume with landing and fused prepare in the opposite parity slot.
+- **Direct asynchronous flags.** ACK, DATA, and OFFLOAD each reserve an exclusive
+  `(kind, peer, round)` CPU word for the whole transfer epoch. The producing sender/waiter submits
+  `write_async` immediately and does not wait for its completion, so there is no unified queue, slot-reuse
+  fence, or publisher-thread head-of-line blocking. A daemon only retires already-submitted transport
+  handles and reports failures off the protocol path. Persistent per-destination bulk waiters await disjoint
+  handles concurrently and submit DATA immediately after their own completion, preserving
+  data-before-flag ordering without coupling peers.
+
+These mechanisms attack the same per-round control/latency overhead as
+[group consolidation](#de-duplication), so they are partly **substitutes** for latency, although
+consolidation can also change which topology-aware exchange groups are formed. Depth-2, three-stage
+topology-aware exchange, and aggressive consolidation are configurable and on by default; direct
+asynchronous flag publication is the control-plane implementation.
+
+See [integration.md](integration.md) for the exact call sequence and the constraints these impose on a
+host framework, [environment.md](environment.md) for the exact defaults and switch dependencies, and
+[limitations.md](limitations.md) for the failure modes if they are violated.

--- a/examples/weightbridge/docs/environment.md
+++ b/examples/weightbridge/docs/environment.md
@@ -1,0 +1,116 @@
+# Environment variables
+
+WeightBridge uses environment variables for deployment and performance experiments that must be selected
+before worker construction. The public Python API remains the preferred place for topology and endpoint
+configuration; these variables control buffer planning, scheduling, transport tuning, and diagnostics.
+
+Export the variables **before importing `wbridge` and before starting Ray or Monarch workers**. Several
+defaults are captured at module import (`WBRIDGE_ROUND_CAP_BYTES`, `WBRIDGE_SAME_NODE_IPC`, Gantt switches,
+and the transport chunk sizes), while the remaining values are read when an endpoint is constructed. Unless
+a row says otherwise, give every sender and receiver the same value. A mismatched round plan or receive depth
+is a protocol error, not a supported heterogeneous configuration.
+
+## Library defaults
+
+The library defaults enable the GPU-direct pipeline:
+
+```bash
+export WBRIDGE_DEDUP_PAIR_BYTES=inf
+export WBRIDGE_RECV_PIPELINE=1
+export WBRIDGE_RECV_3STAGE=1
+export WBRIDGE_TOPO_EXCHANGE=1
+export WBRIDGE_SAME_NODE_IPC=1
+```
+
+The library's round cap is 2 GiB. Override memory and scheduling values only as a complete, recorded
+deployment profile: changing a cap can also change the number of rounds, buffer footprint, and overlap.
+
+## Planning, buffers, and scheduling
+
+| variable | library default | meaning |
+|---|---:|---|
+| `WBRIDGE_SPECGEN_I64_CAP_BYTES` | `536870912` (512 MiB) | Maximum int64 structured-index slice used while inferring a LoadSpec. Oversized checkpoint sources and worker probe tensors are divided on dimension 0, inferred independently, translated back to physical coordinates, and merged before specgen returns. The loader still sees the original checkpoint names and tensor shapes. `inf` disables logical splitting for equivalence/debug runs; it does not disable the smaller arithmetic tiles used while constructing an index tensor. |
+| `WBRIDGE_LOGICAL_TENSOR_CAP_BYTES` | `134217728` (128 MiB) | Maximum full size of one logical checkpoint-source tensor. Larger tensors are divided into deterministic first-dimension intervals before routing and round planning; model parameters and checkpoint files remain unchanged. `0` disables the translation. A single row larger than the cap or a non-rectangular mapping is rejected rather than copied incorrectly. |
+| `WBRIDGE_REPLICA_RELAY` | `0` | Experimental replica-group relay data plane. Trainers pack once per replication group and send to its node-head; one representative per rollout node relays the canonical assembled payload down a chain while local members consume its depth-2 PREP buffers over CUDA IPC. Adjacent writes, assembles, and consumes are completion-ordered per group/edge; depth-2 parity reuse additionally waits for the exact previous parity ACK/free fence. Requires depth-2 sender/receiver buffers, same-node IPC, and no host staging. |
+| `WBRIDGE_DIRECT_SAME_NODE` | `0` | Single-node direct-consume path. When every trainer and rollout worker is on one host and staging/relay are off, receiver replicas take complete trainer routes and one fused CUDA-IPC kernel reads sender pack buffers directly into live model parameters. The sender's DATA-ready sequence acts as READY after packing and the receiver ACK after the kernel is the source-lifetime fence. RECV/PREP/GRECV/DOFF payload buffers and rollout exchange are skipped. |
+| `WBRIDGE_ROUND_CAP_BYTES` | `2147483648` (2 GiB) | Hard per-receiver byte cap used to divide weights into balanced global rounds. Larger values normally improve fabric efficiency and reduce handshakes, but increase sender pack buffers and receiver ingress/exchange memory. |
+| `WBRIDGE_SENDER_NUM_BUF` | `2` | Number of reusable GPU pack buffers per sender/peer. `2` overlaps packing with the previous round's RDMA; `1` is the memory-saving, non-overlapped control. Values above two are experimental and increase trainer HBM. |
+| `WBRIDGE_TCP_CONTROL` | `0` | Routes inter-node DATA-ready, ACK, READY, and CONS/OFFLOAD sequence records over one persistent full-duplex TCP connection per worker pair on the host-network interface. Bulk weights remain on the selected RDMA data plane, while same-node topology flags remain in shared memory. Each receiver has an independent socket lock and receive loop; set `1` to isolate control-message tail latency from data-plane submission traffic. |
+| `WBRIDGE_COORDINATOR_IPC_DIR` | system temporary directory | Directory for the single-node coordinator and receiver-hub Unix sockets. Set it to a node-local writable directory when the system temporary directory is unavailable or has a restrictive path-length limit. |
+| `WBRIDGE_LOCAL_SHM_DIR` | `/dev/shm` when available, otherwise system temporary directory | Directory for mmap-backed same-node replica flags. It must be visible to all local receiver processes and should reside on memory-backed storage. |
+| `WBRIDGE_RECV_PIPELINE` | `1` | `1` gives the receiver two isolated trainer-ingress slots, two rollout `own/send/topo-send` prepare slots, and two slots per active external GRECV source; `0` gives one of each. At depth one, ACK immediately after A+R gates the trainer's next write into the lone RECV, while SEND and GRECV retain their independent data-plane reuse gates. |
+| `WBRIDGE_RECV_3STAGE` | `1` | Runs external exchange, GRECV→DOFF offload, and internal consume on a progress worker. With depth two the main thread can prepare the opposite SEND parity; with depth one it can pre-land the next ACK-gated RECV and waits for the prior SEND to become free before A+R. The fixed-DOFF topology path requires this setting. |
+| `WBRIDGE_DOFF` | `1` | Number of fixed non-RDMA internal-offload generations. Each generation contains one full SEND/PREP shadow plus one exclusive maximum-sized region per direct external source; differently sized external receives are never pooled. GRECV is OFFLOAD-released after its D2D copy, while this DOFF slot is reused only after all local readers return DONE. |
+| `WBRIDGE_MERGED_RECV_PREP` | `0` | Experimental memory profile. Overlays each of the two trainer RECV slots with its rollout PREP slot, snapshots landed RECV into one epoch-scoped non-RDMA buffer, and performs A+R back into the merged slot. The scratch tensor is released after the final A+R. This lowers persistent and peak HBM at the cost of one D2D snapshot per round and whole-slot backpressure; it requires depth-2 topology-aware three-stage exchange and does not support receiver staging. |
+| `WBRIDGE_DEDUP_PAIR_BYTES` | `inf` | Per-pair crossing-byte threshold for replication-group consolidation. `0` keeps natural tensor replication classes. A positive number dissolves eligible groups whose pair traffic is below the threshold; `inf` is the aggressive production setting and normally reduces each worker to one low-fanout exchange group. Consolidation is an optimization, not a topology eligibility requirement. |
+| `WBRIDGE_TOPO_EXCHANGE` | `1` | Enables topology-aware external exchange + fused internal consume. Replication groups are split into one-worker-per-node columns. Incoming DATA is copied immediately from compact GRECV into the matching source-exclusive DOFF slot; OFFLOAD then frees GRECV independently of local readers. The common 1T2R layout has one consume lane per local GPU. |
+| `WBRIDGE_SAME_NODE_IPC` | `1` | Enables CUDA-IPC for same-node bulk. Internal consume maps each peer's unregistered DOFF allocation and reads it directly from its descriptor kernel; READY/DONE use shared CPU sequences plus CUDA events. `0` is incompatible with a structurally selected compact topology. |
+| `WBRIDGE_RECEIVER_STAGING` | `0` | SGLang-adapter switch that lands the complete update in pinned CPU memory while generation continues. After all local rounds arrive, the worker preloads the first active GPU ingress round; rank 0's host-side GPU-ready flag triggers GO. Host RDMA is slower, direct CUDA IPC is unavailable, and the GPU receiver schedule is serial. |
+
+The receiver allocations for depth `D` are:
+
+```text
+D × isolated trainer RECV (stable lane per sender)
++ D × rollout own/send/topo-send prepare
++ up to D × each active external grecv source slot
++ WBRIDGE_DOFF × (one SEND/PREP shadow + one exclusive max region per external source)
+```
+
+The isolated RECV slot stride is `max_parity(sum_sender(max_round_bytes(sender, parity)))`: padding is paid
+only when a sender's peak occurs in a different round from another sender's peak. In return, no trainer can
+overwrite another trainer's live lane, and ACK dependencies remain local to one trainer/rollout pair.
+
+Consequently `WBRIDGE_RECV_PIPELINE=1` means two RECV buffers, two fused send/prepare buffers, and two
+GRECV parity slots per active external source. Trainer addresses point only into RECV; external RDMA addresses
+point only into SEND/GRECV; internal CUDA-IPC readers map only DOFF. This prevents a later external transfer
+from waiting for readers after the previous GRECV payload has been safely offloaded.
+
+## Transport tuning
+
+| variable | default | meaning |
+|---|---:|---|
+| `WBRIDGE_EFA_SUBSLICE_BYTES` | `16777216` (16 MiB) | Maximum Mooncake request sub-slice. WeightBridge splits a large write into contiguous requests so Mooncake round-robins them across the GPU's EFA paths. `0` disables WeightBridge striping and typically limits one large write to one NIC. Flags and transfers already below the threshold are unchanged. |
+| `WBRIDGE_MONARCH_CHUNK_BYTES` | `67108864` (64 MiB) | Tile size used to publish and address exact Monarch RDMA regions. It is not a correctness limit; larger tiles reduce handle count and connect time. Both peers must use the same value. |
+| `WBRIDGE_MONARCH_SWITCH_INTERVAL` | `0` | If positive, calls `sys.setswitchinterval(value)` in seconds inside a Monarch endpoint. A shorter interval can help synthetic workloads whose Python threads delay RDMA completion messages, but it did not improve the representative workload and is process-global, so it is off by default. |
+
+For Mooncake/EFA deployments, configure these transport-owned variables before importing Mooncake:
+
+| variable | typical value | meaning |
+|---|---:|---|
+| `FI_PROVIDER` | `efa` | Restricts libfabric to the EFA provider so a silent TCP-provider measurement cannot be mistaken for RDMA. |
+| `FI_EFA_USE_DEVICE_RDMA` | `1` | Enables EFA device RDMA for GPU-direct transfers. |
+| `FI_EFA_ENABLE_SHM_TRANSFER` | `0` | Disables libfabric's shared-memory transfer path. WeightBridge handles supported same-node bulk transfers with CUDA IPC. |
+| `MC_PATH_ROUNDROBIN` | `1` | Tells Mooncake to distribute requests over available EFA paths. This works with `WBRIDGE_EFA_SUBSLICE_BYTES`: WeightBridge creates the subrequests and Mooncake assigns their paths. |
+| `MC_NUM_QP_PER_EP` | library fallback `4` | Number of Mooncake queue pairs per endpoint. It must be set before Mooncake is imported and may need tuning for the target fabric. |
+| `MC_EFA_CQ_THREADS` | `1` | Mooncake `>=0.3.12.post1` worker count for the pool that services all EFA completion queues in one transport endpoint. `0` restores the legacy one-busy-poller-per-device behavior and can create excessive CPU polling. It must be set before Mooncake is imported and forwarded to spawned workers. |
+| `MC_FORCE_TCP` | automatic for `protocol="tcp"` | Prevents stock Mooncake from attempting an unsupported RC-QP transport in TCP/toy runs. Do not set it for EFA runs. |
+
+These variables do not replace the deployment requirements: Mooncake must be built with EFA support, and
+Mooncake and NCCL must resolve to a compatible libfabric installation. WeightBridge does not prepend a
+vendor installation directory; configure the system linker or `LD_LIBRARY_PATH` before launching the
+driver so spawned workers inherit the same libraries. See
+[Assumptions, Limitations & Pitfalls](limitations.md#3-mooncake-on-efa).
+
+## Instrumentation and correctness checks
+
+All switches in this section default to off. They can perturb timing or generate substantial output and
+should not be enabled in a production benchmark unless their overhead is being measured.
+
+| variable | value when enabled | meaning |
+|---|---:|---|
+| `WBRIDGE_GANTT` | `1` | Records wall-clock spans for sender, RDMA, receiver, exchange, consume, and waits. Each process writes `gantt_pid<PID>.jsonl`. |
+| `WBRIDGE_GANTT_DIR` | directory | Output directory for Gantt JSONL files. If unset, events go through the logger instead of assuming a shared filesystem path. |
+| `WBRIDGE_PROFILE` | `1` | Adds `wbridge::<operation>` `torch.profiler.record_function` labels to every Gantt span. This is independent of wall-clock Gantt recording. |
+| `WBRIDGE_RECV_PROFILE_WT` | zero-based integer | Captures a PyTorch CPU+CUDA trace around exactly that receiver update. Leave unset to disable. A value at least `1` avoids the cold update. |
+| `WBRIDGE_RECV_PROFILE_DIR` | directory, default system temporary directory | Destination for targeted receiver profiler traces selected by `WBRIDGE_RECV_PROFILE_WT`. |
+| `WBRIDGE_CTL_PROFILE` | `1` | Logs per-epoch control primitives (`w_ack`, `p_recv`, `w_ready`, `p_ready`, `w_cons`, `p_cons`) and sender bulk submit/wait bandwidth. It adds host timers to these operations. |
+| `WBRIDGE_DUMP_LOADSPEC` | directory | Pickles each rank's inferred metadata and tensor shapes for the frameworkless replay harness. Dumps are diagnostic and failures are logged rather than made fatal. |
+| `WBRIDGE_FUSE_SELFCHECK` | `1` | At connect, compares every fused sender pack against the two-stage reference. It allocates temporary full-size scratch buffers and can cause OOM at large scale. |
+| `WBRIDGE_DEDUP_DIAG` | `1` | Prints consolidation and byte-savings summaries and adds per-tensor detail when a fused-copy self-check fails. |
+| `WBRIDGE_XCHECK` | `1` | Computes and logs per-slice `WXCHK` fingerprints on both sides of receiver exchange. The reductions synchronize GPUs and substantially perturb performance. Use `RAY_DEDUP_LOGS=0` so Ray does not collapse records. |
+| `WBRIDGE_TOPO_DEBUG` | `1` | Emits topology-resolution reasons, protocol steps, and machine-readable `WBSTATE` transitions with rank and thread. It is intended for deadlock-cycle reconstruction. |
+| `WBRIDGE_TIMING` | `1` | Logs `wbridge-snap` sender wire-byte maps per rank and round during plan construction. |
+
+Use `WBRIDGE_DEDUP_PAIR_BYTES=0` to disable consolidation. Use `WBRIDGE_RECV_3STAGE=0` to run external
+exchange and internal consume serially inline on the receiver thread; the default progress worker overlaps
+adjacent prepared rounds.

--- a/examples/weightbridge/docs/examples.md
+++ b/examples/weightbridge/docs/examples.md
@@ -1,0 +1,143 @@
+# Examples
+
+`examples/` is a complete, **runnable** 2-node Ray demo that transfers weights from a trainer layout to
+a different rollout layout on a toy model. It is the concrete companion to
+[integration.md](integration.md): every step of the contract appears here in real code, small enough to
+read end to end.
+
+This example demonstrates the API and validates data movement; it is not a production benchmark recipe.
+Choose topology, transport, and memory settings for the target cluster rather than treating its defaults
+as a performance configuration.
+
+## What it demonstrates
+
+- A trainer runtime and a rollout runtime with **different parameter names and layouts**, bridged with
+  no hand-written shard math.
+- `LoadSpec` inference discovering, by probing each side's `load_weights`: QKV merge, gate/up merge,
+  row-parallel and column-parallel slices, vocab slices, and a **transpose** (the rollout stores
+  `down_proj` transposed, exercising the negative-width transpose path).
+- The standalone coordinator process, the poll-driven receiver, and connect-once / send-per-update on
+  the trainer.
+- End-to-end **correctness verification** (see [below](#what-it-verifies)).
+
+## Files
+
+| file | role |
+|---|---|
+| `qwen_tiny.py` | a one-block Qwen2-style toy: builds the HF checkpoint and the two runtime layouts (trainer = Megatron-style packed `linear_qkv`/`linear_fc1`; rollout = SGLang-style stacked `qkv_proj`/`gate_up_proj`, transposed `down_proj`) plus each side's `load_weights`. |
+| `utils.py` | `make_hf_weights` (build the `hf_weights` factory dict + `hf_shapes` from a CPU checkpoint) and Ray node discovery. |
+| `workers.py` | the Ray actors: `RolloutEngine` (spawns the coordinator + `RolloutWorker`s), `RolloutWorker` (builds a `ReceiverAdapter`, polls), `TrainerWorker`/`TrainerEngine` (build a `SenderAdapter`, connect + send). This is the integration reference. |
+| `train.py` | entrypoint: pins Ray nodes, starts both engines, runs one transfer, verifies correctness and (via `check_transports`) that each leg used the transport its placement implies. |
+
+## Running it
+
+The example needs **2 nodes with ≥ 4 GPUs total** (2 trainer + 2 rollout workers). Install Ray and a
+Mooncake build suitable for the selected transport before starting it. If EFA libraries are not on the
+system loader path, set `LD_LIBRARY_PATH` before launching Ray; the example forwards the existing value
+unchanged rather than assuming a vendor-specific installation directory.
+
+From the directory containing `pyproject.toml`, `pip install -e '.[examples]'` installs the declared
+example dependencies. An EFA run may preinstall its fabric-specific Mooncake wheel first.
+
+```bash
+# on each node, after the environment is set up:
+ray start --head              # node A
+ray start --address=<A:port>  # node B
+
+# transfer over Mooncake TCP (default; works without EFA):
+python examples/train.py
+
+# on an AWS EFA cluster, use the RDMA fabric:
+python examples/train.py --network-provider efa --network-interface <efa-iface>
+```
+
+Useful flags/env: `--rollout-ip`/`--trainer-ip` (pin which Ray node is which), `--rollout-port`
+(the per-engine integer the coordinator endpoints derive from), `--network-interface`
+(`NCCL_/GLOO_SOCKET_IFNAME` for the Gloo rendezvous), and `WB_VISIBLE_DEVICES` for replay utilities that
+manually place several ranks inside one Ray actor. See [Environment Variables](environment.md) for the
+buffering, topology, transport, and diagnostic switches inherited by workers.
+
+### Orchestrator: Ray (default) or Monarch
+
+`--orchestrator {ray,monarch}` selects the actor framework the workers run in; **Ray is the default**.
+This is not cosmetic — the Monarch wbridge transport is only reachable from inside a Monarch actor
+(`RDMABuffer`/`RDMAAction` resolve `context()`), so Ray workers can never host it. Ray is the reference
+path for the Mooncake transports.
+
+Monarch is not a WeightBridge package dependency. Install the `torchmonarch` version supplied by the
+target runtime only when using this backend or its examples.
+
+The roles are identical either way: `worker_bodies.py` holds all the actual work, and `workers.py` /
+`workers_monarch.py` are thin actor wrappers around it.
+
+A Monarch run needs worker loops already serving on each node. Start those loops with the scheduler or
+process manager used by your cluster, then pass their addresses explicitly:
+
+```bash
+python examples/train.py \
+  --orchestrator monarch \
+  --protocol monarch \
+  --monarch-workers tcp://<trainer-host>:<port>,tcp://<rollout-host>:<port>
+```
+
+`--protocol {auto,tcp,efa,monarch}` picks the wbridge backend independently of the orchestrator; `auto`
+follows `--network-provider`. `--protocol monarch` requires `--orchestrator monarch`.
+
+Two Monarch quirks the example handles, both of which cost a debugging cycle to find: worker `init` is a
+single **broadcast** (`.call()`), because `ControlChannel`'s constructor is a rendezvous and initializing
+ranks one at a time deadlocks; and each actor explicitly `set_device`s its own GPU, because Monarch's
+`spawn_procs({"gpus": N})` — unlike Ray's `num_gpus=1` — does not set `CUDA_VISIBLE_DEVICES`, so every
+rank would otherwise land on device 0 (and share one NIC).
+
+### Co-located config: validating the NVLink bypass
+
+`--colocate` (or `WB_COLOCATE=1`) pins **both** engines to one Ray node — the placement in which
+WeightBridge skips the network RDMA backend and moves weights with a direct CUDA-IPC copy over NVLink
+([architecture](architecture.md#data-plane-one-sided-rdma)). It needs **1 node with ≥ 4 free GPUs**:
+
+```bash
+ray start --head
+python examples/train.py --colocate                     # asserts the bypass engaged
+WBRIDGE_SAME_NODE_IPC=0 python examples/train.py --colocate   # A/B: forced through the RDMA backend
+```
+
+Either way the run ends with a `check_transports` report and a hard assertion. The evidence is byte
+counters, not log lines: `wire_rdma_bytes` is incremented at the `engine.write_async` call site and
+`wire_ipc_bytes` at the CUDA-IPC `copy_`, so a co-located run must report `wire_rdma_bytes == 0` with
+`wire_ipc_bytes > 0` on **every** trainer and rollout worker — i.e. the transfer engine carried no
+weight bytes at all. `agh_*` is the same split for the rollout↔rollout dedup exchange. Flags are
+excluded: they are 8 bytes and use the selected control path. Per-GPU NVLink link counts (via NVML) are
+printed alongside so you can see what the IPC copies ran over; they are reported rather than asserted because
+NVML reports NVSwitch endpoints, not peer GPUs, on HGX-class nodes.
+
+Running **without** `--colocate` exercises the negative control: the same assertion inverts and
+requires that nothing took the IPC path.
+
+## How it maps to the integration contract
+
+Reading `workers.py` against [integration.md](integration.md):
+
+- **Adapter context (both sides)** — each worker builds the four data fields from the toy model:
+  `make_hf_weights(...)` → `hf_weights` + `hf_shapes`; `wksd_factory=lambda: self.state_dict` (the toy
+  loader copies in place); `load_weights` = the toy loader wrapped to take the fetcher dict
+  (`_wrap_load_weights`). Constructing the adapter runs inference + verification.
+- **Coordinator** — `RolloutEngine.init` derives `coordinator_ipc(port)` and calls
+  `coordinator.spawn(ipc, port)` once; workers connect their `ReceiverAdapter` to the same IPC.
+- **Receiver polling** — `RolloutWorker.recv_weights` loops on `poll_requests()`; a production runtime
+  passes `before_receive` to quiesce local inference before weights are mutated
+  (the example polls until ready; a real engine calls this once per scheduler tick, on all ranks).
+- **Sender** — `TrainerWorker` builds `SenderArgs` with `receiver_urls=["tcp://host:rollout_port"]`,
+  constructs a `SenderAdapter`, calls `connect()` once, then `send_weights()`.
+- **Rank rules** — `num_workers=num_rollout_workers` and per-worker `rank` (the toy is TP-only, so
+  `num_workers = TP`).
+
+To adapt this to a real framework, replace `qwen_tiny.py`'s toy layouts/loaders with your runtime's
+real `state_dict` and `load_weights`, and place the receiver poll in your scheduler loop instead of the
+`recv_weights` loop. A framework adapter does exactly that.
+
+## What it verifies
+
+Each `RolloutWorker` snapshots its loaded weights, then after the transfer `verify()` checks every
+rollout shard against the expected value. Because receive buffers are zero-initialized, a silent
+no-op transfer produces zeros and fails the check — so a passing run is real evidence that bytes moved
+and landed in the right place (see [validation](limitations.md#validation--a-green-run-is-not-a-successful-transfer)).

--- a/examples/weightbridge/docs/integration.md
+++ b/examples/weightbridge/docs/integration.md
@@ -1,0 +1,261 @@
+# Integration Guide
+
+This guide is framework-agnostic: follow it to wire WeightBridge into **any** well-formed RL stack
+that has a training runtime (the *trainer*, which produces updated weights) and an
+inference/generation runtime (the *rollout engine*, which must periodically refresh its weights).
+WeightBridge does not parse your model or own your scheduler — you describe your runtime through a
+small **adapter context**, and drive two calls from your loops.
+
+If you learn best from code, read this alongside [`examples/`](examples.md), a complete, runnable
+2-node Ray demo that implements everything below on a toy model.
+
+The toy example is an API demonstration, not a performance configuration. Before benchmarking, freeze
+the target cluster's placement, transport environment, library versions, and measurement window in the
+experiment artifact rather than in the reusable library tree.
+
+---
+
+## The three pieces
+
+| Piece | How many | What it is |
+|---|---|---|
+| **Coordinator** | one per rollout engine | a standalone ZMQ relay **process** you spawn; not part of any worker |
+| **Receiver** (`ReceiverAdapter`) | one per rollout **model-parallel rank** | lives inside each rollout worker process; receives + loads weights |
+| **Sender** (`SenderAdapter`) | one per trainer **shard-owning rank** | lives inside each trainer worker process; packs + sends weights |
+
+You keep these long-lived: build once, reuse for every update. Never construct them per update, and
+never lazily from a request handler.
+
+---
+
+## The integration contract: `AdapterContext`
+
+WeightBridge never introspects your model. On **both** sides you supply an `AdapterContext` — five
+things — and it infers everything else (the layout mapping, the routing, the RDMA plan) from them:
+
+```python
+from wbridge.frontend.adapters import AdapterContext
+
+ctx = AdapterContext(
+    hf_weights=hf_weights,        # dict[str, Callable[[], Tensor]]  — HF name → zero-arg factory
+    hf_shapes=hf_shapes,          # dict[str, tuple[int, ...]]       — HF name → shape
+    wksd_factory=wksd_factory,    # Callable[[], dict[str, Tensor]]  — fresh GPU worker-state-dict
+    load_weights=load_weights,    # Callable[[HFWeightFetcher], Any] — your native loader, adapted
+    rank=rank,                    # int                              — this adapter's rank
+)
+```
+
+Requirements — each is load-bearing:
+
+1. **`hf_weights`** — maps every HuggingFace checkpoint tensor name to a **zero-arg factory** returning
+   that tensor (on CPU is fine). The factory is called **many times** (probe, restore, verify) and must
+   be re-callable and side-effect-free — yield a fresh/cloned tensor if the underlying storage is
+   shared. For a standard safetensors checkpoint, don't write this yourself:
+   `hf_weights, hf_shapes = wbridge.utils.specgen.hf_weights_from_checkpoint(path)` builds both from a
+   metadata-only scan (O(1) per-tensor reads).
+2. **`hf_shapes`** — HF name → shape; used to size the index-probe tensors.
+3. **`wksd_factory`** — returns a **fresh snapshot of your live GPU worker state dict** on each call.
+   It must be a *factory*, not a captured dict, because inference happens after the loader runs and the
+   loader may *replace* parameter tensors (e.g. MoE expert fusion). If your loader does strictly
+   in-place `copy_`, `lambda: wksd` is sufficient; if it swaps tensors, pass the model's `state_dict`
+   method. Values must be CUDA tensors.
+4. **`load_weights`** — your framework's **existing** weight loader, adapted to the signature
+   `load_weights(hf_weights: dict[str, Callable[[], Tensor]]) -> Any` and writing into your params.
+   WeightBridge probes it to learn your layout, so it must satisfy two properties:
+   - a **pure, bijective copy/scatter** for same-dtype elements — only layout ops (`copy_`, `narrow`,
+     `view`, `reshape`, `permute`, `transpose`, `split`, `cat`, `index_select`, `scatter_`, …), never
+     arithmetic on values (no scaling, quantization, normalization inside `load_weights`);
+   - it accepts the **complete** name→factory dict each call (some loaders do cross-rank comms, e.g.
+     broadcasting tied embeddings, and break on a partial dict).
+   Most mainstream dense/MoE loaders already satisfy this in bf16; see
+   [limitations](limitations.md#loadspec-inference) for the assumptions and known exceptions.
+5. **`rank`** — this adapter's rank (see [rank rules](#rank--worker-count-rules)).
+
+Constructing a `SenderAdapter`/`ReceiverAdapter` with the context runs the whole metadata plane
+(`infer_load_spec` → `verify_load_spec`) at construction. `verify_load_spec` reconstructs your worker
+tensors from the checkpoint through the inferred spec and asserts byte-equality, so a bad adapter
+context fails loudly at build time, not silently at transfer time.
+
+> **Both sides must present the same source format.** specgen infers one canonical spec (from the HF
+> checkpoint) and assumes the trainer and the rollout each expose weights that map to *that same*
+> reference. If the two sides expose **different source formats** — e.g. one presents its raw
+> parallel/native layout while the other presents the HF reference layout — specgen aligns them against
+> mismatched references: the transfer completes but **merged and grouped tensors silently come out
+> wrong** (fused QKV, fused gate/up, and especially **grouped MoE experts**), failing the equality
+> check while simpler tensors still pass. Note that `verify_load_spec` validates the *receiver* against
+> the checkpoint, so it will **not** catch a trainer that exposes an unexpected source format — you must
+> ensure the trainer exposes weights in the **same reference format** the rollout loads from.
+
+> Writing an adapter for a new framework is essentially: wrap your existing `load_weights`, expose the
+> HF factories + a state-dict snapshot. You write **no** shard/layout math — it is inferred.
+
+---
+
+## Rank & worker-count rules
+
+- **Trainer:** every rank that owns a shard of the model is a sender; `SenderArgs.world_size` is the
+  number of such ranks. `rank` is that rank.
+- **Rollout:** one receiver per **model-parallel** process. `rank` and `num_workers` must count the
+  full model-parallel grid: **`num_workers = TP × PP`**, and `rank = TP_size × PP_rank + TP_rank`
+  (the global model-parallel rank). Do **not** multiply by data-parallel size (DP replicas share the
+  TP processes) or expert-parallel size (experts reshard within TP ranks). Keying on bare `TP_rank`
+  with PP > 1 collides ranks and spawns a coordinator per stage.
+
+---
+
+## Step-by-step
+
+### Rollout side (receiver)
+
+1. **Choose one deterministic integer per engine** (e.g. your inference server's port) and derive the
+   control endpoints from it so trainer and all ranks agree with no handoff:
+   ```python
+   from wbridge.backend.control_channel import coordinator_ipc, coordinator_tcp_port
+   ipc = coordinator_ipc(port)
+   ```
+2. **On rank 0 only, spawn the coordinator process** (once per engine):
+   ```python
+   from wbridge.backend import coordinator
+   coord_proc = coordinator.spawn(ipc, coordinator_tcp_port(port))  # detached subprocess
+   ```
+3. **In every model-parallel worker process**, after weights are loaded but **before** other large
+   allocations (so specgen + RDMA registration have free HBM), build the context and the receiver:
+   ```python
+   from wbridge.frontend.adapters import ReceiverAdapter
+   adapter = ReceiverAdapter(ctx, ipc, num_workers=TP*PP)   # rank came from ctx
+   ```
+4. **Drive the receiver from your scheduler/generation loop, on every tick, on all ranks in
+   lockstep:**
+   ```python
+   pending_epoch = [None]
+
+   def before_receive(epoch):
+       pending_epoch[0] = epoch
+       quiesce_and_cancel_requests(epoch)
+
+   if adapter.poll_requests(before_receive=before_receive):
+       record_rollout_consume_end(pending_epoch[0])
+       record_rollout_block_end()
+       adapter.flush_profile_outputs()
+   ```
+   Put this call in *every* path the loop can take — including any idle/paused wait where no batches
+   are running — so an update can land whenever the trainer sends one. `poll_requests()` performs the
+   control round, may complete deferred connect setup, and performs the blocking receive+load only when
+   there is work. Its optional hook receives the update epoch and runs after GO but before weights are
+   mutated. The call returns `True` only when weights were applied.
+
+### Trainer side (sender)
+
+5. **Expose each engine's coordinator URL to trainer rank 0** as `tcp://{host}:{coordinator_tcp_port(port)}`
+   (rank 0 collects one per engine).
+6. **Rank 0 picks a Gloo rendezvous** (its own host + a free port) and broadcasts
+   `[receiver_urls, master_addr, master_port]` to all trainer ranks (over your existing trainer group).
+7. **Every trainer rank builds the context and the sender:**
+   ```python
+   from wbridge.backend.sender import SenderArgs
+   from wbridge.frontend.adapters import SenderAdapter
+   sender_args = SenderArgs(
+       world_size=num_trainer_ranks,
+       receiver_urls=receiver_urls,     # ["tcp://host:port", ...], one per engine
+       master_addr=master_addr,
+       master_port=master_port,
+       protocol=rdma_protocol,           # "efa" for Mooncake/EFA or "monarch" for Monarch RDMA
+   )
+   adapter = SenderAdapter(ctx, sender_args)
+   ```
+8. **All trainer ranks call `connect()` once** (barrier first). While they do, the **rollout side must
+   already be calling** `poll_requests()`, because connect is driven through the poll loop: the
+   coordinator relays `connect` to receiver rank 0, which joins the same Gloo rendezvous during a
+   `poll_requests()` call. WeightBridge handles the ordering internally (fire connect → join Gloo → gather
+   acks); your only obligation is that the rollout loop is running.
+
+### Per update
+
+9. **Trainer:** each time the rollout engine should get a fresh policy version:
+   ```python
+   record_trainer_send_start(epoch)
+   ev = adapter.send_weights()   # packs on the calling thread; RDMA runs in the background
+   if ev is not None:
+       ev.synchronize()          # weights are now safe to overwrite for the next training step
+   record_trainer_block_end()
+   adapter.flush_profile_outputs()
+   ```
+   That's it — no collective with the rollout engine, no pause.
+10. **Rollout:** nothing extra — the sender's first data-ready flag wakes rank 0, and the poll from step 4
+    applies the update. There is no normal per-update trainer→coordinator doorbell.
+
+### EWTT measurement hooks
+
+For an end-to-end weight-transfer measurement, use application-owned structured events around the two
+API calls above:
+
+- Emit `send_start(epoch)` on every participating trainer rank immediately before its
+  `send_weights()` call, after any pre-send barrier. Do not place it at the outer update entry or before
+  unrelated pause/preparation work.
+- Emit `consume_end(epoch)` on every rollout model-parallel rank immediately after
+  `poll_requests()` returns `True`, before generation resumes, scheduler bookkeeping runs, or profiling
+  output is flushed.
+- Compute `EWTT(epoch) = max(consume_end wall time) - min(send_start wall time)` across all trainer
+  ranks, rollout ranks, and rollout engines. Use a synchronized cross-host wall clock such as
+  `time.time_ns()` for the endpoints; retain `time.monotonic_ns()` only for within-process diagnostics.
+- Measure performance with expensive equality/debug gates disabled. Use a separate gate-on run as
+  correctness evidence, because readback and completion waits change the measured interval.
+
+This boundary includes packing, background delivery, receive/assemble, and the native weight load. It
+does not confuse the sender's pack-handoff event with completion, which is important because
+`send_weights()` is intentionally asynchronous.
+
+---
+
+## Ordering & correctness constraints
+
+These follow directly from the [threading model](architecture.md#threading-model). Violating them
+deadlocks or silently corrupts weights.
+
+- **Enter in lockstep.** Call `poll_requests()` on **all** model-parallel ranks
+  every tick, driven by rank 0's broadcast. Never self-schedule per rank, never skip ranks.
+- **Treat GO as quiescence.** Rank 0 emits GO on its own first GPU-ingress readiness. Every peer stops
+  scheduler/TP work on that decision, then waits for its own readiness before assemble/repack; it must not
+  continue inference independently after rank 0 leaves the TP path. Each external-slot internal-consume kernel
+  then depends only on that exact slot's READY. A per-slot cyclic aggregate CONS protects its next external
+  generation after every local reader kernel finishes; unrelated slots and ranks impose no exchange barrier.
+- **Never pause the rollout engine around the transfer.** A blanket "pause generation" bracket inside
+  the update path deadlocks the flag handshake (a paused receiver won't complete its lockstep role).
+  Enforce on-policy freshness at the **orchestration layer** — drain in-flight rollouts *before*
+  triggering the update — not by pausing the engine.
+- **Keep the rollout loop running during `connect()`.** Connect is a rendezvous between trainer rank 0
+  and receiver rank 0; if the rollout side isn't polling, connect blocks.
+- **`send_weights()` returns after packing, not after delivery.** Call `ev.synchronize()` before you
+  overwrite the packed weights. Delivery overlaps your next step; only debug flows need
+  `wait_send_complete()`.
+
+## Reconnect & teardown
+
+- **Reconnect** (e.g. new rollout engines appear): re-run the connect path. WeightBridge tears down
+  the old RDMA engine, unregisters buffers, and destroys the Gloo group before rebuilding, so
+  `connect()` is idempotent.
+- **Teardown** currently relies on process death: the sender's RDMA thread and the receiver's daemons
+  are `daemon=True`, and the coordinator process self-exits when its spawning parent dies. For
+  deterministic shutdown call `WeightReceiver.stop()` and terminate the coordinator `Popen` yourself.
+
+## Sync vs. async
+
+The same calls serve both modes; only *where you place them* differs:
+
+- **Sync / on-policy:** the trainer calls `send_weights()` at the update barrier; the rollout applies
+  it before continuing. Achieve on-policy by draining rollouts before the update.
+- **Async / off-policy:** the trainer returns after `ev.synchronize()` and continues training while
+  the RDMA overlaps; the rollout applies the update whenever its poll next reports ready.
+
+## Redundancy checklist (common mistakes)
+
+- **Don't** call `connect()` before every send — connect once, then only `send_weights()`.
+- **Don't** create an HTTP server or route weight readiness through your engine's internal messaging —
+  the coordinator is a process and the receiver polls.
+- **Don't** construct adapters/coordinator lazily from request handlers — build them at init.
+- **Don't** wrap the transfer in a generation pause (see above).
+- **Don't** hand-write shard math — provide a correct `load_weights` and let specgen infer it.
+
+For the pitfalls that cause silent failures (transport zero-transfer, dedup correctness, transpose/dtype),
+read [limitations.md](limitations.md) before your first real run. For per-class API details, see
+[api.md](api.md).

--- a/examples/weightbridge/docs/limitations.md
+++ b/examples/weightbridge/docs/limitations.md
@@ -1,0 +1,215 @@
+# Assumptions, Limitations & Pitfalls
+
+Read this before your first real run. Several failure modes here are **silent** — the job exits 0 while
+no weights actually moved — so the section ends with how to validate.
+
+Treat the values in this document as library defaults or observed operating points, not as a portable
+benchmark profile. Freeze and validate the complete environment in the experiment artifact for each
+deployment.
+
+---
+
+## `LoadSpec` inference
+
+WeightBridge learns your layout by probing your `load_weights` (see
+[architecture](architecture.md#metadata-plane-gloo-once)). That probe is valid only when:
+
+1. **`load_weights` is a pure, bijective copy/scatter for same-dtype elements.** Each destination
+   element is an exact bitwise copy of exactly one source element. Only layout operations are allowed
+   (`copy_`, `narrow`, `select`, `view`, `reshape`, `permute`, `transpose`, `split`, `chunk`, `cat`,
+   `index_select`, `scatter_`, `contiguous`). **Any arithmetic on values** — scaling, addition,
+   clamping, quantization, normalization — corrupts the probe. Post-load hooks that requantize are
+   fine *as long as* they run **after** `load_weights` returns (they usually do).
+2. **Same dtype on both sides** for each `(hf_name, worker_name)` pair. The probe encodes indices using
+   the worker tensor's element size; a differing HF element size corrupts them. Trust an inferred spec
+   only for same-dtype source/dest pairs.
+3. **The full name→factory dict is passed each call** (some loaders do cross-rank comms, e.g.
+   broadcasting tied embeddings under PP > 1).
+4. **Shard mappings are rectangular**, between tensors of equal dimensionality; each contiguous
+   component is a rectangular box; >2D tensors map as a single component.
+
+**Verified** for mainstream dense and MoE models (Llama, Qwen, Mistral, DeepSeek, GLM) in bf16.
+**Known exceptions** (arithmetic inside `load_weights`, so incompatible unless bypassed): Gemma-1
+(`+= 1.0` on norms), AMD-HIP INT4 MoE scaling, DeepSeek NvFP4 requant, `flash_rl` per-token-group FP8
+quant, BitsAndBytes 4-bit. `verify_load_spec` (run at adapter construction) will fail loudly if your
+loader violates these — trust that assertion.
+
+---
+
+## Pitfalls
+
+### 1. The in-process receiver must enter every step in lockstep
+The receiver is a thread inside each rollout worker process, not a separate process. If model-parallel
+ranks enter WeightBridge's blocking step at different times, one rank can be inside a WeightBridge
+collective while another is still inside your runtime's own TP/EP collective → two communicators
+entered in opposite order → a **silent, intermittent deadlock**. **Avoid:**
+drive `poll_requests()` on **all** ranks every tick via rank 0's hub broadcast
+(the built-in behavior) — never per-rank/self-scheduled, and keep the control notification on the main
+thread. This is *the* headline constraint.
+
+### 2. Never pause the rollout engine around the transfer
+A "pause generation" bracket inside the update path deadlocks the flag handshake (a paused receiver
+won't complete its lockstep role); `pause`/`flush` return 200 OK, masking it. **Avoid:** enforce
+on-policy freshness by draining in-flight rollouts at the orchestration layer *before* the update.
+
+### 3. Mooncake on EFA
+- **Mooncake must be built with EFA support.** Mooncake is the default RDMA backend; on an EFA fabric
+  select it with `protocol="efa"` (native RC-QP `"rdma"` does not work on EFA — no reliable-connection
+  QPs), or `protocol="tcp"` for a local/toy run (the engine sets `MC_FORCE_TCP=1`). Supplying an
+  EFA-capable Mooncake build, and a runtime in which it can actually reach the EFA fabric, is an
+  **environment/deployment responsibility** that is intentionally out of scope for this library doc —
+  see your stack's own setup/deployment guide for the concrete steps.
+- **Use Mooncake `>=0.3.12.post1` and keep `MC_EFA_CQ_THREADS=1`.** Older EFA builds start one
+  busy-polling completion-queue thread for every discovered EFA device. With one WeightBridge endpoint
+  per GPU this can produce hundreds of pollers per node, contend with NCCL and trainer CPU work, and make
+  the integration appear to slow compute even while weight transfer itself is fast. The upstream bounded
+  worker pool removes that cliff; `MC_EFA_CQ_THREADS=0` is only a diagnostic legacy-behavior control.
+- **A mis-deployed transport can silently move zero bytes** — Mooncake can report `initialize`
+  success yet enumerate no usable device, so transfers no-op while the run stays green. Never treat a
+  clean exit as proof bytes moved; always gate with the equality check (see *Validation*).
+- **Bandwidth needs striping.** EFA round-robins one NIC per transfer request, so a single big write can
+  ride only one path. WeightBridge stripes large writes according to `WBRIDGE_EFA_SUBSLICE_BYTES`;
+  the default performed well on the evaluated cluster, but should be retuned for a different fabric.
+- **Host (CPU-staged) RDMA can be substantially slower than GPUDirect** and needs each rank pinned to a
+  distinct switch-local NIC with a NUMA-local staging buffer; bulk and flags must use separate NICs or a
+  saturating bulk write can starve the flag handshake. Prefer the default straight-from-GPU path unless
+  HBM headroom forces staging, and measure the tradeoff on the target cluster.
+
+### 4. Monarch transport
+Selected with `protocol="monarch"`. It is only reachable from inside a Monarch actor, and it imposes
+constraints on the *surrounding process* that Mooncake does not. Each of the first three fails **without
+a usable error** — a hang, or a panic that is not an exception.
+
+- **Do not enable `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`** — despite Monarch warning at
+  import that it is "required to maximize RDMA performance with CUDA tensors". A CUDA VMM segment is
+  mapped from physical granules piecewise and one ibverbs MR cannot span such a range, so large writes
+  fail in a repeatable periodic pattern (`IBV_WC_REM_ACCESS_ERR` / `IBV_WC_LOC_PROT_ERR`). **Small
+  transfers do not trip it**, so a toy example passes and the
+  real model does not — and the failure reads like an addressing bug, not an allocator one. This also
+  puts the bandwidth that warning promises out of reach.
+- **Never block the actor's event loop.** An RDMA completion arrives as a *message to the submitting
+  actor*, so an endpoint that blocks its own loop waiting on that completion can never observe it: the
+  transfer wedges forever with nothing in any log. Run all WeightBridge work on a **dedicated thread per
+  actor** — one thread, not a pool, because `torch.cuda.set_device` is thread-local and a pool scatters
+  ranks onto device 0. `MonarchEngine.wait()` raises rather than hangs if called on a live loop.
+- **The actor context is a `contextvar` and does not reach WeightBridge's own threads** (the sender's
+  RDMA thread and the receiver's progress/waiter threads). Calling from a thread without it trips a Rust
+  panic that is **not an `Exception` subclass** — `except Exception` will not catch it — and it poisons
+  the actor's dispatch loop, making it unrecoverable rather than degradable. `MonarchEngine` installs the
+  context on every thread it is called from, and installs the context *value* rather than reusing a
+  shared captured `Context`: a `Context` cannot be entered twice, so two threads submitting concurrently
+  would raise `cannot enter context: already entered`.
+- **Staging is unsupported** — `protocol="monarch"` with sender or receiver staging raises at connect.
+  Beyond the missing plumbing it would be a poor trade: Monarch hash-spreads *host* memory across NICs
+  instead of pinning it to the GPU-local one, and a CPU-pinned destination measured substantially worse.
+- **One NIC per GPU, by design.** Device memory is bound to the NIC co-located with its GPU, so there is
+  no equivalent of Mooncake's configurable sub-slicing across the switch's NICs. Per-rank bandwidth is one
+  NIC's worth. Monarch wins a like-for-like comparison at equal NIC count; on a fabric with several NICs
+  per GPU, striping is worth more than that margin.
+- **Bring-up quirks** — mesh transport configuration, passing peer meshes as constructor arguments,
+  awaiting mesh initialization before pickling — belong to the orchestration layer rather than the
+  transport; see [examples](examples.md#orchestrator-monarch-default-or-ray).
+
+### 5. Transport performance traps
+Latent in any backend whose completions are delivered through Python, and both are easy to measure past.
+
+- **Batch throughput and peer-progress latency are different objectives.** A synchronized fan-out may run
+  faster as one backend action: on Monarch, splitting destinations barely moved median bandwidth but
+  materially reduced the slowest rank's throughput. WeightSender instead submits each
+  destination independently because its ACK and DATA-ready boundary is peer-specific; otherwise one slow
+  receiver stalls every unrelated receiver. Always measure end-to-end worker blocking as well as aggregate
+  bandwidth when changing this tradeoff; a median-only benchmark misses both peer head-of-line blocking and
+  the batched-action straggler spread.
+- **CPU-bound Python in the same process can throttle RDMA.** Where a completion is delivered as an actor
+  message it needs the GIL to be observed: the bytes have landed but the wait cannot return. On a
+  synthetic ladder, competing CPU-bound Python work severely reduced Monarch's bandwidth. The
+  representative workload was *not* in this regime — `sys.setswitchinterval` recovered the synthetic
+  loss and changed nothing meaningful on the real run — but any deployment that adds a busy Python thread
+  to a rollout worker should re-measure. It is GIL *handoff latency*, not CPU starvation, so shortening
+  the switch interval is the lever (`WBRIDGE_MONARCH_SWITCH_INTERVAL`, off by default because it is
+  process-global and costs context switches in compute-heavy Python). Mooncake polls its completion queue
+  in C++ with the GIL released and is structurally immune.
+
+### 6. De-duplication correctness
+Replica-aware transfer is subtle; the built-in implementation handles it, but if you touch it:
+receiver dedup must key on the **whole** receive spec (not per-tensor), consume must use an
+**intersection** mapping (a partial `1/m` slice is not "contained"), the receiver↔receiver exchange
+must preserve exact source ownership, and reused external ingress slots need an aggregate
+**consumed-flag** handshake (a fast writer must not overwrite a slot until self and every local
+internal-consume reader kernel have finished).
+Reductions must be deterministic across ranks (sorted keys) or the flag ping-pong desyncs.
+
+### 7. Layout / transpose / dtype
+- **Transpose** must be honored on **every** copy path (it is encoded as a negative width in the shard
+  tuple). A model that stores a tensor transposed relative to the checkpoint (e.g. a RowParallel
+  `down_proj`) will be silently wrong if a copy path ignores it. The bundled path handles transpose;
+  the example deliberately includes a transposed tensor to exercise it.
+- **Split shards on a contiguous axis.** Splitting the longest axis of a wide tensor yields strided
+  sub-shards and a substantially slower copy kernel. (Correctness-neutral, large perf trap; the planner
+  auto-picks contiguous vs. strided.)
+- **Multi-destination HF names use the widest destination dtype** for the wire buffer.
+
+### 8. Ordering & synchronization
+- There is no transport notify primitive: cross-node "done"/"consumed" signals are tiny flag writes the
+  peer polls. A blocking write returns only after data lands, which makes the subsequent flag safe —
+  preserve **data write → flag write** and the globally-monotonic sequence. Same-node replica peers publish
+  that sequence through shared CPU memory, but must still preserve **CUDA event record → CPU sequence →
+  imported event wait → internal-consume kernel**.
+- The RDMA engine is unordered w.r.t. CUDA kernels — synchronize after the fused pack before writing.
+- Cached copy plans bind to **address-stable** buffers (in-place params, reused wire buffers).
+
+### 9. Memory / OOM
+Wire buffers and the arena scale with the round cap, all inside the rollout's free HBM. At receiver depth
+`D`, the topology arena is `D × (RECV + fused own/send prepare)` plus up to `D` exact cross-node GRECV ingress
+slots per active source; same-node internal-consume columns have no local staging allocation. The generic
+fallback retains the same peer-partitioned, parity-buffered GRECV bank.
+Tune `WBRIDGE_ROUND_CAP_BYTES` to free HBM; allocations near 80% of the remaining free HBM emit a warning.
+Keep logical/pack buffers transient or fused — don't cache many persistent ones. Real-weight validation can also hit a **cgroup** memory limit
+(not host OOM) mid-registration; lean the config if so.
+
+---
+
+## Validation — a green run is not a successful transfer
+
+The single most dangerous failure class is a **silent no-op** (zero-transfer from a libfabric conflict,
+or a swallowed transport return code). Do not trust timings or exit codes alone:
+
+- Validate with a **zero-init equality check**: on the rollout, snapshot params → reset → transfer →
+  compare. Receive buffers are zero-initialized, so a no-op yields zeros and the compare fails. (The
+  example does exactly this via `verify_all`.)
+- Add hard asserts on every transport return code (`initialize`/`register_memory`: `!= 0` is error;
+  `batch_transfer_sync_write`: `< 0` is error).
+- Confirm the fabric is actually in use before trusting bandwidth: under Mooncake, `FI_PROVIDER=efa` and
+  the `efa` provider in the logs. Under Monarch this one is already enforced — `MonarchEngine.init`
+  refuses to start unless the backend reports `ibverbs`, because a silent TCP fallback measures the wrong
+  thing while looking healthy.
+- Benchmark **steady state**, not the first transfer — connect, registration, and warmup impose a large
+  one-time cost, while later transfers stabilize.
+
+---
+
+## Current simplifications
+
+These are implementation choices, not fundamental limits:
+
+- **Transfers are split into byte-capped rounds, run in sequence.** Within a round, packing and consume
+  are *fully fused* — the transpose-aware model↔wire copy (both packing stages collapsed into one plan)
+  replays as O(1) Triton launches per dtype group, not tensor-by-tensor. The remaining granularity is
+  the round: a transfer is chunked to `WBRIDGE_ROUND_CAP_BYTES` (default 2 GiB) and the cap must be
+  sized to the rollout's free HBM (wire buffers are double-buffered, the dedup arena scales with the
+  cap; see the Memory / OOM pitfall above).
+- **Pipelining is partial.** The sender's RDMA overlaps the next training step (background thread +
+  double-buffered wire buffers), and on the receiver the sender's RDMA-fill of the next round's landing
+  zone overlaps current work (the zones are disjoint). The depth-2/3-stage dispatcher may keep both prepared
+  parity rounds' E+C work active; exact per-destination generation gates serialize only reuse of the same
+  stable slot, while source-slot kernels remain readiness-driven and independent. The **pack runs synchronously on the
+  caller's thread**, so its cost sits on the training critical path. Optional CPU **staging** (off by default) overlaps the
+  transfer with generation at the cost of substantially lower host-RDMA bandwidth; the validated default transfers
+  straight from GPU.
+- **Cross-engine / data-parallel matching is the caller's responsibility.** The router computes shard
+  overlaps and deduplicates *within* a replica class, but does not infer cross-engine replica
+  equivalence or decide which trainer ranks feed which rollout engine. A tensor replicated wider than
+  its class is under-deduplicated (sent more than once) — never incorrect, just less bandwidth saved.
+- **Teardown relies on process death** (daemon threads + the coordinator's parent-death watchdog); there
+  is no wired-in graceful shutdown — call `WeightReceiver.stop()` and terminate the coordinator `Popen`
+  if you need one.

--- a/examples/weightbridge/docs/motivation.md
+++ b/examples/weightbridge/docs/motivation.md
@@ -1,0 +1,202 @@
+# Motivation
+
+WeightBridge is an open source library for efficient, reusable weight transfer
+between RL trainer runtimes and rollout or inference runtimes.
+
+Modern RL systems often train a policy in one distributed runtime and serve
+rollouts in another. The trainer may store parameters as Megatron-style
+tensor-parallel shards, while rollout may expect SGLang, vLLM, or another
+inference layout. Weight updates therefore need to solve two problems at once:
+move bytes quickly, and translate between runtime-specific parameter layouts.
+
+WeightBridge focuses on this boundary. It is not a complete RL framework,
+scheduler, or inference engine. It provides the transfer layer that those systems
+can reuse.
+
+## Weight Transfer In RL
+
+A typical RL pipeline has a Trainer Engine that updates policy weights and a
+Rollout Engine that serves prompts, generates samples, and periodically refreshes
+its model copy.
+
+```mermaid
+flowchart LR
+    subgraph Trainer["Trainer Engine"]
+        T0["Trainer Worker 0"]
+        T1["Trainer Worker N"]
+    end
+
+    subgraph Rollout["Rollout Engine"]
+        R0["Rollout Worker 0"]
+        R1["Rollout Worker M"]
+    end
+
+    T0 -- "policy weight update" --> R0
+    T0 -- "policy weight update" --> R1
+    T1 -- "policy weight update" --> R0
+    T1 -- "policy weight update" --> R1
+    Rollout -- "rollout samples" --> Trainer
+```
+
+The update mode determines how directly weight transfer affects system
+performance:
+
+| Deployment mode | Policy mode | Is weight transfer on the critical path? | Why it matters |
+| --- | --- | --- | --- |
+| Collocated | On-policy | Yes | Rollout must use the latest policy, so training waits for weight update before generating the next batch. |
+| Disaggregated sync | 1-off-policy | Yes | Trainer and rollout are separated, but each synchronized round still waits for the weight update boundary. |
+| Disaggregated async | Unbounded off-policy | No, it can overlap with compute | Transfer can run while training or rollout continues, but slow updates increase policy staleness. |
+
+The first two modes mainly turn weight-transfer latency into lower throughput.
+The async mode can hide some transfer time behind compute, but it still cares
+about update freshness: stale rollout weights affect scheduling, sample
+distribution, and convergence.
+
+## Existing Frameworks Leave A Gap
+
+RL frameworks usually include a weight update mechanism, but it is often tied to
+one runtime pairing, one execution mode, or one communication strategy.
+
+| System / approach | Bandwidth optimal | Supports sync mode | Supports async mode | Hard-coded models | Hard-coded parallelism | Other limitations |
+| --- | --- | --- | --- | --- | --- | --- |
+| SLIME-style Megatron + SGLang integration | No, all-gather plus broadcast, GPU to GPU | Yes | No | Yes | No | Collocated/sync-oriented path; transfer logic is tied to the supported stack. |
+| VeRL-style integrated runtime | No, all-gather plus broadcast, GPU to GPU | Yes | No | Yes | No | Default assumptions favor collocated sync execution rather than a reusable transfer layer. |
+| AReaL-style sync systems | No, all-gather plus broadcast, GPU to GPU | Yes | No | Yes | No | Sync-oriented and framework-owned. |
+| Async direct-write designs | No, usually all-gather plus broadcast into rollout GPUs | No | Yes | Yes | No | Can write rollout weights while inference is running, which risks correctness bugs. |
+| StreamRL-style async systems | No, all-gather plus broadcast, GPU to GPU | No | Yes | Yes | No | Often requires additional GPU buffers for async update. |
+| Laminar-style CPU-staged systems | No, all-gather plus broadcast through GPU-CPU-GPU paths | No | Yes | Yes | No | Requires each node's CPU memory to hold large weights and pays CPU staging cost. |
+| P2P frameworks in production | Yes for the targeted layout | Usually one mode | Usually one mode | Yes | Yes | Efficient inside one production setup, but difficult to reuse when model, parallelism, or runtime pairing changes. |
+| WeightBridge | Yes, routes shard overlaps | Yes | Yes | No | No | Focused on the weight-transfer layer; surrounding RL scheduling remains the framework's responsibility. |
+
+These systems are valuable end-to-end RL stacks. The gap is that weight transfer
+itself is rarely packaged as a layout-aware, mode-independent library. A team
+that changes model family, tensor-parallel size, rollout engine, or sync/async
+policy often has to rewrite framework-specific synchronization code.
+
+## Performance: All-Gather And Broadcast Move Too Much
+
+The common baseline is to reconstruct broad tensor views with all-gather and then
+broadcast those views to rollout workers. This is easy to implement because it
+uses standard collectives and existing save/load paths, but it sends much more
+data than each destination actually needs.
+
+```mermaid
+flowchart TB
+    subgraph AG["All-gather + broadcast"]
+        A0["Trainer shard 0"] --> AF["Full or broad tensor view"]
+        A1["Trainer shard 1"] --> AF
+        AF --> AR0["Rollout shard 0"]
+        AF --> AR1["Rollout shard 1"]
+    end
+
+    subgraph Routed["Overlap-routed transfer"]
+        P0["Trainer shard 0"] -- "needed slice" --> PR0["Rollout shard 0"]
+        P0 -- "needed slice" --> PR1["Rollout shard 1"]
+        P1["Trainer shard 1"] -- "needed slice" --> PR0
+        P1 -- "needed slice" --> PR1
+    end
+```
+
+The waste grows with parallelism:
+
+- With TP8, a transfer that could be shard-routed can become roughly 8x larger.
+- With EP256, expert weights can create roughly 256x avoidable traffic when each
+  destination needs only a subset.
+- With MoE and sparse models, total stored parameters grow quickly while
+  activated parameters per token stay comparatively stable.
+
+DeepSeek-style MoE scaling illustrates the trend. DeepSeek-V3 has
+[671B total parameters and 37B activated parameters][deepseek-v3]. DeepSeek-V4-Pro
+has [1.6T total parameters and 49B activated parameters][deepseek-v4-api]. In
+other words, total stored parameters grow by about 2.4x, while activated
+parameters grow by about 1.3x.
+
+That ratio matters for RL weight update. Inference and training compute scale
+more closely with activated parameters, but a naive weight update path moves
+stored weights. DeepSeek-V4 also reports that, at 1M context, V4-Pro uses only
+[27% of the single-token inference FLOPs and 10% of the KV cache][deepseek-v4-card]
+compared with DeepSeek-V3.2. As model architectures make per-token compute more
+efficient while resident weights keep growing, all-gather/broadcast can consume
+a larger share of the time and bandwidth budget.
+
+WeightBridge targets this mismatch directly: each receiver should get only the
+logical tensor regions it needs.
+
+## Flexibility: The Configuration Space Is Large
+
+Performance alone is not enough. RL weight transfer also has to handle a large
+configuration space:
+
+- different trainer and rollout runtimes
+- different parameter names
+- different tensor-parallel or expert-parallel layouts
+- different sharding sizes on the trainer and rollout sides
+- merged tensors such as QKV or gate/up projections
+- row-parallel, column-parallel, vocab, and expert shards
+- collocated, disaggregated sync, and disaggregated async deployment modes
+
+Many existing implementations hard-code two things:
+
+- **Format translation**: model-specific rules for how trainer tensors map into
+  rollout tensors.
+- **Execution configuration**: sync-only, async-only, collocated-only, or
+  runtime-pair-specific assumptions embedded into the update protocol.
+
+That can be workable for one production configuration, but it is fragile for open
+source users who want to mix frameworks, change sharding, or experiment with
+policy freshness.
+
+WeightBridge treats HuggingFace checkpoint tensors as a common logical coordinate
+system. Each runtime describes how its local tensors relate to that coordinate
+system, and WeightBridge computes the overlaps between sender and receiver
+regions. The goal is to make the efficient path also the reusable path.
+
+## What This Motivates
+
+WeightBridge exists because RL weight transfer needs all of the following at the
+same time:
+
+- shard-level bandwidth efficiency instead of full-tensor broadcast
+- reusable format translation instead of model-specific synchronization code
+- one integration surface for collocated, disaggregated sync, and disaggregated
+  async modes
+- enough separation from the surrounding RL framework that trainers, rollout
+  engines, and custom research systems can adopt only the transfer layer
+
+The rest of the documentation describes how WeightBridge provides that layer:
+
+- [Architecture](architecture.md) explains the Data Plane, Metadata Plane, and
+  Control Plane.
+- [Integration Guide](integration.md) shows how Trainer Workers and Rollout
+  Workers call the adapter APIs.
+- [API Reference](api.md) documents the public classes and helpers.
+- [Examples](examples.md) is a runnable end-to-end walkthrough.
+- [Limitations](limitations.md) documents current assumptions, caveats, and pitfalls.
+
+## Non-Goals
+
+WeightBridge intentionally keeps a narrow scope:
+
+- It is not a full RL framework.
+- It does not own rollout scheduling.
+- It does not define the RL algorithm.
+- It does not require trainer and rollout runtimes to share internal parameter
+  names.
+- It does not guarantee that every arbitrary loader transformation can be inferred
+  without adapter support.
+
+## Summary
+
+Current RL frameworks often lack both the performance needed for the latest large
+models and the flexibility needed for the broad RL configuration space. Many
+systems rely on all-gather/broadcast, which wastes bandwidth, or embed
+runtime-specific P2P logic that is hard to reuse.
+
+WeightBridge turns weight update into a reusable library layer. It uses
+parallelism-agnostic metadata and overlap routing so RL systems can avoid
+unnecessary traffic without committing to one hard-coded model, sharding layout,
+or update mode.
+
+[deepseek-v3]: https://api-docs.deepseek.com/news/news1226
+[deepseek-v4-api]: https://api-docs.deepseek.com/news/news260424
+[deepseek-v4-card]: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro

--- a/examples/weightbridge/examples/analyze_consolidate.py
+++ b/examples/weightbridge/examples/analyze_consolidate.py
@@ -1,0 +1,165 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Offline analysis of the dedup group-consolidation pass on captured LoadSpecs (no Ray/GPU).
+
+Rebuilds the exact WeightRouter the real run builds (all sender + receiver ShardSpecs in global rank
+order), then compares the exchange plan with ``WBRIDGE_DEDUP_PAIR_BYTES=0`` vs the requested threshold:
+
+  * # exchange groups (per-tensor classes of size >= 2), # singletons (0-peer direct receives)
+  * total directed exchange pairs (proxy for control-plane flag handshakes)
+  * trainer->rollout RDMA bytes (rises: each sub-group re-fetches its full shard from the trainer)
+  * receiver<->receiver exchange bytes (falls: dissolved groups stop all-gathering)
+
+Run inside the container on ONE node (no Ray needed):
+    python3 examples/analyze_consolidate.py --specs <dir> [--threshold-mb 20]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import torch  # noqa: F401  (ShardSpec dtypes)
+from loadspec_replay import group_records, load_records, summary
+from wbridge.backend.router import WeightRouter
+from wbridge.utils.data import shards_nbytes, ShardSpec
+
+
+def build_all_specs(recs):
+    """All sender + receiver ShardSpecs in global rank order (senders 0..ws-1, then engines packed
+    contiguously onto the receiver rank space, mirroring bench_transfer's engine_base)."""
+    senders, engines = group_records(recs)
+    ws = len(senders)
+    all_specs = [ShardSpec(senders[r]["src_shard_spec"]) for r in sorted(senders)]
+    dtype_spec: dict = {}
+    for r in sorted(senders):
+        for name, dt in senders[r]["dtype_spec"].items():
+            dtype_spec.setdefault(name, dt)
+    for eid in engines.keys():  # engine_base packs engines contiguously
+        for lr in sorted(engines[eid]):
+            rec = engines[eid][lr]
+            all_specs.append(ShardSpec(rec["src_shard_spec"]))
+            for name, dt in rec["dtype_spec"].items():
+                dtype_spec.setdefault(name, dt)
+    return all_specs, ws, dtype_spec
+
+
+def plan_metrics(router, classes):
+    """(groups>=2, singletons, directed_pairs, exchange_bytes, peerset) for a {name:[class,...]} plan.
+
+    peerset[ri] = union of distinct exchange peers of receiver ri across ALL tensors — the real
+    control-plane driver (a flag ping-pong is per (peer, round); piggybacking onto an already-active
+    peer is free, so what matters is how many DISTINCT peers each receiver must handshake)."""
+    from collections import defaultdict
+
+    groups = singles = pairs = xbytes = 0
+    peerset = defaultdict(set)
+    for name, cls in classes.items():
+        for c in cls:
+            k = len(c)
+            sb = shards_nbytes(
+                router.recv_specs_full[c[0]][name], router.dtype_spec[name]
+            )
+            if k >= 2:
+                groups += 1
+                pairs += k * (
+                    k - 1
+                )  # directed peer pairs (each pulls from every other)
+                xbytes += sb * (k - 1)  # total bytes pulled across the class
+                cs = set(c)
+                for ri in c:
+                    peerset[ri] |= cs - {ri}
+            else:
+                singles += 1
+    return groups, singles, pairs, xbytes, peerset
+
+
+def trainer_bytes(router):
+    """Total trainer->rollout RDMA bytes = sum over (receiver, sender) overlap of the (deduped) recv spec."""
+    tot = 0
+    for ri in range(router.receiver_ws):
+        for si in range(router.sender_ws):
+            ov = ShardSpec.compute_overlap(router.send_specs[si], router.recv_specs[ri])
+            tot += ov.nbytes(router.dtype_spec)
+    return tot
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--specs", required=True)
+    ap.add_argument("--threshold-mb", type=float, default=20.0)
+    a = ap.parse_args()
+
+    recs = load_records(a.specs)
+    print(summary(recs), flush=True)
+    all_specs, ws, dtype_spec = build_all_specs(recs)
+    thr = str(int(a.threshold_mb * 1024 * 1024))
+
+    # OFF: natural class-based dedup.
+    os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = "0"
+    r_off = WeightRouter(
+        rank=0, sender_ws=ws, all_specs=all_specs, dtype_spec=dict(dtype_spec)
+    )
+    cls_off = r_off.recv_tensor_classes()
+    g0, s0, p0, xb0, ps0 = plan_metrics(r_off, cls_off)
+    tb0 = trainer_bytes(r_off)
+
+    # ON: consolidated sub-groups at the given pair threshold.
+    os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = thr
+    r_on = WeightRouter(
+        rank=0, sender_ws=ws, all_specs=all_specs, dtype_spec=dict(dtype_spec)
+    )
+    cls_on = r_on.recv_tensor_classes()
+    g1, s1, p1, xb1, ps1 = plan_metrics(r_on, cls_on)
+    tb1 = trainer_bytes(r_on)
+
+    GB = 1024**3
+    print(
+        f"\n=== dedup consolidation @ threshold {a.threshold_mb:.0f} MB (world={len(all_specs)}, "
+        f"senders={ws}, receivers={r_off.receiver_ws}, tensors={len(cls_off)}) ==="
+    )
+    print(f"{'metric':<34}{'OFF':>16}{'ON':>16}{'delta':>16}")
+
+    def row(lbl, off, on, unit=""):
+        d = on - off
+        print(f"{lbl:<34}{off:>16}{on:>16}{('%+d' % d):>14}{unit:>2}")
+
+    row("exchange groups (size>=2)", g0, g1)
+    row("singletons (0-peer direct)", s0, s1)
+    row("directed exchange pairs", p0, p1)
+    print(
+        f"{'exchange bytes (recv<->recv)':<34}{xb0 / GB:>15.3f}G{xb1 / GB:>15.3f}G{(xb1 - xb0) / GB:>+14.3f}G"
+    )
+    print(
+        f"{'trainer->rollout RDMA bytes':<34}{tb0 / GB:>15.3f}G{tb1 / GB:>15.3f}G{(tb1 - tb0) / GB:>+14.3f}G"
+    )
+    # Distinct exchange peers per receiver — the control-plane driver (fewer peers = fewer flag handshakes).
+    tot0 = sum(len(ps0[r]) for r in range(r_off.receiver_ws))
+    tot1 = sum(len(ps1[r]) for r in range(r_off.receiver_ws))
+    mx0 = max(len(ps0[r]) for r in range(r_off.receiver_ws))
+    mx1 = max(len(ps1[r]) for r in range(r_off.receiver_ws))
+    row("sum distinct peers (all recv)", tot0, tot1)
+    row("max distinct peers (one recv)", mx0, mx1)
+    print(
+        "per-receiver distinct peers  OFF:",
+        [len(ps0[r]) for r in range(r_off.receiver_ws)],
+        "\n                             ON :",
+        [len(ps1[r]) for r in range(r_off.receiver_ws)],
+    )
+
+    # Show the tensors whose class was actually decomposed (the wide-small ones the pass targets).
+    changed = [(n, cls_off[n], cls_on[n]) for n in cls_off if cls_off[n] != cls_on[n]]
+    print(f"\ndecomposed tensors: {len(changed)}")
+    for n, before, after in sorted(changed, key=lambda x: x[0])[:25]:
+        sb = shards_nbytes(r_off.recv_specs_full[before[0][0]][n], r_off.dtype_spec[n])
+        print(f"  {n[:60]:<60} {sb / 1024:.0f}KB  {before} -> {after}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/bench_bodies.py
+++ b/examples/weightbridge/examples/bench_bodies.py
@@ -1,0 +1,254 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Orchestrator-agnostic bodies for the frameworkless 30B replay.
+
+Same split as :mod:`worker_bodies` does for the toy example: the *work* — rebuild the captured specs,
+construct a real ``WeightSender``/``WeightReceiver``, run K transfers, digest the result — lives here, and
+:mod:`bench_transfer` (Ray) and :mod:`bench_monarch` (Monarch) each wrap it in their own actor type. Monarch
+RDMA is only reachable from inside a Monarch actor, so the second wrapper is not optional if we want to
+measure that transport on the real 30B layout.
+
+Correctness is the reason this module exists rather than the bodies staying inline in ``bench_transfer``:
+the replay was perf-only (``torch.empty`` worker values, no check), and comparing two transports needs the
+values to be reproducible. With ``--seed`` the sender's shards are fixed by ``(name, rank)`` and each
+receiver digests its post-consume wksd; the digests must be identical under Mooncake and under Monarch.
+That is a full-path equivalence check — real 30B sharding, dedup exchange and consume — with no
+Megatron/SGLang in the loop.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import socket
+import time
+
+import torch
+from loadspec_replay import rebuild, wksd_digest
+from utils import apply_network_env, network_env_vars
+from wbridge.backend.receiver import WeightReceiver
+from wbridge.backend.sender import SenderArgs, WeightSender
+
+# Distinct salts per role. The receiver's wksd starts as *its own* deterministic noise, not the sender's,
+# so a region the transport silently never wrote does not accidentally already hold the right bytes.
+SENDER_SALT = "wbridge-replay-sender"
+RECEIVER_SALT = "wbridge-replay-receiver"
+
+
+def _wait_for_replay_drain(barrier, participant: str, epoch: int) -> None:
+    """Join the replay-only full-drain barrier for one completed epoch.
+
+    The barrier is deliberately outside WeightBridge.  A receiver arrives only after
+    ``poll_requests()`` has joined its E+C worker and synchronized CUDA; a sender arrives only after
+    ``wait_send_complete()``.  Consequently the barrier's release proves that no participant can start
+    epoch N+1 while any participant is still draining epoch N.
+    """
+    if barrier is None:
+        return
+    if not participant:
+        raise ValueError("replay drain barrier requires a participant id")
+    import ray
+
+    ray.get(barrier.arrive.remote(participant, epoch))
+
+
+def _load(rec_path: str) -> dict:
+    with open(rec_path, "rb") as f:
+        return pickle.load(f)
+
+
+class ReplayReceiverBody:
+    """One captured rollout rank: a real :class:`WeightReceiver` over the recorded LoadSpec."""
+
+    def init(
+        self,
+        rec_path: str,
+        ipc: str,
+        num_workers: int,
+        provider: str,
+        iface: str,
+        phys_dev: int,
+        seed: bool = False,
+    ) -> int:
+        apply_network_env(provider, iface)
+        # Distinct physical GPU per rank, so receiver<->receiver dedup exchange is genuinely cross-device
+        # (as under SGLang) rather than a same-device memcpy that would flatter the numbers.
+        torch.cuda.set_device(phys_dev)
+        if os.environ.get("WBRIDGE_HBM_DEBUG"):
+            free_bytes, total_bytes = torch.cuda.mem_get_info()
+            print(
+                "WBHBM_ACTOR "
+                f"stage=receiver_device_selected host={socket.gethostname()} pid={os.getpid()} "
+                f"rank=unknown requested_device={phys_dev} current_device={torch.cuda.current_device()} "
+                f"visible={os.environ.get('CUDA_VISIBLE_DEVICES', '')} "
+                f"free_bytes={free_bytes} total_bytes={total_bytes}",
+                flush=True,
+            )
+        rec = _load(rec_path)
+        self.rank = rec["rank"]
+        src, dtype_spec, load_spec, wksd = rebuild(
+            rec, seed_salt=RECEIVER_SALT if seed else ""
+        )
+        self.wksd = wksd
+        if os.environ.get("WBRIDGE_HBM_DEBUG"):
+            free_bytes, total_bytes = torch.cuda.mem_get_info()
+            print(
+                "WBHBM_ACTOR "
+                f"stage=receiver_model_allocated host={socket.gethostname()} pid={os.getpid()} "
+                f"rank={self.rank} requested_device={phys_dev} current_device={torch.cuda.current_device()} "
+                f"visible={os.environ.get('CUDA_VISIBLE_DEVICES', '')} "
+                f"free_bytes={free_bytes} total_bytes={total_bytes} "
+                f"allocated_bytes={torch.cuda.memory_allocated()} reserved_bytes={torch.cuda.memory_reserved()}",
+                flush=True,
+            )
+        self.receiver = WeightReceiver(
+            ipc,
+            rec["rank"],
+            src,
+            dtype_spec,
+            load_spec,
+            wksd,
+            num_workers=num_workers,
+            receiver_staging=bool(rec.get("receiver_staging")),
+        )
+        self._recv_timings: list[dict[str, int]] = []
+        return self.rank
+
+    def run_recv(
+        self,
+        k_updates: int,
+        timeout_s: float = 1800.0,
+        drain_barrier=None,
+        participant: str = "",
+    ) -> int:
+        self._recv_timings = []
+        got, t_end = 0, time.time() + timeout_s
+        while got < k_updates:
+            if time.time() > t_end:
+                raise TimeoutError(
+                    f"receiver rank {self.rank}: {got}/{k_updates} updates"
+                )
+
+            start_ns = None
+            mono_start_ns = None
+
+            def before_receive(_epoch: int) -> None:
+                nonlocal start_ns, mono_start_ns
+                # These are the replay equivalent of the rollout block_start/consume_end markers:
+                # the receiver has observed the update and is about to enter the blocking receive,
+                # exchange, and in-place consume path. Wall time is intentional because E2E spans nodes;
+                # the per-rank monotonic duration is retained as a clock-skew-independent cross-check.
+                start_ns = time.time_ns()
+                mono_start_ns = time.perf_counter_ns()
+
+            updated = self.receiver.poll_requests(before_receive=before_receive)
+            if updated:
+                mono_end_ns = time.perf_counter_ns()
+                end_ns = time.time_ns()
+                assert start_ns is not None and mono_start_ns is not None
+                self._recv_timings.append(
+                    {
+                        "epoch": got,
+                        "block_start_ns": start_ns,
+                        "consume_end_ns": end_ns,
+                        "block_end_ns": end_ns,
+                        "block_duration_ns": mono_end_ns - mono_start_ns,
+                    }
+                )
+                # All replay timing boundaries above are fixed before trace/control-profile output.
+                self.receiver.flush_profile_outputs()
+                _wait_for_replay_drain(drain_barrier, participant, got)
+                got += 1
+            else:
+                time.sleep(0.005)
+        return got
+
+    def timings(self) -> dict:
+        """Return lightweight replay timestamps collected outside the transfer's CUDA work."""
+        return {"rank": self.rank, "epochs": list(self._recv_timings)}
+
+    def digest(self) -> dict:
+        """Post-consume content digest. Compared across transports, never inside the timed loop."""
+        return {"rank": self.rank, "digest": wksd_digest(self.wksd)}
+
+
+class ReplaySenderBody:
+    """One captured trainer rank: a real :class:`WeightSender` over the recorded LoadSpec."""
+
+    def init(
+        self,
+        rec_path: str,
+        sender_args: SenderArgs,
+        provider: str,
+        iface: str,
+        phys_dev: int,
+        seed: bool = False,
+    ) -> int:
+        apply_network_env(provider, iface)
+        torch.cuda.set_device(phys_dev)
+        rec = _load(rec_path)
+        self.rank = rec["rank"]
+        src, dtype_spec, load_spec, wksd = rebuild(
+            rec, seed_salt=SENDER_SALT if seed else ""
+        )
+        self.wksd = wksd
+        self.sender = WeightSender(sender_args, rec["rank"], src, load_spec, wksd)
+        self._send_timings: list[dict[str, int]] = []
+        return self.rank
+
+    def run_send(self, k_updates: int, drain_barrier=None, participant: str = ""):
+        t0 = time.time()
+        self.sender.connect()
+        connect_s = time.time() - t0
+        wtts = []
+        self._send_timings = []
+        for epoch in range(k_updates):
+            t = time.time()
+            send_start_ns = time.time_ns()
+            mono_start_ns = time.perf_counter_ns()
+            ev = self.sender.send()
+            if ev is not None:
+                ev.synchronize()
+            trainer_end_ns = time.time_ns()
+            trainer_block_ns = time.perf_counter_ns() - mono_start_ns
+            self.sender.wait_send_complete()  # block until delivered + consumed by all receivers
+            local_complete_ns = time.time_ns()
+            local_complete_duration_ns = time.perf_counter_ns() - mono_start_ns
+            wtts.append(time.time() - t)
+            self._send_timings.append(
+                {
+                    "epoch": epoch,
+                    "send_start_ns": send_start_ns,
+                    "trainer_end_ns": trainer_end_ns,
+                    "trainer_block_ns": trainer_block_ns,
+                    "local_complete_ns": local_complete_ns,
+                    "local_complete_duration_ns": local_complete_duration_ns,
+                }
+            )
+            # Preserve both the report block and the optional full-delivery timing before emitting files/logs.
+            self.sender.flush_profile_outputs()
+            _wait_for_replay_drain(drain_barrier, participant, epoch)
+        nr = getattr(self.sender, "num_rounds", -1)
+        return self.rank, connect_s, wtts, nr
+
+    def timings(self) -> dict:
+        """Return trainer enqueue/block timestamps without changing the legacy replay result tuple."""
+        return {"rank": self.rank, "epochs": list(self._send_timings)}
+
+    def plan_stats(self) -> dict:
+        router = getattr(self.sender, "router", None)
+        return {
+            "rank": self.rank,
+            "planner_mode": getattr(router, "planner_mode", "unknown"),
+            "rounds": len(getattr(router, "global_rounds", ())),
+            "rollout_rdma_peak_bytes": getattr(
+                router, "planned_rollout_rdma_peak_bytes", None
+            ),
+        }
+
+    def digest(self) -> dict:
+        return {"rank": self.rank, "digest": wksd_digest(self.wksd)}

--- a/examples/weightbridge/examples/bench_monarch.py
+++ b/examples/weightbridge/examples/bench_monarch.py
@@ -1,0 +1,279 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Frameworkless replay of a captured 30B weight transfer, on **Monarch** actors + the Monarch RDMA
+transport — the counterpart of :mod:`bench_transfer` (Ray + Mooncake).
+
+Same captured layout, same bodies (:mod:`bench_bodies`), same report (:mod:`bench_report`); only the
+process layer and the transport differ. That is the point: with ``--seed`` both front-ends digest each
+receiver's post-consume weights, so ``bench_report.compare_digests`` can assert Monarch delivered
+byte-identical bytes through the real 30B sharding, dedup exchange and consume path — and the warm WTTs
+sit side by side on identical work.
+
+Monarch RDMA is only reachable from inside a Monarch actor (``RDMABuffer`` and ``RDMAAction.submit``
+both resolve ``context().actor_instance``), so a Ray actor cannot host it and this second front-end is
+required rather than convenient.
+
+Placement mirrors ``bench_transfer``: all rollout engines on the rollout node (so cross-engine dedup
+exchange takes NVLink), all senders on the trainer node, each rank on its own GPU.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from bench_bodies import ReplayReceiverBody, ReplaySenderBody
+from bench_report import report_run
+from loadspec_replay import group_records, load_records, summary
+from monarch.actor import Actor, endpoint
+from monarch_common import ActorThread, attach_hosts, bind_gpu, host_index, my_rank
+from wbridge.backend import coordinator
+from wbridge.backend.control_channel import coordinator_ipc
+from wbridge.backend.sender import SenderArgs
+
+
+class BenchReceiverActor(Actor):
+    """One captured rollout rank. All work is dispatched off the actor's event loop — see ActorThread."""
+
+    def __init__(self) -> None:
+        self._b = ReplayReceiverBody()
+        self._t = ActorThread("wb-bench-recv")
+
+    @endpoint
+    async def init(
+        self,
+        rank_to_path: dict,
+        ipc: str,
+        provider: str,
+        iface: str,
+        engine_base: int,
+        seed: bool,
+    ) -> int:
+        # ONE broadcast to the whole mesh: the receiver's ControlChannel constructor is a rendezvous
+        # across the engine's ranks, so initializing them one at a time deadlocks on rank 0.
+        rank = my_rank()
+        path = rank_to_path[rank]
+        dev = (
+            engine_base + rank
+        )  # distinct physical GPU per rank -> cross-device dedup exchange
+        await self._t.run(bind_gpu, dev)
+        return await self._t.run(
+            self._b.init, path, ipc, len(rank_to_path), provider, iface, dev, seed
+        )
+
+    @endpoint
+    async def run_recv(self, k_updates: int) -> int:
+        return await self._t.run(self._b.run_recv, k_updates)
+
+    @endpoint
+    async def digest(self) -> dict:
+        return await self._t.run(self._b.digest)
+
+
+class BenchSenderActor(Actor):
+    def __init__(self) -> None:
+        self._b = ReplaySenderBody()
+        self._t = ActorThread("wb-bench-send")
+
+    @endpoint
+    async def init(
+        self,
+        rank_to_path: dict,
+        args: SenderArgs,
+        provider: str,
+        iface: str,
+        seed: bool,
+    ) -> int:
+        rank = my_rank()
+        await self._t.run(bind_gpu, rank)
+        return await self._t.run(
+            self._b.init, rank_to_path[rank], args, provider, iface, rank, seed
+        )
+
+    @endpoint
+    async def run_send(self, k_updates: int):
+        return await self._t.run(self._b.run_send, k_updates)
+
+
+class BenchCoordinatorActor(Actor):
+    """Runs one engine's ZMQ coordinator subprocess; must share a machine with that engine's rank 0."""
+
+    def __init__(self) -> None:
+        self._procs: list = []
+
+    @endpoint
+    async def spawn(self, ipcs: list[str], ports: list[int]) -> str:
+        import socket
+
+        for ipc, port in zip(ipcs, ports):
+            self._procs.append(coordinator.spawn(ipc, port))
+        return f"{len(ipcs)} coordinators on {socket.gethostname()} ports {ports}"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--specs",
+        required=True,
+        help="dir of loadspec_*.pkl from WBRIDGE_DUMP_LOADSPEC",
+    )
+    ap.add_argument("--iters", type=int, default=6)
+    ap.add_argument(
+        "--monarch-workers",
+        required=True,
+        default=os.environ.get("WORKER_ADDRS", ""),
+        help="comma-separated tcp://ip:port of the already-serving Monarch worker loops",
+    )
+    ap.add_argument(
+        "--network-provider",
+        default=os.environ.get("WB_NETWORK_PROVIDER", "efa"),
+        choices=["tcp", "efa"],
+    )
+    ap.add_argument(
+        "--network-interface", default=os.environ.get("WB_NETWORK_INTERFACE", "")
+    )
+    ap.add_argument("--rollout-ip", required=True)
+    ap.add_argument("--trainer-ip", required=True)
+    ap.add_argument(
+        "--base-port",
+        type=int,
+        default=62000,
+        help="first coordinator port (one per engine)",
+    )
+    ap.add_argument(
+        "--pg-port", type=int, default=62100, help="Gloo metadata rendezvous port"
+    )
+    ap.add_argument(
+        "--gpus-per-node",
+        type=int,
+        default=int(os.environ.get("WB_GPUS_PER_NODE", "0")),
+        help="optional capacity check for each host; 0 lets Monarch validate the requested meshes",
+    )
+    ap.add_argument(
+        "--seed",
+        action="store_true",
+        help="deterministic worker values + per-receiver post-consume digests (correctness)",
+    )
+    ap.add_argument("--digest-out", default="")
+    ap.add_argument("--label", default="monarch")
+    a = ap.parse_args()
+
+    recs = load_records(a.specs)
+    print(summary(recs), flush=True)
+    senders, engines = group_records(recs)
+    ws = len(senders)
+    eids = list(engines.keys())
+    if sorted(senders) != list(range(ws)):
+        raise RuntimeError(
+            f"sender ranks must be 0..{ws - 1} to map onto a proc mesh, got {sorted(senders)}"
+        )
+
+    addrs = [w.strip() for w in a.monarch_workers.split(",") if w.strip()]
+    hosts = attach_hosts(addrs, name="wbbench")
+    t_idx, r_idx = host_index(addrs, a.trainer_ip), host_index(addrs, a.rollout_ip)
+    print(
+        f"rollout={a.rollout_ip}(slice {r_idx}) trainer={a.trainer_ip}(slice {t_idx}) "
+        f"engines={len(eids)} senders={ws} iters={a.iters} provider={a.network_provider}",
+        flush=True,
+    )
+
+    # 1) One coordinator per engine, all on the rollout node (each engine's rank 0 dials its own).
+    ports = [a.base_port + i for i in range(len(eids))]
+    ipcs = [coordinator_ipc(p) for p in ports]
+    c_procs = hosts.slice(hosts=r_idx).spawn_procs({"gpus": 1})
+    c_procs.initialized.get()
+    coord = c_procs.spawn("wb_bench_coord", BenchCoordinatorActor)
+    coord.initialized.get()
+    print("[monarch] " + coord.spawn.call_one(ipcs=ipcs, ports=ports).get(), flush=True)
+
+    # 2) Rollout engines: one proc mesh per engine, packed onto contiguous GPUs so every receiver owns a
+    #    distinct device — and therefore, under Monarch, a distinct NIC.
+    engine_meshes, base, _acc = [], [], 0
+    for eid in eids:
+        base.append(_acc)
+        _acc += len(engines[eid])
+    if a.gpus_per_node and _acc > a.gpus_per_node:
+        raise RuntimeError(
+            f"{_acc} receiver ranks do not fit on a {a.gpus_per_node}-GPU rollout node"
+        )
+    for i, eid in enumerate(eids):
+        ranks = engines[eid]
+        procs = hosts.slice(hosts=r_idx).spawn_procs({"gpus": len(ranks)})
+        procs.initialized.get()
+        mesh = procs.spawn(f"wb_bench_recv{i}", BenchReceiverActor)
+        mesh.initialized.get()
+        mesh.init.call(
+            rank_to_path={r: ranks[r]["_path"] for r in ranks},
+            ipc=ipcs[i],
+            provider=a.network_provider,
+            iface=a.network_interface,
+            engine_base=base[i],
+            seed=a.seed,
+        ).get()
+        engine_meshes.append(mesh)
+        print(
+            f"[monarch] engine {i}: {len(ranks)} receivers ready (gpus {base[i]}..{base[i] + len(ranks) - 1})",
+            flush=True,
+        )
+    receiver_urls = [f"tcp://{a.rollout_ip}:{p}" for p in ports]
+
+    # 3) Trainer senders on the trainer node, one per captured rank.
+    if a.gpus_per_node and ws > a.gpus_per_node:
+        raise RuntimeError(
+            f"{ws} sender ranks do not fit on a {a.gpus_per_node}-GPU trainer node"
+        )
+    s_procs = hosts.slice(hosts=t_idx).spawn_procs({"gpus": ws})
+    s_procs.initialized.get()
+    smesh = s_procs.spawn("wb_bench_send", BenchSenderActor)
+    smesh.initialized.get()
+    sender_args = SenderArgs(
+        world_size=ws,
+        receiver_urls=receiver_urls,
+        master_addr=a.trainer_ip,
+        master_port=a.pg_port,
+        protocol="monarch",
+        sender_staging=False,  # protocol='monarch' has no staging path (rdma/monarch.py refuses it)
+    )
+    smesh.init.call(
+        rank_to_path={r: senders[r]["_path"] for r in senders},
+        args=sender_args,
+        provider=a.network_provider,
+        iface=a.network_interface,
+        seed=a.seed,
+    ).get()
+    print(f"[monarch] {ws} senders ready", flush=True)
+
+    # 4) Run K transfers. Receivers poll while the senders drive, exactly as on the Ray path.
+    recv = [m.run_recv.call(k_updates=a.iters) for m in engine_meshes]
+    send = smesh.run_send.call(k_updates=a.iters)
+    send_res = [v for _, v in send.get()]
+    for f in recv:
+        f.get()
+
+    # 5) Report. Digests come after the timed loop so hashing never lands in a WTT.
+    digests = None
+    if a.seed:
+        digests = []
+        for i, m in enumerate(engine_meshes):
+            digests += [
+                dict(d, key=f"e{i}/r{d['rank']}") for _, d in m.digest.call().get()
+            ]
+    report_run(
+        a.label,
+        send_res,
+        digests,
+        a.iters,
+        a.digest_out,
+        extra=f"{len(eids)} engines x {ws} senders",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/bench_monarch_ladder.py
+++ b/examples/weightbridge/examples/bench_monarch_ladder.py
@@ -1,0 +1,321 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Ladder benchmark: walk from the Monarch RDMA microbenchmark up to WeightBridge's real write pattern,
+one axis of complexity at a time, to identify the source of the throughput gap.
+
+Context. On the captured replay at equal NIC count, Monarch's bulk wire time was materially worse than
+Mooncake's. This benchmark isolates four independent differences from the real sender, walking them one
+at a time and reporting GB/s per rank at each step:
+
+* **ranks** — 1 writer per node vs 8 (the real topology).
+* **dst memory** — direct GPU destinations vs a staged receiver's CPU-pinned arena; Monarch picks
+  a NIC *per region*: device memory takes the NIC co-located with its GPU, host memory is hashed over all
+  tied-best NICs. Hash collisions across 8 concurrent ranks would show up here and nowhere else.
+* **fan-out** — one-to-one rank pairing vs writing to 4 receiver ranks per round,
+  which is 4 destination sessions and 4 separate ``RDMAAction`` submits in flight.
+* **issuing thread** — actor-thread submission vs the sender's Stage-2 daemon thread with the actor
+  context replayed onto it.
+
+Total bytes per writer per iteration is held constant across levels, so GB/s is directly comparable: with
+``--fanout 4`` each of the 4 targets receives a quarter of the same total.
+
+Host 0 writes and host 1 is the target, matching the real trainer-to-rollout direction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import torch
+from monarch.actor import Actor, endpoint
+from monarch_common import ActorThread, attach_hosts, bind_gpu, my_rank
+
+# Per-op tile. 64 MiB is MonarchEngine's default; prior sweeps showed little steady-state sensitivity
+# across the tested range, so this is held fixed rather than swept again.
+CHUNK = 64 << 20
+
+
+class Target(Actor):
+    """Host 1: owns the destination buffer and publishes it as per-chunk RDMABuffers."""
+
+    def __init__(self) -> None:
+        self.rank = my_rank()
+        self.gpu = bind_gpu(self.rank)
+        self._t: torch.Tensor | None = None
+        self._bufs: list = []
+
+    @endpoint
+    async def publish(self, nbytes: int, dst_mem: str, force_nic: bool = False) -> dict:
+        import os
+        import socket
+
+        from monarch.rdma import get_rdma_backend, RDMABuffer
+
+        if force_nic:
+            # Mechanism probe. Monarch pins DEVICE memory to the NIC co-located with its GPU, but hashes
+            # HOST memory over all tied-best NICs — with 8 concurrent ranks that can collide, leaving some
+            # NICs doubled and others idle. gpu:<ordinal> forces the same deterministic 1-NIC-per-rank
+            # choice the device path gets. If this restores the cpu-destination bandwidth, hashing is the
+            # mechanism. Set before the first RDMA call in this proc so it is in place at registration.
+            os.environ["MONARCH_RDMA_IBVERBS_TARGET"] = f"gpu:{self.gpu}"
+        if dst_mem == "cuda":
+            self._t = torch.zeros(nbytes, dtype=torch.uint8, device="cuda")
+            torch.cuda.synchronize()
+        else:
+            # Pinned host memory: what a staged receiver's CPU arena looks like to the NIC.
+            self._t = torch.zeros(nbytes, dtype=torch.uint8).pin_memory()
+        self._bufs = [
+            RDMABuffer(self._t[off : off + min(CHUNK, nbytes - off)])
+            for off in range(0, nbytes, CHUNK)
+        ]
+        return {
+            "host": socket.gethostname(),
+            "rank": self.rank,
+            "gpu": self.gpu,
+            "n": len(self._bufs),
+            "backend": get_rdma_backend(),
+        }
+
+    @endpoint
+    async def handles(self):
+        return self._bufs
+
+
+class Writer(Actor):
+    """Host 0: writes into `fanout` targets' buffers, from the actor thread or a dedicated thread."""
+
+    def __init__(self, targets) -> None:
+        self.rank = my_rank()
+        self.gpu = bind_gpu(self.rank)
+        self._targets = (
+            targets  # peer mesh as a CONSTRUCTOR arg; as an endpoint arg it hangs
+        )
+        self._src: torch.Tensor | None = None
+        self._thread = ActorThread(f"ladder-w{self.rank}")
+
+    @endpoint
+    async def run(
+        self,
+        nbytes: int,
+        fanout: int,
+        nranks: int,
+        reps: int,
+        on_thread: bool,
+        gil_load: int = 0,
+        switch_s: float = 0.0,
+        coalesce: bool = False,
+    ) -> dict:
+        import socket
+        import sys
+        import threading
+
+        # A GIL-holding Python thread only yields every sys.getswitchinterval() (default 5 ms), so each
+        # completion the actor loop needs to observe can wait a full handoff. Monarch's own test_gil_stall
+        # calls this out. Shrinking the interval should buy most of the throughput back if that latency
+        # -- rather than raw CPU starvation -- is what costs the bandwidth.
+        if switch_s:
+            sys.setswitchinterval(switch_s)
+
+        from monarch.rdma import RDMAAction
+
+        # Handles must be fetched from INSIDE the consuming actor; relaying them via the driver hangs.
+        per = nbytes // fanout
+        peers = [(self.rank + k) % nranks for k in range(fanout)]
+        handles = [await self._targets.slice(gpus=p).handles.call_one() for p in peers]
+
+        if self._src is None or self._src.numel() != nbytes:
+            self._src = torch.full((nbytes,), 0x5A, dtype=torch.uint8, device="cuda")
+        torch.cuda.synchronize()
+
+        def _build():
+            """One RDMAAction per destination session — the same shape sender.py issues per round.
+
+            With `coalesce`, every destination's ops go into a SINGLE action instead. An RDMAAction's ops
+            may target different peers, so this is legal, and it collapses `fanout` submits/Futures/
+            completion messages into one. That is the candidate fix if per-action cost is what scales.
+            """
+            acts = []
+            one = RDMAAction() if coalesce else None
+            for i in range(fanout):
+                act = one if coalesce else RDMAAction()
+                base = i * per
+                for j in range(0, per, CHUNK):
+                    n = min(CHUNK, per - j)
+                    # handles[i] tiles the WHOLE target buffer; take the tiles covering our slice.
+                    h = handles[i][(base + j) // CHUNK]
+                    act.write_remote(h, self._src[base + j : base + j + n])
+                if not coalesce:
+                    acts.append(act)
+            return [one] if coalesce else acts
+
+        # Monarch delivers an RDMA completion as a message to the actor, so observing it needs the GIL
+        # and the actor's event loop. The real sender runs Python-heavy WeightBridge work (packing, spec
+        # walking) on the very same proc, which this reproduces; Mooncake polls a CQ in C++ with the GIL
+        # released and is structurally immune.
+        stop = threading.Event()
+        burners = []
+        for _ in range(gil_load):
+
+            def _burn():
+                x = 0
+                while not stop.is_set():
+                    for k in range(5000):
+                        x += k * k
+
+            t = threading.Thread(target=_burn, daemon=True)
+            t.start()
+            burners.append(t)
+
+        times = []
+        for i in range(reps + 1):
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            if on_thread:
+                # Submit AND complete off the actor's loop, exactly as the Stage-2 daemon thread does.
+                def _go():
+                    futs = [a.submit(timeout=300) for a in _build()]
+                    for f in futs:
+                        f.get()
+
+                await self._thread.run(_go)
+            else:
+                acts = _build()
+                futs = [a.submit(timeout=300) for a in acts]
+                for f in futs:
+                    await f
+            torch.cuda.synchronize()
+            dt = time.perf_counter() - t0
+            if i:  # drop the first: registration + QP warmup
+                times.append(dt)
+        stop.set()
+        for t in burners:
+            t.join(timeout=5)
+        return {
+            "host": socket.gethostname(),
+            "rank": self.rank,
+            "gpu": self.gpu,
+            "median_s": statistics.median(times),
+            "best_s": min(times),
+        }
+
+
+# (label, ranks, dst_mem, fanout, on_thread, force_nic) — each row changes ONE axis from its baseline.
+# (label, ranks, dst_mem, fanout, on_thread, force_nic, gil, switch_s, coalesce)
+LEVELS = [
+    ("f1  1 peer   separate actions ", 8, "cuda", 1, True, False, 0, 0.0, False),
+    ("f2  2 peers  separate actions ", 8, "cuda", 2, True, False, 0, 0.0, False),
+    ("f4  4 peers  separate actions ", 8, "cuda", 4, True, False, 0, 0.0, False),
+    ("f8  8 peers  separate actions ", 8, "cuda", 8, True, False, 0, 0.0, False),
+    ("f8  8 peers  ONE coalesced act", 8, "cuda", 8, True, False, 0, 0.0, True),
+    ("f4  4 peers  ONE coalesced act", 8, "cuda", 4, True, False, 0, 0.0, True),
+]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--workers", required=True, help="comma-separated tcp://ip:port worker loops"
+    )
+    ap.add_argument(
+        "--mib",
+        type=int,
+        default=512,
+        help="bytes written per writer per iteration, MiB",
+    )
+    ap.add_argument("--reps", type=int, default=5)
+    ap.add_argument(
+        "--only", default="", help="comma-separated level indices to run (default all)"
+    )
+    cli = ap.parse_args()
+
+    workers = [w.strip() for w in cli.workers.split(",") if w.strip()]
+    hosts = attach_hosts(workers, name="wbladder")
+    nbytes = cli.mib << 20
+    keep = {int(x) for x in cli.only.split(",") if x.strip()} if cli.only else None
+    print(
+        f"[ladder] hosts={hosts.extent} bytes/writer/iter={cli.mib} MiB chunk={CHUNK >> 20} MiB "
+        f"reps={cli.reps}",
+        flush=True,
+    )
+    print(f"\n  {'level':46} {'GB/s/rank':>10} {'aggregate GB/s':>15}", flush=True)
+
+    rows = []
+    for idx, (
+        label,
+        ranks,
+        dst_mem,
+        fanout,
+        on_thread,
+        force_nic,
+        gil,
+        sw,
+        co,
+    ) in enumerate(LEVELS):
+        if keep is not None and idx not in keep:
+            continue
+        try:
+            tp = hosts.slice(hosts=1).spawn_procs({"gpus": ranks})
+            wp = hosts.slice(hosts=0).spawn_procs({"gpus": ranks})
+            tp.initialized.get()
+            wp.initialized.get()
+            targets = tp.spawn(f"tgt{idx}", Target)
+            targets.initialized.get()
+            writers = wp.spawn(f"wrt{idx}", Writer, targets)
+            writers.initialized.get()
+
+            # Every target publishes the FULL nbytes so any writer's slice of it is addressable.
+            pub = [
+                v
+                for _, v in targets.publish.call(
+                    nbytes=nbytes, dst_mem=dst_mem, force_nic=force_nic
+                ).get()
+            ]
+            if any(p["backend"] != "ibverbs" for p in pub):
+                print(f"  {label:46} FAIL: backend not ibverbs", flush=True)
+                continue
+
+            res = [
+                v
+                for _, v in writers.run.call(
+                    nbytes=nbytes,
+                    fanout=fanout,
+                    nranks=ranks,
+                    reps=cli.reps,
+                    on_thread=on_thread,
+                    gil_load=gil,
+                    switch_s=sw,
+                    coalesce=co,
+                ).get()
+            ]
+            # Per-rank GB/s from each rank's own median; aggregate from the SLOWEST rank, since the
+            # round does not finish until the last writer does.
+            per_rank = statistics.median([nbytes / r["median_s"] / 1e9 for r in res])
+            agg = len(res) * nbytes / max(r["median_s"] for r in res) / 1e9
+            print(f"  {label:46} {per_rank:10.2f} {agg:15.2f}", flush=True)
+            rows.append((label, per_rank, agg))
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"  {label:46} ERROR: {str(e).strip().splitlines()[-1][:90]}",
+                flush=True,
+            )
+
+    if len(rows) > 1:
+        print(
+            "\n  step-to-step change in per-rank GB/s (where the bandwidth actually goes):",
+            flush=True,
+        )
+        for i in range(1, len(rows)):
+            prev, cur = rows[i - 1], rows[i]
+            ratio = cur[1] / prev[1] if prev[1] else float("nan")
+            print(f"    {prev[0][:20]:22} -> {cur[0][:20]:22} x{ratio:.2f}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/weightbridge/examples/bench_peer_copy_methods.py
+++ b/examples/weightbridge/examples/bench_peer_copy_methods.py
@@ -1,0 +1,360 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Compare three ways to copy many tensors over a same-node GPU peer link.
+
+The payload and tensor addresses are static, matching WeightBridge's replay use
+case.  The three steady-state paths are:
+
+* a Python loop of ``Tensor.copy_`` peer copies;
+* an explicitly constructed CUDA Graph containing the same chained memcpy
+  nodes; and
+* one descriptor-driven Triton kernel which reads peer UVA addresses and
+  writes the local destination tensors.
+
+Run this on a node with two mutually accessible GPUs.  Graph construction,
+descriptor construction, and Triton compilation/warmup are intentionally
+excluded from the steady-state measurements and reported separately.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import statistics
+import time
+from pathlib import Path
+from typing import Callable
+
+import torch
+import triton
+from cuda.bindings import runtime as cudart
+from wbridge.utils.data import CopyPlan
+
+
+def _cuda_call(name: str, *args):
+    result = getattr(cudart, name)(*args)
+    if not isinstance(result, tuple):
+        result = (result,)
+    error, *values = result
+    if error != cudart.cudaError_t.cudaSuccess:
+        raise RuntimeError(f"{name} failed: {error}")
+    if not values:
+        return None
+    return values[0] if len(values) == 1 else tuple(values)
+
+
+def _enable_peer_access(dst_device: int, src_device: int) -> None:
+    """Enable SM loads from ``src_device`` while executing on ``dst_device``."""
+    torch.cuda.set_device(dst_device)
+    result = cudart.cudaDeviceEnablePeerAccess(src_device, 0)
+    error = result[0]
+    allowed = {
+        cudart.cudaError_t.cudaSuccess,
+        cudart.cudaError_t.cudaErrorPeerAccessAlreadyEnabled,
+    }
+    if error not in allowed:
+        raise RuntimeError(
+            f"cudaDeviceEnablePeerAccess({src_device}) on device {dst_device} failed: {error}"
+        )
+
+
+class PeerMemcpyGraph:
+    """A CUDA Graph containing a stream-ordered chain of peer memcpy nodes."""
+
+    def __init__(self, pairs: list[tuple[torch.Tensor, torch.Tensor]]) -> None:
+        self.graph = _cuda_call("cudaGraphCreate", 0)
+        previous = None
+        self.nodes = []
+        for dst, src in pairs:
+            dependencies = None if previous is None else [previous]
+            node = _cuda_call(
+                "cudaGraphAddMemcpyNode1D",
+                self.graph,
+                dependencies,
+                0 if previous is None else 1,
+                dst.data_ptr(),
+                src.data_ptr(),
+                dst.numel() * dst.element_size(),
+                cudart.cudaMemcpyKind.cudaMemcpyDefault,
+            )
+            self.nodes.append(node)
+            previous = node
+        self.executable = _cuda_call("cudaGraphInstantiate", self.graph, 0)
+
+    def launch(self, stream: torch.cuda.Stream) -> None:
+        _cuda_call("cudaGraphLaunch", self.executable, stream.cuda_stream)
+
+    def close(self) -> None:
+        if self.executable is not None:
+            _cuda_call("cudaGraphExecDestroy", self.executable)
+            self.executable = None
+        if self.graph is not None:
+            _cuda_call("cudaGraphDestroy", self.graph)
+            self.graph = None
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    position = fraction * (len(ordered) - 1)
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def _measure(
+    launch: Callable[[], None],
+    stream: torch.cuda.Stream,
+    total_bytes: int,
+    *,
+    warmup: int,
+    repeats: int,
+) -> dict[str, float]:
+    for _ in range(warmup):
+        launch()
+    stream.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    gpu_ms: list[float] = []
+    enqueue_us: list[float] = []
+    end_to_end_ms: list[float] = []
+
+    for _ in range(repeats):
+        start.record(stream)
+        before = time.perf_counter()
+        launch()
+        submitted = time.perf_counter()
+        end.record(stream)
+        end.synchronize()
+        finished = time.perf_counter()
+        gpu_ms.append(start.elapsed_time(end))
+        enqueue_us.append((submitted - before) * 1e6)
+        end_to_end_ms.append((finished - before) * 1e3)
+
+    median_gpu_ms = statistics.median(gpu_ms)
+    return {
+        "gpu_ms_median": median_gpu_ms,
+        "gpu_ms_p10": _percentile(gpu_ms, 0.10),
+        "gpu_ms_p90": _percentile(gpu_ms, 0.90),
+        "enqueue_us_median": statistics.median(enqueue_us),
+        "end_to_end_ms_median": statistics.median(end_to_end_ms),
+        "payload_gbps": total_bytes / (median_gpu_ms * 1e-3) / 1e9,
+    }
+
+
+def _sample_indices(total_elements: int, tensor_count: int) -> list[int]:
+    elements_per_tensor = total_elements // tensor_count
+    result: list[int] = []
+    for tensor_index in range(tensor_count):
+        base = tensor_index * elements_per_tensor
+        result.extend(
+            (base, base + elements_per_tensor // 2, base + elements_per_tensor - 1)
+        )
+    return sorted(set(result))
+
+
+def _verify(
+    launch: Callable[[], None],
+    stream: torch.cuda.Stream,
+    src_storage: torch.Tensor,
+    dst_storage: torch.Tensor,
+    tensor_count: int,
+) -> None:
+    with torch.cuda.device(dst_storage.device), torch.cuda.stream(stream):
+        dst_storage.zero_()
+    stream.synchronize()
+    launch()
+    stream.synchronize()
+    indices = _sample_indices(src_storage.numel(), tensor_count)
+    src_index = torch.tensor(indices, dtype=torch.int64, device=src_storage.device)
+    dst_index = src_index.to(dst_storage.device)
+    expected = src_storage.index_select(0, src_index).to(dst_storage.device)
+    actual = dst_storage.index_select(0, dst_index)
+    if not torch.equal(actual, expected):
+        raise AssertionError(f"copy verification failed for {tensor_count} tensors")
+
+
+def _run_count(
+    src_storage: torch.Tensor,
+    dst_storage: torch.Tensor,
+    tensor_count: int,
+    stream: torch.cuda.Stream,
+    *,
+    warmup: int,
+    repeats: int,
+) -> dict:
+    if src_storage.numel() % tensor_count:
+        raise ValueError(
+            f"payload elements must be divisible by tensor count {tensor_count}"
+        )
+    src_tensors = list(src_storage.view(tensor_count, -1).unbind(0))
+    dst_tensors = list(dst_storage.view(tensor_count, -1).unbind(0))
+    pairs = list(zip(dst_tensors, src_tensors))
+    dst_device = dst_storage.device.index
+
+    def sequential() -> None:
+        with torch.cuda.device(dst_device), torch.cuda.stream(stream):
+            for dst, src in pairs:
+                dst.copy_(src, non_blocking=True)
+
+    graph_build_start = time.perf_counter()
+    graph = PeerMemcpyGraph(pairs)
+    graph_build_ms = (time.perf_counter() - graph_build_start) * 1e3
+
+    def graph_replay() -> None:
+        graph.launch(stream)
+
+    plan_build_start = time.perf_counter()
+    plan = CopyPlan(pairs)
+    plan_build_ms = (time.perf_counter() - plan_build_start) * 1e3
+    if len(plan._flat_groups) != 1 or plan._groups or plan._fallback:
+        raise RuntimeError(
+            "the single-kernel benchmark unexpectedly produced "
+            f"flat={len(plan._flat_groups)} strided={len(plan._groups)} "
+            f"fallback={len(plan._fallback)}"
+        )
+
+    def single_kernel() -> None:
+        with torch.cuda.device(dst_device), torch.cuda.stream(stream):
+            plan.run()
+
+    methods = {
+        "sequential_copy": sequential,
+        "cuda_graph": graph_replay,
+        "single_kernel": single_kernel,
+    }
+    measurements = {}
+    try:
+        for name, launch in methods.items():
+            _verify(launch, stream, src_storage, dst_storage, tensor_count)
+            measurements[name] = _measure(
+                launch,
+                stream,
+                src_storage.numel() * src_storage.element_size(),
+                warmup=warmup,
+                repeats=repeats,
+            )
+    finally:
+        graph.close()
+
+    return {
+        "tensor_count": tensor_count,
+        "bytes_per_tensor": src_storage.numel()
+        * src_storage.element_size()
+        // tensor_count,
+        "graph_build_ms": graph_build_ms,
+        "kernel_plan_build_ms": plan_build_ms,
+        "methods": measurements,
+    }
+
+
+def _format_table(results: list[dict]) -> str:
+    header = (
+        f"{'tensors':>8} {'KiB/tensor':>12} {'method':>18} "
+        f"{'GPU ms':>10} {'E2E ms':>10} {'enqueue us':>12} {'GB/s':>10}"
+    )
+    lines = [header, "-" * len(header)]
+    for result in results:
+        for method, values in result["methods"].items():
+            lines.append(
+                f"{result['tensor_count']:8d} {result['bytes_per_tensor'] / 1024:12.1f} "
+                f"{method:>18} {values['gpu_ms_median']:10.3f} "
+                f"{values['end_to_end_ms_median']:10.3f} "
+                f"{values['enqueue_us_median']:12.1f} {values['payload_gbps']:10.1f}"
+            )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--src-device", type=int, default=1)
+    parser.add_argument("--dst-device", type=int, default=0)
+    parser.add_argument("--total-mib", type=int, default=512)
+    parser.add_argument(
+        "--counts", type=int, nargs="+", default=[1, 8, 32, 128, 512, 2048]
+    )
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--repeats", type=int, default=30)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    if torch.cuda.device_count() <= max(args.src_device, args.dst_device):
+        raise RuntimeError(
+            f"need devices {args.dst_device} and {args.src_device}; "
+            f"only {torch.cuda.device_count()} CUDA devices are visible"
+        )
+    if not torch.cuda.can_device_access_peer(args.dst_device, args.src_device):
+        raise RuntimeError(
+            f"device {args.dst_device} cannot access peer {args.src_device}"
+        )
+
+    dtype = torch.bfloat16
+    total_bytes = args.total_mib * 1024 * 1024
+    element_size = torch.empty((), dtype=dtype).element_size()
+    if total_bytes % element_size:
+        raise ValueError("payload is not aligned to dtype")
+    total_elements = total_bytes // element_size
+    for count in args.counts:
+        if count <= 0 or total_elements % count:
+            raise ValueError(
+                f"invalid tensor count {count} for {total_elements} elements"
+            )
+
+    _enable_peer_access(args.dst_device, args.src_device)
+    with torch.cuda.device(args.src_device):
+        src_storage = torch.empty(total_elements, dtype=dtype, device=args.src_device)
+        src_storage.uniform_(-1.0, 1.0)
+    with torch.cuda.device(args.dst_device):
+        dst_storage = torch.empty(total_elements, dtype=dtype, device=args.dst_device)
+        stream = torch.cuda.Stream(device=args.dst_device)
+    torch.cuda.synchronize(args.src_device)
+    torch.cuda.synchronize(args.dst_device)
+
+    metadata = {
+        "hostname": socket.gethostname(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "triton": triton.__version__,
+        "src_device": args.src_device,
+        "src_gpu": torch.cuda.get_device_name(args.src_device),
+        "dst_device": args.dst_device,
+        "dst_gpu": torch.cuda.get_device_name(args.dst_device),
+        "peer_access": True,
+        "dtype": str(dtype),
+        "total_bytes": total_bytes,
+        "warmup": args.warmup,
+        "repeats": args.repeats,
+        "graph_shape": "stream-ordered chain of explicit cudaGraphAddMemcpyNode1D nodes",
+        "single_kernel": "WeightBridge CopyPlan flat Triton descriptor kernel",
+    }
+    results = []
+    for count in args.counts:
+        print(f"benchmarking {count} tensors ...", flush=True)
+        results.append(
+            _run_count(
+                src_storage,
+                dst_storage,
+                count,
+                stream,
+                warmup=args.warmup,
+                repeats=args.repeats,
+            )
+        )
+
+    document = {"metadata": metadata, "results": results}
+    print()
+    print(_format_table(results))
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(document, indent=2) + "\n")
+        print(f"\nwrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/bench_plan.py
+++ b/examples/weightbridge/examples/bench_plan.py
@@ -1,0 +1,303 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Time rank-0 WeightRouter planning from captured per-rank LoadSpecs.
+
+This is intentionally a metadata-only replay: it reconstructs the captured ShardSpecs and merged dtype
+map that ``WBEndpoint._finish_setup`` gives rank 0, then invokes the production ``WeightRouter`` once.
+Tensor storage, process groups, GPUs, Ray, Megatron, and SGLang are not involved.
+
+Large distributed captures may not preserve a globally unique receiver engine id.  When several replicas
+contain the same receiver-local ranks, this script verifies that every copy of a local rank has identical
+metadata and repeats that rank template in replica-major order.  That is equivalent for routing and avoids
+guessing an engine identity that is absent from the capture.
+
+Example (after installing from the directory containing ``pyproject.toml``)::
+
+    python3 -u examples/bench_plan.py --specs /path/to/capture
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import resource
+import threading
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Callable
+
+
+def _seconds(value: float) -> str:
+    return f"{value:.3f}s"
+
+
+class PhaseTimer:
+    """Low-overhead nested phase timers plus periodic progress/memory output."""
+
+    def __init__(self, heartbeat_seconds: float) -> None:
+        self.heartbeat_seconds = heartbeat_seconds
+        self.started = time.perf_counter()
+        self.timings: dict[str, list[float]] = defaultdict(list)
+        self._stack: list[str] = []
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @staticmethod
+    def _max_rss_gib() -> float:
+        # Linux reports ru_maxrss in KiB.
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024**2
+
+    def start_heartbeat(self) -> None:
+        if self.heartbeat_seconds <= 0:
+            return
+
+        def run() -> None:
+            while not self._stop.wait(self.heartbeat_seconds):
+                with self._lock:
+                    current = self._stack[-1] if self._stack else "between phases"
+                print(
+                    f"HEARTBEAT elapsed={_seconds(time.perf_counter() - self.started)} "
+                    f"phase={current} max_rss={self._max_rss_gib():.2f}GiB",
+                    flush=True,
+                )
+
+        self._thread = threading.Thread(
+            target=run, name="plan-bench-heartbeat", daemon=True
+        )
+        self._thread.start()
+
+    def stop_heartbeat(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1)
+
+    @contextmanager
+    def phase(self, label: str):
+        with self._lock:
+            self._stack.append(label)
+        print(f"PHASE_START {label}", flush=True)
+        started = time.perf_counter()
+        try:
+            yield
+        finally:
+            elapsed = time.perf_counter() - started
+            self.timings[label].append(elapsed)
+            with self._lock:
+                popped = self._stack.pop()
+            assert popped == label
+            print(
+                f"PHASE_END {label} elapsed={_seconds(elapsed)} max_rss={self._max_rss_gib():.2f}GiB",
+                flush=True,
+            )
+
+    def wrap(self, label: str, fn: Callable) -> Callable:
+        def timed(*args, **kwargs):
+            with self.phase(label):
+                return fn(*args, **kwargs)
+
+        timed.__name__ = getattr(fn, "__name__", label)
+        timed.__doc__ = getattr(fn, "__doc__")
+        return timed
+
+
+def _host_from_path(path: str) -> str:
+    match = re.search(r"loadspec_(.*?)_(?:sender|receiver)_", Path(path).name)
+    return match.group(1) if match else "unknown"
+
+
+def _ordered_records(records: list[dict]) -> tuple[list[dict], int, int]:
+    """Return production-equivalent global-rank order and sender/replica counts."""
+    senders: dict[int, dict] = {}
+    receivers: dict[int, list[dict]] = defaultdict(list)
+    for record in records:
+        if record["role"] == "sender":
+            rank = int(record["rank"])
+            if rank in senders:
+                raise ValueError(f"duplicate sender rank {rank}")
+            senders[rank] = record
+        elif record["role"] == "receiver":
+            receivers[int(record["rank"])].append(record)
+        else:
+            raise ValueError(f"unknown role {record['role']!r}")
+
+    sender_ranks = sorted(senders)
+    receiver_ranks = sorted(receivers)
+    if sender_ranks != list(range(len(sender_ranks))):
+        raise ValueError(f"sender ranks are not contiguous: {sender_ranks}")
+    if receiver_ranks != list(range(len(receiver_ranks))):
+        raise ValueError(f"receiver-local ranks are not contiguous: {receiver_ranks}")
+
+    replica_counts = {len(copies) for copies in receivers.values()}
+    if len(replica_counts) != 1:
+        raise ValueError(
+            f"receiver ranks have unequal replica counts: {sorted(replica_counts)}"
+        )
+    replicas = replica_counts.pop()
+
+    # Some captures record the same node-local IPC engine id for every tensor-parallel replica. The
+    # receiver metadata must therefore be replica-identical; verify that fact rather than silently
+    # depending on filename/PID clustering to recover an identity the pickle format does not contain.
+    for rank, copies in receivers.items():
+        copies.sort(key=lambda record: record["_path"])
+        reference = copies[0]
+        for copy in copies[1:]:
+            if copy["src_shard_spec"] != reference["src_shard_spec"]:
+                raise ValueError(
+                    f"receiver rank {rank} has non-identical replica ShardSpecs"
+                )
+            if copy["dtype_spec"] != reference["dtype_spec"]:
+                raise ValueError(
+                    f"receiver rank {rank} has non-identical replica dtype specs"
+                )
+
+    ordered = [senders[rank] for rank in sender_ranks]
+    # Any same-index selection is valid after the replica-identity check above. Keep replica-major
+    # ordering because live registration packs each rollout replica contiguously.
+    ordered.extend(
+        receivers[rank][replica]
+        for replica in range(replicas)
+        for rank in receiver_ranks
+    )
+    return ordered, len(senders), replicas
+
+
+def _merge_dtype_specs(records: list[dict]) -> dict:
+    merged: dict = {}
+    for record in records:
+        for name, dtype in record["dtype_spec"].items():
+            if name in merged and merged[name] != dtype:
+                raise ValueError(
+                    f"dtype mismatch for {name}: {merged[name]} versus {dtype}"
+                )
+            merged.setdefault(name, dtype)
+    return {name: merged[name] for name in sorted(merged)}
+
+
+def _install_router_timers(router_module, timer: PhaseTimer) -> None:
+    # Inclusive timers are deliberately nested.  In particular, compute_global_rounds includes
+    # name_rank_bytes; the report derives round packing as their difference.
+    module_functions = (
+        ("validate_logical_partitions", "validate_logical_tensor_partitions"),
+        ("dedup_sender_specs", "dedup_send_specs"),
+        ("consolidate_receiver_groups", "consolidate_groups"),
+        ("dedup_receiver_specs", "_dedup_specs_by_subgroups"),
+    )
+    for label, name in module_functions:
+        setattr(router_module, name, timer.wrap(label, getattr(router_module, name)))
+
+    methods = (
+        ("find_receiver_classes", "_natural_recv_classes"),
+        ("name_rank_bytes", "_name_rank_bytes"),
+        ("legacy_round_packing_inclusive", "_legacy_cap_rounds"),
+        ("global_rounds_inclusive", "compute_global_rounds"),
+        ("local_rounds", "compute_local_rounds"),
+    )
+    for label, name in methods:
+        original = getattr(router_module.WeightRouter, name)
+        setattr(router_module.WeightRouter, name, timer.wrap(label, original))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--specs", required=True, help="directory containing loadspec_*.pkl"
+    )
+    parser.add_argument("--heartbeat-seconds", type=float, default=30.0)
+    parser.add_argument("--json-out", default="", help="optional result JSON path")
+    args = parser.parse_args()
+
+    # These are read while wbridge.backend.router is imported. Keep caller overrides, but make this
+    # benchmark's defaults explicit for an invocation that supplies no environment.
+    os.environ.setdefault("WBRIDGE_ROUND_CAP_BYTES", str(1024**3))
+    os.environ.setdefault("WBRIDGE_DEDUP_PAIR_BYTES", "inf")
+
+    import wbridge.backend.router as router_module
+    from loadspec_replay import load_records
+    from wbridge.utils.data import ShardSpec
+
+    timer = PhaseTimer(args.heartbeat_seconds)
+    timer.start_heartbeat()
+    try:
+        with timer.phase("load_and_translate_capture"):
+            records = load_records(args.specs)
+        with timer.phase("reconstruct_global_rank_order"):
+            ordered, sender_ws, replicas = _ordered_records(records)
+        with timer.phase("construct_shard_specs_and_merge_dtypes"):
+            all_specs = [ShardSpec(record["src_shard_spec"]) for record in ordered]
+            dtype_spec = _merge_dtype_specs(ordered)
+            # The legacy planner ignores placement, but pass the same shape of map as production.
+            peer_ip = {
+                rank: _host_from_path(record["_path"])
+                for rank, record in enumerate(ordered)
+            }
+
+        print(
+            "INPUT "
+            f"records={len(records)} world_size={len(all_specs)} senders={sender_ws} "
+            f"receivers={len(all_specs) - sender_ws} receiver_replicas={replicas} "
+            f"tensor_names={len(dtype_spec)} round_cap={os.environ['WBRIDGE_ROUND_CAP_BYTES']} "
+            f"pair_bytes={os.environ['WBRIDGE_DEDUP_PAIR_BYTES']} "
+            f"num_rounds_env={os.environ.get('WBRIDGE_NUM_ROUNDS', '') or 'unset'} "
+            f"rdma_cap_env={os.environ.get('WBRIDGE_ROLLOUT_RDMA_CAP_BYTES', '') or 'unset'}",
+            flush=True,
+        )
+
+        _install_router_timers(router_module, timer)
+        with timer.phase("weight_router_total"):
+            router = router_module.WeightRouter(
+                rank=0,
+                sender_ws=sender_ws,
+                all_specs=all_specs,
+                dtype_spec=dtype_spec,
+                peer_ip=peer_ip,
+            )
+        with timer.phase("serialize_round_plan"):
+            round_plan = [sorted(names) for names in router.global_rounds]
+
+        global_rounds = timer.timings["global_rounds_inclusive"][0]
+        name_rank_bytes = timer.timings["name_rank_bytes"][0]
+        report = {
+            "specs": str(Path(args.specs).resolve()),
+            "world_size": len(all_specs),
+            "sender_ws": sender_ws,
+            "receiver_ws": len(all_specs) - sender_ws,
+            "receiver_replicas": replicas,
+            "tensor_names": len(dtype_spec),
+            "rounds": len(round_plan),
+            "round_tensor_counts": [len(names) for names in round_plan],
+            "round_cap_bytes": int(os.environ["WBRIDGE_ROUND_CAP_BYTES"]),
+            "dedup_pair_bytes": os.environ["WBRIDGE_DEDUP_PAIR_BYTES"],
+            "planner_mode": router.planner_mode,
+            "planner_invariant_seconds": router.planner_invariant_seconds,
+            "planner_probe_timings": router.planner_probe_timings,
+            "max_rss_gib": timer._max_rss_gib(),
+            "timings_seconds": {
+                label: values for label, values in timer.timings.items()
+            },
+            "derived_seconds": {
+                "round_packing_excluding_name_rank_bytes": global_rounds
+                - name_rank_bytes,
+            },
+        }
+        print("RESULT_JSON " + json.dumps(report, sort_keys=True), flush=True)
+        if args.json_out:
+            Path(args.json_out).write_text(
+                json.dumps(report, indent=2, sort_keys=True) + "\n"
+            )
+    finally:
+        timer.stop_heartbeat()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/bench_plan_workers.py
+++ b/examples/weightbridge/examples/bench_plan_workers.py
@@ -1,0 +1,174 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Benchmark deterministic independent WeightRouter planning in several worker processes.
+
+The parent launches fresh Python interpreters with distinct ``PYTHONHASHSEED`` values.  Each child loads
+the same captured metadata, builds the production rank-specific ``WeightRouter``, and hashes the complete
+global round plan.  The run fails unless every child produces exactly the same digest.
+
+Example::
+
+    python3 -u examples/bench_plan_workers.py --specs /path/to/capture
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import resource
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _worker(spec_dir: str, rank: int) -> dict:
+    from bench_plan import _host_from_path, _merge_dtype_specs, _ordered_records
+    from loadspec_replay import load_records
+    from wbridge.backend.router import WeightRouter
+    from wbridge.utils.data import ShardSpec
+
+    started = time.perf_counter()
+    records = load_records(spec_dir)
+    ordered, sender_ws, replicas = _ordered_records(records)
+    all_specs = [ShardSpec(record["src_shard_spec"]) for record in ordered]
+    dtype_spec = _merge_dtype_specs(ordered)
+    peer_ip = {
+        global_rank: _host_from_path(record["_path"])
+        for global_rank, record in enumerate(ordered)
+    }
+    prepared = time.perf_counter()
+
+    router = WeightRouter(
+        rank=rank,
+        sender_ws=sender_ws,
+        all_specs=all_specs,
+        dtype_spec=dtype_spec,
+        peer_ip=peer_ip,
+    )
+    round_plan = [sorted(names) for names in router.global_rounds]
+    planned = time.perf_counter()
+    encoded = json.dumps(round_plan, ensure_ascii=True, separators=(",", ":")).encode()
+    return {
+        "rank": rank,
+        "python_hash_seed": os.environ.get("PYTHONHASHSEED", "random"),
+        "world_size": len(all_specs),
+        "sender_ws": sender_ws,
+        "receiver_replicas": replicas,
+        "tensor_names": len(dtype_spec),
+        "rounds": len(round_plan),
+        "round_tensor_counts": [len(names) for names in round_plan],
+        "plan_sha256": hashlib.sha256(encoded).hexdigest(),
+        "prepare_seconds": prepared - started,
+        "plan_seconds": planned - prepared,
+        "max_rss_gib": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024**2,
+    }
+
+
+def _parent(spec_dir: str, workers: int) -> None:
+    if workers < 2:
+        raise ValueError("--workers must be at least 2")
+    # Captures contain one file per global worker. Spread samples across sender and receiver ranges
+    # rather than benchmarking adjacent local projections.
+    world_size = len(list(Path(spec_dir).glob("loadspec_*.pkl")))
+    if world_size < workers:
+        raise ValueError(f"capture has only {world_size} records for {workers} workers")
+    ranks = [index * world_size // workers for index in range(workers)]
+    processes: list[tuple[int, subprocess.Popen]] = []
+    wall_started = time.perf_counter()
+    for index, rank in enumerate(ranks):
+        env = dict(os.environ)
+        env["PYTHONHASHSEED"] = str(index + 1)
+        command = [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--specs",
+            spec_dir,
+            "--worker-rank",
+            str(rank),
+        ]
+        processes.append(
+            (
+                rank,
+                subprocess.Popen(
+                    command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    env=env,
+                ),
+            )
+        )
+
+    results = []
+    for rank, process in processes:
+        stdout, stderr = process.communicate()
+        if process.returncode != 0:
+            raise RuntimeError(
+                f"planner worker rank {rank} exited {process.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+        lines = [
+            line for line in stdout.splitlines() if line.startswith("WORKER_RESULT ")
+        ]
+        if len(lines) != 1:
+            raise RuntimeError(
+                f"planner worker rank {rank} emitted no unique result: {stdout!r}"
+            )
+        result = json.loads(lines[0].removeprefix("WORKER_RESULT "))
+        results.append(result)
+        print("WORKER_RESULT " + json.dumps(result, sort_keys=True), flush=True)
+
+    wall_seconds = time.perf_counter() - wall_started
+    digests = {result["plan_sha256"] for result in results}
+    round_counts = {tuple(result["round_tensor_counts"]) for result in results}
+    if len(digests) != 1 or len(round_counts) != 1:
+        raise RuntimeError(
+            f"independent planners diverged: digests={digests}, round_counts={round_counts}"
+        )
+    plan_times = [result["plan_seconds"] for result in results]
+    summary = {
+        "workers": workers,
+        "ranks": ranks,
+        "distinct_hash_seeds": len({result["python_hash_seed"] for result in results}),
+        "distinct_plan_digests": len(digests),
+        "plan_sha256": next(iter(digests)),
+        "rounds": results[0]["rounds"],
+        "round_tensor_counts": results[0]["round_tensor_counts"],
+        "plan_seconds_min": min(plan_times),
+        "plan_seconds_median": statistics.median(plan_times),
+        "plan_seconds_max": max(plan_times),
+        "concurrent_wall_seconds_including_capture_load": wall_seconds,
+    }
+    print("SUMMARY " + json.dumps(summary, sort_keys=True), flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--specs", required=True)
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--worker-rank", type=int, default=-1, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    os.environ.setdefault("WBRIDGE_ROUND_CAP_BYTES", str(1024**3))
+    os.environ.setdefault("WBRIDGE_DEDUP_PAIR_BYTES", "inf")
+    if args.worker_rank >= 0:
+        print(
+            "WORKER_RESULT "
+            + json.dumps(_worker(args.specs, args.worker_rank), sort_keys=True),
+            flush=True,
+        )
+    else:
+        _parent(args.specs, args.workers)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/bench_report.py
+++ b/examples/weightbridge/examples/bench_report.py
@@ -1,0 +1,158 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared reporting + env plumbing for the replay benchmarks (Ray and Monarch front-ends).
+
+Both front-ends must print the *same* numbers computed the *same* way, or the 3-way transport comparison
+is comparing formatting as much as transports. They also have to forward the same set of ``WBRIDGE_*``
+knobs to their workers, so those lists live here too rather than being duplicated and drifting.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+
+# Knobs that change what the transfer *does*, so a sweep or an A/B is meaningless unless the workers see
+# them. Kept as one list per role because the receiver side has a few the sender has no use for.
+ENGINE_ENV_KEYS = (
+    "WBRIDGE_ROUND_CAP_BYTES",
+    "WBRIDGE_NUM_ROUNDS",
+    "WBRIDGE_ROLLOUT_RDMA_CAP_BYTES",
+    "WBRIDGE_LOGICAL_TENSOR_CAP_BYTES",
+    "WBRIDGE_REPLICA_RELAY",
+    "WBRIDGE_SENDER_NUM_BUF",
+    "WBRIDGE_RECV_PIPELINE",
+    "WBRIDGE_RECV_3STAGE",
+    "WBRIDGE_CTL_PROFILE",
+    "WBRIDGE_XCHECK",
+    "WBRIDGE_DEDUP_PAIR_BYTES",
+    "WBRIDGE_DEDUP_DIAG",
+    "WBRIDGE_TOPO_EXCHANGE",
+    "WBRIDGE_SAME_NODE_IPC",
+    "WBRIDGE_TCP_CONTROL",
+    # The whole point of the 3-way table: 0 disables Mooncake's 16 MiB multi-NIC striping, giving the
+    # 1-NIC-per-rank configuration that is apples-to-apples with Monarch.
+    "WBRIDGE_EFA_SUBSLICE_BYTES",
+    "WBRIDGE_MONARCH_CHUNK_BYTES",
+    "WBRIDGE_HBM_DEBUG",
+)
+
+SENDER_ENV_KEYS = (
+    # CTL_PROFILE matters most on the sender: _write_flag/_poll_flag both run on its Stage-2 thread.
+    "WBRIDGE_ROUND_CAP_BYTES",
+    "WBRIDGE_NUM_ROUNDS",
+    "WBRIDGE_ROLLOUT_RDMA_CAP_BYTES",
+    "WBRIDGE_LOGICAL_TENSOR_CAP_BYTES",
+    "WBRIDGE_REPLICA_RELAY",
+    "WBRIDGE_RECV_PIPELINE",
+    "WBRIDGE_XCHECK",
+    "WBRIDGE_CTL_PROFILE",
+    "WBRIDGE_DEDUP_PAIR_BYTES",
+    "WBRIDGE_DEDUP_DIAG",
+    "WBRIDGE_TOPO_EXCHANGE",
+    "WBRIDGE_SAME_NODE_IPC",
+    "WBRIDGE_FUSE_SELFCHECK",
+    "WBRIDGE_TCP_CONTROL",
+    "WBRIDGE_EFA_SUBSLICE_BYTES",
+    "WBRIDGE_MONARCH_CHUNK_BYTES",
+    "WBRIDGE_HBM_DEBUG",
+)
+
+
+def report_run(
+    label: str,
+    send_res: list,
+    digests: list[dict] | None,
+    iters: int,
+    digest_out: str = "",
+    extra: str = "",
+) -> dict:
+    """Print rank 0's WTT series + the receiver digests, and return the machine-readable summary.
+
+    The first iteration is dropped from the warm statistics: it pays arena first-touch, Mooncake/Monarch
+    handle setup and the CUDA graph/JIT warm-up, none of which a steady-state RL loop repeats.
+    """
+    send_res = sorted(send_res, key=lambda x: x[0])
+    rank0, connect_s, wtts, nr = send_res[0]
+    print(
+        f"\n=== {label}: replay WTT (rank {rank0}, {nr} rounds{', ' + extra if extra else ''}) ===",
+        flush=True,
+    )
+    print(f"connect (cold setup): {connect_s:.3f} s", flush=True)
+    for i, w in enumerate(wtts):
+        print(
+            f"  WT{i}: {w:.3f} s{'   <- cold, dropped' if i == 0 and len(wtts) > 1 else ''}",
+            flush=True,
+        )
+    warm = wtts[1:] or wtts
+    out = {
+        "label": label,
+        "iters": iters,
+        "rounds": nr,
+        "connect_s": connect_s,
+        "wtts": wtts,
+        "warm_min": min(warm),
+        "warm_median": statistics.median(warm),
+        "warm_mean": statistics.mean(warm),
+    }
+    print(
+        f"warm: min={out['warm_min']:.3f} median={out['warm_median']:.3f} "
+        f"mean={out['warm_mean']:.3f} s",
+        flush=True,
+    )
+
+    if digests:
+        # Keyed by engine AND rank: every engine numbers its receivers from 0, so keying on rank alone
+        # would silently collapse N engines' digests into one set and compare a quarter of the weights.
+        d = {x["key"]: x["digest"] for x in digests}
+        if len(d) != len(digests):
+            raise RuntimeError(
+                f"duplicate digest keys: {len(digests)} receivers, {len(d)} unique keys"
+            )
+        out["digests"] = d
+        print(f"receiver digests ({len(d)} receivers):", flush=True)
+        for r in sorted(d):
+            print(f"  {r}: {d[r]}", flush=True)
+    if digest_out:
+        with open(digest_out, "w") as f:
+            json.dump(out, f, indent=2)
+        print(f"summary -> {digest_out}", flush=True)
+    return out
+
+
+def compare_digests(a_path: str, b_path: str) -> bool:
+    """Compare two ``--digest-out`` files; print a per-rank verdict. True iff every rank matches."""
+    with open(a_path) as f:
+        a = json.load(f)
+    with open(b_path) as f:
+        b = json.load(f)
+    da, db = a.get("digests") or {}, b.get("digests") or {}
+    if not da or not db:
+        print(
+            f"FAIL: missing digests ({a_path}: {len(da)} ranks, {b_path}: {len(db)} ranks). "
+            "Both runs must use --seed.",
+            flush=True,
+        )
+        return False
+    if set(da) != set(db):
+        print(f"FAIL: rank sets differ: {sorted(da)} vs {sorted(db)}", flush=True)
+        return False
+    ok = True
+    for r in sorted(da):
+        same = da[r] == db[r]
+        ok &= same
+        print(
+            f"  {r}: {'match' if same else 'MISMATCH'}  {a['label']}={da[r]} {b['label']}={db[r]}",
+            flush=True,
+        )
+    print(
+        ("OK: " if ok else "FAIL: ") + f"{a['label']} and {b['label']} delivered "
+        f"{'byte-identical' if ok else 'DIFFERENT'} weights to every receiver "
+        f"({a['warm_median']:.3f} s vs {b['warm_median']:.3f} s warm median)",
+        flush=True,
+    )
+    return ok

--- a/examples/weightbridge/examples/bench_round_probe.py
+++ b/examples/weightbridge/examples/bench_round_probe.py
@@ -1,0 +1,116 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Measure individual WeightRouter RDMA-cap probes from captured LoadSpecs.
+
+Unlike ``bench_plan.py``, this does not run the exponential/binary cap search.  It constructs the
+round-invariant metadata once, then reports packing, topology, and arena time for each requested exact
+round count.  That makes R=1/R=2 comparisons fast enough to use while optimizing Kimi-scale plans.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+
+from bench_plan import _host_from_path, _merge_dtype_specs, _ordered_records
+from loadspec_replay import load_records
+from wbridge.backend.router import WeightRouter
+from wbridge.utils.data import ShardSpec
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--specs", required=True)
+    parser.add_argument("--rounds", type=int, nargs="+", default=[1, 2])
+    args = parser.parse_args()
+
+    os.environ.setdefault("WBRIDGE_DEDUP_PAIR_BYTES", "0")
+    os.environ.pop("WBRIDGE_NUM_ROUNDS", None)
+    os.environ.pop("WBRIDGE_ROLLOUT_RDMA_CAP_BYTES", None)
+
+    started = time.perf_counter()
+    records = load_records(args.specs)
+    ordered, sender_ws, replicas = _ordered_records(records)
+    all_specs = [ShardSpec(record["src_shard_spec"]) for record in ordered]
+    dtype_spec = _merge_dtype_specs(ordered)
+    peer_ip = {
+        rank: _host_from_path(record["_path"]) for rank, record in enumerate(ordered)
+    }
+    prepared_seconds = time.perf_counter() - started
+    print(
+        "INPUT "
+        + json.dumps(
+            {
+                "world_size": len(all_specs),
+                "sender_ws": sender_ws,
+                "receiver_ws": len(all_specs) - sender_ws,
+                "receiver_replicas": replicas,
+                "tensor_names": len(dtype_spec),
+                "cons": os.environ["WBRIDGE_DEDUP_PAIR_BYTES"],
+                "prepared_seconds": prepared_seconds,
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+
+    # Supplying a complete plan skips automatic cap selection while retaining normal validation/local-plan
+    # construction.  The benchmark replaces this plan before every measured probe below.
+    construct_started = time.perf_counter()
+    router = WeightRouter(
+        rank=0,
+        sender_ws=sender_ws,
+        all_specs=all_specs,
+        dtype_spec=dtype_spec,
+        global_rounds=[set(dtype_spec)],
+    )
+    construct_seconds = time.perf_counter() - construct_started
+
+    invariant_started = time.perf_counter()
+    name_send, name_recv = router._name_rank_bytes()
+    invariant_seconds = time.perf_counter() - invariant_started
+    print(
+        "INVARIANTS "
+        + json.dumps(
+            {
+                "constructor_seconds": construct_seconds,
+                "name_rank_and_cache_seconds": invariant_seconds,
+                "production_cache_seconds": router.planner_invariant_seconds,
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+
+    results = []
+    for round_count in args.rounds:
+        pack_started = time.perf_counter()
+        router.global_rounds = router._pack_exact_rounds(
+            name_send, name_recv, round_count
+        )
+        pack_seconds = time.perf_counter() - pack_started
+
+        probe_started = time.perf_counter()
+        sizes = router.rollout_rdma_bytes(peer_ip)
+        probe_seconds = time.perf_counter() - probe_started
+        result = {
+            "rounds": round_count,
+            "pack_seconds": pack_seconds,
+            "probe_seconds": probe_seconds,
+            "peak_gib": max(sizes, default=0) / 1024**3,
+            **router._last_rollout_rdma_timing,
+        }
+        results.append(result)
+        print("PROBE " + json.dumps(result, sort_keys=True), flush=True)
+
+    print("RESULT " + json.dumps({"probes": results}, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/bench_transfer.py
+++ b/examples/weightbridge/examples/bench_transfer.py
@@ -1,0 +1,380 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Frameworkless replay of a captured 30B weight transfer — fast WTT iteration.
+
+Reads per-rank LoadSpecs dumped by ``WBRIDGE_DUMP_LOADSPEC`` (from one real run), rebuilds
+``WeightSender``/``WeightReceiver`` **directly** (no Megatron/SGLang/specgen), and runs K timed
+transfers over Ray with RDMA across nodes and CUDA IPC within a node. Startup is seconds; each iteration is
+one real transfer (pack -> RDMA -> receiver<->receiver dedup exchange -> consume) with the *exact* captured
+layout.
+
+Worker tensor values are synthetic. By default they are uninitialized and the run is perf-only; with
+``--seed`` they become deterministic and each receiver reports a post-consume digest, which is what makes
+two transports comparable for *correctness* as well as speed (see :mod:`bench_bodies`). Topology comes
+from the captured records: ``world_size`` trainer senders + N rollout engines each with ``num_workers``
+receivers; both engines pin to the rollout node so corresponding ranks take the NVLink
+receiver<->receiver path.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+
+import ray
+import torch  # noqa: F401 — ensures torch/CUDA import in the driver
+from bench_bodies import network_env_vars, ReplayReceiverBody, ReplaySenderBody
+from bench_report import ENGINE_ENV_KEYS, report_run, SENDER_ENV_KEYS
+from loadspec_replay import group_records, load_records, summary
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+from utils import get_ray_nodes, visible_device_list
+from wbridge.backend import coordinator
+from wbridge.backend.control_channel import coordinator_ipc
+from wbridge.backend.sender import SenderArgs
+
+_network_env_vars = network_env_vars  # back-compat for importers of this module
+
+
+@ray.remote(
+    num_gpus=0, num_cpus=1
+)  # num_gpus=0 -> actor sees ALL node GPUs (like SGLang); set_device manually
+class ReplayReceiver(ReplayReceiverBody):
+    """Ray wrapper; every method is :class:`ReplayReceiverBody`'s (shared with the Monarch front-end)."""
+
+
+@ray.remote(num_cpus=0)
+class ReplayDrainBarrier:
+    """Replay-only epoch barrier proving complete drain before the next WT starts.
+
+    This actor carries no WeightBridge protocol traffic.  Every sender and every physical receiver rank
+    reports completion after its local full-drain boundary, then waits for the complete participant set.
+    The method is async so one actor can retain all concurrent arrivals without head-of-line blocking.
+    """
+
+    def __init__(self, participants: list[str], timeout_s: float = 1800.0) -> None:
+        if not participants or len(set(participants)) != len(participants):
+            raise ValueError(
+                "replay drain-barrier participants must be non-empty and unique"
+            )
+        self._participants = frozenset(participants)
+        self._timeout_s = float(timeout_s)
+        self._arrivals: dict[int, set[str]] = {}
+        self._events: dict[int, asyncio.Event] = {}
+        self._last_epoch: dict[str, int] = {}
+
+    async def arrive(self, participant: str, epoch: int) -> dict[str, int]:
+        if participant not in self._participants:
+            raise ValueError(
+                f"unknown replay drain-barrier participant {participant!r}"
+            )
+        epoch = int(epoch)
+        previous = self._last_epoch.get(participant, -1)
+        if epoch != previous + 1:
+            raise RuntimeError(
+                f"replay drain-barrier participant {participant!r} arrived at epoch {epoch} "
+                f"after epoch {previous}"
+            )
+        self._last_epoch[participant] = epoch
+        arrivals = self._arrivals.setdefault(epoch, set())
+        arrivals.add(participant)
+        event = self._events.setdefault(epoch, asyncio.Event())
+        if arrivals == self._participants:
+            event.set()
+        try:
+            await asyncio.wait_for(event.wait(), timeout=self._timeout_s)
+        except TimeoutError as error:
+            missing = sorted(self._participants - arrivals)
+            raise TimeoutError(
+                f"replay drain barrier epoch {epoch} timed out; missing {missing}"
+            ) from error
+        return {"epoch": epoch, "participants": len(arrivals)}
+
+
+@ray.remote(num_cpus=1)
+class ReplayEngine:
+    """Spawns one coordinator + this engine's ReplayReceiver actors (all on the rollout node)."""
+
+    def init(
+        self,
+        rank_to_path: dict,
+        port: int,
+        sched,
+        provider: str,
+        iface: str,
+        gantt_dir: str,
+        engine_base: int,
+        visible_devices: str,
+        extra_env: dict | None = None,
+        seed: bool = False,
+    ) -> str:
+        self.ipc = coordinator_ipc(port)
+        self._coord = coordinator.spawn(self.ipc, port)
+        env = _network_env_vars(provider, iface)
+        env["CUDA_VISIBLE_DEVICES"] = visible_devices
+        env["WBRIDGE_GANTT"] = "1" if gantt_dir else "0"
+        if gantt_dir:
+            env["WBRIDGE_GANTT_DIR"] = gantt_dir
+        for k in ENGINE_ENV_KEYS:
+            if os.environ.get(k) is not None:
+                env[k] = os.environ[k]
+        if extra_env:  # per-config overrides (sweep: cap, num_buf)
+            env.update({k: str(v) for k, v in extra_env.items()})
+        runtime_env = {"env_vars": env}
+        ranks = sorted(rank_to_path)
+        self._ranks = ranks
+        self._workers = [
+            ReplayReceiver.options(
+                scheduling_strategy=sched, runtime_env=runtime_env
+            ).remote()
+            for _ in ranks
+        ]
+        # phys_dev = engine_base + rank: distinct GPUs per rank, with engines packed contiguously.
+        ray.get(
+            [
+                w.init.remote(
+                    rank_to_path[r],
+                    self.ipc,
+                    len(ranks),
+                    provider,
+                    iface,
+                    engine_base + r,
+                    seed,
+                )
+                for r, w in zip(ranks, self._workers)
+            ]
+        )
+        return self.ipc
+
+    def run_recv(
+        self, k_updates: int, drain_barrier=None, engine_idx: int = 0
+    ) -> list[int]:
+        return ray.get(
+            [
+                w.run_recv.remote(
+                    k_updates,
+                    drain_barrier=drain_barrier,
+                    participant=f"receiver:{engine_idx}:{rank}",
+                )
+                for rank, w in zip(self._ranks, self._workers)
+            ]
+        )
+
+    def digests(self) -> list[dict]:
+        return ray.get([w.digest.remote() for w in self._workers])
+
+    def timings(self) -> list[dict]:
+        return ray.get([w.timings.remote() for w in self._workers])
+
+    def shutdown(self) -> None:
+        """Kill this engine's receiver actors + coordinator so GPU arenas free between sweep configs."""
+        for w in self._workers:
+            try:
+                ray.kill(w)
+            except Exception:  # noqa: BLE001
+                pass
+        try:
+            if getattr(self, "_coord", None) is not None:
+                self._coord.terminate()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+@ray.remote(
+    num_gpus=0, num_cpus=1
+)  # see all GPUs; set_device manually (match the trainer device layout)
+class ReplaySender(ReplaySenderBody):
+    """Ray wrapper; every method is :class:`ReplaySenderBody`'s (shared with the Monarch front-end)."""
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--specs",
+        required=True,
+        help="dir of loadspec_*.pkl from WBRIDGE_DUMP_LOADSPEC",
+    )
+    ap.add_argument("--iters", type=int, default=4)
+    ap.add_argument(
+        "--network-provider",
+        default=os.environ.get("WB_NETWORK_PROVIDER", "efa"),
+        choices=["tcp", "efa"],
+    )
+    ap.add_argument(
+        "--network-interface", default=os.environ.get("WB_NETWORK_INTERFACE", "")
+    )
+    ap.add_argument("--rollout-ip", default=os.environ.get("WB_ROLLOUT_IP"))
+    ap.add_argument("--trainer-ip", default=os.environ.get("WB_TRAINER_IP"))
+    ap.add_argument(
+        "--base-port",
+        type=int,
+        default=62000,
+        help="first coordinator port (one per engine)",
+    )
+    ap.add_argument(
+        "--pg-port", type=int, default=62100, help="Gloo metadata rendezvous port"
+    )
+    ap.add_argument("--gantt-dir", default="")
+    ap.add_argument(
+        "--allow-cross-wt-overlap",
+        action="store_true",
+        help="disable the replay-only full-drain barrier and allow epoch N+1 to overlap epoch N drain",
+    )
+    ap.add_argument(
+        "--seed",
+        action="store_true",
+        help="deterministic worker values + per-receiver post-consume digests (correctness)",
+    )
+    ap.add_argument(
+        "--digest-out", default="", help="write the run summary + digests as JSON here"
+    )
+    ap.add_argument(
+        "--label", default="mooncake", help="name for this configuration in the report"
+    )
+    a = ap.parse_args()
+
+    recs = load_records(a.specs)
+    print(summary(recs), flush=True)
+    senders, engines = group_records(recs)
+    ws = len(senders)
+    rec_ws = next(iter(senders.values())).get("world_size")
+    if rec_ws is not None and rec_ws != ws:
+        print(
+            f"WARN: captured world_size={rec_ws} but found {ws} sender specs",
+            flush=True,
+        )
+
+    rollout_ip, trainer_ip, rollout_node, trainer_node = get_ray_nodes(
+        a.rollout_ip, a.trainer_ip
+    )
+    roll_sched = NodeAffinitySchedulingStrategy(node_id=rollout_node, soft=False)
+    train_sched = NodeAffinitySchedulingStrategy(node_id=trainer_node, soft=False)
+    print(
+        f"rollout={rollout_ip} trainer={trainer_ip} engines={len(engines)} senders={ws} "
+        f"iters={a.iters} provider={a.network_provider}",
+        flush=True,
+    )
+
+    # 1) Rollout engines (distinct ports, all on the rollout node). engine_base packs engines onto
+    #    contiguous GPUs so each receiver selects a distinct device for cross-device exchange.
+    eids = list(engines.keys())
+    ports = [a.base_port + i for i in range(len(eids))]
+    bases, _acc = [], 0
+    for eid in eids:
+        bases.append(_acc)
+        _acc += len(engines[eid])
+    rollout_visible_devices = visible_device_list(_acc)
+    engine_actors = [
+        ReplayEngine.options(scheduling_strategy=roll_sched).remote() for _ in eids
+    ]
+    ray.get(
+        [
+            ea.init.remote(
+                {r: engines[eid][r]["_path"] for r in engines[eid]},
+                port,
+                roll_sched,
+                a.network_provider,
+                a.network_interface,
+                a.gantt_dir,
+                base,
+                rollout_visible_devices,
+                None,
+                a.seed,
+            )
+            for ea, eid, port, base in zip(engine_actors, eids, ports, bases)
+        ]
+    )
+    receiver_urls = [f"tcp://{rollout_ip}:{p}" for p in ports]
+
+    # 2) Trainer senders (on the trainer node).
+    tenv = _network_env_vars(a.network_provider, a.network_interface)
+    tenv["CUDA_VISIBLE_DEVICES"] = visible_device_list(ws)
+    if a.gantt_dir:
+        tenv.update({"WBRIDGE_GANTT": "1", "WBRIDGE_GANTT_DIR": a.gantt_dir})
+    for k in SENDER_ENV_KEYS:
+        if os.environ.get(k) is not None:
+            tenv[k] = os.environ[k]
+    truntime = {"env_vars": tenv}
+    sender_actors = []
+    for r in sorted(senders):
+        args = SenderArgs(
+            world_size=ws,
+            receiver_urls=receiver_urls,
+            master_addr=trainer_ip,
+            master_port=a.pg_port,
+            protocol=("efa" if a.network_provider == "efa" else "tcp"),
+            sender_staging=bool(senders[r].get("sender_staging")),
+        )
+        s = ReplaySender.options(
+            scheduling_strategy=train_sched, runtime_env=truntime
+        ).remote()
+        sender_actors.append((r, s, args))
+    ray.get(
+        [
+            s.init.remote(
+                senders[r]["_path"],
+                args,
+                a.network_provider,
+                a.network_interface,
+                r,
+                a.seed,
+            )
+            for r, s, args in sender_actors
+        ]
+    )
+
+    # 3) Run K transfers: receivers poll (drive connect + K receives); senders connect + K send/wait.
+    participant_ids = [f"sender:{rank}" for rank in sorted(senders)] + [
+        f"receiver:{engine_idx}:{rank}"
+        for engine_idx, eid in enumerate(eids)
+        for rank in sorted(engines[eid])
+    ]
+    drain_barrier = None
+    if not a.allow_cross_wt_overlap:
+        drain_barrier = ReplayDrainBarrier.remote(participant_ids)
+        print(
+            f"replay full-drain barrier: {len(participant_ids)} participants",
+            flush=True,
+        )
+    recv_futs = [
+        ea.run_recv.remote(a.iters, drain_barrier=drain_barrier, engine_idx=engine_idx)
+        for engine_idx, ea in enumerate(engine_actors)
+    ]
+    send_futs = [
+        s.run_send.remote(
+            a.iters, drain_barrier=drain_barrier, participant=f"sender:{rank}"
+        )
+        for rank, s, _ in sender_actors
+    ]
+    send_res = ray.get(send_futs)
+    ray.get(recv_futs)
+
+    # 4) Report. Digests are collected only after the timed loop, so hashing never lands in a WTT.
+    digests = None
+    if a.seed:
+        digests = []
+        for i, ea in enumerate(engine_actors):
+            digests += [
+                dict(d, key=f"e{i}/r{d['rank']}") for d in ray.get(ea.digests.remote())
+            ]
+    report_run(
+        a.label,
+        send_res,
+        digests,
+        a.iters,
+        a.digest_out,
+        extra=f"{len(eids)} engines x {ws} senders",
+    )
+    if a.gantt_dir:
+        print(f"gantt jsonl -> {a.gantt_dir}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/bench_transfer_4node.py
+++ b/examples/weightbridge/examples/bench_transfer_4node.py
@@ -1,0 +1,552 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Frameworkless replay of a 4-node 30B capture (16 senders across 2 trainer nodes, 16 receivers = 4
+physical engines across 2 rollout nodes, matching the real disagg run that produced the loadspecs).
+
+This is a synthetic workload: it replays the captured tensor layout and placement but does not execute
+model training or generation. Tensor values are uninitialized for performance-only runs; ``--seed``
+uses deterministic synthetic values so receivers can verify post-transfer digests.
+
+bench_transfer.py packs everything onto ONE trainer + ONE rollout node (<=8 GPUs/side); this variant
+spreads it across a 4-node lease (32 GPUs).
+
+Engine grouping subtlety: the captured ``engine_id`` is a node-local coordinator socket
+(``coordinator_ipc(<port>)``) that COLLIDES across rollout nodes — two physical engines on
+different nodes share it. ``loadspec_replay.group_records`` keys purely on engine_id and would merge
+them, silently dropping half the receivers. Here we split each engine_id into physical engines by
+pid-clustering (one SGLang scheduler spawns its workers with clustered pids), then co-locate the engines
+that shared a node in the real run (lowest-pid cluster -> rollout node 0, etc.) so same-node
+cross-engine dedup exchange takes NVLink and cross-node takes RDMA — as in the real run.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import statistics
+from collections import defaultdict
+
+import ray
+from bench_report import SENDER_ENV_KEYS
+from bench_transfer import ReplayDrainBarrier, ReplayEngine, ReplaySender
+from loadspec_replay import load_records, summary
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+from utils import network_env_vars, visible_device_list
+from wbridge.backend.sender import SenderArgs
+
+
+def _pid_of(rec: dict) -> int:
+    m = re.search(r"_pid(\d+)", rec.get("_path", ""))
+    return int(m.group(1)) if m else 0
+
+
+def physical_engines(recs: list[dict]) -> list[dict[int, dict]]:
+    """Split receivers into PHYSICAL engines (list of {rank: rec}).
+
+    engine_id collides across nodes, so within each engine_id we sort by pid and chunk into
+    num_workers-sized, rank-complete groups — each chunk is one physical engine on one node. The result
+    is sorted by each engine's min pid so co-located engines (same pid cluster == same node) are adjacent.
+    """
+    by_eid: dict[object, list[dict]] = defaultdict(list)
+    for r in recs:
+        if r.get("role") == "receiver":
+            by_eid[r["engine_id"]].append(r)
+    phys: list[dict[int, dict]] = []
+    for eid in sorted(by_eid, key=str):
+        rs = sorted(by_eid[eid], key=_pid_of)
+        nw = rs[0].get("num_workers") or 4
+        for i in range(0, len(rs), nw):
+            chunk = rs[i : i + nw]
+            eng = {r["rank"]: r for r in chunk}
+            if len(eng) != len(chunk):
+                raise RuntimeError(
+                    f"engine split failed for {eid!r}: chunk ranks "
+                    f"{sorted(r['rank'] for r in chunk)} (pid clustering ambiguous)"
+                )
+            phys.append(eng)
+    phys.sort(
+        key=lambda e: min(_pid_of(r) for r in e.values())
+    )  # cluster by node (pid range)
+    return phys
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--specs", required=True)
+    ap.add_argument("--iters", type=int, default=6)
+    ap.add_argument(
+        "--network-provider",
+        default=os.environ.get("WB_NETWORK_PROVIDER", "efa"),
+        choices=["tcp", "efa"],
+    )
+    ap.add_argument(
+        "--network-interface", default=os.environ.get("WB_NETWORK_INTERFACE", "")
+    )
+    ap.add_argument(
+        "--gpus-per-node",
+        type=int,
+        default=int(os.environ.get("WB_GPUS_PER_NODE", "8")),
+    )
+    ap.add_argument(
+        "--engines-per-rollout-node",
+        type=int,
+        default=int(os.environ.get("WB_ENGINES_PER_ROLLOUT_NODE", "2")),
+    )
+    ap.add_argument(
+        "--rollout-dp",
+        type=int,
+        default=0,
+        help=(
+            "number of physical rollout engines to replay; 0 uses every captured engine. "
+            "When larger than the capture, engine templates are repeated cyclically (A,B,A,B,...) "
+            "with distinct actors/coordinators/global ranks"
+        ),
+    )
+    ap.add_argument("--base-port", type=int, default=62000)
+    ap.add_argument("--pg-port", type=int, default=62100)
+    ap.add_argument("--gantt-dir", default="")
+    ap.add_argument(
+        "--allow-cross-wt-overlap",
+        action="store_true",
+        help="disable the replay-only full-drain barrier and allow epoch N+1 to overlap epoch N drain",
+    )
+    ap.add_argument(
+        "--metrics-out",
+        default="",
+        help="optional JSON output for trainer block, rollout block, and E2E WTT",
+    )
+    ap.add_argument(
+        "--seed",
+        action="store_true",
+        help="deterministic sender/receiver values for post-consume correctness digests",
+    )
+    ap.add_argument(
+        "--digest-out",
+        default="",
+        help="optional JSON output containing every physical receiver digest",
+    )
+    ap.add_argument(
+        "--discard-first",
+        type=int,
+        default=2,
+        help="cold replay iterations excluded from the three-metric summary",
+    )
+    a = ap.parse_args()
+
+    recs = load_records(a.specs)
+    print(summary(recs), flush=True)
+    senders = {r["rank"]: r for r in recs if r.get("role") == "sender"}
+    ws = len(senders)
+    captured_engs = physical_engines(
+        recs
+    )  # list of {rank: rec}, one per captured PHYSICAL engine
+    if a.rollout_dp < 0:
+        raise ValueError(f"--rollout-dp must be >= 0, got {a.rollout_dp}")
+    if a.rollout_dp:
+        if not captured_engs:
+            raise RuntimeError(
+                "--rollout-dp requires at least one captured rollout engine"
+            )
+        # A replay engine only reads the capture files. Reusing its rank->path mapping is therefore an exact
+        # logical duplicate, while the actors/coordinator port and the WeightBridge global ranks allocated
+        # below remain independent. Cycle all captured templates before repeating the first one so DP<=capture
+        # retains the captured physical-engine ordering.
+        engs = [captured_engs[i % len(captured_engs)] for i in range(a.rollout_dp)]
+    else:
+        engs = captured_engs
+    n_engines = len(engs)
+    gpn, epn = a.gpus_per_node, a.engines_per_rollout_node
+    n_roll_nodes = (n_engines + epn - 1) // epn
+    n_train_nodes = (ws + gpn - 1) // gpn
+    print(
+        f"physical engines={n_engines} (captured={len(captured_engs)}, "
+        f"templates={[i % len(captured_engs) for i in range(n_engines)] if captured_engs else []}, "
+        f"ranks/engine={[len(e) for e in engs]}); "
+        f"need {n_roll_nodes} rollout + {n_train_nodes} trainer nodes",
+        flush=True,
+    )
+
+    ray.init(address="auto", ignore_reinit_error=True)
+    alive = sorted(
+        (n for n in ray.nodes() if n["Alive"]),
+        key=lambda n: str(n["NodeManagerAddress"]),
+    )
+    need = n_roll_nodes + n_train_nodes
+    if len(alive) < need:
+        raise RuntimeError(f"need {need} alive Ray nodes, have {len(alive)}")
+    roll_nodes = alive[:n_roll_nodes]
+    train_nodes = alive[n_roll_nodes : n_roll_nodes + n_train_nodes]
+    roll_ips = [str(n["NodeManagerAddress"]) for n in roll_nodes]
+    train_ips = [str(n["NodeManagerAddress"]) for n in train_nodes]
+    print(
+        f"rollout nodes={roll_ips} trainer nodes={train_ips} iters={a.iters} "
+        f"provider={a.network_provider}",
+        flush=True,
+    )
+
+    # 1) Rollout engines: engine i -> roll_nodes[i//epn]; engine_base=(i%epn)*ranks so a node's engines
+    #    pack onto contiguous GPUs. Each engine has a unique global port.
+    ports = [a.base_port + i for i in range(n_engines)]
+    node_idx = [i // epn for i in range(n_engines)]
+    bases = [(i % epn) * len(engs[i]) for i in range(n_engines)]
+    roll_scheds = [
+        NodeAffinitySchedulingStrategy(
+            node_id=str(roll_nodes[node_idx[i]]["NodeID"]), soft=False
+        )
+        for i in range(n_engines)
+    ]
+    engine_actors = [
+        ReplayEngine.options(scheduling_strategy=roll_scheds[i]).remote()
+        for i in range(n_engines)
+    ]
+    rollout_visible_devices = visible_device_list(gpn)
+    ray.get(
+        [
+            engine_actors[i].init.remote(
+                {r: engs[i][r]["_path"] for r in engs[i]},
+                ports[i],
+                roll_scheds[i],
+                a.network_provider,
+                a.network_interface,
+                a.gantt_dir,
+                bases[i],
+                rollout_visible_devices,
+                None,
+                a.seed,
+            )
+            for i in range(n_engines)
+        ]
+    )
+    receiver_urls = [
+        f"tcp://{roll_ips[node_idx[i]]}:{ports[i]}" for i in range(n_engines)
+    ]
+
+    # 2) Trainer senders: rank r -> train_nodes[r//gpn], phys_dev r%gpn. Gloo PG rendezvous at trainer 0.
+    sender_actors = []
+    for r in sorted(senders):
+        tsched = NodeAffinitySchedulingStrategy(
+            node_id=str(train_nodes[r // gpn]["NodeID"]), soft=False
+        )
+        args = SenderArgs(
+            world_size=ws,
+            receiver_urls=receiver_urls,
+            master_addr=train_ips[0],
+            master_port=a.pg_port,
+            protocol=("efa" if a.network_provider == "efa" else "tcp"),
+            sender_staging=bool(senders[r].get("sender_staging")),
+        )
+        sender_options = {"scheduling_strategy": tsched}
+        sender_env = network_env_vars(a.network_provider, a.network_interface)
+        sender_env["CUDA_VISIBLE_DEVICES"] = visible_device_list(gpn)
+        sender_env.update(
+            {
+                key: os.environ[key]
+                for key in SENDER_ENV_KEYS
+                if os.environ.get(key) is not None
+            }
+        )
+        if a.gantt_dir:
+            # Gantt is read when wbridge is imported in the Ray worker, before ReplaySender.init().
+            sender_env.update({"WBRIDGE_GANTT": "1", "WBRIDGE_GANTT_DIR": a.gantt_dir})
+        if sender_env:
+            sender_options["runtime_env"] = {"env_vars": sender_env}
+        s = ReplaySender.options(**sender_options).remote()
+        sender_actors.append((r, s, args))
+    ray.get(
+        [
+            s.init.remote(
+                senders[r]["_path"],
+                args,
+                a.network_provider,
+                a.network_interface,
+                r % gpn,
+                a.seed,
+            )
+            for r, s, args in sender_actors
+        ]
+    )
+
+    # 3) Run K transfers.
+    participant_ids = [f"sender:{rank}" for rank in sorted(senders)] + [
+        f"receiver:{engine_idx}:{rank}"
+        for engine_idx, engine in enumerate(engs)
+        for rank in sorted(engine)
+    ]
+    drain_barrier = None
+    if not a.allow_cross_wt_overlap:
+        drain_barrier = ReplayDrainBarrier.remote(participant_ids)
+        print(
+            f"replay full-drain barrier: {len(participant_ids)} participants",
+            flush=True,
+        )
+    recv_futs = [
+        ea.run_recv.remote(a.iters, drain_barrier=drain_barrier, engine_idx=engine_idx)
+        for engine_idx, ea in enumerate(engine_actors)
+    ]
+    send_futs = [
+        s.run_send.remote(
+            a.iters, drain_barrier=drain_barrier, participant=f"sender:{rank}"
+        )
+        for rank, s, _ in sender_actors
+    ]
+    send_res = ray.get(send_futs)
+    ray.get(recv_futs)
+
+    # Collect timestamps after the timed loops to keep file I/O and Ray RPCs off the transfer path:
+    # trainer block ends when the pack-safe CUDA event fires;
+    # rollout block spans poll_requests(); E2E runs from trainer-rank-0 send_start to the slowest
+    # receiver's consume_end across both engines.
+    sender_timings = ray.get([s.timings.remote() for _, s, _ in sender_actors])
+    sender_plan_stats = ray.get([s.plan_stats.remote() for _, s, _ in sender_actors])
+    engine_timings = ray.get([ea.timings.remote() for ea in engine_actors])
+    digests: dict[str, str] = {}
+    if a.seed:
+        for engine_idx, engine in enumerate(engine_actors):
+            for item in ray.get(engine.digests.remote()):
+                key = f"e{engine_idx}/r{item['rank']}"
+                if key in digests:
+                    raise RuntimeError(f"duplicate receiver digest key {key}")
+                digests[key] = item["digest"]
+        print(f"receiver digests: {len(digests)} physical ranks", flush=True)
+
+    # 4) Report timing.  Trainer blocking is the union of every physical trainer worker's
+    # WeightBridge window: first send() entry through last pack-handoff completion.  Reporting only
+    # rank 0 hides uneven sharding/packing work and is not comparable with a multi-worker run.
+    send_res.sort(key=lambda x: x[0])
+    rank0, connect_s, wtts, nr = send_res[0]
+    print(
+        f"\n=== replay WTT (rank {rank0}, {nr} rounds, {n_engines} engines x {ws} senders) ===",
+        flush=True,
+    )
+    print(f"connect (cold setup): {connect_s:.3f} s", flush=True)
+    for i, w in enumerate(wtts):
+        print(f"  WT{i}: {w:.3f} s", flush=True)
+    warm = wtts[1:] or wtts
+    print(
+        f"warm: min={min(warm):.3f} median={statistics.median(warm):.3f} mean={statistics.mean(warm):.3f} s",
+        flush=True,
+    )
+
+    by_sender_rank = {x["rank"]: x["epochs"] for x in sender_timings}
+    plan_by_sender_rank = {x["rank"]: x for x in sender_plan_stats}
+    if 0 not in by_sender_rank:
+        raise RuntimeError(
+            f"replay timing is missing trainer rank 0: {sorted(by_sender_rank)}"
+        )
+    rank0_epochs = by_sender_rank[0]
+    if len(rank0_epochs) != a.iters:
+        raise RuntimeError(
+            f"trainer rank 0 timing count {len(rank0_epochs)} != iters {a.iters}"
+        )
+    for sender_rank, epochs in sorted(by_sender_rank.items()):
+        if len(epochs) != a.iters:
+            raise RuntimeError(
+                f"trainer rank {sender_rank} timing count {len(epochs)} != iters {a.iters}"
+            )
+    for engine_idx, ranks in enumerate(engine_timings):
+        if len(ranks) != len(engs[engine_idx]):
+            raise RuntimeError(
+                f"engine {engine_idx}: timing ranks {len(ranks)} != captured ranks {len(engs[engine_idx])}"
+            )
+        for rank_timing in ranks:
+            if len(rank_timing["epochs"]) != a.iters:
+                raise RuntimeError(
+                    f"engine {engine_idx} rank {rank_timing['rank']}: timing count "
+                    f"{len(rank_timing['epochs'])} != iters {a.iters}"
+                )
+
+    rows = []
+    for epoch in range(a.iters):
+        trainer = rank0_epochs[epoch]
+        trainer_workers = {
+            rank: epochs[epoch] for rank, epochs in sorted(by_sender_rank.items())
+        }
+        trainer_rank_endpoints = {
+            str(rank): {
+                "start_ns": worker["send_start_ns"],
+                "end_ns": worker["trainer_end_ns"],
+                "duration_ns": worker["trainer_block_ns"],
+                "full_delivery_end_ns": worker["local_complete_ns"],
+            }
+            for rank, worker in trainer_workers.items()
+        }
+        trainer_first_rank, trainer_first = min(
+            trainer_workers.items(), key=lambda item: item[1]["send_start_ns"]
+        )
+        trainer_last_rank, trainer_last = max(
+            trainer_workers.items(), key=lambda item: item[1]["trainer_end_ns"]
+        )
+        engine_blocks = {}
+        engine_consumed = {}
+        engine_endpoints = {}
+        for engine_idx, ranks in enumerate(engine_timings):
+            spans = [rank_timing["epochs"][epoch] for rank_timing in ranks]
+            rank_spans = {
+                str(rank_timing["rank"]): rank_timing["epochs"][epoch]
+                for rank_timing in ranks
+            }
+            first_rank, first_span = min(
+                rank_spans.items(), key=lambda item: item[1]["block_start_ns"]
+            )
+            last_rank, last_span = max(
+                rank_spans.items(), key=lambda item: item[1]["block_end_ns"]
+            )
+            engine_start_ns = first_span["block_start_ns"]
+            engine_end_ns = last_span["block_end_ns"]
+            engine_key = str(engine_idx)
+            engine_blocks[engine_key] = (engine_end_ns - engine_start_ns) / 1e6
+            engine_consumed[engine_key] = max(span["consume_end_ns"] for span in spans)
+            engine_endpoints[engine_key] = {
+                "start_ns": engine_start_ns,
+                "end_ns": engine_end_ns,
+                "duration_ns": engine_end_ns - engine_start_ns,
+                "first_rank": int(first_rank),
+                "last_rank": int(last_rank),
+                "rank_endpoints": {
+                    rank: {
+                        "start_ns": span["block_start_ns"],
+                        "consume_end_ns": span["consume_end_ns"],
+                        "end_ns": span["block_end_ns"],
+                        "duration_ns": span["block_duration_ns"],
+                    }
+                    for rank, span in sorted(
+                        rank_spans.items(), key=lambda item: int(item[0])
+                    )
+                },
+            }
+        row = {
+            "epoch": epoch,
+            "trainer_block_ms": (
+                trainer_last["trainer_end_ns"] - trainer_first["send_start_ns"]
+            )
+            / 1e6,
+            "trainer_rank0_block_ms": trainer["trainer_block_ns"] / 1e6,
+            "trainer_interval": {
+                "start_ns": trainer_first["send_start_ns"],
+                "end_ns": trainer_last["trainer_end_ns"],
+                "duration_ns": trainer_last["trainer_end_ns"]
+                - trainer_first["send_start_ns"],
+                "first_rank": trainer_first_rank,
+                "last_rank": trainer_last_rank,
+                "rank_endpoints": trainer_rank_endpoints,
+            },
+            "rollout_block_avg_ms": statistics.fmean(engine_blocks.values()),
+            "rollout_block_by_engine_ms": engine_blocks,
+            "rollout_engine_intervals": engine_endpoints,
+            "e2e_wtt_ms": (max(engine_consumed.values()) - trainer["send_start_ns"])
+            / 1e6,
+        }
+        rows.append(row)
+        print(
+            "INTERVAL_ENDPOINTS "
+            + json.dumps(
+                {
+                    "epoch": epoch,
+                    "trainer": row["trainer_interval"],
+                    "rollout_engines": row["rollout_engine_intervals"],
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+    print("\n=== replay three-metric WTT ===", flush=True)
+    print("epoch trainer_block_ms rollout_block_avg_ms e2e_wtt_ms", flush=True)
+    for row in rows:
+        print(
+            f"{row['epoch']:5d} {row['trainer_block_ms']:16.3f} "
+            f"{row['rollout_block_avg_ms']:20.3f} {row['e2e_wtt_ms']:10.3f}",
+            flush=True,
+        )
+    if not 0 <= a.discard_first < len(rows):
+        raise ValueError(
+            f"discard-first must be in [0, {len(rows) - 1}], got {a.discard_first}"
+        )
+    selected = rows[a.discard_first :]
+    summary_out = {
+        "threshold": os.environ.get("WBRIDGE_DEDUP_PAIR_BYTES", ""),
+        "control_transport": (
+            "tcp" if os.environ.get("WBRIDGE_TCP_CONTROL") == "1" else "rdma_flag_write"
+        ),
+        "rollout_dp": n_engines,
+        "rounds": nr,
+        "requested_num_rounds": (
+            int(os.environ["WBRIDGE_NUM_ROUNDS"])
+            if os.environ.get("WBRIDGE_NUM_ROUNDS")
+            else None
+        ),
+        "rollout_rdma_cap_bytes": (
+            int(os.environ["WBRIDGE_ROLLOUT_RDMA_CAP_BYTES"])
+            if os.environ.get("WBRIDGE_ROLLOUT_RDMA_CAP_BYTES")
+            else None
+        ),
+        "planner_mode": plan_by_sender_rank[0]["planner_mode"],
+        "rollout_rdma_peak_bytes": plan_by_sender_rank[0]["rollout_rdma_peak_bytes"],
+        "drain_between_wts": not a.allow_cross_wt_overlap,
+        "iters": a.iters,
+        "discard_first": a.discard_first,
+        "num_selected": len(selected),
+        "interval_endpoint_schema": 1,
+        "trainer_block_definition": "first trainer send_start to last trainer pack-handoff end",
+        "rollout_block_definition": (
+            "per engine: first receiver-rank block_start to last receiver-rank block_end; "
+            "reported value is the mean across engines"
+        ),
+        "trainer_block_mean_ms": statistics.fmean(
+            r["trainer_block_ms"] for r in selected
+        ),
+        "trainer_block_median_ms": statistics.median(
+            r["trainer_block_ms"] for r in selected
+        ),
+        "trainer_rank0_block_mean_ms": statistics.fmean(
+            r["trainer_rank0_block_ms"] for r in selected
+        ),
+        "trainer_rank0_block_median_ms": statistics.median(
+            r["trainer_rank0_block_ms"] for r in selected
+        ),
+        "rollout_block_avg_mean_ms": statistics.fmean(
+            r["rollout_block_avg_ms"] for r in selected
+        ),
+        "rollout_block_avg_median_ms": statistics.median(
+            r["rollout_block_avg_ms"] for r in selected
+        ),
+        "e2e_wtt_mean_ms": statistics.fmean(r["e2e_wtt_ms"] for r in selected),
+        "e2e_wtt_median_ms": statistics.median(r["e2e_wtt_ms"] for r in selected),
+        "rows": rows,
+    }
+    if digests:
+        summary_out["digests"] = dict(sorted(digests.items()))
+    print(f"THREE_METRIC_SUMMARY {json.dumps(summary_out, sort_keys=True)}", flush=True)
+    if a.metrics_out:
+        out_dir = os.path.dirname(os.path.abspath(a.metrics_out))
+        os.makedirs(out_dir, exist_ok=True)
+        with open(a.metrics_out, "w") as f:
+            json.dump(summary_out, f, indent=2, sort_keys=True)
+        print(f"three-metric summary -> {a.metrics_out}", flush=True)
+    if a.digest_out:
+        if not digests:
+            raise ValueError("--digest-out requires --seed")
+        out_dir = os.path.dirname(os.path.abspath(a.digest_out))
+        os.makedirs(out_dir, exist_ok=True)
+        digest_report = {
+            "label": f"cons-{summary_out['threshold']}",
+            "iters": a.iters,
+            "warm_median": statistics.median(warm),
+            "digests": dict(sorted(digests.items())),
+        }
+        with open(a.digest_out, "w") as f:
+            json.dump(digest_report, f, indent=2, sort_keys=True)
+        print(f"digest summary -> {a.digest_out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/check_rounds.py
+++ b/examples/weightbridge/examples/check_rounds.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Check whether consolidation drops any tensor from the global round packing (→ never transferred → nan)."""
+
+import os
+
+import torch  # noqa: F401
+from analyze_consolidate import build_all_specs
+from loadspec_replay import load_records
+from wbridge.backend.router import WeightRouter
+
+recs = load_records(os.environ["SPECS"])
+all_specs, ws, dts = build_all_specs(recs)
+
+
+def rounds_cover(cons):
+    if cons:
+        os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = str(20 * 1024 * 1024)
+    else:
+        os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = "0"
+    r = WeightRouter(rank=0, sender_ws=ws, all_specs=all_specs, dtype_spec=dict(dts))
+    in_rounds = set()
+    for names in r.global_rounds:
+        in_rounds |= set(names)
+    recv_names = set()
+    for s in r.recv_specs_full:
+        recv_names |= set(s.entries.keys())
+    missing = recv_names - in_rounds
+    return len(r.global_rounds), len(in_rounds), len(recv_names), sorted(missing)
+
+
+for c in (0, 1):
+    nr, nin, nall, miss = rounds_cover(c)
+    print(
+        f"CONS={c}: rounds={nr} names_in_rounds={nin} recv_names={nall} MISSING_FROM_ROUNDS={len(miss)}"
+    )
+    if miss:
+        print("   e.g.:", miss[:12])

--- a/examples/weightbridge/examples/consume_test.py
+++ b/examples/weightbridge/examples/consume_test.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Compare fuse vs 2-stage (canonical) packing of the RECEIVER's own slice (recv_spec[0]) for decomposed
+tensors. The assemble fills own canonically (setitem_pairs) but the consume reads it via fuse; if fuse and
+canonical disagree on the own/full_spec layout, that mix corrupts. Natural should agree; consolidated may not.
+"""
+
+import os
+
+import torch
+from analyze_consolidate import build_all_specs
+from loadspec_replay import group_records, load_records, rebuild
+from wbridge.backend.router import WeightRouter
+from wbridge.utils.data import batched_copy
+
+recs = load_records(os.environ["SPECS"])
+all_specs, ws, dts = build_all_specs(recs)
+senders, engines = group_records(recs)
+eid0 = next(iter(engines))
+rec0 = engines[eid0][sorted(engines[eid0])[0]]
+_src, dtype_spec, load_spec, wksd = rebuild(rec0, device="cuda")
+for name, t in wksd.items():
+    flat = t.reshape(-1)
+    flat.copy_(
+        torch.arange(flat.numel(), device=t.device, dtype=torch.float32).to(t.dtype)
+    )
+
+TENSORS = [
+    "model.layers.0.self_attn.q_norm.weight",
+    "model.layers.0.mlp.gate.weight",
+    "model.layers.0.input_layernorm.weight",
+    "model.layers.0.self_attn.q_proj.weight",
+]
+
+
+def cmp(cons):
+    if cons:
+        os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = str(20 * 1024 * 1024)
+    else:
+        os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = "0"
+    r = WeightRouter(rank=0, sender_ws=ws, all_specs=all_specs, dtype_spec=dict(dts))
+    print(
+        f"\n===== consolidate={cons} : fuse SAVE vs canonical SAVE of own (recv_spec[0]) ====="
+    )
+    for t in TENSORS:
+        if t not in r.recv_specs[0].entries:
+            continue
+        spec = r.recv_specs[0].subset({t})
+        nb = spec.nbytes(dtype_spec)
+        wire_fuse = torch.zeros(nb, dtype=torch.uint8, device="cuda")
+        batched_copy(
+            load_spec.fuse_copy_pairs(
+                spec, wire_fuse, wksd, dtype_spec, src_to_dst=False
+            )
+        )
+        # canonical 2-stage: model -> logical buf -> wire
+        buf = spec.make_named_buffer(dtype_spec, "cuda")
+        batched_copy(load_spec.copy_fromto_pairs(spec, buf, wksd, src_to_dst=False))
+        wire_2s = torch.zeros(nb, dtype=torch.uint8, device="cuda")
+        _n, pp = spec(buf).pack_into_pairs(spec, wire_2s)
+        batched_copy(pp)
+        torch.cuda.synchronize()
+        eq = torch.equal(wire_fuse, wire_2s)
+        ndiff = int((wire_fuse != wire_2s).sum())
+        print(
+            f"  {t.split('.', 2)[-1]:<28} nb={nb:<8} fuse==canonical: {eq}  bytes_diff={ndiff}"
+        )
+
+
+cmp(0)
+cmp(1)

--- a/examples/weightbridge/examples/loadspec_replay.py
+++ b/examples/weightbridge/examples/loadspec_replay.py
@@ -1,0 +1,192 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Read per-rank LoadSpecs captured by ``WBRIDGE_DUMP_LOADSPEC`` and rebuild the objects needed to
+replay the exact transfer frameworklessly (no Megatron/SGLang/specgen).
+
+Each pkl (written by ``wbridge.frontend.adapters._dump_loadspec_if_requested``) holds one rank's
+``load_spec``/``dtype_spec``/``src_shard_spec`` entries + ``wksd_meta`` (name -> shape, dtype) +
+topology. ``rebuild()`` reconstructs the specs and allocates a **synthetic** worker state dict of the
+recorded shapes/dtypes — values are irrelevant to WTT (specgen + the equality check are skipped;
+correctness stays with the real run).
+"""
+
+from __future__ import annotations
+
+import glob
+import hashlib
+import os
+import pickle
+import zlib
+
+import torch
+from wbridge.utils.data import (
+    LoadSpec,
+    logical_tensor_cap_bytes,
+    ShardSpec,
+    split_large_load_spec_sources,
+)
+
+
+def load_records(spec_dir: str) -> list[dict]:
+    """Load every ``loadspec_*.pkl`` in *spec_dir* (one per captured rank)."""
+    recs = []
+    for fp in sorted(glob.glob(os.path.join(spec_dir, "loadspec_*.pkl"))):
+        with open(fp, "rb") as f:
+            r = pickle.load(f)
+        r = translate_record_logical_tensors(r)
+        r["_path"] = fp
+        recs.append(r)
+    if not recs:
+        raise FileNotFoundError(f"no loadspec_*.pkl under {spec_dir}")
+    return recs
+
+
+def translate_record_logical_tensors(rec: dict) -> dict:
+    """Apply the configured logical-source cap to captured metadata without allocating tensors.
+
+    This keeps placement logic, offline memory inspection, and replay actors on the exact same translated
+    LoadSpec. New captures are already translated and pass through idempotently.
+    """
+    load_spec = LoadSpec(rec["load_spec"])
+    dtype_spec = dict(rec["dtype_spec"])
+    load_spec, dtype_spec, split_report = split_large_load_spec_sources(
+        load_spec,
+        dtype_spec,
+        logical_tensor_cap_bytes(),
+    )
+    if not split_report:
+        return rec
+    translated = dict(rec)
+    translated["load_spec"] = load_spec.entries
+    translated["dtype_spec"] = dtype_spec
+    translated["src_shard_spec"] = load_spec.src_shard_spec.entries
+    translated["logical_tensor_splits"] = split_report
+    return translated
+
+
+def group_records(
+    recs: list[dict],
+) -> tuple[dict[int, dict], dict[object, dict[int, dict]]]:
+    """Return (senders, engines): senders={rank: rec}; engines={engine_id: {rank: rec}}.
+
+    De-duplicates by (role, engine_id, rank) — a real run may launch a rank's process more than once
+    (Ray retries); the last write for a (role, engine, rank) wins.
+    """
+    senders: dict[int, dict] = {}
+    engines: dict[object, dict[int, dict]] = {}
+    for r in sorted(recs, key=lambda x: x["_path"]):
+        if r["role"] == "sender":
+            senders[r["rank"]] = r
+        else:
+            engines.setdefault(r["engine_id"], {})[r["rank"]] = r
+    return senders, engines
+
+
+def _is_contiguous(shape, stride) -> bool:
+    exp = 1
+    for s, st in zip(reversed(shape), reversed(stride)):
+        if s != 1 and st != exp:
+            return False
+        exp *= s
+    return True
+
+
+def _alloc(shape, dtype, stride, device):
+    """Synthetic worker tensor of the recorded shape/dtype — matching the recorded strides (so a real
+    non-contiguous SGLang/Megatron param reproduces the same copy path), else contiguous."""
+    shape = tuple(shape)
+    if not stride or _is_contiguous(shape, tuple(stride)):
+        return torch.empty(shape, dtype=dtype, device=device)
+    need = 1 + sum((s - 1) * st for s, st in zip(shape, stride)) if shape else 1
+    base = torch.empty(int(need), dtype=dtype, device=device)
+    return torch.as_strided(base, shape, tuple(stride))
+
+
+def _fill_deterministic(t: torch.Tensor, salt: str, name: str, rank: int) -> None:
+    """Fill *t* with values fixed by ``(salt, name, rank)`` — same content on every run, on any transport.
+
+    This is what turns the perf replay into a correctness check: the sender's shards become known,
+    reproducible bytes, so a receiver's post-consume hash is a function of the transport delivering them
+    correctly and of nothing else. ``torch.empty`` would make the hash depend on whatever was in HBM.
+
+    The generator is per-tensor and seeded from the *name*, not drawn from a single stream, so the content
+    does not depend on dict iteration order or on which ranks happen to exist.
+    """
+    seed = zlib.crc32(f"{salt}|{name}|{rank}".encode()) & 0x7FFFFFFF
+    g = torch.Generator(device=t.device).manual_seed(seed)
+    if t.dtype.is_floating_point:
+        # normal_ works elementwise, so it fills a non-contiguous as_strided view correctly too.
+        t.normal_(mean=0.0, std=1.0, generator=g)
+    else:
+        t.random_(0, 127, generator=g)
+
+
+def rebuild(
+    rec: dict, device: str = "cuda", seed_salt: str = ""
+) -> tuple[ShardSpec, dict, LoadSpec, dict]:
+    """Rebuild (src_shard_spec, dtype_spec, load_spec, synthetic wksd) from a captured record.
+
+    wksd_meta entries are (shape, dtype) [legacy] or (shape, dtype, stride) [current].
+
+    *seed_salt* non-empty makes the wksd contents deterministic instead of uninitialized (see
+    :func:`_fill_deterministic`); pass different salts for the sender and receiver roles so a region the
+    transport never wrote is still visible as "not the sender's bytes".
+    """
+    load_spec = LoadSpec(rec["load_spec"])
+    dtype_spec = dict(rec["dtype_spec"])
+    load_spec, dtype_spec, split_report = split_large_load_spec_sources(
+        load_spec,
+        dtype_spec,
+        logical_tensor_cap_bytes(),
+    )
+    # New captures already store logical names; old captures are translated here. Recompute from LoadSpec
+    # whenever translation occurred so the synthetic replay sees the same virtual checkpoint layout as a
+    # live adapter. Otherwise retain the recorded source spec byte-for-byte for legacy compatibility.
+    src_shard_spec = (
+        load_spec.src_shard_spec if split_report else ShardSpec(rec["src_shard_spec"])
+    )
+    wksd = {}
+    for name, meta in rec["wksd_meta"].items():
+        shape, dtype = meta[0], meta[1]
+        stride = meta[2] if len(meta) > 2 else None
+        t = _alloc(shape, dtype, stride, device)
+        if seed_salt:
+            _fill_deterministic(t, seed_salt, name, int(rec["rank"]))
+        wksd[name] = t
+    return src_shard_spec, dtype_spec, load_spec, wksd
+
+
+def wksd_digest(wksd: dict) -> str:
+    """Order-independent-of-dict, content-dependent digest of a worker state dict.
+
+    Used to compare a receiver's post-consume weights across two transports. Names are sorted and folded
+    in alongside the bytes, so a transport that delivered the right bytes to the wrong tensor still
+    changes the digest. Hashing on the CPU (rather than a GPU reduction) keeps it exact and trivially
+    comparable across processes; it runs once after the timed loop, never inside it.
+    """
+    h = hashlib.blake2b(digest_size=16)
+    for name in sorted(wksd):
+        t = wksd[name]
+        h.update(name.encode())
+        h.update(f"{tuple(t.shape)}|{t.dtype}".encode())
+        h.update(t.detach().contiguous().view(torch.uint8).cpu().numpy().tobytes())
+    return h.hexdigest()
+
+
+def summary(recs: list[dict]) -> str:
+    senders, engines = group_records(recs)
+    lines = [
+        f"senders={len(senders)} (ranks {sorted(senders)})",
+        f"engines={len(engines)}",
+    ]
+    for eid, ranks in engines.items():
+        r0 = next(iter(ranks.values()))
+        lines.append(
+            f"  engine {eid}: ranks {sorted(ranks)} num_workers={r0.get('num_workers')} "
+            f"({len(r0['wksd_meta'])} wksd tensors/rank)"
+        )
+    return "\n".join(lines)

--- a/examples/weightbridge/examples/make_multigroup_replay_specs.py
+++ b/examples/weightbridge/examples/make_multigroup_replay_specs.py
@@ -1,0 +1,196 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Generate a scalable replay capture for the overlapping 11-group topology case.
+
+The synthetic layout has eight trainer ranks and two eight-worker rollout engines, one engine per
+rollout node.  Its tensors are split evenly among three replication patterns:
+
+* ``wide_*`` is replicated across all 16 rollout workers (one replica group);
+* ``pair_*`` is sharded by local GPU rank and replicated across the two nodes (eight groups); and
+* ``half_*`` has one shard on local ranks 0..3 and one on ranks 4..7 (two groups).
+
+Consequently the topology planner sees 1 + 8 + 2 = 11 groups, including workers that belong to three
+different groups.  With the defaults, every source tensor is 1 GiB of BF16 and there are eight tensors
+per pattern: 24 GiB of unique weights.  Every rollout worker receives 64 MiB from the trainers for each
+tensor, so a 512 MiB round cap produces three balanced rounds.
+
+The output has the same pickle schema as ``WBRIDGE_DUMP_LOADSPEC`` and is consumed directly by
+``bench_transfer_4node.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pickle
+
+import torch
+from wbridge.utils.data import shards_numel
+
+
+SENDERS = 8
+ROLLOUT_NODES = 2
+WORKERS_PER_ENGINE = 8
+ROLLOUT_WORKERS = ROLLOUT_NODES * WORKERS_PER_ENGINE
+
+
+def _d1(left: int, right: int, width: int):
+    return [[(left, right, width)]]
+
+
+def _identity(entries: dict, dtype: torch.dtype) -> tuple[dict, dict, dict]:
+    """Return dtype/load/wksd metadata for flat tensors matching *entries*."""
+    dtype_spec = {}
+    load_spec = {}
+    wksd_meta = {}
+    for name, shards in entries.items():
+        assert len(shards) == 1
+        numel = shards_numel(shards)
+        dtype_spec[name] = dtype
+        load_spec[name] = {name: [(shards[0], [(0, numel, numel)])]}
+        wksd_meta[name] = ((numel,), dtype, (1,))
+    return dtype_spec, load_spec, wksd_meta
+
+
+def _sender_entries(width: int, names: list[str]) -> dict:
+    return {name: _d1(0, width, width) for name in names}
+
+
+def _receiver_entries(worker: int, width: int, names_per_pattern: int) -> dict:
+    lane = worker % WORKERS_PER_ENGINE
+    half = 0 if lane < WORKERS_PER_ENGINE // 2 else 1
+    pair_width = width // WORKERS_PER_ENGINE
+    half_width = width // 2
+    entries = {}
+    for i in range(names_per_pattern):
+        entries[f"half_{i:02d}"] = _d1(
+            half * half_width, (half + 1) * half_width, width
+        )
+        entries[f"pair_{i:02d}"] = _d1(
+            lane * pair_width, (lane + 1) * pair_width, width
+        )
+        entries[f"wide_{i:02d}"] = _d1(0, width, width)
+    return entries
+
+
+def _write(path: str, record: dict) -> None:
+    with open(path, "wb") as f:
+        pickle.dump(record, f)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--output", required=True, help="new or empty output directory")
+    ap.add_argument(
+        "--tensor-mib", type=int, default=1024, help="global bytes per source tensor"
+    )
+    ap.add_argument("--tensors-per-pattern", type=int, default=8)
+    args = ap.parse_args()
+
+    if args.tensor_mib <= 0 or args.tensors_per_pattern <= 0:
+        ap.error("tensor size and count must be positive")
+    tensor_bytes = args.tensor_mib * 1024**2
+    dtype = torch.bfloat16
+    if tensor_bytes % dtype.itemsize:
+        ap.error(f"tensor bytes must be divisible by {dtype.itemsize}")
+    width = tensor_bytes // dtype.itemsize
+    if width % ROLLOUT_WORKERS:
+        ap.error(f"tensor element count must be divisible by {ROLLOUT_WORKERS}")
+
+    os.makedirs(args.output, exist_ok=True)
+    existing = os.listdir(args.output)
+    if existing:
+        ap.error(
+            f"output directory must be empty: {args.output} contains {existing[:3]}"
+        )
+
+    names = [
+        f"{pattern}_{i:02d}"
+        for pattern in ("half", "pair", "wide")
+        for i in range(args.tensors_per_pattern)
+    ]
+    sentries = _sender_entries(width, names)
+    sdtypes, sload, swksd = _identity(sentries, dtype)
+    for rank in range(SENDERS):
+        rec = {
+            "role": "sender",
+            "rank": rank,
+            "engine_id": None,
+            "load_spec": sload,
+            "dtype_spec": sdtypes,
+            "src_shard_spec": sentries,
+            "wksd_meta": swksd,
+            "world_size": SENDERS,
+            "sender_staging": False,
+        }
+        _write(
+            os.path.join(args.output, f"loadspec_sender_r{rank}_pid{1000 + rank}.pkl"),
+            rec,
+        )
+
+    receiver_model_bytes = None
+    for node in range(ROLLOUT_NODES):
+        for rank in range(WORKERS_PER_ENGINE):
+            worker = node * WORKERS_PER_ENGINE + rank
+            rentries = _receiver_entries(worker, width, args.tensors_per_pattern)
+            rdtypes, rload, rwksd = _identity(rentries, dtype)
+            receiver_model_bytes = sum(
+                meta[0][0] * meta[1].itemsize for meta in rwksd.values()
+            )
+            rec = {
+                "role": "receiver",
+                "rank": rank,
+                "engine_id": f"synthetic://rollout-node-{node}/engine-0",
+                "load_spec": rload,
+                "dtype_spec": rdtypes,
+                "src_shard_spec": rentries,
+                "wksd_meta": rwksd,
+                "num_workers": WORKERS_PER_ENGINE,
+                "receiver_staging": False,
+            }
+            # The replay's physical-engine splitter uses pid clusters to retain captured node placement.
+            fake_pid = 2000 + node * 1000 + rank
+            _write(
+                os.path.join(
+                    args.output,
+                    f"loadspec_receiver_n{node}_r{rank}_pid{fake_pid}.pkl",
+                ),
+                rec,
+            )
+
+    model_bytes = tensor_bytes * args.tensors_per_pattern * 3
+    ingress_per_worker = model_bytes // ROLLOUT_WORKERS
+    manifest = {
+        "dtype": str(dtype),
+        "senders": SENDERS,
+        "rollout_nodes": ROLLOUT_NODES,
+        "workers_per_rollout_node": WORKERS_PER_ENGINE,
+        "replica_groups": 11,
+        "tensors_per_pattern": args.tensors_per_pattern,
+        "tensor_bytes": tensor_bytes,
+        "unique_model_bytes": model_bytes,
+        "trainer_tx_bytes": model_bytes,
+        # Trainers seed half of every replica class on each rollout node.  The topology exchange then
+        # imports the other half from the peer rollout node, so total cross-node RDMA RX per rollout node is
+        # one model.
+        "trainer_ingress_bytes_per_rollout_node": model_bytes // ROLLOUT_NODES,
+        "rollout_exchange_rx_bytes_per_node": model_bytes // ROLLOUT_NODES,
+        "total_rdma_rx_bytes_per_rollout_node": model_bytes,
+        "trainer_ingress_bytes_per_worker": ingress_per_worker,
+        "receiver_model_bytes_per_worker": receiver_model_bytes,
+        "recommended_round_cap_bytes": ingress_per_worker // 3,
+    }
+    with open(os.path.join(args.output, "manifest.json"), "w") as f:
+        json.dump(manifest, f, indent=2)
+    print(json.dumps(manifest, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/monarch_common.py
+++ b/examples/weightbridge/examples/monarch_common.py
@@ -1,0 +1,127 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Monarch actor plumbing shared by the toy example (:mod:`workers_monarch`) and the 30B replay
+(:mod:`bench_monarch`).
+
+Everything here is a workaround for something Monarch does differently from Ray, and each one silently
+produces a wrong or wedged run rather than an error if it is missing. They are collected in one module so
+the two front-ends cannot drift apart on any of them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
+from monarch._rust_bindings.monarch_hyperactor.config import configure
+from monarch._src.actor.actor_mesh import _set_context
+from monarch.actor import attach_to_workers, context, current_rank
+
+logger = logging.getLogger("wbridge.example.monarch_common")
+
+# LOAD-BEARING: without it this driver's agent serves on an abstract unix socket (ipc://@...), whose
+# namespace is local to this node, so remote workers cannot dial back and attach dies with
+# MESH_ATTACH_CONFIG_TIMEOUT. SlurmJob sets exactly this (monarch/_src/job/slurm.py:87).
+configure(default_transport=ChannelTransport.TcpWithHostname)
+
+
+def my_rank() -> int:
+    """This actor's index within its proc mesh — the worker's TP rank."""
+    return int(current_rank()["gpus"])
+
+
+def bind_gpu(dev: int) -> int:
+    """Pin this proc (really: this *thread*) to GPU *dev*.
+
+    Monarch's ``spawn_procs({"gpus": N})`` does NOT set ``CUDA_VISIBLE_DEVICES`` per proc (verified: every
+    actor otherwise reports the same PCI bus id), unlike Ray's ``num_gpus=1``. Without this every rank on
+    a node shares device 0 — and since Monarch picks a NIC by the owning GPU's ordinal, they would all
+    share one NIC too, silently collapsing the per-rank bandwidth the multi-NIC measurements depend on.
+    Must run before the adapter is built: wbridge captures ``cuda:{current_device()}`` at construction.
+    Must also run on the same thread as everything that follows — ``set_device`` is thread-local, which is
+    half the reason :class:`ActorThread` owns exactly one thread.
+    """
+    import torch
+
+    if torch.cuda.is_available():
+        dev = dev % torch.cuda.device_count()
+        torch.cuda.set_device(dev)
+        torch.zeros(1, device="cuda")  # materialize the primary context on THIS device
+        return dev
+    return -1
+
+
+class ActorThread:
+    """One dedicated thread per actor; every WeightBridge call runs on it, never on the actor's loop.
+
+    Three separate reasons it has to be exactly this — one thread, owned, and off the event loop:
+
+    * **Off the loop.** A Monarch RDMA completion arrives as a message to the submitting actor, and only
+      the actor's event loop processes messages. An endpoint that blocks its own loop on ``Future.get()``
+      can therefore never observe its own transfer: it hangs forever with nothing in the log. That is what
+      wedged the first end-to-end run.
+    * **One thread.** ``torch``'s current CUDA device is thread-local, so a pool that hands successive
+      calls to different threads would run ``send_weights`` on device 0 no matter what :func:`bind_gpu`
+      did. WeightBridge also builds adapter state on the thread that later uses it.
+    * **Owned.** The Monarch context is a contextvar that ``run_in_executor`` does not propagate, so the
+      thread is primed once with the actor's context before any work reaches it.
+    """
+
+    def __init__(self, name: str) -> None:
+        self._ex = ThreadPoolExecutor(max_workers=1, thread_name_prefix=name)
+        self._primed = False
+
+    async def run(self, fn, *a):
+        loop = asyncio.get_running_loop()
+        if not self._primed:
+            # context() is only meaningful on the actor's own thread, so read it here and replay it there.
+            ctx = context()
+            await loop.run_in_executor(self._ex, _set_context, ctx)
+            self._primed = True
+        return await loop.run_in_executor(self._ex, fn, *a)
+
+
+def attach_hosts(worker_addrs: list[str], attempts: int = 5, name: str = "wbexample"):
+    """Attach to already-serving worker loops, retrying the flaky handshake.
+
+    The attach intermittently dies with MESH_ATTACH_CONFIG_TIMEOUT when a worker loop is still settling
+    (most often on a node reused straight after a previous run). Retrying is far cheaper than losing the
+    whole job to it.
+    """
+    last = None
+    for attempt in range(1, attempts + 1):
+        try:
+            hosts = attach_to_workers(
+                name=f"{name}{attempt}",
+                ca="trust_all_connections",
+                workers=worker_addrs,
+            )
+            hosts.initialized.get()
+            return hosts
+        except Exception as e:  # noqa: BLE001
+            last = e
+            logger.warning(
+                "monarch attach attempt %d/%d failed: %s",
+                attempt,
+                attempts,
+                str(e).strip().splitlines()[-1][:100],
+            )
+            time.sleep(10)
+    raise RuntimeError(f"could not attach to Monarch workers {worker_addrs}: {last}")
+
+
+def host_index(worker_addrs: list[str], ip: str) -> int:
+    """Index of the worker address serving *ip*; the host slice to place a role on."""
+    for i, addr in enumerate(worker_addrs):
+        if (
+            addr.rsplit(":", 1)[0].removeprefix("tcp://") == ip
+        ):  # addr is "tcp://<ip>:<port>"
+            return i
+    raise RuntimeError(f"no Monarch worker for host {ip} in {worker_addrs}")

--- a/examples/weightbridge/examples/qwen_tiny.py
+++ b/examples/weightbridge/examples/qwen_tiny.py
@@ -1,0 +1,455 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+One decoder-block Qwen2-style toy (no ``model.layers.N`` in HF keys).
+
+**HF checkpoint** — split ``q_proj`` / ``k_proj`` / ``v_proj``, ``gate_proj`` / ``up_proj``, etc.
+
+**Trainer Worker / actor** — Megatron ``linear_qkv`` packing (GQA): per group, Q heads then K then V
+(see ``slime/.../megatron_to_hf/qwen2.py``). TP splits output rows of each parameter.
+
+**Rollout Worker** — SGLang-style stacked tensors (same idea as ``Qwen2ForCausalLM.load_weights`` in
+``sglang/srt/models/qwen2.py``): ``qkv_proj`` holds ``[Q_shard; K_shard; V_shard]`` on dim 0;
+``gate_up_proj`` holds ``[gate; up]`` with column-parallel-style row sharding. TP matches
+``QKVParallelLinear`` / ``MergedColumnParallelLinear`` / ``RowParallelLinear`` when ``num_heads``
+and ``num_kv_heads`` divide ``tp_size``.
+
+Loaders only **narrow + copy** for keys present in the iterable (``infer_load_spec`` subsets).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+import torch
+
+__all__ = [
+    "DEFAULT_QWEN_TINY_CONFIG",
+    "QwenTinyConfig",
+    "build_trainer_wksd",
+    "build_qwen_tiny_hf_checkpoint",
+    "build_rollout_wksd",
+    "make_trainer_load_weights",
+    "make_rollout_load_weights",
+]
+
+
+@dataclass(frozen=True)
+class QwenTinyConfig:
+    vocab_size: int = 64
+    hidden_size: int = 32
+    intermediate_size: int = 48
+    num_attn_heads: int = 4
+    num_kv_heads: int = 2
+
+    def __post_init__(self) -> None:
+        if self.num_attn_heads % self.num_kv_heads != 0:
+            raise ValueError("num_attn_heads must be divisible by num_kv_heads")
+
+    @property
+    def head_dim(self) -> int:
+        return self.hidden_size // self.num_attn_heads
+
+    @property
+    def q_out(self) -> int:
+        return self.num_attn_heads * self.head_dim
+
+    @property
+    def kv_out(self) -> int:
+        return self.num_kv_heads * self.head_dim
+
+    @property
+    def num_query_groups(self) -> int:
+        return self.num_kv_heads
+
+    @property
+    def value_num_per_group(self) -> int:
+        return self.num_attn_heads // self.num_query_groups
+
+    @property
+    def megatron_qkv_rows(self) -> int:
+        g, v, d = self.num_query_groups, self.value_num_per_group, self.head_dim
+        return g * (v + 2) * d
+
+
+DEFAULT_QWEN_TINY_CONFIG = QwenTinyConfig()
+
+
+def _assert_tp(cfg: QwenTinyConfig, tp: int) -> None:
+    assert cfg.vocab_size % tp == 0
+    assert cfg.q_out % tp == 0
+    assert cfg.kv_out % tp == 0
+    assert cfg.intermediate_size % tp == 0
+    assert cfg.megatron_qkv_rows % tp == 0
+    assert (2 * cfg.intermediate_size) % tp == 0
+
+
+def _scatter_rows(
+    dst_shard: torch.Tensor,
+    shard_global_lo: int,
+    shard_nrows: int,
+    src: torch.Tensor,
+    src_row_offset: int,
+    block_global_lo: int,
+    block_nrows: int,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> None:
+    a = max(shard_global_lo, block_global_lo)
+    b = min(shard_global_lo + shard_nrows, block_global_lo + block_nrows)
+    if a >= b:
+        return
+    sr = src_row_offset + (a - block_global_lo)
+    dr = a - shard_global_lo
+    dst_shard[dr : dr + (b - a)].copy_(
+        src[sr : sr + (b - a)].to(device=device, dtype=dtype)
+    )
+
+
+def _trainer_scatter_megatron_qkv(
+    dst: torch.Tensor,
+    cfg: QwenTinyConfig,
+    tp_rank: int,
+    tp_size: int,
+    w: dict[str, torch.Tensor],
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> None:
+    R, part = cfg.megatron_qkv_rows, cfg.megatron_qkv_rows // tp_size
+    lo, n_g = tp_rank * part, cfg.num_query_groups
+    vpg, d = cfg.value_num_per_group, cfg.head_dim
+    if "self_attn.q_proj.weight" in w:
+        q = w["self_attn.q_proj.weight"]
+        for g in range(n_g):
+            gr = g * (vpg + 2) * d
+            _scatter_rows(
+                dst, lo, part, q, g * vpg * d, gr, vpg * d, device=device, dtype=dtype
+            )
+    if "self_attn.k_proj.weight" in w:
+        k = w["self_attn.k_proj.weight"]
+        for g in range(n_g):
+            gr = g * (vpg + 2) * d + vpg * d
+            _scatter_rows(dst, lo, part, k, g * d, gr, d, device=device, dtype=dtype)
+    if "self_attn.v_proj.weight" in w:
+        v = w["self_attn.v_proj.weight"]
+        for g in range(n_g):
+            gr = g * (vpg + 2) * d + (vpg + 1) * d
+            _scatter_rows(dst, lo, part, v, g * d, gr, d, device=device, dtype=dtype)
+
+
+def build_qwen_tiny_hf_checkpoint(
+    cfg: QwenTinyConfig,
+    *,
+    dtype: torch.dtype = torch.float32,
+    seed: int = 42,
+    device: str = "cpu",
+) -> dict[str, torch.Tensor]:
+    g = torch.Generator(device=device).manual_seed(seed)
+    h, iq, ikv = cfg.hidden_size, cfg.intermediate_size, cfg.kv_out
+    qo, v = cfg.q_out, cfg.vocab_size
+
+    def R(*s: int) -> torch.Tensor:
+        return torch.randn(*s, dtype=dtype, device=device, generator=g)
+
+    return {
+        "model.embed_tokens.weight": R(v, h),
+        "self_attn.q_proj.weight": R(qo, h),
+        "self_attn.k_proj.weight": R(ikv, h),
+        "self_attn.v_proj.weight": R(ikv, h),
+        "self_attn.o_proj.weight": R(h, qo),
+        "mlp.gate_proj.weight": R(iq, h),
+        "mlp.up_proj.weight": R(iq, h),
+        "mlp.down_proj.weight": R(h, iq),
+        "input_layernorm.weight": R(h),
+        "post_attention_layernorm.weight": R(h),
+    }
+
+
+def _actor_shapes(cfg: QwenTinyConfig, tp: int) -> dict[str, tuple[int, ...]]:
+    _assert_tp(cfg, tp)
+    h, iq = cfg.hidden_size, cfg.intermediate_size
+    v0, qkv0 = cfg.vocab_size // tp, cfg.megatron_qkv_rows // tp
+    q0, i0 = cfg.q_out // tp, cfg.intermediate_size // tp
+    return {
+        "embedding.word_embeddings.weight": (v0, h),
+        "self_attention.linear_qkv.weight": (qkv0, h),
+        "self_attention.linear_proj.weight": (h, q0),
+        "mlp.linear_fc1.weight": (2 * iq // tp, h),
+        "mlp.linear_fc2.weight": (h, i0),
+        "self_attention.linear_qkv.layer_norm_weight": (h,),
+        "mlp.linear_fc1.layer_norm_weight": (h,),
+    }
+
+
+def build_trainer_wksd(
+    cfg: QwenTinyConfig,
+    *,
+    device: str,
+    dtype: torch.dtype = torch.float32,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+) -> dict[str, torch.Tensor]:
+    del tp_rank
+    return {
+        k: torch.empty(s, dtype=dtype, device=device)
+        for k, s in _actor_shapes(cfg, tp_size).items()
+    }
+
+
+def trainer_load_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    wksd: dict[str, torch.Tensor],
+    cfg: QwenTinyConfig,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    tp_rank: int,
+    tp_size: int,
+) -> None:
+    _assert_tp(cfg, tp_size)
+    w = dict(weights)
+    iq, h = cfg.intermediate_size, cfg.hidden_size
+    q0, i0 = cfg.q_out // tp_size, cfg.intermediate_size // tp_size
+    fc1_part = 2 * iq // tp_size
+    fc1_lo = tp_rank * fc1_part
+
+    if "model.embed_tokens.weight" in w:
+        vp = cfg.vocab_size // tp_size
+        sl = slice(tp_rank * vp, (tp_rank + 1) * vp)
+        wksd["embedding.word_embeddings.weight"].copy_(
+            w["model.embed_tokens.weight"][sl].to(device=device, dtype=dtype)
+        )
+
+    if any(
+        k in w
+        for k in (
+            "self_attn.q_proj.weight",
+            "self_attn.k_proj.weight",
+            "self_attn.v_proj.weight",
+        )
+    ):
+        _trainer_scatter_megatron_qkv(
+            wksd["self_attention.linear_qkv.weight"],
+            cfg,
+            tp_rank,
+            tp_size,
+            w,
+            device=device,
+            dtype=dtype,
+        )
+
+    if "self_attn.o_proj.weight" in w:
+        o = w["self_attn.o_proj.weight"]
+        c0, c1 = tp_rank * q0, (tp_rank + 1) * q0
+        wksd["self_attention.linear_proj.weight"].copy_(
+            o[:, c0:c1].to(device=device, dtype=dtype)
+        )
+
+    if "mlp.gate_proj.weight" in w:
+        _scatter_rows(
+            wksd["mlp.linear_fc1.weight"],
+            fc1_lo,
+            fc1_part,
+            w["mlp.gate_proj.weight"],
+            0,
+            0,
+            iq,
+            device=device,
+            dtype=dtype,
+        )
+    if "mlp.up_proj.weight" in w:
+        _scatter_rows(
+            wksd["mlp.linear_fc1.weight"],
+            fc1_lo,
+            fc1_part,
+            w["mlp.up_proj.weight"],
+            0,
+            iq,
+            iq,
+            device=device,
+            dtype=dtype,
+        )
+
+    if "mlp.down_proj.weight" in w:
+        c0, c1 = tp_rank * i0, (tp_rank + 1) * i0
+        wksd["mlp.linear_fc2.weight"].copy_(
+            w["mlp.down_proj.weight"][:, c0:c1].to(device=device, dtype=dtype)
+        )
+
+    if "input_layernorm.weight" in w:
+        wksd["self_attention.linear_qkv.layer_norm_weight"].copy_(
+            w["input_layernorm.weight"].to(device=device, dtype=dtype)
+        )
+    if "post_attention_layernorm.weight" in w:
+        wksd["mlp.linear_fc1.layer_norm_weight"].copy_(
+            w["post_attention_layernorm.weight"].to(device=device, dtype=dtype)
+        )
+
+
+def make_trainer_load_weights(
+    wksd: dict[str, torch.Tensor],
+    cfg: QwenTinyConfig,
+    *,
+    device: str,
+    dtype: torch.dtype,
+    tp_rank: int,
+    tp_size: int,
+) -> Callable[[Iterable[tuple[str, torch.Tensor]]], None]:
+    dev = torch.device(device)
+
+    def lw(it: Iterable[tuple[str, torch.Tensor]]) -> None:
+        trainer_load_weights(
+            it, wksd, cfg, device=dev, dtype=dtype, tp_rank=tp_rank, tp_size=tp_size
+        )
+
+    return lw
+
+
+def _rollout_shapes(cfg: QwenTinyConfig, tp: int) -> dict[str, tuple[int, ...]]:
+    _assert_tp(cfg, tp)
+    h, iq = cfg.hidden_size, cfg.intermediate_size
+    q_loc, kv_loc = cfg.q_out // tp, cfg.kv_out // tp
+    qkv_r = q_loc + 2 * kv_loc
+    return {
+        "model.embed_tokens.weight": (cfg.vocab_size // tp, h),
+        "self_attn.qkv_proj.weight": (qkv_r, h),
+        "self_attn.o_proj.weight": (h, q_loc),
+        "mlp.gate_up_proj.weight": (2 * iq // tp, h),
+        # down_proj stored TRANSPOSED (in, out) — mimics a Megatron RowParallel weight; forces the
+        # LoadSpec to carry a transpose (negative w) so the transfer path must handle it.
+        "mlp.down_proj.weight": (iq // tp, h),
+        "input_layernorm.weight": (h,),
+        "post_attention_layernorm.weight": (h,),
+    }
+
+
+def build_rollout_wksd(
+    cfg: QwenTinyConfig,
+    *,
+    device: str,
+    dtype: torch.dtype = torch.float32,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+) -> dict[str, torch.Tensor]:
+    del tp_rank
+    return {
+        k: torch.empty(s, dtype=dtype, device=device)
+        for k, s in _rollout_shapes(cfg, tp_size).items()
+    }
+
+
+def rollout_load_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    wksd: dict[str, torch.Tensor],
+    cfg: QwenTinyConfig,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    tp_rank: int,
+    tp_size: int,
+) -> None:
+    """Map HF shards into Rollout Worker ``wksd`` (stacked qkv / gate_up, TP on outputs or inputs)."""
+    _assert_tp(cfg, tp_size)
+    w = dict(weights)
+    iq, h = cfg.intermediate_size, cfg.hidden_size
+    q_loc, kv_loc = cfg.q_out // tp_size, cfg.kv_out // tp_size
+    i0 = iq // tp_size
+
+    if "model.embed_tokens.weight" in w:
+        vp = cfg.vocab_size // tp_size
+        sl = slice(tp_rank * vp, (tp_rank + 1) * vp)
+        wksd["model.embed_tokens.weight"].copy_(
+            w["model.embed_tokens.weight"][sl].to(device=device, dtype=dtype)
+        )
+
+    qkv = wksd["self_attn.qkv_proj.weight"]
+    if "self_attn.q_proj.weight" in w:
+        sl = slice(tp_rank * q_loc, (tp_rank + 1) * q_loc)
+        qkv[:q_loc].copy_(
+            w["self_attn.q_proj.weight"][sl].to(device=device, dtype=dtype)
+        )
+    if "self_attn.k_proj.weight" in w:
+        sl = slice(tp_rank * kv_loc, (tp_rank + 1) * kv_loc)
+        qkv[q_loc : q_loc + kv_loc].copy_(
+            w["self_attn.k_proj.weight"][sl].to(device=device, dtype=dtype)
+        )
+    if "self_attn.v_proj.weight" in w:
+        sl = slice(tp_rank * kv_loc, (tp_rank + 1) * kv_loc)
+        qkv[q_loc + kv_loc :].copy_(
+            w["self_attn.v_proj.weight"][sl].to(device=device, dtype=dtype)
+        )
+
+    if "self_attn.o_proj.weight" in w:
+        c0, c1 = tp_rank * q_loc, (tp_rank + 1) * q_loc
+        wksd["self_attn.o_proj.weight"].copy_(
+            w["self_attn.o_proj.weight"][:, c0:c1].to(device=device, dtype=dtype)
+        )
+
+    part = 2 * iq // tp_size
+    glo = tp_rank * part
+    if "mlp.gate_proj.weight" in w:
+        _scatter_rows(
+            wksd["mlp.gate_up_proj.weight"],
+            glo,
+            part,
+            w["mlp.gate_proj.weight"],
+            0,
+            0,
+            iq,
+            device=device,
+            dtype=dtype,
+        )
+    if "mlp.up_proj.weight" in w:
+        _scatter_rows(
+            wksd["mlp.gate_up_proj.weight"],
+            glo,
+            part,
+            w["mlp.up_proj.weight"],
+            0,
+            iq,
+            iq,
+            device=device,
+            dtype=dtype,
+        )
+
+    if "mlp.down_proj.weight" in w:
+        c0, c1 = tp_rank * i0, (tp_rank + 1) * i0
+        # store TRANSPOSED: HF [h, iq] -> slice [h, i0] -> .t() -> param [i0, h]
+        wksd["mlp.down_proj.weight"].copy_(
+            w["mlp.down_proj.weight"][:, c0:c1].t().to(device=device, dtype=dtype)
+        )
+
+    if "input_layernorm.weight" in w:
+        wksd["input_layernorm.weight"].copy_(
+            w["input_layernorm.weight"].to(device=device, dtype=dtype)
+        )
+    if "post_attention_layernorm.weight" in w:
+        wksd["post_attention_layernorm.weight"].copy_(
+            w["post_attention_layernorm.weight"].to(device=device, dtype=dtype)
+        )
+
+
+def make_rollout_load_weights(
+    wksd: dict[str, torch.Tensor],
+    cfg: QwenTinyConfig,
+    *,
+    device: str,
+    dtype: torch.dtype,
+    tp_rank: int,
+    tp_size: int,
+) -> Callable[[Iterable[tuple[str, torch.Tensor]]], None]:
+    dev = torch.device(device)
+
+    def lw(it: Iterable[tuple[str, torch.Tensor]]) -> None:
+        rollout_load_weights(
+            it, wksd, cfg, device=dev, dtype=dtype, tp_rank=tp_rank, tp_size=tp_size
+        )
+
+    return lw

--- a/examples/weightbridge/examples/shape_diag.py
+++ b/examples/weightbridge/examples/shape_diag.py
@@ -1,0 +1,73 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Print natural-dedup vs consolidated recv_specs shard shapes for decomposed tensors, to see what
+'correct shape' the fuse kernel expects. The natural shapes map cleanly; the consolidated ones don't."""
+
+import os
+
+import torch  # noqa: F401
+from analyze_consolidate import build_all_specs
+from loadspec_replay import load_records
+from wbridge.backend.router import WeightRouter
+
+recs = load_records(os.environ["SPECS"])
+all_specs, ws, dts = build_all_specs(recs)
+TENSORS = [
+    "model.layers.0.self_attn.q_norm.weight",
+    "model.layers.0.mlp.gate.weight",
+    "model.layers.0.input_layernorm.weight",
+    "model.layers.0.self_attn.q_proj.weight",
+]
+
+
+def show(cons):
+    if cons:
+        os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = str(20 * 1024 * 1024)
+    else:
+        os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = "0"
+    r = WeightRouter(rank=0, sender_ws=ws, all_specs=all_specs, dtype_spec=dict(dts))
+    print(f"\n===== consolidate={cons} =====")
+    for t in TENSORS:
+        orig = (
+            all_specs[ws][t] if t in all_specs[ws].entries else None
+        )  # receiver 0 original full shard
+        rs0 = r.recv_specs[0][t] if t in r.recv_specs[0].entries else None
+        cls = r.recv_tensor_classes().get(t)
+        print(f"{t.split('.', 2)[-1]:<28} class0={cls}")
+        print(f"    orig recv0 : {[list(s) for s in orig] if orig else None}")
+        print(f"    dedup recv0: {[list(s) for s in rs0] if rs0 else None}")
+
+
+show(0)
+show(1)
+
+# Load receiver rank 0's load_spec mappings for the decomposed tensors — reveals why the fuse handles the
+# narrow natural slice but mis-maps the wide consolidated one (multiple mappings / transpose per piece).
+from loadspec_replay import group_records, rebuild  # noqa: E402
+
+_senders, engines = group_records(recs)
+eid0 = next(iter(engines))
+rec0 = engines[eid0][
+    sorted(engines[eid0])[0]
+]  # engine0 local rank 0 = global receiver 0
+_src, _dt, load_spec, _wksd = rebuild(rec0, device="cuda")
+print(
+    "\n===== receiver0 load_spec.entries (mappings: HF name -> {model: [(s_shard, d_shard),...]}) ====="
+)
+for t in TENSORS:
+    ent = load_spec.entries.get(t)
+    if ent is None:
+        print(f"{t.split('.', 2)[-1]:<28} (not in load_spec)")
+        continue
+    for dname, mappings in ent.items():
+        print(
+            f"{t.split('.', 2)[-1]:<28} -> {dname.split('.', 2)[-1]}: {len(mappings)} mapping(s)"
+        )
+        for s_shard, d_shard in mappings[:6]:
+            print(
+                f"        s={[list(x) for x in s_shard]}  d={[list(x) for x in d_shard]}"
+            )

--- a/examples/weightbridge/examples/sweep_transfer.py
+++ b/examples/weightbridge/examples/sweep_transfer.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Sweep round-count (via WBRIDGE_ROUND_CAP_BYTES) x sender double-buffering (WBRIDGE_SENDER_NUM_BUF)
+using the frameworkless replay, all in ONE Ray session.
+
+For each (cap, num_buf) config it spins up fresh sender+engine actors (distinct ports), connects (which
+plans the round partition for that cap), runs K timed transfers, records the actual round count + warm
+WTT, then tears the actors down (freeing GPU arenas) before the next config. Prints a rounds x num_buf
+WTT table.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import time
+
+import ray
+import torch  # noqa: F401
+from bench_transfer import _network_env_vars, ReplayEngine, ReplaySender
+from loadspec_replay import group_records, load_records, summary
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+from utils import get_ray_nodes, visible_device_list
+from wbridge.backend.sender import SenderArgs
+
+
+def run_config(
+    senders,
+    engines,
+    ws,
+    rollout_ip,
+    trainer_ip,
+    roll_sched,
+    train_sched,
+    provider,
+    iface,
+    cap,
+    num_buf,
+    iters,
+    base_port,
+    pg_port,
+):
+    """One (cap, num_buf) point: build fresh actors, connect+run, return (rounds, warm_wtts). Tears down."""
+    eids = list(engines.keys())
+    ports = [base_port + i for i in range(len(eids))]
+    bases, acc = [], 0
+    for eid in eids:
+        bases.append(acc)
+        acc += len(engines[eid])
+    rollout_visible_devices = visible_device_list(acc)
+    # Constant-across-sweep planning flags; direct-async control publication has no runtime switch.
+    pipe = {
+        k: os.environ[k]
+        for k in (
+            "WBRIDGE_RECV_PIPELINE",
+            "WBRIDGE_DEDUP_PAIR_BYTES",
+        )
+        if os.environ.get(k)
+    }
+    extra = {
+        "WBRIDGE_ROUND_CAP_BYTES": str(cap),
+        "WBRIDGE_SENDER_NUM_BUF": str(num_buf),
+        **pipe,
+    }
+
+    engine_actors = [
+        ReplayEngine.options(scheduling_strategy=roll_sched).remote() for _ in eids
+    ]
+    ray.get(
+        [
+            ea.init.remote(
+                {r: engines[eid][r]["_path"] for r in engines[eid]},
+                port,
+                roll_sched,
+                provider,
+                iface,
+                "",
+                base,
+                rollout_visible_devices,
+                extra,
+            )
+            for ea, eid, port, base in zip(engine_actors, eids, ports, bases)
+        ]
+    )
+    receiver_urls = [f"tcp://{rollout_ip}:{p}" for p in ports]
+
+    tenv = _network_env_vars(provider, iface)
+    tenv["CUDA_VISIBLE_DEVICES"] = visible_device_list(ws)
+    tenv["WBRIDGE_ROUND_CAP_BYTES"] = str(cap)
+    tenv["WBRIDGE_SENDER_NUM_BUF"] = str(num_buf)
+    tenv.update(pipe)  # sender needs WBRIDGE_RECV_PIPELINE for the depth-back await
+    truntime = {"env_vars": tenv}
+    sender_actors = []
+    for r in sorted(senders):
+        args = SenderArgs(
+            world_size=ws,
+            receiver_urls=receiver_urls,
+            master_addr=trainer_ip,
+            master_port=pg_port,
+            protocol=("efa" if provider == "efa" else "tcp"),
+            sender_staging=bool(senders[r].get("sender_staging")),
+        )
+        s = ReplaySender.options(
+            scheduling_strategy=train_sched, runtime_env=truntime
+        ).remote()
+        sender_actors.append((r, s, args))
+    ray.get(
+        [
+            s.init.remote(senders[r]["_path"], args, provider, iface, r)
+            for r, s, args in sender_actors
+        ]
+    )
+
+    recv_futs = [ea.run_recv.remote(iters) for ea in engine_actors]
+    send_futs = [s.run_send.remote(iters) for _, s, _ in sender_actors]
+    send_res = ray.get(send_futs)
+    ray.get(recv_futs)
+    send_res.sort(key=lambda x: x[0])
+    _, _connect_s, wtts, nr = send_res[0]
+    # Each fresh actor set needs a few transfers to reach steady state (CUDA graph / pool / QP warmup),
+    # so take the warmest tail rather than everything-after-WT0.
+    warm = wtts[-3:] if len(wtts) >= 4 else (wtts[1:] or wtts)
+
+    # Teardown: free GPU arenas before the next config.
+    for _, s, _ in sender_actors:
+        try:
+            ray.kill(s)
+        except Exception:  # noqa: BLE001
+            pass
+    ray.get([ea.shutdown.remote() for ea in engine_actors])
+    for ea in engine_actors:
+        try:
+            ray.kill(ea)
+        except Exception:  # noqa: BLE001
+            pass
+    time.sleep(5)
+    return nr, warm
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--specs", required=True)
+    ap.add_argument("--iters", type=int, default=4)
+    ap.add_argument(
+        "--caps",
+        required=True,
+        help="comma-separated round-cap byte values (one per target round count)",
+    )
+    ap.add_argument(
+        "--numbuf", default="1,2", help="comma-separated sender NUM_BUF values"
+    )
+    ap.add_argument(
+        "--network-provider",
+        default=os.environ.get("WB_NETWORK_PROVIDER", "efa"),
+        choices=["tcp", "efa"],
+    )
+    ap.add_argument(
+        "--network-interface", default=os.environ.get("WB_NETWORK_INTERFACE", "")
+    )
+    ap.add_argument("--base-port", type=int, default=62000)
+    ap.add_argument("--pg-port", type=int, default=62100)
+    a = ap.parse_args()
+
+    recs = load_records(a.specs)
+    print(summary(recs), flush=True)
+    senders, engines = group_records(recs)
+    ws = len(senders)
+    rollout_ip, trainer_ip, rollout_node, trainer_node = get_ray_nodes(None, None)
+    roll_sched = NodeAffinitySchedulingStrategy(node_id=rollout_node, soft=False)
+    train_sched = NodeAffinitySchedulingStrategy(node_id=trainer_node, soft=False)
+    caps = [int(c) for c in a.caps.split(",")]
+    numbufs = [int(n) for n in a.numbuf.split(",")]
+    print(
+        f"rollout={rollout_ip} trainer={trainer_ip} engines={len(engines)} senders={ws} "
+        f"iters={a.iters} caps={len(caps)} numbuf={numbufs}",
+        flush=True,
+    )
+
+    results = []  # (num_buf, rounds, cap, median, min, warm)
+    cfg = 0
+    for nb in numbufs:
+        for cap in caps:
+            bp = a.base_port + cfg * 20
+            pgp = a.pg_port + cfg
+            print(
+                f"\n### config {cfg}: num_buf={nb} cap={cap / 2**30:.2f}GiB ports={bp}/{pgp} ###",
+                flush=True,
+            )
+            try:
+                nr, warm = run_config(
+                    senders,
+                    engines,
+                    ws,
+                    rollout_ip,
+                    trainer_ip,
+                    roll_sched,
+                    train_sched,
+                    a.network_provider,
+                    a.network_interface,
+                    cap,
+                    nb,
+                    a.iters,
+                    bp,
+                    pgp,
+                )
+                med, mn = statistics.median(warm), min(warm)
+                print(
+                    f"   -> rounds={nr} warm_median={med:.3f}s warm_min={mn:.3f}s "
+                    f"warm={['%.3f' % w for w in warm]}",
+                    flush=True,
+                )
+                results.append((nb, nr, cap, med, mn, warm))
+            except Exception as e:  # noqa: BLE001
+                print(f"   !! failed: {e}", flush=True)
+                results.append((nb, -1, cap, float("nan"), float("nan"), []))
+            cfg += 1
+
+    # Table: rounds x num_buf -> warm-median WTT.
+    print(
+        "\n=== SWEEP: warm-median WTT (s) — rounds x sender double-buffering ===",
+        flush=True,
+    )
+    by = {}
+    for nb, nr, cap, med, mn, warm in results:
+        by.setdefault(nr, {})[nb] = (med, mn)
+    hdr = "rounds | " + " | ".join(f"NUM_BUF={nb} (med/min)" for nb in numbufs)
+    print(hdr, flush=True)
+    for nr in sorted(k for k in by if k > 0):
+        row = f"{nr:>6} | "
+        row += " | ".join(
+            (f"{by[nr][nb][0]:.3f}/{by[nr][nb][1]:.3f}" if nb in by[nr] else "   -   ")
+            for nb in numbufs
+        )
+        print(row, flush=True)
+    print("\nraw (num_buf, rounds, cap_bytes, median_s, min_s):", flush=True)
+    for nb, nr, cap, med, mn, warm in results:
+        print(
+            f"  nb={nb} rounds={nr} cap={cap} median={med:.3f} min={mn:.3f}", flush=True
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/train.py
+++ b/examples/weightbridge/examples/train.py
@@ -1,0 +1,318 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Minimal WeightBridge example: Ray node pinning + weight transfer.
+
+Uses a single-layer Qwen2-style HF checkpoint built on each worker via ``build_checkpoint``.
+Trainer Workers hold TP shards
+of HF names in ``wksd``; Rollout Workers hold merged weights (``qkv_proj``, ``gate_up_proj``, ...).
+:class:`~wbridge.frontend.adapters.SenderAdapter` / :class:`~wbridge.frontend.adapters.ReceiverAdapter`
+
+Weight transfer uses the selected WeightBridge data-plane backend. Mooncake provides the TCP toy transport
+and EFA RDMA; Monarch provides a separate libibverbs RDMA backend. With ``--protocol auto``,
+``--network-provider`` selects the Mooncake transport. ``wksd`` tensors stay on GPU.
+
+Usage::
+
+    ray start --head          # node A (GPUs for trainer + rollout workers)
+    ray start --address=...   # node B
+    python examples/train.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import tempfile
+from functools import partial
+from pathlib import Path
+
+import torch
+from qwen_tiny import build_qwen_tiny_hf_checkpoint, DEFAULT_QWEN_TINY_CONFIG
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+from utils import apply_network_env, get_ray_nodes
+from worker_bodies import EngineArgs
+from workers import RayOrchestrator
+
+logger = logging.getLogger("example")
+
+DTYPE = torch.float32
+
+
+def _fmt(stat: dict) -> str:
+    nvl = stat.get("nvlink_active_links")
+    link = "nvlink=?" if nvl is None else f"nvlink_links={nvl}"
+    return (
+        f"  {stat['role']:8s} rank {stat['rank']:2d} gpu {stat.get('pci_bus_id') or '?':12s} {link:16s} "
+        f"wire: ipc={stat['wire_ipc_bytes']:>12,d} B  rdma={stat['wire_rdma_bytes']:>12,d} B   "
+        f"agh: ipc={stat['agh_ipc_bytes']:>10,d} B  rdma={stat['agh_rdma_bytes']:>10,d} B   "
+        f"ipc_peers={stat['ipc_peers']} rdma_peers={stat['rdma_peers']}"
+    )
+
+
+def check_transports(
+    stats: list[dict], colocate: bool, expect: str = "auto", transport: str = "Mooncake"
+) -> None:
+    """Assert the data plane used the transport the placement implies, and print the evidence.
+
+    This is the point of ``--colocate``: prove that co-located trainer/rollout traffic really does bypass
+    the network RDMA backend. The byte counters are exact — ``wire_rdma_bytes`` is incremented at the
+    ``engine.write_async`` call site and ``wire_ipc_bytes`` at the CUDA-IPC ``copy_`` — so
+    ``wire_rdma_bytes == 0`` with ``wire_ipc_bytes > 0`` means every weight byte moved GPU-to-GPU without
+    entering the transfer engine. (Flags are excluded from both counters: they are 8 bytes each and use
+    the selected control path.) The NVLink column is what the CUDA-IPC copies ran over; it is
+    reported rather than asserted because NVML reports NVSwitch endpoints on HGX-class nodes.
+
+    *transport* only names the engine in the output — the counters are engine-agnostic, so this reads
+    "Monarch" under ``--protocol monarch`` instead of claiming bytes went through Mooncake.
+
+    *expect* is normally ``"auto"`` (co-located ⇒ IPC, split ⇒ RDMA). Force it to ``"rdma"`` to check
+    the A/B control: same co-located placement, ``WBRIDGE_SAME_NODE_IPC=0``, so the identical run must
+    fall back through the transfer engine.
+    """
+    want_ipc = colocate if expect == "auto" else (expect == "ipc")
+    print(
+        f"\ntransport breakdown (bulk weight bytes, flags excluded) — expecting "
+        f"{'CUDA-IPC' if want_ipc else transport}:"
+    )
+    for s in sorted(stats, key=lambda s: (s["role"], s["rank"])):
+        print(_fmt(s))
+
+    bad = []
+    for s in stats:
+        tag = f"{s['role']} rank {s['rank']}"
+        if want_ipc:
+            if s["wire_rdma_bytes"]:
+                bad.append(
+                    f"{tag}: {s['wire_rdma_bytes']} trainer<->rollout bytes went through {transport} "
+                    f"(expected 0 — co-located peers should use the CUDA-IPC bypass)"
+                )
+            if not s["wire_ipc_bytes"]:
+                bad.append(f"{tag}: no CUDA-IPC bytes recorded (bypass never engaged)")
+            if s["agh_rdma_bytes"]:
+                bad.append(
+                    f"{tag}: {s['agh_rdma_bytes']} dedup-exchange bytes went through {transport}"
+                )
+        elif s["wire_ipc_bytes"]:
+            # Negative control: nothing may take the IPC path when it is not expected — either the
+            # engines are on different nodes, or the bypass was disabled.
+            bad.append(
+                f"{tag}: {s['wire_ipc_bytes']} bytes took the CUDA-IPC path unexpectedly"
+            )
+
+    total_ipc = sum(s["wire_ipc_bytes"] + s["agh_ipc_bytes"] for s in stats)
+    total_rdma = sum(s["wire_rdma_bytes"] + s["agh_rdma_bytes"] for s in stats)
+    if not want_ipc and not total_rdma:
+        # Per-rank byte counts depend on the shard overlap, so only the aggregate is meaningful here.
+        bad.append(f"recorded no {transport} bytes at all")
+    if bad:
+        raise AssertionError("transport check failed:\n  " + "\n  ".join(bad))
+
+    if want_ipc:
+        no_nvml = [s for s in stats if not s.get("nvlink_active_links")]
+        if no_nvml:
+            print(
+                "  NOTE: NVML reported no active NVLink on "
+                f"{len(no_nvml)}/{len(stats)} GPU(s) — the IPC copies ran over PCIe P2P, not NVLink "
+                "(or pynvml is unavailable in this container)."
+            )
+        print(
+            f"\nOK: co-located run moved {total_ipc:,d} B over CUDA-IPC and {total_rdma:,d} B "
+            f"through {transport} — the transfer engine carried no weight bytes."
+        )
+    else:
+        where = "co-located (bypass disabled)" if colocate else "2-node"
+        print(
+            f"\nOK: {where} run moved {total_rdma:,d} B through {transport}, {total_ipc:,d} B over CUDA-IPC."
+        )
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(filename)s:%(lineno)d - %(message)s",
+    )
+
+    parser = argparse.ArgumentParser(description="WeightBridge train/rollout example")
+    parser.add_argument("--rollout-ip", default=os.environ.get("WB_ROLLOUT_IP"))
+    parser.add_argument("--trainer-ip", default=os.environ.get("WB_TRAINER_IP"))
+    parser.add_argument(
+        "--colocate",
+        action="store_true",
+        default=os.environ.get("WB_COLOCATE", "") == "1",
+        help="Pin the trainer and rollout engines to the SAME Ray node (needs 4 free GPUs there) and "
+        "assert that the weight bytes bypass the RDMA backend for a direct CUDA-IPC copy over NVLink. "
+        "Without it the two engines land on different nodes and the same run asserts the opposite.",
+    )
+    parser.add_argument(
+        "--expect-transport",
+        choices=("auto", "ipc", "rdma"),
+        default=os.environ.get("WB_EXPECT_TRANSPORT", "auto"),
+        help="Which transport the bulk weight bytes must use. 'auto' (default) derives it from the "
+        "placement. Force 'rdma' for the A/B control: co-located placement with "
+        "WBRIDGE_SAME_NODE_IPC=0, where the same run must fall back through the RDMA backend.",
+    )
+    parser.add_argument(
+        "--network-provider",
+        choices=("tcp", "efa"),
+        default=os.environ.get("WB_NETWORK_PROVIDER", "tcp"),
+        help="Process-group network provider. Use efa on AWS EFA clusters; tcp only sets socket IFNAME.",
+    )
+    parser.add_argument(
+        "--orchestrator",
+        choices=("monarch", "ray"),
+        default=os.environ.get("WB_ORCHESTRATOR", "ray"),
+        help="Which actor framework runs the workers. Ray is the portable default; the Monarch wbridge "
+        "transport requires Monarch actors (RDMABuffer/RDMAAction only work inside one).",
+    )
+    parser.add_argument(
+        "--monarch-workers",
+        default=os.environ.get("WB_MONARCH_WORKERS", ""),
+        help="Comma-separated tcp://ip:port Monarch worker-loop addresses (started by the launcher). "
+        "Required for --orchestrator monarch; also supplies node placement, so Ray is not needed.",
+    )
+    parser.add_argument(
+        "--protocol",
+        choices=("auto", "tcp", "efa", "monarch"),
+        default=os.environ.get("WB_PROTOCOL", "auto"),
+        help="wbridge RDMA backend. 'auto' follows --network-provider (Mooncake tcp/efa); 'monarch' "
+        "selects MonarchEngine, which needs --orchestrator monarch.",
+    )
+    parser.add_argument(
+        "--network-interface", default=os.environ.get("WB_NETWORK_INTERFACE", "")
+    )
+    parser.add_argument(
+        "--rollout-port",
+        type=int,
+        default=int(os.environ.get("WB_ROLLOUT_PORT", "15000")),
+    )
+    parser.add_argument(
+        "--trainer-pg-port",
+        type=int,
+        default=int(os.environ.get("WB_TRAINER_PG_PORT", "60010")),
+    )
+    parser.add_argument(
+        "--num-rollout-workers",
+        type=int,
+        default=int(os.environ.get("WB_NUM_ROLLOUT_WORKERS", "2")),
+    )
+    parser.add_argument(
+        "--num-trainer-workers",
+        type=int,
+        default=int(os.environ.get("WB_NUM_TRAINER_WORKERS", "2")),
+    )
+    parser.add_argument(
+        "--load-spec-dir",
+        default=os.environ.get(
+            "WB_LOAD_SPEC_DIR",
+            str(Path(tempfile.gettempdir()) / "wbridge_example_qwen_loadspec_v1"),
+        ),
+    )
+    cli = parser.parse_args()
+    apply_network_env(cli.network_provider, cli.network_interface)
+
+    protocol = cli.protocol
+    if protocol == "auto":
+        protocol = "efa" if cli.network_provider == "efa" else "tcp"
+    if protocol == "monarch" and cli.orchestrator != "monarch":
+        parser.error(
+            "--protocol monarch requires --orchestrator monarch "
+            "(RDMABuffer/RDMAAction only work inside a Monarch actor)"
+        )
+
+    # Node placement. Ray discovers it from the cluster; Monarch takes it from the worker-loop addresses
+    # the launcher already knows, so a Monarch run needs no Ray cluster at all.
+    worker_addrs: list[str] = [
+        w.strip() for w in cli.monarch_workers.split(",") if w.strip()
+    ]
+    if cli.orchestrator == "monarch":
+        if not worker_addrs:
+            parser.error(
+                "--orchestrator monarch requires --monarch-workers tcp://ip:port,..."
+            )
+        ips = [a.rsplit(":", 1)[0].removeprefix("tcp://") for a in worker_addrs]
+        if cli.colocate:
+            host = cli.rollout_ip or cli.trainer_ip or ips[0]
+            rollout_ip = trainer_ip = host
+        else:
+            if len(ips) < 2:
+                parser.error(
+                    "a 2-node run needs >=2 --monarch-workers (or pass --colocate)"
+                )
+            trainer_ip = cli.trainer_ip or ips[0]
+            rollout_ip = cli.rollout_ip or ips[1]
+        rollout_sched = trainer_sched = None
+    else:
+        rollout_ip, trainer_ip, rollout_node_id, trainer_node_id = get_ray_nodes(
+            cli.rollout_ip, cli.trainer_ip, colocate=cli.colocate
+        )
+        rollout_sched = NodeAffinitySchedulingStrategy(
+            node_id=rollout_node_id, soft=False
+        )
+        trainer_sched = NodeAffinitySchedulingStrategy(
+            node_id=trainer_node_id, soft=False
+        )
+
+    logger.info(
+        "orchestrator %s, protocol %s, rollout node %s, trainer node %s, network provider %s, "
+        "interface %s, colocate %s",
+        cli.orchestrator,
+        protocol,
+        rollout_ip,
+        trainer_ip,
+        cli.network_provider,
+        cli.network_interface,
+        cli.colocate,
+    )
+    # Bump dirname if layout / LoadSpec format changes (stale JSON under old dirs still hurts until deleted).
+
+    cfg = DEFAULT_QWEN_TINY_CONFIG
+    build_checkpoint = partial(
+        build_qwen_tiny_hf_checkpoint, cfg, dtype=DTYPE, seed=42, device="cpu"
+    )
+
+    engine_args = EngineArgs(
+        rollout_host=rollout_ip,
+        rollout_port=cli.rollout_port,
+        rollout_scheduling_strategy=rollout_sched,
+        num_rollout_workers=cli.num_rollout_workers,
+        trainer_host=trainer_ip,
+        trainer_pg_port=cli.trainer_pg_port,
+        trainer_scheduling_strategy=trainer_sched,
+        num_trainer_workers=cli.num_trainer_workers,
+        model_config=cfg,
+        build_checkpoint=build_checkpoint,
+        dtype=DTYPE,
+        network_provider=cli.network_provider,
+        network_interface=cli.network_interface,
+        protocol=protocol,
+    )
+
+    if cli.orchestrator == "monarch":
+        from workers_monarch import MonarchOrchestrator
+
+        orch = MonarchOrchestrator(engine_args, worker_addrs)
+    else:
+        orch = RayOrchestrator(engine_args)
+
+    orch.start()
+    orch.run_transfer()
+    logger.info("Weights received")
+    logger.info(orch.verify_all())
+
+    check_transports(
+        orch.transport_stats(),
+        colocate=cli.colocate,
+        expect=cli.expect_transport,
+        transport="Monarch" if protocol == "monarch" else "Mooncake",
+    )
+
+    orch.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/utils.py
+++ b/examples/weightbridge/examples/utils.py
@@ -1,0 +1,213 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from collections.abc import Callable
+
+import torch
+from wbridge.utils.specgen import HFWeightFetcher
+
+
+def network_env_vars(provider: str, iface: str) -> dict[str, str]:
+    """Return worker environment variables for a Mooncake transport.
+
+    The caller owns installation-specific dynamic-linker configuration.  If
+    ``LD_LIBRARY_PATH`` is already set, preserve and forward it unchanged
+    instead of assuming an EFA SDK location.
+    """
+    env: dict[str, str] = {}
+    if iface:
+        env["NCCL_SOCKET_IFNAME"] = iface
+        env["GLOO_SOCKET_IFNAME"] = iface
+
+    if provider == "tcp":
+        env["MC_FORCE_TCP"] = "1"
+        return env
+    if provider != "efa":
+        raise ValueError(f"Unsupported network provider: {provider}")
+
+    existing_ld = os.environ.get("LD_LIBRARY_PATH")
+    if existing_ld:
+        env["LD_LIBRARY_PATH"] = existing_ld
+    env.update(
+        {
+            "FI_PROVIDER": "efa",
+            "FI_EFA_USE_DEVICE_RDMA": "1",
+            "FI_EFA_ENABLE_SHM_TRANSFER": "0",
+            "NCCL_DEBUG": "INFO",
+            "NCCL_DEBUG_SUBSYS": "INIT,NET",
+            "NCCL_NET_GDR_LEVEL": "SYS",
+            "NCCL_NET_GDR_READ": "1",
+        }
+    )
+    return env
+
+
+def apply_network_env(provider: str, iface: str) -> None:
+    """Apply :func:`network_env_vars` without replacing explicit settings."""
+    for key, value in network_env_vars(provider, iface).items():
+        os.environ.setdefault(key, value)
+
+
+def visible_device_list(required: int) -> str:
+    """Return a CUDA visibility list large enough for a manual-device-placement actor.
+
+    Replay actors request no Ray GPU resource because one parent actor manages several child ranks.
+    ``WB_VISIBLE_DEVICES`` lets a deployment name the physical GPUs explicitly; otherwise a contiguous
+    zero-based list is derived from the capture rather than assuming an eight-GPU host.
+    """
+    if required <= 0:
+        raise ValueError(
+            f"required visible device count must be positive, got {required}"
+        )
+    configured = os.environ.get("WB_VISIBLE_DEVICES", "").strip()
+    if configured:
+        devices = [device.strip() for device in configured.split(",") if device.strip()]
+        if len(devices) < required:
+            raise ValueError(
+                f"WB_VISIBLE_DEVICES exposes {len(devices)} devices, but the replay needs {required}"
+            )
+        return ",".join(devices)
+    return ",".join(str(index) for index in range(required))
+
+
+def get_ray_nodes(
+    rollout_ip: str | None = None, trainer_ip: str | None = None, colocate: bool = False
+):
+    """``ray.init()`` then return rollout and trainer nodes.
+
+    With *colocate*, both roles are pinned to ONE node (a single alive node is enough) so the trainer and
+    rollout workers are co-located — the placement that lets WeightBridge move weights over NVLink with a
+    direct CUDA-IPC copy instead of the network RDMA backend. Pass a single
+    ``--rollout-ip``/``--trainer-ip`` to choose
+    which node; they must agree.
+
+    Returns ``(rollout_ip, trainer_ip, rollout_node_id, trainer_node_id)``.
+    """
+    import ray
+
+    ray.init(address="auto")
+    ray_nodes = [n for n in ray.nodes() if n["Alive"]]
+    need = 1 if colocate else 2
+    if len(ray_nodes) < need:
+        raise RuntimeError(
+            f"Need at least {need} alive Ray node(s), found {len(ray_nodes)}."
+        )
+
+    by_ip = {str(n["NodeManagerAddress"]): n for n in ray_nodes}
+    if colocate:
+        want = rollout_ip or trainer_ip
+        if rollout_ip and trainer_ip and rollout_ip != trainer_ip:
+            raise RuntimeError(
+                f"--colocate needs one node, got rollout={rollout_ip} trainer={trainer_ip}"
+            )
+        if want is not None and want not in by_ip:
+            raise RuntimeError(
+                f"Requested Ray node IP not alive: {want}. Alive Ray IPs: {sorted(by_ip)}"
+            )
+        node = (
+            by_ip[want]
+            if want
+            else sorted(ray_nodes, key=lambda n: str(n["NodeManagerAddress"]))[0]
+        )
+        rollout = trainer = node
+    elif rollout_ip is not None or trainer_ip is not None:
+        missing = [
+            ip for ip in (rollout_ip, trainer_ip) if ip is not None and ip not in by_ip
+        ]
+        if missing:
+            alive = ", ".join(sorted(by_ip))
+            raise RuntimeError(
+                f"Requested Ray node IP(s) not alive: {missing}. Alive Ray IPs: {alive}"
+            )
+        if rollout_ip is None or trainer_ip is None:
+            raise RuntimeError("Pass both rollout_ip and trainer_ip, or neither.")
+        rollout, trainer = by_ip[rollout_ip], by_ip[trainer_ip]
+    else:
+        rollout, trainer = sorted(
+            ray_nodes, key=lambda n: str(n["NodeManagerAddress"])
+        )[:2]
+
+    return (
+        str(rollout["NodeManagerAddress"]),
+        str(trainer["NodeManagerAddress"]),
+        str(rollout["NodeID"]),
+        str(trainer["NodeID"]),
+    )
+
+
+def gpu_link_info() -> dict:
+    """Physical identity + NVLink state of the GPU this process is bound to.
+
+    Reported by :mod:`examples.train` alongside the transport byte counters, so a co-located run shows not
+    just *that* the RDMA backend was bypassed but that the CUDA-IPC copies really had NVLink underneath them.
+    ``pci_bus_id`` comes from the CUDA runtime (CUDA_VISIBLE_DEVICES-safe: ``current_device()`` is a
+    *visible* index, and the runtime maps it to the physical device). NVLink state needs NVML; if
+    ``pynvml`` is missing the link fields come back ``None`` and the caller just skips that part of the
+    report. On NVSwitch machines the remote bus ids are the switches, not the peer GPUs, so treat the link
+    COUNT — not the remote ids — as the "NVLink present" signal.
+    """
+    import ctypes
+
+    info: dict = {
+        "pci_bus_id": None,
+        "nvlink_active_links": None,
+        "nvlink_remote_bus_ids": None,
+    }
+    try:
+        lib = ctypes.CDLL("libcudart.so")
+        buf = ctypes.create_string_buffer(64)
+        dev = torch.cuda.current_device()
+        if (
+            lib.cudaDeviceGetPCIBusId(buf, ctypes.c_int(64), ctypes.c_int(int(dev)))
+            == 0
+        ):
+            info["pci_bus_id"] = buf.value.decode()
+    except Exception:  # noqa: BLE001 — best-effort diagnostics, never fail the run
+        return info
+    if info["pci_bus_id"] is None:
+        return info
+    try:
+        import pynvml
+
+        pynvml.nvmlInit()
+        h = pynvml.nvmlDeviceGetHandleByPciBusId(info["pci_bus_id"].encode())
+        active, remotes = 0, []
+        for link in range(pynvml.NVML_NVLINK_MAX_LINKS):
+            try:
+                if (
+                    pynvml.nvmlDeviceGetNvLinkState(h, link)
+                    != pynvml.NVML_FEATURE_ENABLED
+                ):
+                    continue
+                active += 1
+                remotes.append(
+                    pynvml.nvmlDeviceGetNvLinkRemotePciInfo(h, link).busId.strip("\x00")
+                )
+            except pynvml.NVMLError:
+                continue  # link index beyond this GPU's count
+        info["nvlink_active_links"] = active
+        info["nvlink_remote_bus_ids"] = sorted(set(remotes))
+    except Exception:  # noqa: BLE001 — pynvml absent or NVML unavailable in the container
+        pass
+    return info
+
+
+def make_hf_weights(
+    full_cpu: dict[str, torch.Tensor],
+) -> tuple[HFWeightFetcher, dict[str, tuple[int, ...]]]:
+    """Build ``(HFWeightFetcher, hf_shapes)`` from a CPU tensor dict.
+
+    Each factory returns a **clone** so :func:`~wbridge.utils.specgen.infer_load_spec` can mutate
+    probe tensors (``fill_``, etc.) without corrupting the shared *full_cpu* checkpoint dict.
+    """
+    fetcher: HFWeightFetcher = {
+        name: (lambda t=t: t.clone().contiguous()) for name, t in full_cpu.items()
+    }
+    shapes: dict[str, tuple[int, ...]] = {
+        name: tuple(t.shape) for name, t in full_cpu.items()
+    }
+    return fetcher, shapes

--- a/examples/weightbridge/examples/verify_arena.py
+++ b/examples/weightbridge/examples/verify_arena.py
@@ -1,0 +1,184 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Offline self-consistency check of the arena/exchange plan (no Ray/GPU), with consolidation on.
+
+The real-run corruption of even UNTOUCHED tensors implies a sender/receiver plan disagreement. This
+script rules the *plan* in or out by checking, purely from the router:
+
+  1. reciprocity  — for every receiver pair (rl, p) sharing a sub-group in a round, the bytes rl writes
+                    to p (send[p]) must equal what p expects from rl (grecv[rl]), and vice-versa. A
+                    mismatch means the all-gather writes land wrong -> corruption.
+  2. arena sizing — S >= s2r(r) + max(prep(r), prep(pred_D(r))); GRECV is outside PREP and parity-slotted.
+  3. coverage     — own(rl) + sum_p grecv[p] bytes == rl's full-shard bytes for the round (nothing lost).
+
+Run: python3 examples/verify_arena.py --specs <dir> [--threshold-mb 20]
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+
+import torch  # noqa: F401
+from analyze_consolidate import build_all_specs
+from loadspec_replay import load_records, summary
+from wbridge.backend.router import (
+    _arena_slot_predecessors,
+    _arena_total_bytes,
+    WeightRouter,
+)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--specs", required=True)
+    ap.add_argument("--threshold-mb", type=float, default=20.0)
+    ap.add_argument("--consolidate", default="1")
+    ap.add_argument("--depth", type=int, default=1)
+    a = ap.parse_args()
+    if a.depth < 1:
+        ap.error("--depth must be >= 1")
+
+    recs = load_records(a.specs)
+    print(summary(recs), flush=True)
+    all_specs, ws, dtype_spec = build_all_specs(recs)
+
+    if a.consolidate == "1":
+        os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = (
+            "inf"
+            if math.isinf(a.threshold_mb)
+            else str(int(a.threshold_mb * 1024 * 1024))
+        )
+    else:
+        os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = "0"
+    r = WeightRouter(
+        rank=0, sender_ws=ws, all_specs=all_specs, dtype_spec=dict(dtype_spec)
+    )
+    rws = r.receiver_ws
+    classes = r.recv_tensor_classes()
+
+    # arena_layout for every receiver (same `classes` object -> identical view every rank would compute).
+    layouts = {rl: r.arena_layout(rl, classes, depth=a.depth) for rl in range(rws)}
+    nrounds = len(r.global_rounds)
+    print(
+        f"consolidate={a.consolidate} receivers={rws} rounds={nrounds} depth={a.depth}",
+        flush=True,
+    )
+
+    recip_bad = size_bad = cov_bad = 0
+    arena_sizes = []
+    for rl in range(rws):
+        rounds_rl, S_rl, _ = layouts[rl]
+        # (2) sizing: predecessor is the previous active global round in the same parity slot.
+        active = [i for i, rd in enumerate(rounds_rl) if rd["s2r"]]
+        pred = _arena_slot_predecessors(active, a.depth)
+        for i, rd in enumerate(rounds_rl):
+            pi = pred.get(i)
+            prev = rounds_rl[pi]["prep"] if pi is not None else 0
+            need = rd["s2r"] + max(rd["prep"], prev)
+            if need > S_rl:
+                size_bad += 1
+                if size_bad <= 5:
+                    print(f"  SIZE rl={rl} round={i}: need {need} > S {S_rl}")
+        total = _arena_total_bytes(rounds_rl, a.depth, S_rl)
+        arena_sizes.append((total, a.depth * S_rl, total - a.depth * S_rl))
+        for p in layouts[rl][2]:
+            for slot in range(a.depth):
+                entries = [
+                    rd["grecv"][p]
+                    for ri, rd in enumerate(rounds_rl)
+                    if ri % a.depth == slot and p in rd["grecv"]
+                ]
+                if len({off for off, _ in entries}) > 1 or any(
+                    off < a.depth * S_rl or off + nb > total for off, nb in entries
+                ):
+                    size_bad += 1
+                    if size_bad <= 5:
+                        print(
+                            f"  SIZE rl={rl} peer={p} parity={slot}: "
+                            f"unstable/out-of-bank grecv slots {entries}"
+                        )
+        # (1) reciprocity + (3) coverage per round
+        for i, rd in enumerate(rounds_rl):
+            for p, (_, nb) in rd["send"].items():
+                # p's grecv[rl] for the same round must equal rl's send[p]
+                p_rd = layouts[p][0][i]
+                pnb = p_rd["grecv"].get(rl, (0, 0))[1]
+                if nb != pnb:
+                    recip_bad += 1
+                    if recip_bad <= 8:
+                        print(
+                            f"  RECIP rl={rl}->p={p} round={i}: send {nb} != peer.grecv {pnb}"
+                        )
+            # coverage: own + sum(grecv) == full-shard bytes rl holds this round
+            own_nb = rd["own"][1]
+            grecv_nb = sum(nb for _, nb in rd["grecv"].values())
+            round_names = set(
+                n for n in r.global_rounds[i] if n in r.recv_specs_full[rl].entries
+            )
+            full_nb = r.recv_specs_full[rl].subset(round_names).nbytes(r.dtype_spec)
+            if own_nb + grecv_nb != full_nb:
+                cov_bad += 1
+                if cov_bad <= 8:
+                    print(
+                        f"  COVER rl={rl} round={i}: own {own_nb} + grecv {grecv_nb} "
+                        f"= {own_nb + grecv_nb} != full {full_nb}"
+                    )
+
+    # (4) ELEMENT-level partition: within each sub-group, members' slices must be pairwise DISJOINT and
+    # together cover the full shard exactly (byte-count coverage above can't see element overlap/gap).
+    from wbridge.utils.data import ShardSpec as _SS
+
+    part_bad = 0
+    for name, subs in classes.items():
+        for sg in subs:
+            members = sorted(sg)
+            if len(members) < 2:
+                continue
+            full_nb = r.recv_specs_full[members[0]].subset({name}).nbytes(r.dtype_spec)
+            slices = [r.recv_specs[m].subset({name}) for m in members]
+            cover = sum(s.nbytes(r.dtype_spec) for s in slices)
+            if cover != full_nb:
+                part_bad += 1
+                if part_bad <= 8:
+                    print(
+                        f"  PART cover rl-group {members} {name}: sum {cover} != full {full_nb}"
+                    )
+                continue
+            for i in range(len(slices)):
+                for j in range(i + 1, len(slices)):
+                    ov = _SS.compute_overlap(slices[i], slices[j]).nbytes(r.dtype_spec)
+                    if ov != 0:
+                        part_bad += 1
+                        if part_bad <= 8:
+                            print(
+                                f"  PART overlap {members[i]}&{members[j]} {name}: {ov} bytes shared"
+                            )
+
+    print(f"\n=== arena consistency (consolidate={a.consolidate}) ===")
+    print(f"reciprocity mismatches: {recip_bad}")
+    print(f"sizing violations:      {size_bad}")
+    print(f"coverage mismatches:    {cov_bad}")
+    print(f"element-partition bad:  {part_bad}")
+    gib = 1024**3
+    print(
+        "arena GiB range:        "
+        f"total={min(x[0] for x in arena_sizes) / gib:.3f}..{max(x[0] for x in arena_sizes) / gib:.3f}, "
+        f"parity={min(x[1] for x in arena_sizes) / gib:.3f}..{max(x[1] for x in arena_sizes) / gib:.3f}, "
+        f"shared_grecv={min(x[2] for x in arena_sizes) / gib:.3f}..{max(x[2] for x in arena_sizes) / gib:.3f}"
+    )
+    print(
+        "RESULT:",
+        "PLAN OK"
+        if (recip_bad == size_bad == cov_bad == part_bad == 0)
+        else "PLAN BROKEN",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/examples/worker_bodies.py
+++ b/examples/weightbridge/examples/worker_bodies.py
@@ -1,0 +1,213 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Orchestrator-agnostic worker logic for the example, shared by the Ray and Monarch front-ends.
+
+The example originally lived entirely inside ``@ray.remote`` classes. Monarch RDMA only works from inside
+a Monarch actor (``RDMABuffer``/``RDMAAction`` both resolve ``context()``), so the example needs a second
+orchestrator — but none of the *work* is orchestrator-specific: building the toy model, constructing the
+adapter, polling for an update, verifying, reporting transport stats. That logic lives here as plain
+classes; :mod:`workers` wraps them in Ray actors and :mod:`workers_monarch` in Monarch actors, so there is
+exactly one copy of the integration reference.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+from qwen_tiny import (
+    build_rollout_wksd,
+    build_trainer_wksd,
+    make_rollout_load_weights,
+    make_trainer_load_weights,
+    QwenTinyConfig,
+)
+from utils import apply_network_env, gpu_link_info, make_hf_weights, network_env_vars
+from wbridge.backend.sender import SenderArgs
+from wbridge.frontend.adapters import AdapterContext, ReceiverAdapter, SenderAdapter
+from wbridge.utils.specgen import HFWeightFetcher
+
+CheckpointBuilder = Callable[[], dict[str, torch.Tensor]]
+
+
+def _wrap_load_weights(orig_lw):
+    """Wrap an old-style ``load_weights(Iterable[(name, Tensor)])`` as ``load_weights(HFWeightFetcher)``."""
+
+    def lw(hf_weights: HFWeightFetcher):
+        orig_lw((name, fn()) for name, fn in hf_weights.items())
+
+    return lw
+
+
+@dataclass
+class EngineArgs:
+    """``build_checkpoint`` must be picklable (e.g. ``functools.partial`` of a module-level function)."""
+
+    rollout_host: str
+    rollout_port: int
+    rollout_scheduling_strategy: (
+        object  # Ray NodeAffinitySchedulingStrategy; unused by Monarch
+    )
+    num_rollout_workers: int
+
+    trainer_host: str
+    trainer_pg_port: int
+    trainer_scheduling_strategy: object  # Ray only
+    num_trainer_workers: int
+
+    model_config: QwenTinyConfig
+    build_checkpoint: CheckpointBuilder
+    dtype: torch.dtype = torch.float32
+    rollout_controller_ipc_name: str = ""
+    network_provider: str = "tcp"
+    network_interface: str = ""
+    # wbridge RDMA backend: "tcp"/"efa" -> Mooncake, "monarch" -> MonarchEngine.
+    protocol: str = "tcp"
+
+
+class RolloutWorkerBody:
+    """One per Rollout Worker GPU. Receives weights and verifies against a pre-update backup."""
+
+    def init(self, rank: int, args: EngineArgs) -> None:
+        apply_network_env(args.network_provider, args.network_interface)
+        self.rank = rank
+        self.args = args
+        cfg = args.model_config
+        hf_cpu = args.build_checkpoint()
+        hf_weights, hf_shapes = make_hf_weights(hf_cpu)
+        self.state_dict = build_rollout_wksd(
+            cfg,
+            device="cuda",
+            dtype=args.dtype,
+            tp_rank=rank,
+            tp_size=args.num_rollout_workers,
+        )
+        orig_lw = make_rollout_load_weights(
+            self.state_dict,
+            cfg,
+            device="cuda",
+            dtype=args.dtype,
+            tp_rank=rank,
+            tp_size=args.num_rollout_workers,
+        )
+        load_weights = _wrap_load_weights(orig_lw)
+        load_weights(hf_weights)
+        ctx = AdapterContext(
+            hf_weights=hf_weights,
+            hf_shapes=hf_shapes,
+            wksd_factory=lambda: self.state_dict,
+            load_weights=load_weights,
+            rank=rank,
+        )
+        self.adapter = ReceiverAdapter(
+            ctx, args.rollout_controller_ipc_name, num_workers=args.num_rollout_workers
+        )
+        # Snapshot the loaded weights before the first recv so verify() can diff backup vs received.
+        self.state_dict_backup = {
+            name: t.detach().clone() for name, t in self.state_dict.items()
+        }
+
+    def recv_weights(self) -> None:
+        for _ in range(500):
+            t0 = time.time()
+            updated = self.adapter.poll_requests()
+            t1 = time.time()
+            if updated:
+                print(
+                    f"RolloutWorker rank {self.rank} recv_weights start wall_s={t0} return wall_s={t1}",
+                    flush=True,
+                )
+                self.adapter.flush_profile_outputs()
+                return
+            time.sleep(0.05)
+        raise TimeoutError("receiver never became ready for weights")
+
+    def transport_stats(self) -> dict:
+        """Bulk bytes this receiver landed, by transport, plus its GPU's NVLink state."""
+        return {**self.adapter.receiver.transport_stats(), **gpu_link_info()}
+
+    def verify(self) -> dict:
+        for name, backup in self.state_dict_backup.items():
+            received = self.state_dict[name]
+            if not torch.allclose(backup, received):
+                return {
+                    "rank": self.rank,
+                    "name": name,
+                    "ok": False,
+                    "detail": (
+                        f"value mismatch for {name} on rank {self.rank}, "
+                        f"expected: {backup[:, :1].view(-1)}, got: {received[:, :1].view(-1)}"
+                    ),
+                }
+        return {"rank": self.rank, "ok": True, "detail": "all values match"}
+
+
+class TrainerWorkerBody:
+    """One per Trainer Worker GPU. Sends shards via :class:`SenderAdapter`."""
+
+    def init(self, rank: int, args: EngineArgs) -> None:
+        apply_network_env(args.network_provider, args.network_interface)
+        self.args = args
+        self.rank = rank
+        cfg = args.model_config
+        hf_cpu = args.build_checkpoint()
+        hf_weights, hf_shapes = make_hf_weights(hf_cpu)
+        self.state_dict = build_trainer_wksd(
+            cfg,
+            device="cuda",
+            dtype=args.dtype,
+            tp_rank=rank,
+            tp_size=args.num_trainer_workers,
+        )
+        orig_lw = make_trainer_load_weights(
+            self.state_dict,
+            cfg,
+            device="cuda",
+            dtype=args.dtype,
+            tp_rank=rank,
+            tp_size=args.num_trainer_workers,
+        )
+        load_weights = _wrap_load_weights(orig_lw)
+        load_weights(hf_weights)
+        ctx = AdapterContext(
+            hf_weights=hf_weights,
+            hf_shapes=hf_shapes,
+            wksd_factory=lambda: self.state_dict,
+            load_weights=load_weights,
+            rank=rank,
+        )
+        sender_args = SenderArgs(
+            world_size=args.num_trainer_workers,
+            protocol=args.protocol,
+            receiver_urls=[f"tcp://{args.rollout_host}:{args.rollout_port}"],
+            master_addr=args.trainer_host,
+            master_port=args.trainer_pg_port,
+        )
+        self.adapter = SenderAdapter(ctx, sender_args)
+
+    def send_weights(self) -> None:
+        self.adapter.connect()
+        t0 = time.time()
+        print(
+            f"TrainerWorker rank {self.rank} send_weights start wall_s={t0}", flush=True
+        )
+        self.adapter.send_weights()
+        # The RDMA/pull completions run on the Stage-2 thread after send() returns; the byte counters are
+        # only final once the epoch has drained, so block here (the example is not measuring overlap).
+        self.adapter.wait_send_complete()
+        t1 = time.time()
+        print(
+            f"TrainerWorker rank {self.rank} send_weights return wall_s={t1} elapsed_s={t1 - t0}",
+            flush=True,
+        )
+        self.adapter.flush_profile_outputs()
+
+    def transport_stats(self) -> dict:
+        """Bulk bytes this sender moved, by transport, plus its GPU's NVLink state."""
+        return {**self.adapter.sender.transport_stats(), **gpu_link_info()}

--- a/examples/weightbridge/examples/workers.py
+++ b/examples/weightbridge/examples/workers.py
@@ -1,0 +1,172 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Ray front-end for the WeightBridge example.
+
+All the actual work lives in :mod:`worker_bodies` (orchestrator-agnostic); the actors here are thin
+delegates, and :class:`RayOrchestrator` is the surface :mod:`train` drives. :mod:`workers_monarch`
+provides the same surface on Monarch actors — which is what a Monarch RDMA run requires, since
+``RDMABuffer``/``RDMAAction`` only work inside a Monarch actor.
+
+HF weights are not serialized in ``EngineArgs``; each worker calls ``build_checkpoint()`` locally so
+checkpoints are identical across nodes without shipping CPU tensors through Ray.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import ray
+from wbridge.backend import coordinator
+from wbridge.backend.control_channel import coordinator_ipc
+
+# Re-exported for callers that import them from here (train.py, bench_transfer.py).
+from worker_bodies import (  # noqa: F401
+    apply_network_env as _apply_network_env_for_process_group,
+    EngineArgs,
+    network_env_vars as _network_env_vars,
+    RolloutWorkerBody,
+    TrainerWorkerBody,
+)
+
+logger = logging.getLogger("wbridge.example.workers")
+
+
+@ray.remote(num_gpus=1, num_cpus=1)
+class RolloutWorker:
+    def __init__(self) -> None:
+        self._b = RolloutWorkerBody()
+
+    def init(self, rank: int, args: EngineArgs):
+        return self._b.init(rank, args)
+
+    def recv_weights(self) -> None:
+        return self._b.recv_weights()
+
+    def transport_stats(self) -> dict:
+        return self._b.transport_stats()
+
+    def verify(self) -> dict:
+        return self._b.verify()
+
+
+@ray.remote(num_cpus=1)
+class RolloutEngine:
+    """Spawns the standalone ZMQ coordinator process and the :class:`RolloutWorker` actors.
+
+    There is no HTTP server: the control plane is a per-engine coordinator subprocess (pure ZMQ).
+    """
+
+    def init(self, args: EngineArgs):
+        # Standalone coordinator process: Trainer-facing tcp://*:rollout_port, rank0-facing IPC. The IPC
+        # path is derived deterministically from the port so the (co-located) workers agree on it.
+        ipc = coordinator_ipc(args.rollout_port)
+        args.rollout_controller_ipc_name = ipc
+        self._coord_proc = coordinator.spawn(ipc, args.rollout_port)
+        print(
+            f"RolloutEngine coordinator on {args.rollout_host}:{args.rollout_port} (ipc {ipc})"
+        )
+
+        n = args.num_rollout_workers
+        runtime_env = {
+            "env_vars": _network_env_vars(args.network_provider, args.network_interface)
+        }
+        self._workers = [
+            RolloutWorker.options(
+                scheduling_strategy=args.rollout_scheduling_strategy,
+                runtime_env=runtime_env,
+            ).remote()
+            for _ in range(n)
+        ]
+        # rank 0 reports num_workers to the coordinator on connect — no set_worker_num needed.
+        ray.get([w.init.remote(rank, args) for rank, w in enumerate(self._workers)])
+
+    def recv_weights(self) -> None:
+        ray.get([w.recv_weights.remote() for w in self._workers])
+
+    def transport_stats_all(self) -> list[dict]:
+        return ray.get([w.transport_stats.remote() for w in self._workers])
+
+    def verify_all(self) -> str:
+        results = ray.get([w.verify.remote() for w in self._workers])
+        results = sorted(results, key=lambda r: r["rank"])
+        for r in results:
+            if not r["ok"]:
+                return f"RolloutWorker rank {r['rank']} failed: {r['detail']}"
+        return "All RolloutWorkers verified their shards independently."
+
+
+@ray.remote(num_gpus=1, num_cpus=1)
+class TrainerWorker:
+    def __init__(self) -> None:
+        self._b = TrainerWorkerBody()
+
+    def init(self, rank: int, args: EngineArgs):
+        return self._b.init(rank, args)
+
+    def send_weights(self):
+        return self._b.send_weights()
+
+    def transport_stats(self) -> dict:
+        return self._b.transport_stats()
+
+
+class TrainerEngine:
+    """Spawns :class:`TrainerWorker` actors (must run before rollout so LoadSpec exists on disk)."""
+
+    def __init__(self, args: EngineArgs):
+        n = args.num_trainer_workers
+        runtime_env = {
+            "env_vars": _network_env_vars(args.network_provider, args.network_interface)
+        }
+        self._workers = [
+            TrainerWorker.options(
+                scheduling_strategy=args.trainer_scheduling_strategy,
+                runtime_env=runtime_env,
+            ).remote()
+            for _ in range(n)
+        ]
+        ray.get([w.init.remote(rank, args) for rank, w in enumerate(self._workers)])
+        print(f"TrainerEngine started on {args.trainer_host}:{args.trainer_pg_port}")
+
+    def send_weights(self):
+        ray.get([w.send_weights.remote() for w in self._workers])
+
+    def transport_stats_all(self) -> list[dict]:
+        return ray.get([w.transport_stats.remote() for w in self._workers])
+
+
+class RayOrchestrator:
+    """Ray implementation of the surface :mod:`train` drives."""
+
+    name = "ray"
+
+    def __init__(self, args: EngineArgs) -> None:
+        self.args = args
+
+    def start(self) -> None:
+        # Trainer first: LoadSpec inference writes to disk and the rollout side reads it.
+        self._trainer = TrainerEngine(self.args)
+        self._rollout = RolloutEngine.options(
+            scheduling_strategy=self.args.rollout_scheduling_strategy
+        ).remote()
+        ray.get(self._rollout.init.remote(self.args))
+
+    def run_transfer(self) -> None:
+        recv = self._rollout.recv_weights.remote()  # poll concurrently with the send
+        self._trainer.send_weights()
+        ray.get(recv)
+
+    def verify_all(self) -> str:
+        return ray.get(self._rollout.verify_all.remote())
+
+    def transport_stats(self) -> list[dict]:
+        return self._trainer.transport_stats_all() + ray.get(
+            self._rollout.transport_stats_all.remote()
+        )
+
+    def shutdown(self) -> None:
+        ray.shutdown()

--- a/examples/weightbridge/examples/workers_monarch.py
+++ b/examples/weightbridge/examples/workers_monarch.py
@@ -1,0 +1,191 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Monarch front-end for the WeightBridge example — the same roles as :mod:`workers`, on actor meshes.
+
+This exists because Monarch RDMA is only reachable from inside a Monarch actor: ``RDMABuffer`` and
+``RDMAAction.submit`` both resolve ``context().actor_instance``. Ray workers can never host it, so running
+WeightBridge over the Monarch transport requires the processes themselves to be Monarch actors. The work
+each role does is unchanged — it delegates to :mod:`worker_bodies`.
+
+Placement mirrors the Ray path: rollout workers on the rollout host, trainer workers on the trainer host,
+matched by IP so ``--colocate`` (both hosts the same) keeps working. The ZMQ coordinator is transport-
+independent and still runs as a subprocess, spawned by an actor on the rollout host so it lands on the
+right machine.
+
+The host mesh is built by attaching to worker loops that the surrounding scheduler or process manager
+already started. Their addresses are passed to the example explicitly; WeightBridge does not assume a
+particular cluster scheduler or launcher layout.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from monarch.actor import Actor, endpoint
+from monarch_common import (
+    ActorThread as _ActorThread,
+    attach_hosts,
+    bind_gpu as _bind_gpu,
+    host_index,
+    my_rank as _my_rank,
+)
+from wbridge.backend import coordinator
+from wbridge.backend.control_channel import coordinator_ipc
+from worker_bodies import EngineArgs, RolloutWorkerBody, TrainerWorkerBody
+
+logger = logging.getLogger("wbridge.example.workers_monarch")
+
+
+class RolloutWorkerActor(Actor):
+    def __init__(self) -> None:
+        self._b = RolloutWorkerBody()
+        self._t = _ActorThread("wb-rollout")
+
+    @endpoint
+    async def init(self, args: EngineArgs) -> None:
+        # Rank comes from the mesh position, so init can be ONE broadcast to all actors. That matters:
+        # ReceiverAdapter's ControlChannel constructor is a rendezvous across the engine's ranks, so
+        # initializing them one at a time deadlocks (rank 0 waits for peers that were never started).
+        rank = _my_rank()
+        await self._t.run(
+            _bind_gpu, rank
+        )  # on the worker thread: set_device is thread-local
+        await self._t.run(self._b.init, rank, args)
+
+    @endpoint
+    async def recv_weights(self) -> None:
+        await self._t.run(self._b.recv_weights)
+
+    @endpoint
+    async def transport_stats(self) -> dict:
+        return await self._t.run(self._b.transport_stats)
+
+    @endpoint
+    async def verify(self) -> dict:
+        return await self._t.run(self._b.verify)
+
+
+class TrainerWorkerActor(Actor):
+    def __init__(self) -> None:
+        self._b = TrainerWorkerBody()
+        self._t = _ActorThread("wb-trainer")
+
+    @endpoint
+    async def init(self, args: EngineArgs) -> None:
+        rank = _my_rank()
+        await self._t.run(_bind_gpu, rank)
+        await self._t.run(self._b.init, rank, args)
+
+    @endpoint
+    async def send_weights(self) -> None:
+        await self._t.run(self._b.send_weights)
+
+    @endpoint
+    async def transport_stats(self) -> dict:
+        return await self._t.run(self._b.transport_stats)
+
+
+class CoordinatorActor(Actor):
+    """Runs the ZMQ coordinator subprocess on the rollout host (it must share a machine with rank 0)."""
+
+    def __init__(self) -> None:
+        self._proc = None
+
+    @endpoint
+    async def spawn(self, ipc: str, port: int) -> str:
+        import socket
+
+        self._proc = coordinator.spawn(ipc, port)
+        return f"coordinator on {socket.gethostname()}:{port} (ipc {ipc})"
+
+
+class MonarchOrchestrator:
+    """Monarch implementation of the surface :mod:`train` drives."""
+
+    name = "monarch"
+
+    def __init__(self, args: EngineArgs, worker_addrs: list[str]) -> None:
+        self.args = args
+        self.worker_addrs = worker_addrs
+
+    def _host_index(self, ip: str) -> int:
+        return host_index(self.worker_addrs, ip)
+
+    def start(self) -> None:
+        a = self.args
+        self.hosts = attach_hosts(self.worker_addrs)
+        t_idx = self._host_index(a.trainer_host)
+        r_idx = self._host_index(a.rollout_host)
+        print(
+            f"[monarch] trainer host slice {t_idx}, rollout host slice {r_idx} "
+            f"({'co-located' if t_idx == r_idx else 'separate nodes'})",
+            flush=True,
+        )
+
+        # Trainer first: its LoadSpec inference writes to disk and the rollout side reads it. Every mesh
+        # is awaited before use — pickling an uninitialized mesh into a later spawn blocks Monarch's
+        # tokio runtime, which is how the 2-node spike first wedged.
+        self._t_procs = self.hosts.slice(hosts=t_idx).spawn_procs(
+            {"gpus": a.num_trainer_workers}
+        )
+        self._t_procs.initialized.get()
+        self._trainers = self._t_procs.spawn("wb_trainer", TrainerWorkerActor)
+        self._trainers.initialized.get()
+        self._trainers.init.call(
+            args=a
+        ).get()  # ONE broadcast: all ranks init concurrently
+        print(f"[monarch] {a.num_trainer_workers} trainer workers ready", flush=True)
+
+        # Coordinator on the rollout host, then the rollout workers pointed at its IPC path.
+        ipc = coordinator_ipc(a.rollout_port)
+        a.rollout_controller_ipc_name = ipc
+        self._c_procs = self.hosts.slice(hosts=r_idx).spawn_procs({"gpus": 1})
+        self._c_procs.initialized.get()
+        self._coord = self._c_procs.spawn("wb_coord", CoordinatorActor)
+        self._coord.initialized.get()
+        print(
+            "[monarch] "
+            + self._coord.spawn.call_one(ipc=ipc, port=a.rollout_port).get(),
+            flush=True,
+        )
+
+        self._r_procs = self.hosts.slice(hosts=r_idx).spawn_procs(
+            {"gpus": a.num_rollout_workers}
+        )
+        self._r_procs.initialized.get()
+        self._rollouts = self._r_procs.spawn("wb_rollout", RolloutWorkerActor)
+        self._rollouts.initialized.get()
+        self._rollouts.init.call(
+            args=a
+        ).get()  # ONE broadcast (see RolloutWorkerActor.init)
+        print(f"[monarch] {a.num_rollout_workers} rollout workers ready", flush=True)
+
+    def run_transfer(self) -> None:
+        # .call() fans out to every actor in the mesh and returns a future, so the receivers poll while
+        # the senders run — the same concurrency the Ray path gets from a detached recv_weights task.
+        recv = self._rollouts.recv_weights.call()
+        send = self._trainers.send_weights.call()
+        send.get()
+        recv.get()
+
+    def verify_all(self) -> str:
+        results = sorted(
+            (v for _, v in self._rollouts.verify.call().get()), key=lambda r: r["rank"]
+        )
+        for r in results:
+            if not r["ok"]:
+                return f"RolloutWorker rank {r['rank']} failed: {r['detail']}"
+        return "All RolloutWorkers verified their shards independently."
+
+    def transport_stats(self) -> list[dict]:
+        return [v for _, v in self._trainers.transport_stats.call().get()] + [
+            v for _, v in self._rollouts.transport_stats.call().get()
+        ]
+
+    def shutdown(self) -> None:
+        # Worker loops are owned by the launcher script, which tears them down on exit.
+        pass

--- a/examples/weightbridge/pyproject.toml
+++ b/examples/weightbridge/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "weightbridge"
+version = "0.1.0"
+description = "WeightBridge"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "packaging",
+    "pyzmq",
+    "torch",
+]
+
+[project.optional-dependencies]
+cuda = [
+    "cuda-python>=12.6",
+]
+mooncake = [
+    "mooncake-transfer-engine>=0.3.12.post1,<0.4",
+]
+ray = [
+    "nvidia-ml-py",
+    "ray",
+]
+checkpoints = [
+    "safetensors",
+]
+examples = [
+    "cuda-python>=12.6",
+    "mooncake-transfer-engine>=0.3.12.post1,<0.4",
+    "nvidia-ml-py",
+    "ray",
+    "triton",
+]
+test = [
+    "pytest",
+]
+dev = [
+    "pytest",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["wbridge*"]

--- a/examples/weightbridge/tests/__init__.py
+++ b/examples/weightbridge/tests/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+

--- a/examples/weightbridge/tests/multi_group_topology_integration.py
+++ b/examples/weightbridge/tests/multi_group_topology_integration.py
@@ -1,0 +1,293 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Manual 3-node integration test for overlapping topology-aware replication groups.
+
+Launch 8 tasks/node: node 0 is eight trainer senders; nodes 1 and 2 are the 16 rollout receivers.
+The receiver layout is the hand-crafted 11-group case used by ``test_arena_planner``:
+
+* one tensor replicated by all 16 workers;
+* one tensor with eight same-rank pairs across rollout nodes; and
+* one tensor with two half-GPU groups.
+
+This driver uses real :class:`WeightSender` / :class:`WeightReceiver` data paths but bypasses their
+application control adapters. It is intentionally not pytest-collected; it requires 24 GPUs on 3 nodes.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import threading
+
+import torch
+import torch.distributed as dist
+from wbridge.backend.receiver import WeightReceiver
+from wbridge.backend.sender import WeightSender
+from wbridge.utils.data import LoadSpec, shards_numel, ShardSpec
+
+
+SENDERS = 8
+RECEIVER_NODES = int(os.environ.get("WBRIDGE_TEST_RECEIVER_NODES", "2"))
+if RECEIVER_NODES < 2:
+    raise ValueError(
+        f"WBRIDGE_TEST_RECEIVER_NODES must be at least 2, got {RECEIVER_NODES}"
+    )
+RECEIVERS = 8 * RECEIVER_NODES
+WORLD = SENDERS + RECEIVERS
+NAME_COPIES = int(os.environ.get("WBRIDGE_TEST_NAME_COPIES", "1"))
+if NAME_COPIES <= 0:
+    raise ValueError(f"WBRIDGE_TEST_NAME_COPIES must be positive, got {NAME_COPIES}")
+NAMES = tuple(
+    kind if NAME_COPIES == 1 else f"{kind}.{index:03d}"
+    for kind in ("half", "pair", "wide")
+    for index in range(NAME_COPIES)
+)
+WIDTH = int(os.environ.get("WBRIDGE_TEST_WIDTH", "160"))
+if WIDTH <= 0 or WIDTH % 8:
+    raise ValueError(
+        f"WBRIDGE_TEST_WIDTH must be a positive multiple of 8, got {WIDTH}"
+    )
+
+
+def name_dtype(name: str) -> torch.dtype:
+    """Optional mixed wire layout matching GLM-5's BF16 weights and FP32 vectors."""
+    if os.environ.get("WBRIDGE_TEST_MIXED_DTYPE") == "1":
+        return torch.float32 if name.startswith("pair") else torch.bfloat16
+    return torch.float32
+
+
+def d1(left: int, right: int, width: int):
+    return [[(left, right, width)]]
+
+
+def receiver_spec(worker: int) -> ShardSpec:
+    lane = worker % 8
+    half = 0 if lane < 4 else 1
+    entries = {}
+    for name in NAMES:
+        if name.startswith("half"):
+            entries[name] = d1(
+                half * (WIDTH // 2),
+                (half + 1) * (WIDTH // 2),
+                WIDTH,
+            )
+        elif name.startswith("pair"):
+            entries[name] = d1(
+                lane * (WIDTH // 8),
+                (lane + 1) * (WIDTH // 8),
+                WIDTH,
+            )
+        else:
+            assert name.startswith("wide")
+            entries[name] = d1(0, WIDTH, WIDTH)
+    return ShardSpec(entries)
+
+
+def sender_spec() -> ShardSpec:
+    return ShardSpec({name: d1(0, WIDTH, WIDTH) for name in NAMES})
+
+
+def identity_side(spec: ShardSpec, *, sender: bool):
+    """Build a LoadSpec mapping each global source shard to one flat local model tensor."""
+    entries = {}
+    wksd = {}
+    for ni, (name, shards) in enumerate(spec):
+        assert len(shards) == 1
+        numel = shards_numel(shards)
+        local = [(0, numel, numel)]
+        entries[name] = {name: [(shards[0], local)]}
+        if sender:
+            left = shards[0][0][0]
+            # Build the value from the integer global coordinate before casting.  A floating-point
+            # ``arange(0, N)[left:]`` is not bitwise equivalent to ``arange(left, N)`` once ``left``
+            # exceeds 2**24, so the old oracle produced false mismatches in large-offset tests.
+            values = torch.arange(
+                left,
+                left + numel,
+                dtype=torch.int32,
+                device="cuda",
+            )
+            values.remainder_(251).add_(ni * 1000)
+            wksd[name] = values.to(name_dtype(name))
+        else:
+            wksd[name] = torch.full(
+                (numel,),
+                -1,
+                dtype=name_dtype(name),
+                device="cuda",
+            )
+    return LoadSpec(entries), wksd
+
+
+def make_sender(
+    rank: int, spec: ShardSpec, load_spec: LoadSpec, wksd: dict
+) -> WeightSender:
+    endpoint = WeightSender.__new__(WeightSender)
+    endpoint.cuda_device = f"cuda:{torch.cuda.current_device()}"
+    endpoint.rank = rank
+    endpoint.shard_spec = spec
+    endpoint.dtype_spec = {}  # learned from receivers in the metadata gather
+    endpoint.load_spec = load_spec
+    endpoint.wksd = wksd
+    endpoint.sender_staging = False
+    endpoint.receiver_staging = False
+    endpoint.connected = False
+    endpoint._offload_ev = {}
+    endpoint._fallback_receive_engines = []
+    return endpoint
+
+
+def start_sender(endpoint: WeightSender) -> None:
+    """The normal connect() starts these after endpoint metadata setup; this test calls setup directly."""
+    endpoint.connected = True
+    endpoint._coord = []
+    endpoint.receiver_urls = []
+    endpoint._sq = queue.Queue()
+    endpoint._cv = threading.Condition()
+    endpoint._completed = set()
+    endpoint._werr = []
+    endpoint._drained_count = 0
+    endpoint._offload_ev = {}
+    endpoint._flag_reaper_ensure()
+    endpoint._send_thread = threading.Thread(
+        target=endpoint._send_worker,
+        name="wbridge-test-send",
+        daemon=True,
+    )
+    endpoint._send_thread.start()
+
+
+def make_receiver(
+    worker: int, spec: ShardSpec, load_spec: LoadSpec, wksd: dict
+) -> WeightReceiver:
+    endpoint = WeightReceiver.__new__(WeightReceiver)
+    endpoint.cuda_device = f"cuda:{torch.cuda.current_device()}"
+    endpoint.rank = worker
+    endpoint.shard_spec = spec
+    endpoint.dtype_spec = {name: name_dtype(name) for name in NAMES}
+    endpoint.load_spec = load_spec
+    endpoint.wksd = wksd
+    endpoint.sender_staging = False
+    endpoint.receiver_staging = False
+    return endpoint
+
+
+def check_receiver(worker: int, wksd: dict) -> None:
+    full = receiver_spec(worker)
+    for ni, (name, shards) in enumerate(full):
+        left, right, _width = shards[0][0]
+        expected = torch.arange(left, right, dtype=torch.int32, device="cuda")
+        expected.remainder_(251).add_(ni * 1000)
+        expected = expected.to(name_dtype(name))
+        if not torch.equal(wksd[name], expected):
+            mismatch_count = int(torch.count_nonzero(wksd[name] != expected).item())
+            print(
+                f"VALUE_MISMATCH worker={worker} name={name} "
+                f"mismatches={mismatch_count}/{expected.numel()} "
+                f"actual_head={wksd[name][:8].cpu().tolist()} "
+                f"expected_head={expected[:8].cpu().tolist()} "
+                f"actual_tail={wksd[name][-8:].cpu().tolist()} "
+                f"expected_tail={expected[-8:].cpu().tolist()}",
+                flush=True,
+            )
+            raise AssertionError(
+                f"worker {worker} tensor {name} mismatch: "
+                f"{mismatch_count}/{expected.numel()} elements"
+            )
+
+
+def main() -> None:
+    # torchrun marks its own MASTER_PORT store as agent-owned. This test deliberately creates a second,
+    # independent TCPStore at WBRIDGE_TEST_PORT; without clearing the marker PyTorch assumes an agent already
+    # owns that second port too, so every rank waits for a server that was never created.
+    os.environ.pop("TORCHELASTIC_USE_AGENT_STORE", None)
+    rank = (
+        int(os.environ["RANK"])
+        if "RANK" in os.environ
+        else int(os.environ.get("WBRIDGE_TEST_RANK_BASE", "0"))
+        + int(os.environ["SLURM_PROCID"])
+    )
+    local_rank = int(os.environ.get("LOCAL_RANK", os.environ.get("SLURM_LOCALID", "0")))
+    assert 0 <= rank < WORLD
+    # CUDA-IPC import needs every local peer GPU visible, matching the production Ray/SGLang actors.
+    # CI may opt into sharing one allocated GPU among all eight local ranks; this preserves the process/node
+    # topology and CUDA-IPC/RDMA protocols while avoiding a full-node lease. Production verification leaves the
+    # switch off and requires all eight GPUs to be visible.
+    visible = torch.cuda.device_count()
+    shared_gpu = os.environ.get("WBRIDGE_TEST_SHARED_GPU") == "1"
+    if not shared_gpu:
+        assert visible >= 8, (rank, local_rank, os.environ.get("CUDA_VISIBLE_DEVICES"))
+    assert visible >= 1
+    torch.cuda.set_device(local_rank % visible)
+
+    is_sender = rank < SENDERS
+    worker = rank - SENDERS
+    spec = sender_spec() if is_sender else receiver_spec(worker)
+    load_spec, wksd = identity_side(spec, sender=is_sender)
+    endpoint = (
+        make_sender(rank, spec, load_spec, wksd)
+        if is_sender
+        else make_receiver(worker, spec, load_spec, wksd)
+    )
+
+    endpoint.set_up_connection(
+        protocol="efa",
+        init_method=(
+            f"tcp://{os.environ['MASTER_ADDR']}:"
+            f"{os.environ.get('WBRIDGE_TEST_PORT', os.environ.get('MASTER_PORT', '62991'))}"
+        ),
+        world_size=WORLD,
+        rank=rank,
+        sender_world_size=SENDERS,
+        group_name="wbridge-multigroup-integration",
+    )
+    if is_sender:
+        start_sender(endpoint)
+    else:
+        print(
+            f"MULTI_GROUP_CONFIG worker={worker} topo_ok={endpoint._topo_ok} "
+            f"groups={len(endpoint.router._topology_groups)} rounds={endpoint.num_rounds} "
+            f"ext_send={endpoint._topo_ext_send_peers_by_round} "
+            f"ext_recv={endpoint._topo_ext_recv_peers_by_round} "
+            f"internal_consume={endpoint._topo_int_peers_by_round}",
+            flush=True,
+        )
+
+    dist.barrier(group=endpoint.group)
+    for _ in range(int(os.environ.get("WBRIDGE_TEST_ITERS", "2"))):
+        if is_sender:
+            event = endpoint.send()
+            if event is not None:
+                event.synchronize()
+            endpoint.wait_send_complete()
+        else:
+            endpoint._receive_weights(False)
+            check_receiver(worker, wksd)
+        dist.barrier(group=endpoint.group)
+
+    if not is_sender and os.environ.get("WBRIDGE_TOPO_EXCHANGE", "1") == "1":
+        assert endpoint._topo_ok
+        assert len(endpoint.router._topology_groups) == 11
+    ok = torch.tensor(1, dtype=torch.int64)
+    dist.all_reduce(ok, group=endpoint.group)
+    if rank == 0:
+        print(
+            "MULTI_GROUP_TOPOLOGY_INTEGRATION_PASS "
+            f"world={WORLD} senders={SENDERS} receivers={RECEIVERS} "
+            f"receiver_nodes={RECEIVER_NODES} rounds={endpoint.num_rounds}",
+            flush=True,
+        )
+
+    dist.barrier(group=endpoint.group)
+    if is_sender:
+        endpoint._sq.put(None)
+        endpoint._send_thread.join(timeout=5)
+    endpoint._teardown()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/tests/run_multi_group_topology_host.sh
+++ b/examples/weightbridge/tests/run_multi_group_topology_host.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Run one rank of multi_group_topology_integration.py inside an EFA-capable image.
+# Launch 24 ranks over three 8-GPU nodes; Slurm block rank order makes node 0 the eight trainers and nodes
+# 1-2 the sixteen rollout workers:
+#
+#   WBRIDGE_TEST_SIF=/path/to/runtime.sif \
+#   srun --jobid="$JOBID" --overlap --mpi=none -N3 --ntasks-per-node=1 --gres=gpu:8 \
+#     --export=ALL,MASTER_ADDR="$HEAD_IP",WBRIDGE_TEST_TORCHRUN=1,WBRIDGE_TEST_SIF \
+#     bash tests/run_multi_group_topology_host.sh
+#
+# Site-specific inputs are environment variables: WBRIDGE_TEST_SIF is required;
+# WBRIDGE_NETWORK_INTERFACE, APPTAINER_CACHEDIR, WBRIDGE_EFA_LIBRARY_PATH, and
+# WBRIDGE_TEST_TMP_ROOT are optional. If WBRIDGE_TEST_PATCH_LIBFABRIC=1, also
+# provide the in-container WBRIDGE_MOONCAKE_LIB_DIR, WBRIDGE_LIBFABRIC_SO, and
+# optional WBRIDGE_LIBEFA_SO paths.
+set -euo pipefail
+
+: "${MASTER_ADDR:?MASTER_ADDR must identify the rank-0 node}"
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+LIB_ROOT=$(cd -- "$SCRIPT_DIR/.." && pwd)
+: "${WBRIDGE_TEST_SIF:?set WBRIDGE_TEST_SIF to an EFA-capable Apptainer image}"
+if [ ! -f "$WBRIDGE_TEST_SIF" ]; then
+  echo "WBRIDGE_TEST_SIF does not exist: $WBRIDGE_TEST_SIF" >&2
+  exit 2
+fi
+
+CONTAINER_LIB=${WBRIDGE_TEST_CONTAINER_LIB:-/wbridge-lib}
+case "$CONTAINER_LIB" in
+  /*) ;;
+  *) echo "WBRIDGE_TEST_CONTAINER_LIB must be absolute inside the container" >&2; exit 2 ;;
+esac
+
+export APPTAINER_CACHEDIR=${APPTAINER_CACHEDIR:-${XDG_CACHE_HOME:-${TMPDIR:-/tmp}}/apptainer}
+mkdir -p "$APPTAINER_CACHEDIR"
+export APPTAINERENV_WBRIDGE_TEST_NNODES=${SLURM_NNODES:-${SLURM_JOB_NUM_NODES:-1}}
+export APPTAINERENV_WBRIDGE_TEST_NODE_RANK=${SLURM_NODEID:-0}
+export APPTAINERENV_MASTER_ADDR=$MASTER_ADDR
+export APPTAINERENV_WBRIDGE_TEST_CONTAINER_LIB=$CONTAINER_LIB
+export APPTAINERENV_WBRIDGE_NETWORK_INTERFACE=${WBRIDGE_NETWORK_INTERFACE:-}
+export APPTAINERENV_WBRIDGE_EFA_LIBRARY_PATH=${WBRIDGE_EFA_LIBRARY_PATH:-}
+export APPTAINERENV_WBRIDGE_TEST_TMP_ROOT=${WBRIDGE_TEST_TMP_ROOT:-}
+export APPTAINERENV_WBRIDGE_TEST_PATCH_LIBFABRIC=${WBRIDGE_TEST_PATCH_LIBFABRIC:-0}
+export APPTAINERENV_WBRIDGE_MOONCAKE_LIB_DIR=${WBRIDGE_MOONCAKE_LIB_DIR:-}
+export APPTAINERENV_WBRIDGE_LIBFABRIC_SO=${WBRIDGE_LIBFABRIC_SO:-}
+export APPTAINERENV_WBRIDGE_LIBEFA_SO=${WBRIDGE_LIBEFA_SO:-}
+export APPTAINERENV_MC_PATH_ROUNDROBIN=${MC_PATH_ROUNDROBIN:-1}
+export APPTAINERENV_MC_NUM_QP_PER_EP=${MC_NUM_QP_PER_EP:-4}
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY
+
+exec apptainer exec --nv --writable-tmpfs --no-mount home \
+  --bind "$LIB_ROOT:$CONTAINER_LIB" \
+  "$WBRIDGE_TEST_SIF" bash -lc '
+set -euo pipefail
+if [ -n "${WBRIDGE_EFA_LIBRARY_PATH:-}" ]; then
+  export LD_LIBRARY_PATH="${WBRIDGE_EFA_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export FI_PROVIDER=efa FI_EFA_USE_DEVICE_RDMA=1 FI_EFA_ENABLE_SHM_TRANSFER=0
+export MC_PATH_ROUNDROBIN=${MC_PATH_ROUNDROBIN:-1}
+export MC_NUM_QP_PER_EP=${MC_NUM_QP_PER_EP:-4}
+IFACE=${WBRIDGE_NETWORK_INTERFACE:-}
+if [ -z "$IFACE" ]; then
+  IFACE=$(ip route show default 2>/dev/null | awk "{print \$5; exit}" || true)
+fi
+if [ -z "$IFACE" ]; then
+  echo "could not determine a network interface; set WBRIDGE_NETWORK_INTERFACE" >&2
+  exit 2
+fi
+export GLOO_SOCKET_IFNAME=$IFACE
+TEST_TMP_ROOT=${WBRIDGE_TEST_TMP_ROOT:-${TMPDIR:-/tmp}/wbridge-multigroup-${SLURM_JOB_ID:-0}-${SLURM_PROCID:-0}}
+mkdir -p "$TEST_TMP_ROOT/tmp" "$TEST_TMP_ROOT/cache" "$TEST_TMP_ROOT/triton"
+export TMPDIR=$TEST_TMP_ROOT/tmp
+export XDG_CACHE_HOME=$TEST_TMP_ROOT/cache
+export TRITON_CACHE_DIR=$TEST_TMP_ROOT/triton
+export PYTHONPATH="${WBRIDGE_TEST_CONTAINER_LIB:?}${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+
+# Avoid loading Mooncake auditwheel libfabric beside the system EFA libfabric.
+if [ "${WBRIDGE_TEST_PATCH_LIBFABRIC:-0}" = "1" ]; then
+  : "${WBRIDGE_MOONCAKE_LIB_DIR:?set to mooncake_transfer_engine.libs inside the container}"
+  : "${WBRIDGE_LIBFABRIC_SO:?set to the system libfabric.so.1 inside the container}"
+  if [ ! -d "$WBRIDGE_MOONCAKE_LIB_DIR" ] || [ ! -f "$WBRIDGE_LIBFABRIC_SO" ]; then
+    echo "invalid Mooncake or libfabric patch path" >&2
+    exit 2
+  fi
+  for f in "$WBRIDGE_MOONCAKE_LIB_DIR"/libfabric-*.so.*; do
+    [ -e "$f" ] && ln -sf "$WBRIDGE_LIBFABRIC_SO" "$f"
+  done
+  if [ -n "${WBRIDGE_LIBEFA_SO:-}" ]; then
+    if [ ! -f "$WBRIDGE_LIBEFA_SO" ]; then
+      echo "WBRIDGE_LIBEFA_SO does not exist: $WBRIDGE_LIBEFA_SO" >&2
+      exit 2
+    fi
+    for f in "$WBRIDGE_MOONCAKE_LIB_DIR"/libefa-*.so.*; do
+      [ -e "$f" ] && ln -sf "$WBRIDGE_LIBEFA_SO" "$f"
+    done
+  fi
+fi
+
+export WBRIDGE_ROUND_CAP_BYTES=${WBRIDGE_ROUND_CAP_BYTES:-40}
+export WBRIDGE_DEDUP_PAIR_BYTES=${WBRIDGE_DEDUP_PAIR_BYTES:-0}
+export WBRIDGE_RECV_PIPELINE=${WBRIDGE_RECV_PIPELINE:-1}
+export WBRIDGE_RECV_3STAGE=${WBRIDGE_RECV_3STAGE:-1}
+export WBRIDGE_TOPO_EXCHANGE=${WBRIDGE_TOPO_EXCHANGE:-1}
+export WBRIDGE_TEST_ITERS=${WBRIDGE_TEST_ITERS:-2}
+if [ "${WBRIDGE_TEST_TORCHRUN:-0}" = "1" ]; then
+  exec torchrun \
+    --nnodes="${WBRIDGE_TEST_NNODES:?}" \
+    --nproc-per-node=8 \
+    --node-rank="${WBRIDGE_TEST_NODE_RANK:?}" \
+    --master-addr="${MASTER_ADDR:?}" \
+    --master-port="${WBRIDGE_TORCHRUN_PORT:-63300}" \
+    "$WBRIDGE_TEST_CONTAINER_LIB/tests/multi_group_topology_integration.py"
+fi
+exec python3 "$WBRIDGE_TEST_CONTAINER_LIB/tests/multi_group_topology_integration.py"
+'

--- a/examples/weightbridge/tests/test_arena_planner.py
+++ b/examples/weightbridge/tests/test_arena_planner.py
@@ -1,0 +1,1279 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Offline unit tests for the tensor-dedup split ingress/exchange layout planner.
+
+Pure, no-GPU accounting: exercises the per-tensor receiver-dedup primitives and the arena LAYOUT PLANNER
+(:meth:`WeightRouter.arena_layout`) — stable per-sender RECV lanes, parity-slotted PREP offsets, and the shared
+GRECV bank — that the runtime consumes to allocate isolated trainer-ingress and rollout-exchange buffers.
+Only ``torch`` (for dtype item sizes) is needed, not CUDA.
+
+Run: ``python tests/test_arena_planner.py`` or ``pytest tests/test_arena_planner.py``.
+"""
+
+import os
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from wbridge.backend import router as R  # noqa: E402
+from wbridge.backend.receiver import _doff_source_predecessors  # noqa: E402
+from wbridge.backend.router import (  # noqa: E402
+    _arena_peer_predecessors,
+    _arena_recv_total_bytes,
+    _arena_slot_offset,
+    _arena_slot_predecessors,
+    _arena_total_bytes,
+    _canonical_dtype_spec,
+    _dedup_specs,
+    _doff_arena_layout,
+    _even_round_soft_target,
+    _ipc_event_readers,
+    _merge_recv_prep_layout,
+    _packed_copy_spans,
+    _shards_canonical_key,
+    WBEndpoint,
+    WeightRouter,
+)
+from wbridge.backend.sender import _recv_lane_predecessors  # noqa: E402
+from wbridge.utils.data import (  # noqa: E402
+    LoadSpec,
+    shard_shape,
+    shards_numel,
+    ShardSpec,
+    split_shard_evenly,
+)
+
+F32 = torch.float32
+
+
+# --------------------------------------------------------------------------- helpers
+def d1(l: int, r: int, n: int):
+    """One 1-D shard covering ``[l, r)`` of a size-``n`` axis (single-shard :class:`Shards`)."""
+    return [[(l, r, n)]]
+
+
+def dtypes(*names):
+    return {n: F32 for n in names}
+
+
+def make_router(send_specs, recv_specs, dtype_spec, *, cap, rank=0):
+    """Construct a pure :class:`WeightRouter` with a forced round cap (per-tensor recv dedup is always on).
+
+    ``RECEIVER_ROUND_CAP_BYTES`` (module global) is read during ``__init__``; set it before construction and
+    restore after (the router caches ``global_rounds``, so a post-construction restore is safe). These tests
+    assert the natural per-tensor classes, so they explicitly disable the production-default consolidation.
+    No CUDA / dist is touched."""
+    old_cap = R.RECEIVER_ROUND_CAP_BYTES
+    old_pair = os.environ.get("WBRIDGE_DEDUP_PAIR_BYTES")
+    R.RECEIVER_ROUND_CAP_BYTES = cap
+    os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = "0"
+    try:
+        return WeightRouter(
+            rank, len(send_specs), list(send_specs) + list(recv_specs), dtype_spec
+        )
+    finally:
+        R.RECEIVER_ROUND_CAP_BYTES = old_cap
+        if old_pair is None:
+            os.environ.pop("WBRIDGE_DEDUP_PAIR_BYTES", None)
+        else:
+            os.environ["WBRIDGE_DEDUP_PAIR_BYTES"] = old_pair
+
+
+def _expected_split_axis(shape, k):
+    """Mirror :func:`split_shard_evenly`'s axis choice: outermost axis with extent >= k, else the longest."""
+    return next(
+        (i for i in range(len(shape)) if shape[i] >= k),
+        max(range(len(shape)), key=lambda i: shape[i]),
+    )
+
+
+def _disjoint(regions):
+    """True iff a list of ``(off, nb)`` byte regions are pairwise disjoint (empty regions ignored)."""
+    ivs = sorted((o, o + n) for o, n in regions if n > 0)
+    return all(ivs[i][1] <= ivs[i + 1][0] for i in range(len(ivs) - 1))
+
+
+def _unique(regions):
+    """Physical regions in first-seen order (multiple peer send entries may intentionally alias)."""
+    return list(dict.fromkeys(regions))
+
+
+def _bind_fake_topology_endpoint(rt, rl, ip, *, depth=2):
+    """Resolve one pure router plan against fake CPU/remote addresses (no CUDA, dist, or RDMA)."""
+    sw = rt.sender_ws
+    rank = sw + rl
+    layout, stride, peers = rt.arena_layout(rl, depth=depth)
+    endpoint = WBEndpoint.__new__(WBEndpoint)
+    endpoint.router = rt
+    endpoint.dtype_spec = rt.dtype_spec
+    endpoint._topo_structure_ok = True
+    endpoint._recv_depth = depth
+    endpoint._arena_layout = layout
+    endpoint._arena_S = stride
+    endpoint._doff_depth = 1
+    endpoint._doff_layout, _doff_bytes, endpoint._doff_S = _doff_arena_layout(
+        layout,
+        stride,
+        endpoint._doff_depth,
+    )
+    endpoint._arena = torch.zeros(
+        max(_arena_total_bytes(layout, depth, stride), 1), dtype=torch.uint8
+    )
+    endpoint._repl_peers = [sw + p for p in peers]
+    endpoint._repl_same_node = {sw + p for p in peers if ip[sw + p] == ip[rank]}
+    endpoint._peer_ip = ip
+    endpoint._local_ip = ip[rank]
+    endpoint._arena_peer_dst = {}
+    for p in peers:
+        peer_layout, _peer_stride, _ = rt.arena_layout(p, depth=depth)
+        remote_base = 10_000_000 * (p + 1)
+        endpoint._arena_peer_dst[sw + p] = [
+            remote_base + rd["grecv"][rl][0] if rl in rd["grecv"] else None
+            for rd in peer_layout
+        ]
+    assert endpoint._resolve_topo_exchange(
+        rank=rank,
+        sw=sw,
+        rl=rl,
+        nr_rounds=len(rt.global_rounds),
+    )
+    return endpoint, layout, stride, peers
+
+
+def test_depth_buffered_arena_slot_offset():
+    """Odd rounds must select slot 1 at depth 2, then wrap without changing the region-relative offset."""
+    stride, off = 4096, 137
+    assert [_arena_slot_offset(off, ri, 2, stride) for ri in range(6)] == [
+        off,
+        stride + off,
+        off,
+        stride + off,
+        off,
+        stride + off,
+    ]
+    assert [_arena_slot_offset(off, ri, 1, stride) for ri in range(4)] == [off] * 4
+
+
+def test_cuda_ipc_events_are_scoped_to_same_node_readers():
+    """A 256-rank topology must not materialize every slot event for all 255 replica peers."""
+    rank = 136
+    peers = [peer for peer in range(256) if peer != rank]
+    peer_ip = {peer: f"node-{peer // 8}" for peer in range(256)}
+    readers = _ipc_event_readers(peers, peer_ip, peer_ip[rank], enabled=True)
+
+    assert readers == [137, 138, 139, 140, 141, 142, 143]
+    assert len(readers) * (1 + 32) == 231
+    assert len(peers) * (1 + 32) == 8415
+    assert _ipc_event_readers(peers, peer_ip, peer_ip[rank], enabled=False) == []
+
+
+def test_doff_layout_is_fixed_depth_and_source_exclusive():
+    rounds = [
+        {"grecv": {2: (1000, 7), 5: (2000, 31)}},
+        {"grecv": {2: (3000, 19), 5: (4000, 11)}},
+        {"grecv": {2: (5000, 3)}},
+    ]
+    layout, total, stride = _doff_arena_layout(rounds, prep_stride=101, depth=1)
+    assert stride == total == 101 + 19 + 31
+    assert {rd["own"] for rd in layout} == {(0, 101)}
+    # Source 2 owns its max-19-byte region; source 5 starts after it and can never overlap despite different
+    # per-round payload lengths.
+    assert [rd["grecv"].get(2) for rd in layout] == [(101, 7), (101, 19), (101, 3)]
+    assert [rd["grecv"].get(5) for rd in layout] == [(120, 31), (120, 11), None]
+
+    depth2, total2, stride2 = _doff_arena_layout(rounds, prep_stride=101, depth=2)
+    assert stride2 == stride and total2 == 2 * stride
+    assert depth2[0]["grecv"][2][0] == depth2[2]["grecv"][2][0]
+    assert depth2[1]["grecv"][2][0] == stride + 101
+
+
+def test_depth_buffered_slot_predecessor_uses_global_round_parity():
+    rounds = [0, 2, 3, 6]
+    assert _arena_slot_predecessors(rounds, 2) == {0: None, 2: 0, 3: None, 6: 2}
+    assert _arena_slot_predecessors(rounds, 1) == {0: None, 2: 0, 3: 2, 6: 3}
+
+
+def test_doff_source_predecessors_are_per_source_and_slot():
+    ext_recv = [(8,), (9,), (8, 9), (), (8,)]
+    pred = _doff_source_predecessors([0, 1, 2, 4], ext_recv, depth=2, rank=7)
+
+    assert pred == [
+        {7: (-1, 4), 8: (-1, 4)},
+        {7: (-1, 1), 9: (-1, 1)},
+        {7: (0, 0), 8: (0, 0), 9: (-1, 2)},
+        {},
+        {7: (0, 2), 8: (0, 2)},
+    ]
+
+
+def test_merged_recv_prep_layout_relocates_only_absolute_grecv():
+    rounds = [
+        {"recv_stride": 120, "own": (7, 80), "grecv": {3: (200, 20)}},
+        {"recv_stride": 120, "own": (9, 70), "grecv": {4: (220, 30)}},
+    ]
+    # Original PREP bank is [0, 2*100); merged bank is [0, 2*120), so GRECV shifts by 40.
+    assert _merge_recv_prep_layout(rounds, depth=2, prep_stride=100) == 120
+    assert [rd["own"] for rd in rounds] == [(7, 80), (9, 70)]
+    assert rounds[0]["grecv"] == {3: (240, 20)}
+    assert rounds[1]["grecv"] == {4: (260, 30)}
+    assert _arena_total_bytes(rounds, 2, 120) == 290
+
+
+def test_grecv_predecessor_is_per_peer_and_parity():
+    rounds = [
+        {"send": {1: (10, 4), 2: (20, 8)}},
+        {"send": {2: (30, 8)}},
+        {"send": {1: (40, 4), 3: (50, 0)}},
+        {"send": {2: (60, 8), 3: (70, 2)}},
+    ]
+    assert _arena_peer_predecessors(rounds) == [
+        {1: (-1, 2), 2: (-1, 3)},
+        {2: (0, 0)},
+        {1: (0, 0)},
+        {2: (0, 1), 3: (-1, 3)},
+    ]
+    assert _arena_peer_predecessors(rounds, depth=2) == [
+        {1: (-1, 2), 2: (-1, 0)},
+        {2: (-1, 3)},
+        {1: (0, 0)},
+        {2: (0, 1), 3: (-1, 3)},
+    ]
+
+
+def test_even_round_soft_headroom_avoids_runt_round():
+    """An exact-average soft gate can strand a hard-cap-feasible tensor in an extra round."""
+    rt = object.__new__(WeightRouter)
+    rt.sender_ws = rt.receiver_ws = 2
+    names = [f"T{i}" for i in range(5)]
+    rt.dtype_spec = {n: F32 for n in names}
+    name_send = dict(zip(names, ([7, 17], [6, 27], [7, 32], [16, 25], [27, 8])))
+    name_recv = dict(zip(names, ([19, 5], [31, 2], [32, 7], [12, 29], [1, 34])))
+    hard = 100
+    inf = float("inf")
+
+    minimum = rt._pack_rounds(name_send, name_recv, hard, hard, [inf, inf], [inf, inf])
+    assert len(minimum) == 2
+    send_tot = [sum(name_send[n][i] for n in names) for i in range(2)]
+    recv_tot = [sum(name_recv[n][i] for n in names) for i in range(2)]
+    exact_send = [-(-total // 2) for total in send_tot]
+    exact_recv = [-(-total // 2) for total in recv_tot]
+    assert (
+        len(rt._pack_rounds(name_send, name_recv, hard, hard, exact_send, exact_recv))
+        == 3
+    )
+
+    soft_send = [_even_round_soft_target(total, 2, hard) for total in send_tot]
+    soft_recv = [_even_round_soft_target(total, 2, hard) for total in recv_tot]
+    balanced = rt._pack_rounds(name_send, name_recv, hard, hard, soft_send, soft_recv)
+    assert len(balanced) == 2
+    for round_names in balanced:
+        assert max(sum(name_send[n][i] for n in round_names) for i in range(2)) <= hard
+        assert max(sum(name_recv[n][i] for n in round_names) for i in range(2)) <= hard
+
+
+def test_explicit_round_mode_produces_exact_balanced_count(monkeypatch):
+    names = tuple(f"w{i:02d}" for i in range(12))
+    send = [ShardSpec({name: d1(0, 120, 120) for name in names})]
+    recv = [ShardSpec({name: d1(0, 120, 120) for name in names}) for _ in range(2)]
+    monkeypatch.setenv("WBRIDGE_NUM_ROUNDS", "3")
+    monkeypatch.delenv("WBRIDGE_ROLLOUT_RDMA_CAP_BYTES", raising=False)
+
+    rt = WeightRouter(0, len(send), send + recv, dtypes(*names))
+    assert len(rt.global_rounds) == 3
+    assert [len(round_names) for round_names in rt.global_rounds] == [4, 4, 4]
+    assert set().union(*rt.global_rounds) == set(names)
+
+
+def test_rollout_rdma_cap_binary_search_selects_smallest_fitting_round_count(
+    monkeypatch,
+):
+    names = tuple(f"w{i:02d}" for i in range(12))
+    send = [ShardSpec({name: d1(0, 120, 120) for name in names})]
+    recv = [ShardSpec({name: d1(0, 120, 120) for name in names}) for _ in range(2)]
+    specs = send + recv
+    dtype = dtypes(*names)
+    peer_ip = {0: "trainer", 1: "rollout-a", 2: "rollout-b"}
+    monkeypatch.delenv("WBRIDGE_NUM_ROUNDS", raising=False)
+    monkeypatch.delenv("WBRIDGE_ROLLOUT_RDMA_CAP_BYTES", raising=False)
+
+    probe = WeightRouter(0, len(send), specs, dtype)
+    name_send, name_recv = probe._name_rank_bytes()
+    probe.global_rounds = probe._pack_exact_rounds(name_send, name_recv, 2)
+    peak_two = max(probe.rollout_rdma_bytes(peer_ip))
+    probe.global_rounds = probe._pack_exact_rounds(name_send, name_recv, 3)
+    peak_three = max(probe.rollout_rdma_bytes(peer_ip))
+    assert peak_three < peak_two
+
+    monkeypatch.setenv("WBRIDGE_ROLLOUT_RDMA_CAP_BYTES", str(peak_three))
+    capped = WeightRouter(0, len(send), specs, dtype, peer_ip=peer_ip)
+    assert len(capped.global_rounds) == 3
+    assert max(capped.rollout_rdma_bytes(peer_ip)) <= peak_three
+
+
+def test_round_planner_modes_are_mutually_exclusive(monkeypatch):
+    send = [ShardSpec({"w": d1(0, 16, 16)})]
+    recv = [ShardSpec({"w": d1(0, 16, 16)})]
+    monkeypatch.setenv("WBRIDGE_NUM_ROUNDS", "1")
+    monkeypatch.setenv("WBRIDGE_ROLLOUT_RDMA_CAP_BYTES", "4096")
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        WeightRouter(0, 1, send + recv, dtypes("w"), peer_ip={0: "t", 1: "r"})
+
+
+def test_direct_same_node_routes_full_receiver_and_allocates_no_exchange_payload(
+    monkeypatch,
+):
+    send = [
+        ShardSpec({"w": d1(0, 16, 16)}),
+        ShardSpec({"w": d1(0, 16, 16)}),
+    ]
+    recv = [
+        ShardSpec({"w": d1(0, 16, 16)}),
+        ShardSpec({"w": d1(0, 16, 16)}),
+    ]
+    monkeypatch.delenv("WBRIDGE_NUM_ROUNDS", raising=False)
+    monkeypatch.setenv("WBRIDGE_ROLLOUT_RDMA_CAP_BYTES", "4096")
+    peer_ip = {0: "node", 1: "node", 2: "node", 3: "node"}
+
+    sender = WeightRouter(
+        0,
+        len(send),
+        send + recv,
+        dtypes("w"),
+        peer_ip=peer_ip,
+        direct_same_node=True,
+    )
+    receiver = WeightRouter(
+        len(send),
+        len(send),
+        send + recv,
+        dtypes("w"),
+        peer_ip=peer_ip,
+        direct_same_node=True,
+    )
+
+    assert len(sender.global_rounds) == 1
+    assert sender.recv_specs == recv
+    assert sender.recv_tensor_classes()["w"] == [[0], [1]]
+    full, overlaps = receiver.local_rounds[0]
+    assert full.nbytes(dtypes("w")) == 16 * torch.empty((), dtype=F32).element_size()
+    assert sum(spec.nbytes(dtypes("w")) for spec in overlaps.values()) == full.nbytes(
+        dtypes("w")
+    )
+    layout, stride, peers = receiver.arena_layout(0, depth=2)
+    assert stride == 0 and peers == []
+    assert _arena_recv_total_bytes(layout, 2) == 0
+    assert _arena_total_bytes(layout, 2, stride) == 0
+
+
+def test_name_rank_bytes_bitmap_matches_dense_reference(monkeypatch):
+    """Bitmap name filtering must preserve exact per-rank bytes, including disjoint same-name shards."""
+    names = ("left", "right", "shared", "absent")
+    send = [
+        ShardSpec({"left": d1(0, 4, 8), "shared": d1(0, 8, 8)}),
+        ShardSpec(
+            {
+                "left": d1(4, 8, 8),
+                "right": d1(4, 8, 8),
+                "shared": d1(0, 8, 8),
+            }
+        ),
+    ]
+    recv = [
+        ShardSpec({"left": d1(4, 8, 8), "shared": d1(0, 4, 8)}),
+        ShardSpec({"right": d1(4, 8, 8), "shared": d1(4, 8, 8)}),
+    ]
+    monkeypatch.setenv("WBRIDGE_DEDUP_PAIR_BYTES", "0")
+    router = WeightRouter(
+        0, len(send), send + recv, dtypes(*names), global_rounds=[set(names)]
+    )
+
+    expected_send = {name: [0] * router.sender_ws for name in names}
+    expected_recv = {name: [0] * router.receiver_ws for name in names}
+    for si, send_spec in enumerate(router.send_specs):
+        for ri, recv_spec in enumerate(router.recv_specs):
+            overlap = ShardSpec.compute_overlap(send_spec, recv_spec)
+            for name, shards in overlap.entries.items():
+                nb = R.shards_nbytes(shards, router.dtype_spec[name])
+                expected_send[name][si] += nb
+                expected_recv[name][ri] += nb
+
+    assert router._name_rank_bytes() == (expected_send, expected_recv)
+
+
+def test_rollout_rdma_reuses_round_invariant_overlap_cache(monkeypatch):
+    names = ("a", "b", "c", "d")
+    send = [
+        ShardSpec({name: d1(0, 16, 16) for name in names}),
+        ShardSpec({name: d1(0, 16, 16) for name in names}),
+    ]
+    recv = [
+        ShardSpec({name: d1(0, 16, 16) for name in names}),
+        ShardSpec({name: d1(0, 16, 16) for name in names}),
+    ]
+    monkeypatch.setenv("WBRIDGE_DEDUP_PAIR_BYTES", "0")
+    router = WeightRouter(
+        0,
+        len(send),
+        send + recv,
+        dtypes(*names),
+        global_rounds=[set(names)],
+    )
+    peer_ip = {0: "trainer-a", 1: "trainer-b", 2: "rollout-a", 3: "rollout-b"}
+
+    original = ShardSpec.compute_overlap
+    overlap_calls = 0
+
+    def counted_overlap(*args, **kwargs):
+        nonlocal overlap_calls
+        overlap_calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(ShardSpec, "compute_overlap", staticmethod(counted_overlap))
+    router.rollout_rdma_bytes(peer_ip)
+    first_probe_calls = overlap_calls
+    assert first_probe_calls > 0
+
+    router.global_rounds = [{"a", "b"}, {"c", "d"}]
+    router.rollout_rdma_bytes(peer_ip)
+    assert overlap_calls == first_probe_calls
+    assert router._trainer_peer_counts_cache == [1, 1]
+
+
+def test_independent_rank_planning_is_deterministic(monkeypatch):
+    names = tuple(f"w{i:02d}" for i in range(12))
+    send = [ShardSpec({name: d1(0, 120, 120) for name in reversed(names)})]
+    recv = [
+        ShardSpec({name: d1(0, 120, 120) for name in names}),
+        ShardSpec({name: d1(0, 120, 120) for name in reversed(names)}),
+    ]
+    canonical = _canonical_dtype_spec(
+        [
+            {name: F32 for name in reversed(names)},
+            {name: F32 for name in names},
+        ]
+    )
+    assert list(canonical) == sorted(names)
+
+    monkeypatch.setenv("WBRIDGE_DEDUP_PAIR_BYTES", "0")
+    monkeypatch.delenv("WBRIDGE_NUM_ROUNDS", raising=False)
+    monkeypatch.delenv("WBRIDGE_ROLLOUT_RDMA_CAP_BYTES", raising=False)
+    old_cap = R.RECEIVER_ROUND_CAP_BYTES
+    R.RECEIVER_ROUND_CAP_BYTES = 1600
+    try:
+        sender = WeightRouter(0, len(send), send + recv, dict(canonical))
+        receiver = WeightRouter(2, len(send), send + recv, dict(canonical))
+    finally:
+        R.RECEIVER_ROUND_CAP_BYTES = old_cap
+
+    assert [sorted(round_names) for round_names in sender.global_rounds] == [
+        sorted(round_names) for round_names in receiver.global_rounds
+    ]
+
+
+# ------------------------------------------------------------------ 1. split_shard_evenly partition
+def test_split_shard_evenly_partition():
+    cases = [
+        ([(0, 12, 12)], "1D exact"),
+        ([(0, 10, 10)], "1D remainder"),
+        ([(3, 11, 16)], "1D offset range"),
+        ([(0, 4, 4), (0, 6, 6)], "2D split outer"),
+        ([(0, 1, 1), (0, 6, 6)], "2D outer<k -> split axis1"),
+        ([(0, 8, -8)], "1D transposed (negative w)"),
+    ]
+    for shard, label in cases:
+        shape = shard_shape(shard)
+        for k in (1, 2, 3, 8):
+            subs = [split_shard_evenly(shard, k, j) for j in range(k)]
+            present = [s for s in subs if s is not None]
+            assert present, f"{label} k={k}: all sub-shards empty"
+            if k == 1:
+                assert present == [list(shard)], f"{label} k=1 not identity"
+                continue
+            ax = _expected_split_axis(shape, k)
+            # w (incl. sign) preserved everywhere; non-split dims unchanged.
+            for s in present:
+                for dpos, (dim_s, dim_o) in enumerate(zip(s, shard)):
+                    assert dim_s[2] == dim_o[2], (
+                        f"{label} k={k}: w changed on dim {dpos}"
+                    )
+                    if dpos != ax:
+                        assert (dim_s[0], dim_s[1]) == (dim_o[0], dim_o[1]), (
+                            f"{label} k={k}: non-split dim {dpos} changed"
+                        )
+            # Split axis: contiguous, disjoint, covers [l, r) exactly.
+            ivs = sorted((s[ax][0], s[ax][1]) for s in present)
+            assert ivs[0][0] == shard[ax][0] and ivs[-1][1] == shard[ax][1], (
+                f"{label} k={k}: coverage gap"
+            )
+            for i in range(len(ivs) - 1):
+                assert ivs[i][1] == ivs[i + 1][0], (
+                    f"{label} k={k}: not contiguous/disjoint"
+                )
+            # None only past the remainder (empty parts are the trailing j's).
+            first_none = next((j for j, s in enumerate(subs) if s is None), k)
+            assert all(s is None for s in subs[first_none:]), (
+                f"{label} k={k}: a None precedes a present part"
+            )
+
+
+# ------------------------------------------------------------------ 2. _dedup_specs (per-tensor)
+def test_dedup_specs_partition_and_determinism():
+    # recv0,1 identical {A,B}; recv2,3 identical {A}.
+    # Per-tensor: A held identically by ALL four -> class {0,1,2,3}; B held by {0,1}.
+    specs = [
+        ShardSpec({"A": d1(0, 100, 100), "B": d1(0, 40, 40)}),
+        ShardSpec({"A": d1(0, 100, 100), "B": d1(0, 40, 40)}),
+        ShardSpec({"A": d1(0, 100, 100)}),
+        ShardSpec({"A": d1(0, 100, 100)}),
+    ]
+
+    ded = _dedup_specs(specs)
+    # Determinism: identical output on a second call.
+    assert [s.entries for s in _dedup_specs(specs)] == [s.entries for s in ded]
+
+    # Per-tensor class sub-shards partition the original (disjoint + full cover => equal total numel).
+    for name in ("A", "B"):
+        holders = [i for i, s in enumerate(specs) if name in s.entries]
+        classes: dict = {}
+        for i in holders:
+            classes.setdefault(_shards_canonical_key(specs[i][name]), []).append(i)
+        for members in classes.values():
+            orig = shards_numel(specs[members[0]][name])
+            got = sum(
+                shards_numel(ded[i][name]) for i in members if name in ded[i].entries
+            )
+            assert got == orig, f"{name}: class {members} numel {got} != {orig}"
+
+    # A is 4-way replicated -> per-tensor dedup gives each holder a QUARTER of it.
+    assert shards_numel(ded[0]["A"]) == 25
+
+    # k=1 identity: a tensor held by exactly one worker is unchanged.
+    solo = _dedup_specs([ShardSpec({"Z": d1(0, 7, 7)}), ShardSpec({"A": d1(0, 5, 5)})])
+    assert solo[0]["Z"] == [[(0, 7, 7)]]
+
+
+# ------------------------------------------------------------------ 3. recv_tensor_classes
+def test_recv_tensor_classes():
+    send = [ShardSpec({"A": d1(0, 100, 100), "B": d1(0, 40, 40)})]
+    recv = [
+        ShardSpec({"A": d1(0, 100, 100), "B": d1(0, 40, 40)}),
+        ShardSpec({"A": d1(0, 100, 100), "B": d1(0, 40, 40)}),
+        ShardSpec({"A": d1(0, 100, 100)}),
+        ShardSpec({"A": d1(0, 100, 100)}),
+    ]
+    rt = make_router(send, recv, dtypes("A", "B"), cap=10**9)
+    classes = rt.recv_tensor_classes()
+    assert classes["A"] == [[0, 1, 2, 3]], classes["A"]  # all hold identical full A
+    assert classes["B"] == [[0, 1]], classes["B"]  # only 0,1 hold B
+    # A member's slice index is its position in its class; a non-holder is in no class.
+    assert rt._arena_class_of(classes, "A", 2) == [0, 1, 2, 3]
+    assert rt._arena_class_of(classes, "B", 3) == []
+
+
+# ------------------------------------------------------------------ 4. arena_layout invariants
+def test_arena_layout_invariants():
+    # 2 senders hold 6 full tensors. recv0,1 hold Ti[0:400]; recv2,3 hold Ti[400:800] => per-tensor class
+    # {0,1} and {2,3} (size 2 each) => an all-gather peer every round.
+    names = [f"T{i}" for i in range(6)]
+    send = [ShardSpec({n: d1(0, 800, 800) for n in names}) for _ in range(2)]
+    recv = []
+    for lo, hi in ((0, 400), (0, 400), (400, 800), (400, 800)):
+        recv.append(ShardSpec({n: d1(lo, hi, 800) for n in names}))
+    rt = make_router(send, recv, dtypes(*names), cap=1700)
+    assert len(rt.global_rounds) >= 2, (
+        f"need >=2 rounds to exercise cross-round coexistence, got {len(rt.global_rounds)}"
+    )
+
+    for rl in range(rt.receiver_ws):
+        rounds, S, peers = rt.arena_layout(rl)
+        total = _arena_total_bytes(rounds, 1, S)
+        recv_total = _arena_recv_total_bytes(rounds, 1)
+        assert rounds and S > 0
+        my = rt.recv_specs[rl]
+        for ri, rd in enumerate(rounds):
+            s2r, prep, base = rd["s2r"], rd["prep"], rd["prep_base"]
+            recv_regs = list(rd["recv"].values())
+            prep_regs = _unique([rd["own"], *rd["send"].values()])
+            grecv_regs = list(rd["grecv"].values())
+
+            # Isolated RECV: per-sender lanes are disjoint/bounded by recv_stride; their CURRENT prefixes sum
+            # to s2r == my deduped receive this round (padding between stable lanes is not charged to s2r).
+            assert _disjoint(recv_regs), f"rl{rl} r{ri}: RECV overlap"
+            assert all(0 <= o and o + n <= rd["recv_stride"] for o, n in recv_regs), (
+                f"rl{rl} r{ri}: RECV out of isolated slot"
+            )
+            assert sum(n for _, n in recv_regs) == s2r
+            round_names = sorted(n for n in rt.global_rounds[ri] if n in my.entries)
+            assert s2r == my.subset(set(round_names)).nbytes(rt.dtype_spec), (
+                f"rl{rl} r{ri}: s2r != my deduped recv (senders don't partition)"
+            )
+            assert rd["own"][1] == s2r, (
+                "own must equal the assembled-canonical (== s2r) bytes"
+            )
+
+            # PREP zone: union(own, unique-send) is disjoint, top-anchored, and sums to prep.
+            assert _disjoint(prep_regs), f"rl{rl} r{ri}: PREP overlap"
+            assert all(base <= o and o + n <= S for o, n in prep_regs), (
+                f"rl{rl} r{ri}: PREP out of slot"
+            )
+            assert sum(n for _, n in prep_regs) == prep
+            assert base == S - prep
+            assert rd["agh"] == prep + sum(n for _, n in grecv_regs)
+
+            # GRECV is outside all rollout PREP parity slots, with current-round views bounded by the bank.
+            assert _disjoint(grecv_regs), f"rl{rl} r{ri}: GRECV peer slots overlap"
+            assert all(S <= o and o + n <= total for o, n in grecv_regs), (
+                f"rl{rl} r{ri}: GRECV out of bank"
+            )
+            assert all(0 <= o and o + n <= S for o, n in prep_regs)
+
+        # A peer has one stable base over all rounds, reserved at its maximum round size.
+        peer_slots = []
+        for p in peers:
+            entries = [rd["grecv"][p] for rd in rounds if p in rd["grecv"]]
+            assert len({off for off, _ in entries}) == 1
+            peer_slots.append((entries[0][0], max(nb for _, nb in entries)))
+        assert _disjoint(peer_slots)
+        assert total == S + sum(nb for _, nb in peer_slots)
+
+        # PREP and RECV are separate allocations. S is only the largest PREP payload; RECV has its own stride.
+        assert S == max(rd["prep"] for rd in rounds)
+        assert recv_total == rounds[0]["recv_stride"]
+        assert len({rd["recv_stride"] for rd in rounds}) == 1
+
+        # At a fixed parity, a trainer's lane base is stable across every round in which it contributes.
+        for si in range(rt.sender_ws):
+            entries = [rd["recv"][si] for rd in rounds if si in rd["recv"]]
+            assert len({off for off, _ in entries}) <= 1
+        assert peers, f"rl{rl}: expected AGH peers"
+
+    assert rt.arena_layout(0) == rt.arena_layout(0), "arena_layout not deterministic"
+
+
+def test_arena_layout_isolates_skipped_depth2_recv_from_live_prep():
+    """A skipped round does not create a RECV/PREP alias when a parity is reused.
+
+    Receiver 0 has a large PREP in round 0, skips round 1, and receives D in round 2. The old unified arena
+    had to co-pack RECV(2) beside still-live PREP(0). They now belong to separate allocations: PREP stride is
+    max(prep), while the trainer's round-0/round-2 RECV lane has one stable base in the isolated ingress slot.
+    """
+    send = [
+        ShardSpec(
+            {
+                "A": d1(0, 300, 300),
+                "B": d1(0, 300, 300),
+                "C": d1(0, 300, 300),
+                "D": d1(0, 500, 500),
+                "X": d1(0, 10, 10),
+            }
+        )
+    ]
+    recv = [
+        ShardSpec(
+            {
+                "A": d1(0, 300, 300),
+                "B": d1(0, 300, 300),
+                "C": d1(0, 300, 300),
+                "D": d1(0, 500, 500),
+            }
+        ),
+        ShardSpec({"A": d1(0, 300, 300), "B": d1(0, 300, 300), "X": d1(0, 10, 10)}),
+        ShardSpec({"B": d1(0, 300, 300), "C": d1(0, 300, 300)}),
+    ]
+    rt = make_router(send, recv, dtypes("A", "B", "C", "D", "X"), cap=10**9)
+    rt.global_rounds = [{"A", "B", "C"}, {"X"}, {"D"}]
+    rt.local_rounds = rt.compute_local_rounds()
+
+    rounds, S, _ = rt.arena_layout(0, depth=2)
+    assert [ri for ri, rd in enumerate(rounds) if rd["s2r"]] == [0, 2]
+    assert rounds[0]["prep"] > rounds[0]["s2r"]
+    assert S == max(rd["prep"] for rd in rounds)
+    assert rounds[0]["recv"][0][0] == rounds[2]["recv"][0][0]
+    assert _arena_recv_total_bytes(rounds, 2) == 2 * rounds[0]["recv_stride"]
+
+
+def test_isolated_recv_lanes_prevent_three_round_cross_sender_overwrite():
+    """Regression for the exact 8-trainer/16-rollout corruption found in the 11-group integration test.
+
+    Worker 11's round-0 half slice comes from trainer 3; its round-2 wide slice comes from trainer 5. Both
+    rounds use parity zero. The old compact RECV layout assigned both writes offset zero, while trainer 5's
+    round-0 ACK set did not include worker 11. Stable sender lanes must give those two writes disjoint offsets.
+    """
+    names = ("half", "pair", "wide")
+    send = [ShardSpec({name: d1(0, 160, 160) for name in names}) for _ in range(8)]
+    recv = []
+    for worker in range(16):
+        lane = worker % 8
+        half = 0 if lane < 4 else 1
+        recv.append(
+            ShardSpec(
+                {
+                    "half": d1(half * 80, (half + 1) * 80, 160),
+                    "pair": d1(lane * 20, (lane + 1) * 20, 160),
+                    "wide": d1(0, 160, 160),
+                }
+            )
+        )
+    rt = make_router(send, recv, dtypes(*names), cap=40)
+    assert [sorted(names) for names in rt.global_rounds] == [
+        ["half"],
+        ["pair"],
+        ["wide"],
+    ]
+
+    worker = 11
+    rounds, _S, _peers = rt.arena_layout(worker, depth=2)
+    assert rounds[0]["recv"] == {3: (0, 40)}
+    assert rounds[2]["recv"] == {5: (40, 40)}
+    assert rounds[0]["recv_stride"] == 80
+    assert _disjoint([rounds[0]["recv"][3], rounds[2]["recv"][5]])
+
+    # Demonstrate why the former global-parity sender gate could not protect this receiver.
+    sender5 = make_router(send, recv, dtypes(*names), cap=40, rank=5)
+    r0_peers = set(sender5.local_rounds[0][1])
+    r2_peers = set(sender5.local_rounds[2][1])
+    worker_global = len(send) + worker
+    assert worker_global not in r0_peers
+    assert worker_global in r2_peers
+
+
+def test_sender_ingress_gate_tracks_destination_and_parity():
+    """A skipped use of one destination must not be hidden by another receiver's newer parity generation."""
+    pred, last = _recv_lane_predecessors(
+        [[10, 11], [12], [11], [12], [10]],
+        depth=2,
+    )
+    assert pred == [
+        {10: None, 11: None},
+        {12: None},
+        {11: 0},
+        {12: 1},
+        {10: 0},
+    ]
+    assert last == {(10, 0): 4, (11, 0): 2, (12, 1): 3}
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="fused CopyPlan execution requires CUDA"
+)
+def test_fused_prepare_reads_isolated_ingress_after_future_round_lands():
+    """Land round 2 before assembling round 0 and prove the fused kernel still reads round 0's sender lane."""
+    names = ("t0", "t1", "t2")
+    send = [ShardSpec({name: d1(0, 20, 20) for name in names}) for _ in range(2)]
+    recv_spec = ShardSpec(
+        {"t0": d1(0, 10, 20), "t1": d1(0, 10, 20), "t2": d1(10, 20, 20)}
+    )
+    rt = make_router(send, [recv_spec], dtypes(*names), cap=10**9, rank=2)
+    rt.global_rounds = [{name} for name in names]
+    rt.local_rounds = rt.compute_local_rounds()
+    layout, stride, peers = rt.arena_layout(0, depth=2)
+    assert not peers
+
+    endpoint = WBEndpoint.__new__(WBEndpoint)
+    endpoint.router = rt
+    endpoint._rank = 2
+    endpoint._recv_depth = 2
+    endpoint._arena_layout = layout
+    endpoint._arena_S = stride
+    endpoint._recv_S = layout[0]["recv_stride"]
+    endpoint._arena = torch.zeros(
+        max(_arena_total_bytes(layout, 2, stride), 1),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    endpoint._recv_arena = torch.zeros(
+        max(_arena_recv_total_bytes(layout, 2), 1),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    endpoint._repl_peers = []
+    endpoint._topo_ok = False
+    endpoint.receiver_staging = False
+    endpoint.dtype_spec = dtypes(*names)
+
+    entries = {}
+    endpoint.wksd = {}
+    expected = {}
+    for ni, (name, shards) in enumerate(recv_spec):
+        numel = shards_numel(shards)
+        entries[name] = {name: [(shards[0], [(0, numel, numel)])]}
+        endpoint.wksd[name] = torch.full((numel,), -1, dtype=F32, device="cuda")
+        left, right, _width = shards[0][0]
+        expected[name] = torch.arange(left, right, dtype=F32, device="cuda") + ni * 1000
+    endpoint.load_spec = LoadSpec(entries)
+    endpoint._build_arena_plans()
+
+    # Populate every ingress round first. In particular r2 lands in parity 0 before r0's fused prepare runs.
+    # The original compact ingress put both writes at parity-0 offset zero and deterministically corrupted t0.
+    for ri, name in enumerate(names):
+        rd = layout[ri]
+        assert len(rd["recv"]) == 1
+        _si, (off, nb) = next(iter(rd["recv"].items()))
+        absolute = _arena_slot_offset(off, ri, 2, endpoint._recv_S)
+        endpoint._recv_arena[absolute : absolute + nb].view(F32).copy_(expected[name])
+
+    for ri, name in enumerate(names):
+        endpoint._arena_prepare[ri].run()
+        endpoint._arena_consume[ri].run()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(endpoint.wksd[name], expected[name], rtol=0, atol=0)
+
+
+# ------------------------------------------------------------------ 5. adversarial: peer set varies per round
+def test_arena_layout_adversarial_varying_peers():
+    # 4 receivers A,B,C,D = 0,1,2,3. Four tensors, each held (identically, fully) by a DIFFERENT pair, so
+    # each tensor's per-tensor class is exactly that pair and different rounds pull in different peers.
+    tens = {"tAB": (0, 1), "tAC": (0, 2), "tBD": (1, 3), "tCD": (2, 3)}
+    send = [ShardSpec({t: d1(0, 600, 600) for t in tens}) for _ in range(2)]
+    recv = [
+        ShardSpec({t: d1(0, 600, 600) for t, pair in tens.items() if rc in pair})
+        for rc in range(4)
+    ]
+    rt = make_router(
+        send, recv, dtypes(*tens), cap=2000
+    )  # 1 tensor (deduped 300*4=1200B) per receiver/round
+
+    classes = rt.recv_tensor_classes()
+    assert classes == {
+        "tAB": [[0, 1]],
+        "tAC": [[0, 2]],
+        "tBD": [[1, 3]],
+        "tCD": [[2, 3]],
+    }, classes
+
+    layouts = {rl: rt.arena_layout(rl)[0] for rl in range(4)}
+    gr = rt.global_rounds
+
+    # Reciprocity: for a tensor shared by pair (a,b), in the round holding it, a.send[b] feeds b.grecv[a].
+    for t, (a, b) in tens.items():
+        ri = next(i for i, s in enumerate(gr) if t in s)
+        la, lb = layouts[a][ri], layouts[b][ri]
+        assert b in la["send"] and a in lb["grecv"], f"{t}: peers not wired"
+        assert la["send"][b][1] == lb["grecv"][a][1], f"{t}: a.send != b.grecv"
+        assert la["grecv"][b][1] == lb["send"][a][1], f"{t}: a.grecv != b.send"
+
+    # Peer set VARIES across rounds for receiver 0 (peer 1 in tAB's round, peer 2 in tAC's round).
+    r0_peers = [set(rd["send"]) for rd in layouts[0]]
+    assert {1} in r0_peers and {2} in r0_peers, r0_peers
+
+    # Offsets valid for every receiver; RECV is isolated, PREP is slotted, GRECV is in the shared bank.
+    for rl in range(4):
+        rounds, S, _ = rt.arena_layout(rl)
+        total = _arena_total_bytes(rounds, 1, S)
+        for rd in rounds:
+            recv_regs = list(rd["recv"].values())
+            prep_regs = _unique([rd["own"], *rd["send"].values()])
+            grecv_regs = list(rd["grecv"].values())
+            assert (
+                _disjoint(recv_regs) and _disjoint(prep_regs) and _disjoint(grecv_regs)
+            )
+            assert all(0 <= o and o + n <= rd["recv_stride"] for o, n in recv_regs)
+            assert all(0 <= o and o + n <= S for o, n in prep_regs)
+            assert all(S <= o and o + n <= total for o, n in grecv_regs)
+
+
+def test_depth2_uses_two_grecv_parity_slots():
+    names = [f"T{i}" for i in range(6)]
+    send = [ShardSpec({n: d1(0, 800, 800) for n in names}) for _ in range(2)]
+    recv = [ShardSpec({n: d1(0, 400, 800) for n in names}) for _ in range(4)]
+    rt = make_router(send, recv, dtypes(*names), cap=1700)
+
+    rounds, S, peers = rt.arena_layout(0, depth=2)
+    total = _arena_total_bytes(rounds, 2, S)
+    shared_by_parity = sum(
+        max(
+            (
+                rd["grecv"].get(p, (0, 0))[1]
+                for ri, rd in enumerate(rounds)
+                if ri % 2 == slot
+            ),
+            default=0,
+        )
+        for p in peers
+        for slot in range(2)
+    )
+    assert total == 2 * S + shared_by_parity
+    assert shared_by_parity > 0
+    for p in peers:
+        offsets = {
+            slot: {
+                rd["grecv"][p][0]
+                for ri, rd in enumerate(rounds)
+                if ri % 2 == slot and p in rd["grecv"]
+            }
+            for slot in range(2)
+        }
+        assert all(len(slot_offsets) <= 1 for slot_offsets in offsets.values())
+        active = [
+            next(iter(slot_offsets))
+            for slot_offsets in offsets.values()
+            if slot_offsets
+        ]
+        assert len(active) == 2 and len(set(active)) == 2
+
+
+def test_grecv_peer_slots_are_distinct_and_sized_per_parity():
+    send = [ShardSpec({"small": d1(0, 40, 40), "large": d1(0, 100, 100)})]
+    recv = [
+        ShardSpec({"small": d1(0, 40, 40), "large": d1(0, 100, 100)}) for _ in range(2)
+    ]
+    rt = make_router(send, recv, dtypes("small", "large"), cap=10**9)
+    rt.global_rounds = [{"small"}, {"large"}]
+    rt.local_rounds = rt.compute_local_rounds()
+
+    rounds, S, peers = rt.arena_layout(0, depth=2)
+    assert peers == [1]
+    slots = [rd["grecv"][1] for rd in rounds]
+    assert slots[0][0] != slots[1][0]
+    assert slots[0][1] < slots[1][1]
+    assert _arena_total_bytes(rounds, 2, S) == 2 * S + sum(nb for _, nb in slots)
+
+
+# ------------------------------------------------------------------ 6. sender-target size agreement
+def test_arena_sender_target_agreement():
+    """The arena RECV nb a sender writes to == the (sender, receiver) compute_overlap nb — the cross-wire
+    size the tensor-mode sender uses (`_fuse_sizes`). This is the runtime invariant _setup_rdma_buffers relies
+    on so a sender writes exactly into its RECV sub-region."""
+    names = [f"T{i}" for i in range(6)]
+    send = [ShardSpec({n: d1(0, 800, 800) for n in names}) for _ in range(2)]
+    recv = [
+        ShardSpec({n: d1(lo, hi, 800) for n in names})
+        for lo, hi in ((0, 400), (0, 400), (400, 800), (400, 800))
+    ]
+    rt = make_router(send, recv, dtypes(*names), cap=1700)
+    for rl in range(rt.receiver_ws):
+        rounds, _S, _ = rt.arena_layout(rl)
+        my = rt.recv_specs[rl]
+        for ri, rd in enumerate(rounds):
+            round_names = set(n for n in rt.global_rounds[ri] if n in my.entries)
+            for si in range(rt.sender_ws):
+                ov = ShardSpec.compute_overlap(rt.send_specs[si], my).subset(
+                    set(round_names)
+                )
+                assert rd["recv"].get(si, (0, 0))[1] == ov.nbytes(rt.dtype_spec), (
+                    f"rl{rl} r{ri} si{si}: arena recv nb != compute_overlap nb"
+                )
+
+
+# ------------------------------------------------------------------ 7. dtype-view alignment (uniform dtype)
+def test_arena_dtype_alignment():
+    """Every region offset is itemsize-aligned for a UNIFORM-dtype spec, so `arena[off:].view(dtype)` (what
+    `_carve_named`/`fuse_copy_pairs` do) is valid — the 30B is bf16 so this holds. Mixed-dtype models would
+    need offset padding across the whole wire layout (a pre-existing `_carve_named` constraint, not arena-specific)."""
+    names = [f"T{i}" for i in range(6)]
+    send = [ShardSpec({n: d1(0, 800, 800) for n in names}) for _ in range(2)]
+    recv = [
+        ShardSpec({n: d1(lo, hi, 800) for n in names})
+        for lo, hi in ((0, 400), (0, 400), (400, 800), (400, 800))
+    ]
+    it = torch.bfloat16.itemsize
+    rt = make_router(send, recv, {n: torch.bfloat16 for n in names}, cap=1700)
+    for rl in range(rt.receiver_ws):
+        rounds, S, _ = rt.arena_layout(rl)
+        total = _arena_total_bytes(rounds, 1, S)
+        recv_total = _arena_recv_total_bytes(rounds, 1)
+        assert S % it == 0
+        assert total % it == 0
+        assert recv_total % it == 0
+        for rd in rounds:
+            regs = list(rd["recv"].values()) + [
+                rd["own"],
+                *rd["send"].values(),
+                *rd["grecv"].values(),
+            ]
+            for off, nb in regs:
+                assert off % it == 0 and nb % it == 0, (
+                    f"unaligned region ({off},{nb}) for itemsize {it}"
+                )
+
+
+# ------------------------------------------------------------------ 8. wide (c=8) class reciprocity
+def test_arena_wide_class_reciprocity():
+    """A c=8 tensor (all 8 receivers hold it identically) + a c=2 tensor + a c=1 tensor — the tiny
+    router-gate case that forces the m>2 all-to-all. Reciprocity `a.send[p].nb == p.grecv[a].nb` and
+    shared-set symmetry hold across the wide fan-out; receiver 0 sees all 7 others as peers."""
+    G, P, solo = "gate", "pairAB", "solo"
+    send = [
+        ShardSpec({G: d1(0, 64, 64), P: d1(0, 256, 256), solo: d1(0, 64, 64)})
+        for _ in range(2)
+    ]
+    recv = []
+    for rc in range(8):
+        e = {G: d1(0, 64, 64)}  # G: all 8 hold it identically -> class {0..7}
+        if rc in (0, 1):
+            e[P] = d1(0, 256, 256)  # P: receivers 0,1 -> class {0,1}
+        if rc == 0:
+            e[solo] = d1(0, 64, 64)  # solo: receiver 0 only -> class {0}
+        recv.append(ShardSpec(e))
+    rt = make_router(send, recv, dtypes(G, P, solo), cap=10**9)
+    classes = rt.recv_tensor_classes()
+    assert classes[G] == [[0, 1, 2, 3, 4, 5, 6, 7]]
+    assert classes[P] == [[0, 1]]
+    assert classes[solo] == [[0]]
+    layouts = {rl: rt.arena_layout(rl) for rl in range(8)}
+    assert layouts[0][2] == [1, 2, 3, 4, 5, 6, 7], (
+        "receiver 0 must all-gather with all 7 others via G"
+    )
+    # Deduplicate sends by logical payload before considering own aliasing: receiver 0 sends {G,P} to peer
+    # 1 and {G} to peers 2..7, hence exactly two physical send regions (neither is own because own has solo).
+    assert len(rt.global_rounds) == 1
+    r0 = layouts[0][0][0]
+    assert len(set(r0["send"].values())) == 2
+    assert r0["own"] not in set(r0["send"].values())
+    for a in range(8):
+        for ri, rd_a in enumerate(layouts[a][0]):
+            rn_a = sorted(
+                n for n in rt.global_rounds[ri] if n in rt.recv_specs[a].entries
+            )
+            for p in rd_a["send"]:
+                rd_b = layouts[p][0][ri]
+                assert a in rd_b["grecv"], (
+                    f"a{a}->p{p} r{ri}: not reciprocated in grecv"
+                )
+                assert rd_a["send"][p][1] == rd_b["grecv"][a][1], (
+                    f"a{a} p{p} r{ri}: send/grecv nb mismatch"
+                )
+                rn_b = sorted(
+                    n for n in rt.global_rounds[ri] if n in rt.recv_specs[p].entries
+                )
+                assert rt._arena_shared(a, p, rn_a, classes) == rt._arena_shared(
+                    p, a, rn_b, classes
+                )
+
+
+def test_topology_external_only_one_worker_per_node_is_eligible():
+    """Two one-worker rollout replicas have a valid external-only topology (empty internal phase)."""
+    send = [ShardSpec({"weight": d1(0, 64, 64)})]
+    recv = [ShardSpec({"weight": d1(0, 64, 64)}) for _ in range(2)]
+    rt = make_router(send, recv, dtypes("weight"), cap=10**9)
+    ip = {0: "trainer", 1: "node-a", 2: "node-b"}
+
+    assert rt.configure_topology(ip)
+    assert len(rt._topology_groups) == 1
+    assert rt.topology_plan(0, 0) == {
+        "external": {1: ("weight",)},
+        "pull": {},
+        "peers": (1,),
+        "internal": (),
+    }
+
+
+def test_topology_external_reuse_waits_two_rounds_back_at_depth2():
+    names = tuple(f"w{i}" for i in range(4))
+    send = [ShardSpec({name: d1(0, 100, 100) for name in names})]
+    recv = [ShardSpec({name: d1(0, 100, 100) for name in names}) for _ in range(2)]
+    rt = make_router(send, recv, dtypes(*names), cap=200)
+    assert len(rt.global_rounds) == 4
+    ip = {0: "trainer", 1: "node-a", 2: "node-b"}
+    assert rt.configure_topology(ip)
+
+    endpoint, layout, _stride, _peers = _bind_fake_topology_endpoint(rt, 0, ip, depth=2)
+    peer = 2
+    assert endpoint._topo_peer_predecessors == [
+        {peer: (-1, 2)},
+        {peer: (-1, 3)},
+        {peer: (0, 0)},
+        {peer: (0, 1)},
+    ]
+    offsets = [rd["grecv"][1][0] for rd in layout]
+    assert offsets[0] == offsets[2]
+    assert offsets[1] == offsets[3]
+    assert offsets[0] != offsets[1]
+
+
+def test_topology_multi_group_16_workers_11_groups():
+    """Hand-crafted two-node topology: 1 wide + 8 rank-pair + 2 half-GPU groups.
+
+    Every receiver belongs to three overlapping groups.  The exact external column is packed once per
+    cross-node peer, while a local peer can require multiple disjoint own/grecv reads because its unrelated
+    rank-pair tensor lies between the selected half/wide tensors in packed-name order.
+    """
+    names = ("half", "pair", "wide")
+    send = [ShardSpec({name: d1(0, 160, 160) for name in names})]
+    recv = []
+    for worker in range(16):
+        lane = worker % 8
+        half = 0 if lane < 4 else 1
+        recv.append(
+            ShardSpec(
+                {
+                    "half": d1(half * 80, (half + 1) * 80, 160),
+                    "pair": d1(lane * 20, (lane + 1) * 20, 160),
+                    "wide": d1(0, 160, 160),
+                }
+            )
+        )
+    rt = make_router(send, recv, dtypes(*names), cap=10**9)
+    sw = rt.sender_ws
+    ip = {0: "trainer"}
+    ip.update(
+        {sw + worker: ("node-a" if worker < 8 else "node-b") for worker in range(16)}
+    )
+
+    assert rt.configure_topology(ip)
+    assert len(rt._topology_groups) == 11
+    assert sum(grp["names"] == ("wide",) for grp in rt._topology_groups) == 1
+    assert sum(grp["names"] == ("pair",) for grp in rt._topology_groups) == 8
+    assert sum(grp["names"] == ("half",) for grp in rt._topology_groups) == 2
+
+    plan = rt.topology_plan(0, 0)
+    assert plan["external"] == {8: names}
+    assert plan["internal"] == tuple(range(1, 8))
+    assert plan["peers"] == tuple(range(1, 16))
+    routes1 = {
+        (kind, source): route_names for kind, source, route_names in plan["pull"][1]
+    }
+    assert routes1 == {
+        ("grecv", 9): ("half", "wide"),
+        ("own", 1): ("half", "wide"),
+    }
+    routes4 = {
+        (kind, source): route_names for kind, source, route_names in plan["pull"][4]
+    }
+    assert routes4 == {("grecv", 12): ("wide",), ("own", 4): ("wide",)}
+
+    layout, stride, peers = rt.arena_layout(0, depth=2)
+    assert peers == list(range(1, 16))
+    assert set(layout[0]["grecv"]) == {8}, (
+        "only the cross-node ingress column gets GRECV storage"
+    )
+    assert layout[0]["grecv_names"] == {8: names}
+    # In this aligned example all three groups choose the same cross-node lane, so the exact packed payload
+    # aliases both the generic peer payload and own rather than reserving another PREP buffer.
+    assert layout[0]["topo_send"][8] == layout[0]["send"][8] == layout[0]["own"]
+
+    # Bind the symbolic plan to fake CPU arena addresses.  This exercises the runtime resolver without CUDA
+    # or RDMA and proves that one local pair really produces multiple direct copy spans.
+    endpoint, _layout, _stride, _peers = _bind_fake_topology_endpoint(rt, 0, ip)
+    assert endpoint._topo_ext_send_peers_by_round == [(sw + 8,)]
+    assert endpoint._topo_ext_recv_peers_by_round == [(sw + 8,)]
+    assert endpoint._topo_int_peers_by_round == [tuple(sw + p for p in range(1, 8))]
+    assert endpoint._topo_int_readers_by_round == [tuple(sw + p for p in range(1, 8))]
+    assert endpoint._topo_peer_predecessors[0][sw + 8] == (-1, 0)
+    assert len(endpoint._topo_ext_xfer[sw + 8][0]) == 1
+    # Logical own and GRECV routes retain their exact source identity. The own descriptor joins the first
+    # external slot at bind time, while that slot can be consumed and released independently of other slots.
+    peer_sources = endpoint._topo_internal_consume_src[sw + 1][0]
+    assert len(peer_sources) == 2
+    assert {source for source, *_rest in peer_sources} == {None, sw + 9}
+
+
+def test_topology_overlapping_groups_can_choose_different_external_columns():
+    """One grecv slot may be populated partly by a direct peer and partly through a local intermediary."""
+    wide, diag = "a_wide", "z_diag"
+    send = [ShardSpec({wide: d1(0, 160, 160), diag: d1(0, 160, 160)})]
+    recv = []
+    for worker in range(4):
+        diag_half = 0 if worker in (0, 3) else 1
+        recv.append(
+            ShardSpec(
+                {
+                    wide: d1(0, 160, 160),
+                    diag: d1(diag_half * 80, (diag_half + 1) * 80, 160),
+                }
+            )
+        )
+    ip = {0: "trainer", 1: "node-a", 2: "node-a", 3: "node-b", 4: "node-b"}
+
+    # In one round, worker 0's wide column goes to worker 2 while its diagonal group goes to worker 3.
+    # Worker 3's generic payload contains both names, but only `diag` is direct; `wide` arrives internally.
+    rt = make_router(send, recv, dtypes(wide, diag), cap=10**9)
+    assert rt.configure_topology(ip)
+    plan = rt.topology_plan(0, 0)
+    assert plan["external"] == {2: (wide,), 3: (diag,)}
+    layout, _stride, _peers = rt.arena_layout(0, depth=2)
+    assert layout[0]["grecv_names"] == {2: (wide,), 3: (diag,)}
+    assert layout[0]["topo_send"][2] == layout[0]["send"][2]
+    assert layout[0]["topo_send"][3] != layout[0]["send"][3]
+    assert layout[0]["topo_send"][3][1] * 2 == layout[0]["send"][3][1]
+    endpoint, _layout, _stride, _peers = _bind_fake_topology_endpoint(rt, 0, ip)
+    assert endpoint._topo_ext_send_peers_by_round == [(3, 4)]
+    assert endpoint._topo_ext_recv_peers_by_round == [(3, 4)]
+    assert endpoint._topo_int_peers_by_round == [(2,)]
+    assert endpoint._topo_int_readers_by_round == [(2,)]
+    assert endpoint._topo_peer_predecessors[0] == {3: (-1, 0), 4: (-1, 0)}
+    assert len(endpoint._topo_internal_consume_src[2][0]) == 2
+
+    # Split the names into two rounds. Worker 3 receives `wide` through an intermediary in round 0, then
+    # receives `diag` directly from worker 0 in round 1. Internal consume has no local staging slot, so the
+    # direct compact GRECV slot's predecessor is its own final direct use in the prior epoch—not round 0.
+    rt2 = make_router(send, recv, dtypes(wide, diag), cap=160)
+    assert rt2.configure_topology(ip)
+    ri_wide = next(ri for ri, names in enumerate(rt2.global_rounds) if names == {wide})
+    ri_diag = next(ri for ri, names in enumerate(rt2.global_rounds) if names == {diag})
+    assert ri_wide < ri_diag
+    assert rt2.topology_plan(0, ri_wide)["external"] == {2: (wide,)}
+    assert rt2.topology_plan(0, ri_diag)["external"] == {3: (diag,)}
+    endpoint2, _layout, _stride, _peers = _bind_fake_topology_endpoint(rt2, 0, ip)
+    assert endpoint2._topo_peer_predecessors[ri_diag][4] == (-1, ri_diag)
+
+
+def test_packed_copy_spans_scatter_selected_names_and_coalesce_neighbors():
+    dtype = dtypes("a", "b", "c")
+    full = ShardSpec({name: d1(0, 8, 8) for name in ("a", "b", "c")})
+    compact_ac = ShardSpec({name: d1(0, 8, 8) for name in ("a", "c")})
+
+    # Compact source -> gapped destination needs two spans.
+    assert _packed_copy_spans(
+        compact_ac, full, ("a", "c"), dtype, src_base=100, dst_base=200
+    ) == [
+        (100, 200, 32),
+        (132, 264, 32),
+    ]
+    # Adjacent names in both layouts merge into one transfer span.
+    assert _packed_copy_spans(
+        full, full, ("a", "b"), dtype, src_base=100, dst_base=200
+    ) == [
+        (100, 200, 64),
+    ]
+
+
+def test_arena_identical_full_peer_sends_alias_own():
+    """Deduplicate peer sends first, then use the canonical own bytes as that full-payload source."""
+    name = "shared"
+    send = [ShardSpec({name: d1(0, 400, 400)})]
+    recv = [ShardSpec({name: d1(0, 400, 400)}) for _ in range(4)]
+    rt = make_router(send, recv, dtypes(name), cap=10**9)
+
+    rounds, _S, peers = rt.arena_layout(0, depth=2)
+    assert peers == [1, 2, 3]
+    rd = next(rd for rd in rounds if rd["s2r"])
+    assert len(rd["send"]) == 3  # protocol remains per-peer
+    assert set(rd["send"].values()) == {
+        rd["own"]
+    }  # storage is the canonical payload itself
+    assert rd["prep"] == rd["own"][1]
+    assert rd["agh"] == rd["own"][1] + sum(nb for _, nb in rd["grecv"].values())
+
+
+if __name__ == "__main__":
+    test_split_shard_evenly_partition()
+    print("PASS test_split_shard_evenly_partition")
+    test_dedup_specs_partition_and_determinism()
+    print("PASS test_dedup_specs_partition_and_determinism")
+    test_recv_tensor_classes()
+    print("PASS test_recv_tensor_classes")
+    test_arena_layout_invariants()
+    print("PASS test_arena_layout_invariants")
+    test_arena_layout_isolates_skipped_depth2_recv_from_live_prep()
+    print("PASS test_arena_layout_isolates_skipped_depth2_recv_from_live_prep")
+    test_isolated_recv_lanes_prevent_three_round_cross_sender_overwrite()
+    print("PASS test_isolated_recv_lanes_prevent_three_round_cross_sender_overwrite")
+    test_sender_ingress_gate_tracks_destination_and_parity()
+    print("PASS test_sender_ingress_gate_tracks_destination_and_parity")
+    test_arena_layout_adversarial_varying_peers()
+    print("PASS test_arena_layout_adversarial_varying_peers")
+    test_arena_sender_target_agreement()
+    print("PASS test_arena_sender_target_agreement")
+    test_arena_dtype_alignment()
+    print("PASS test_arena_dtype_alignment")
+    test_arena_wide_class_reciprocity()
+    print("PASS test_arena_wide_class_reciprocity")
+    test_arena_identical_full_peer_sends_alias_own()
+    print("PASS test_arena_identical_full_peer_sends_alias_own")
+    print("ALL ARENA PLANNER TESTS PASSED")

--- a/examples/weightbridge/tests/test_control_channel.py
+++ b/examples/weightbridge/tests/test_control_channel.py
@@ -1,0 +1,202 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the rank0-mediated ZMQ control star (:class:`ControlChannel`).
+
+Torch/GPU-free: exercises the per-round rendezvous directly. Skipped where ``zmq`` is unavailable.
+Also runnable as a script (``python tests/test_control_channel.py``) for reliable multiprocessing spawn.
+"""
+
+import json
+import multiprocessing as mp
+import tempfile
+import time
+
+import pytest
+
+pytest.importorskip("zmq")
+import zmq  # noqa: E402
+from wbridge.backend.control_channel import (  # noqa: E402
+    CONNECT_REQUEST,
+    ControlChannel,
+    EMPTY,
+    RECEIVE_REQUEST,
+    STARTUP_REGISTER_TIMEOUT_ENV,
+    startup_register_timeout_s,
+    WORKER_REGISTER,
+)
+
+N_ROUNDS = 8
+
+
+def test_rank0_uses_shared_startup_registration_timeout(monkeypatch):
+    """The launcher timeout covers the peer hub as well as the coordinator."""
+    monkeypatch.setenv(STARTUP_REGISTER_TIMEOUT_ENV, "14400")
+    observed = []
+    monkeypatch.setattr(
+        ControlChannel,
+        "_await_registration",
+        lambda self, timeout_s: observed.append(timeout_s),
+    )
+
+    ch0 = ControlChannel(_new_ipc(), 0, 2)
+    ch0.close()
+
+    assert startup_register_timeout_s() == 14400.0
+    assert observed == [14400.0]
+
+
+def _new_ipc() -> str:
+    return f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}"
+
+
+def _controller(ctx, ipc):
+    """A mock WeightReceiverController ROUTER that refuses to silently drop (ROUTER_MANDATORY)."""
+    sock = ctx.socket(zmq.ROUTER)
+    sock.setsockopt(zmq.ROUTER_MANDATORY, 1)
+    sock.bind(ipc)
+    return sock
+
+
+def _send_routable(ctrl, ident: bytes, obj: dict, tries: int = 300) -> None:
+    """Send to ``ident``, retrying until the peer's DEALER is connected (handshake done)."""
+    data = json.dumps(obj).encode()
+    for _ in range(tries):
+        try:
+            ctrl.send_multipart([ident, data])
+            return
+        except zmq.error.ZMQError:
+            time.sleep(0.02)
+    raise RuntimeError(f"could not route to {ident!r}: peer never connected")
+
+
+def _recv_register(ctrl, timeout_ms: int = 5000) -> int:
+    """Consume receiver rank 0's WORKER_REGISTER (sent at :class:`ControlChannel` init); return num_workers."""
+    ctrl.setsockopt(zmq.RCVTIMEO, timeout_ms)
+    msg = json.loads(ctrl.recv_multipart()[1].decode())
+    assert msg["type"] == WORKER_REGISTER, f"expected WORKER_REGISTER first, got {msg}"
+    return int(msg["num_workers"])
+
+
+def _drain_acks(ctrl, timeout_ms: int = 1000) -> int:
+    ctrl.setsockopt(zmq.RCVTIMEO, timeout_ms)
+    n = 0
+    while True:
+        try:
+            frames = ctrl.recv_multipart()
+        except zmq.Again:
+            return n
+        assert json.loads(frames[1].decode())["status"] == "ack"
+        n += 1
+
+
+def _peer_proc(ipc: str, rank: int, num_workers: int, n_rounds: int, out_q) -> None:
+    ch = ControlChannel(ipc, rank, num_workers)
+    seq = [ch.step().get("type") for _ in range(n_rounds)]
+    ch.close()
+    out_q.put((rank, seq))
+
+
+def test_star_lockstep_and_ordering():
+    """All ranks observe the identical decision sequence; connect precedes receive; one ack per msg."""
+    ipc = _new_ipc()
+    num_workers = 4
+    ctx = zmq.Context()
+    ctrl = _controller(ctx, ipc)
+
+    spawn = mp.get_context(
+        "spawn"
+    )  # avoid inheriting the parent's zmq context via fork
+    out_q = spawn.Queue()
+    peers = [
+        spawn.Process(target=_peer_proc, args=(ipc, r, num_workers, N_ROUNDS, out_q))
+        for r in range(1, num_workers)
+    ]
+    for p in peers:
+        p.start()
+
+    # rank0 lives here; its ctor blocks until all peers register (also lets its controller
+    # DEALER finish the handshake, so the ROUTER can route to it).
+    ch0 = ControlChannel(ipc, 0, num_workers)
+    assert (
+        _recv_register(ctrl) == num_workers
+    )  # rank 0 reports its worker count to the coordinator at init
+
+    inject = {
+        1: {
+            "type": CONNECT_REQUEST,
+            "rank": 8,
+            "world_size": 12,
+            "sender_world_size": 8,
+            "init_method": "tcp://x:1",
+            "group_name": "wbridge",
+        },
+        4: {"type": RECEIVE_REQUEST},
+    }
+    r0_seq = []
+    for i in range(N_ROUNDS):
+        if i in inject:
+            _send_routable(ctrl, b"worker-0", inject[i])
+            time.sleep(
+                0.05
+            )  # let it reach rank0's DEALER before its non-blocking drain
+        r0_seq.append(ch0.step().get("type"))
+    ch0.close()
+
+    assert _drain_acks(ctrl) == len(inject)
+
+    results = {}
+    for _ in peers:
+        rank, seq = out_q.get(timeout=15)
+        results[rank] = seq
+    for p in peers:
+        p.join(timeout=10)
+
+    for rank, seq in results.items():
+        assert seq == r0_seq, f"rank {rank} desynced: {seq} != {r0_seq}"
+    assert CONNECT_REQUEST in r0_seq and RECEIVE_REQUEST in r0_seq
+    assert r0_seq.index(CONNECT_REQUEST) < r0_seq.index(RECEIVE_REQUEST)
+
+    ctrl.close(linger=0)
+    ctx.term()
+
+
+def test_single_worker_no_peers():
+    """num_workers=1: rank0 alone, no registration wait, decisions still flow from the controller."""
+    ipc = _new_ipc()
+    ctx = zmq.Context()
+    ctrl = _controller(ctx, ipc)
+
+    ch0 = ControlChannel(ipc, 0, 1)
+    assert (
+        _recv_register(ctrl) == 1
+    )  # rank 0 reports its worker count to the coordinator at init
+    assert ch0.step().get("type") == EMPTY  # nothing queued -> empty
+
+    _send_routable(ctrl, b"worker-0", {"type": RECEIVE_REQUEST})
+    got = EMPTY
+    for _ in range(
+        50
+    ):  # drain rounds until the receive decision lands (delivery is async)
+        got = ch0.step().get("type")
+        if got == RECEIVE_REQUEST:
+            break
+        time.sleep(0.02)
+    assert got == RECEIVE_REQUEST
+    assert _drain_acks(ctrl) == 1
+
+    ch0.close()
+    ctrl.close(linger=0)
+    ctx.term()
+
+
+if __name__ == "__main__":
+    # Standalone runner (reliable multiprocessing 'spawn' without pytest collection quirks).
+    test_star_lockstep_and_ordering()
+    print("PASS test_star_lockstep_and_ordering")
+    test_single_worker_no_peers()
+    print("PASS test_single_worker_no_peers")
+    print("ALL RENDEZVOUS TESTS PASSED")

--- a/examples/weightbridge/tests/test_dedup_consolidate.py
+++ b/examples/weightbridge/tests/test_dedup_consolidate.py
@@ -1,0 +1,148 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for the dedup group consolidation pass (router.consolidate_groups).
+
+Threshold is now a float (0 = off, inf = most aggressive). The overlap guard means a group is only
+decomposed when ANOTHER multi-worker group overlaps it (shares a worker); a standalone group is left
+intact (covering it by singletons would destroy its dedup) — this also terminates threshold=inf.
+"""
+
+import math
+
+from wbridge.backend.router import consolidate_groups
+
+MB = 1024 * 1024
+
+
+def _partition_ok(nat, out):
+    """Output must be a partition-refinement of the natural classes: same coverage, each worker once, and
+    every sub-group a subset of some natural class of that tensor."""
+    for name, subs in out.items():
+        flat = [w for sg in subs for w in sg]
+        assert len(flat) == len(set(flat)), f"{name}: worker repeated in {subs}"
+        nat_workers = {w for c in nat[name] for w in c}
+        assert set(flat) == nat_workers, f"{name}: coverage {subs} != {nat[name]}"
+        for sg in subs:
+            assert any(set(sg) <= set(c) for c in nat[name]), (
+                f"{name}: {sg} not a subset of any class"
+            )
+
+
+def test_high_traffic_noop():
+    # {0,1,2,3} @ 200 MB -> per-pair 2*200/4 = 100 MB > 20 MB threshold -> untouched.
+    nat = {"big": [[0, 1, 2, 3]]}
+    cb = {("big", (0, 1, 2, 3)): 200 * MB}
+    assert consolidate_groups(nat, cb, 20 * MB) == {"big": [[0, 1, 2, 3]]}
+
+
+def test_threshold_zero_noop():
+    nat = {"t": [[0, 1, 2, 3]]}
+    cb = {("t", (0, 1, 2, 3)): 1 * MB}
+    assert consolidate_groups(nat, cb, 0) == {"t": [[0, 1, 2, 3]]}
+
+
+def test_wide_small_standalone_intact():
+    # Small wide group with NO other overlapping group -> the overlap guard leaves it INTACT (covering it by
+    # singletons would destroy its dedup). (Before the overlap guard this was singletonized.)
+    nat = {"s": [[0, 1, 2, 3]]}
+    cb = {("s", (0, 1, 2, 3)): 1 * MB}
+    out = consolidate_groups(nat, cb, 20 * MB)
+    assert out == {"s": [[0, 1, 2, 3]]}
+    _partition_ok(nat, out)
+
+
+def test_piggyback_onto_existing_group():
+    # big={0,1}@200MB keeps its high-traffic edge; small={0,1,2,3}@1MB overlaps it, so it dissolves,
+    # piggybacking {0,1} and sending {2},{3} directly.
+    nat = {"big": [[0, 1]], "small": [[0, 1, 2, 3]]}
+    cb = {("big", (0, 1)): 200 * MB, ("small", (0, 1, 2, 3)): 1 * MB}
+    out = consolidate_groups(nat, cb, 20 * MB)
+    assert out["big"] == [[0, 1]]
+    assert out["small"] == [[0, 1], [2], [3]]
+    _partition_ok(nat, out)
+
+
+def test_piggyback_prefers_larger_subgroup():
+    # A size-3 existing group is preferred (worker-count desc) over splitting into singletons.
+    nat = {"z": [[0, 1, 2]], "small": [[0, 1, 2, 3]]}
+    cb = {("z", (0, 1, 2)): 300 * MB, ("small", (0, 1, 2, 3)): 1 * MB}
+    out = consolidate_groups(nat, cb, 20 * MB)
+    assert out["small"] == [[0, 1, 2], [3]]
+    _partition_ok(nat, out)
+
+
+def test_determinism_and_termination():
+    nat = {"a": [[0, 1, 2, 3]], "b": [[1, 2]], "c": [[0, 1, 2, 3, 4, 5]]}
+    cb = {
+        ("a", (0, 1, 2, 3)): 1 * MB,
+        ("b", (1, 2)): 300 * MB,
+        ("c", (0, 1, 2, 3, 4, 5)): 2 * MB,
+    }
+    o1 = consolidate_groups(nat, cb, 20 * MB)
+    o2 = consolidate_groups(nat, cb, 20 * MB)
+    assert o1 == o2  # deterministic (and it returned -> terminated)
+    _partition_ok(nat, o1)
+
+
+def test_multiclass_disjoint_classes_intact():
+    # A partially-sharded tensor (two disjoint classes). The low-traffic class (1,3) does NOT overlap the
+    # other class (0,2), so the overlap guard leaves BOTH intact.
+    nat = {"tp": [[0, 2], [1, 3]]}
+    cb = {("tp", (0, 2)): 300 * MB, ("tp", (1, 3)): 1 * MB}
+    out = consolidate_groups(nat, cb, 20 * MB)
+    assert out["tp"] == [[0, 2], [1, 3]]
+    _partition_ok(nat, out)
+
+
+def test_float_threshold_and_inf():
+    nat = {"t": [[0, 1, 2, 3]]}
+    cb = {("t", (0, 1, 2, 3)): 5 * MB}
+    assert consolidate_groups(nat, cb, 0.0) == {"t": [[0, 1, 2, 3]]}  # 0.0 -> off
+    assert consolidate_groups(nat, cb, math.inf) == {
+        "t": [[0, 1, 2, 3]]
+    }  # standalone stays intact at inf
+
+
+def test_inf_terminates_and_preserves_standalone():
+    # threshold=inf: an OVERLAPPED group decomposes; STANDALONE groups stay intact; the loop terminates.
+    nat = {"big": [[0, 1]], "small": [[0, 1, 2, 3]], "solo": [[4, 5, 6, 7]]}
+    cb = {
+        ("big", (0, 1)): 200 * MB,
+        ("small", (0, 1, 2, 3)): 1 * MB,
+        ("solo", (4, 5, 6, 7)): 1 * MB,
+    }
+    out = consolidate_groups(nat, cb, math.inf)  # returns => terminated
+    assert out["small"] == [[0, 1], [2], [3]]  # overlaps big -> decomposed
+    assert out["big"] == [[0, 1]]  # standalone after small dissolves -> intact
+    assert out["solo"] == [[4, 5, 6, 7]]  # never overlapped -> intact
+    _partition_ok(nat, out)
+
+
+def test_one_group_per_worker():
+    # 4 engines x 4 ranks = 16 receivers. Expert tensors are size-4 same-rank classes {r,r+4,r+8,r+12};
+    # a dense tensor is the size-16 all-class. At inf the dense folds onto the (partitioning) expert groups,
+    # so each worker ends up in exactly ONE multi-worker group, minimizing topology fan-out.
+    experts = {f"e{r}": [[r, r + 4, r + 8, r + 12]] for r in range(4)}
+    dense = {"dense": [list(range(16))]}
+    nat = {**experts, **dense}
+    cb = {("dense", tuple(range(16))): 1 * MB}
+    for r in range(4):
+        cb[(f"e{r}", (r, r + 4, r + 8, r + 12))] = 100 * MB
+    out = consolidate_groups(nat, cb, math.inf)
+    wg: dict[int, set] = {}
+    for subs in out.values():
+        for sg in subs:
+            if len(sg) >= 2:
+                for w in sg:
+                    wg.setdefault(w, set()).add(tuple(sg))
+    assert all(len(g) == 1 for g in wg.values()), (
+        wg
+    )  # one multi-worker group per worker
+    assert all(
+        len(sg) in (1, 4) for sg in out["dense"]
+    )  # dense dissolved onto size-4 expert groups
+    _partition_ok(nat, out)

--- a/examples/weightbridge/tests/test_fuse_copy.py
+++ b/examples/weightbridge/tests/test_fuse_copy.py
@@ -1,0 +1,301 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""test_fuse_copy.py — verify the fused model↔wire copy is byte-identical to the 2-stage path.
+
+The fused path (`LoadSpec.fuse_copy_pairs`, data.py) collapses stage-1 (`copy_fromto_params`,
+model↔logical, transpose) + stage-2 (`pack_into`/`__setitem__`, logical↔wire overlap reshard) into a
+single model↔wire copy with no intermediate logical buffer. This test builds the REAL toy LoadSpecs via
+specgen (so it exercises the transposed rollout down_proj + QKV/gate_up fusion), then asserts, for both
+full and partial overlaps, on both trainer and rollout sides:
+
+  * SAVE (model→wire): fused wire bytes == 2-stage `copy_fromto`+`pack_into` wire bytes.
+  * LOAD (wire→model): fused model == 2-stage `setitem`+`copy_fromto` model.
+
+Requires CUDA (specgen + the Triton batched copy). Run: ``python tests/test_fuse_copy.py``.
+"""
+
+import os
+import sys
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "examples"))
+
+from qwen_tiny import (  # noqa: E402
+    build_qwen_tiny_hf_checkpoint,
+    build_rollout_wksd,
+    build_trainer_wksd,
+    DEFAULT_QWEN_TINY_CONFIG,
+    make_rollout_load_weights,
+    make_trainer_load_weights,
+)
+from utils import make_hf_weights  # noqa: E402
+from wbridge.utils.data import (  # noqa: E402
+    batched_copy,
+    FuseUnsupported,
+    LoadSpec,
+    ShardSpec,
+    split_large_load_spec_sources,
+)
+from wbridge.utils.specgen import infer_load_spec  # noqa: E402
+
+
+def _side(
+    build_wksd,
+    make_lw,
+    cfg,
+    hf_weights,
+    hf_shapes,
+    device,
+    dtype,
+    *,
+    tp_rank=0,
+    tp_size=1,
+):
+    wksd = build_wksd(
+        cfg,
+        device=device,
+        dtype=dtype,
+        tp_rank=tp_rank,
+        tp_size=tp_size,
+    )
+    lw_raw = make_lw(
+        wksd,
+        cfg,
+        device=device,
+        dtype=dtype,
+        tp_rank=tp_rank,
+        tp_size=tp_size,
+    )
+
+    def load_weights(fetcher):
+        lw_raw((name, fn()) for name, fn in fetcher.items())
+
+    load_spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, load_weights)
+    dtype_spec = {
+        hf: max((wksd[wk].dtype for wk in entry), key=lambda d: d.itemsize)
+        for hf, entry in load_spec.entries.items()
+    }
+    load_weights(hf_weights)  # fill wksd with real (reference) values
+    return wksd, load_spec, dtype_spec
+
+
+def _subregion(spec: ShardSpec) -> ShardSpec:
+    """A strict sub-region of *spec*: halve the first splittable axis of each name's first shard."""
+    out = {}
+    for name, shards in spec:
+        sh = list(shards[0])
+        for d, (l, r, w) in enumerate(sh):
+            if r - l >= 2:
+                sh[d] = (l, l + (r - l) // 2, w)
+                break
+        out[name] = [sh]
+    return ShardSpec(out)
+
+
+def _check(tag, load_spec, wksd, dtype_spec, ospec, device):
+    full = load_spec.src_shard_spec
+
+    # ---- SAVE: model -> wire ----
+    logical = full.make_named_buffer(dtype_spec, device)
+    load_spec.copy_fromto_params(
+        full, logical, wksd, src_to_dst=False
+    )  # model -> logical
+    wire_ref = ospec.make_byte_chunk(dtype_spec, device)
+    full(logical).pack_into(ospec, wire_ref)  # logical -> wire (2-stage)
+
+    wire_fused = ospec.make_byte_chunk(dtype_spec, device)
+    batched_copy(
+        load_spec.fuse_copy_pairs(ospec, wire_fused, wksd, dtype_spec, src_to_dst=False)
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(wire_ref, wire_fused), (
+        f"[{tag}] SAVE wire mismatch ({(wire_ref != wire_fused).sum()} bytes)"
+    )
+
+    # ---- LOAD: wire -> model (zero everything so non-overlap regions match trivially) ----
+    logical2 = full.make_named_buffer(dtype_spec, device)
+    for t in logical2.values():
+        t.zero_()
+    full(logical2)[{0: ospec}] = {0: wire_ref}  # wire -> logical
+    model_ref = {k: torch.zeros_like(v) for k, v in wksd.items()}
+    load_spec.copy_fromto_params(
+        full, logical2, model_ref, src_to_dst=True
+    )  # logical -> model (2-stage)
+
+    model_fused = {k: torch.zeros_like(v) for k, v in wksd.items()}
+    batched_copy(
+        load_spec.fuse_copy_pairs(
+            ospec, wire_ref, model_fused, dtype_spec, src_to_dst=True
+        )
+    )
+    torch.cuda.synchronize()
+    for name in model_ref:
+        assert torch.equal(model_ref[name], model_fused[name]), (
+            f"[{tag}] LOAD model mismatch for {name}"
+        )
+    print(f"  ok [{tag}]  names={len(ospec.entries)}  wire={wire_ref.numel()}B")
+
+
+def main(device="cuda"):
+    assert device == "cuda", "fused copy needs CUDA (specgen + Triton)"
+    cfg = DEFAULT_QWEN_TINY_CONFIG
+    dtype = torch.float32
+    hf_cpu = build_qwen_tiny_hf_checkpoint(cfg, dtype=dtype, seed=1, device=device)
+    hf_weights, hf_shapes = make_hf_weights(hf_cpu)
+
+    for tp_rank, tp_size in ((0, 1), (0, 4), (3, 4)):
+        sides = {
+            "trainer": _side(
+                build_trainer_wksd,
+                make_trainer_load_weights,
+                cfg,
+                hf_weights,
+                hf_shapes,
+                device,
+                dtype,
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+            ),
+            "rollout": _side(
+                build_rollout_wksd,
+                make_rollout_load_weights,
+                cfg,
+                hf_weights,
+                hf_shapes,
+                device,
+                dtype,
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+            ),
+        }
+        for who, (wksd, load_spec, dtype_spec) in sides.items():
+            full = load_spec.src_shard_spec
+            tag = f"{who}/tp{tp_size}-rank{tp_rank}"
+            _check(f"{tag}/full", load_spec, wksd, dtype_spec, full, device)
+            partial = ShardSpec.compute_overlap(full, _subregion(full))
+            _check(f"{tag}/partial", load_spec, wksd, dtype_spec, partial, device)
+            if tp_size > 1:
+                split_spec, split_dtypes, _report = split_large_load_spec_sources(
+                    load_spec,
+                    dtype_spec,
+                    max_bytes=256,
+                )
+                split_full = split_spec.src_shard_spec
+                _check(
+                    f"{tag}/logical/full",
+                    split_spec,
+                    wksd,
+                    split_dtypes,
+                    split_full,
+                    device,
+                )
+                split_partial = ShardSpec.compute_overlap(
+                    split_full,
+                    _subregion(split_full),
+                )
+                _check(
+                    f"{tag}/logical/partial",
+                    split_spec,
+                    wksd,
+                    split_dtypes,
+                    split_partial,
+                    device,
+                )
+    print("ALL FUSE COPY TESTS PASSED")
+    return True
+
+
+def test_fuse_copy():
+    if not torch.cuda.is_available():
+        import pytest
+
+        pytest.skip("no CUDA")
+    assert main("cuda")
+
+
+def test_fuse_copy_rejects_copying_parameter_reshape():
+    """A cached plan must never retain a raw pointer into a temporary reshape allocation."""
+    if not torch.cuda.is_available():
+        pytest.skip("fused copy requires CUDA")
+    source = [(0, 2, 2), (0, 3, 3)]
+    destination = [(0, 2, 2), (0, 3, 3)]
+    load_spec = LoadSpec({"weight": {"model.weight": [(source, destination)]}})
+    # Shape differs from destination's logical shape and flattening this transpose requires a copy.
+    model = {"model.weight": torch.arange(6, device="cuda").reshape(2, 3).t()}
+    wire = torch.empty(
+        6 * model["model.weight"].element_size(), dtype=torch.uint8, device="cuda"
+    )
+    with pytest.raises(FuseUnsupported, match="reshape.*allocates"):
+        load_spec.fuse_copy_pairs(
+            load_spec.src_shard_spec,
+            wire,
+            model,
+            {"weight": model["model.weight"].dtype},
+            src_to_dst=False,
+        )
+
+
+@pytest.mark.parametrize("sender_start,peer_start", [(0, 384), (3072, 3456)])
+def test_fused_save_matches_two_stage_for_deduplicated_partial_source(
+    sender_start, peer_start
+):
+    """Reproduce GLM's nested sender-de-dup and receiver-overlap slicing.
+
+    The sender owns a strict 768-element piece of a 6144-element replicated norm, and one rollout peer
+    receives a 48-element sub-piece.  The self-check reference must populate that ordinary (non-logical)
+    partial source before comparing it with the fused model-to-wire copy.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("fused copy requires CUDA")
+    source = [(0, 6144, 6144)]
+    load_spec = LoadSpec({"weight": {"model.weight": [(source, source)]}})
+    sender_spec = ShardSpec(
+        {
+            "weight": [[(sender_start, sender_start + 768, 6144)]],
+        }
+    )
+    peer_spec = ShardSpec(
+        {
+            "weight": [[(peer_start, peer_start + 48, 6144)]],
+        }
+    )
+    dtype_spec = {"weight": torch.bfloat16}
+    model = {
+        "model.weight": torch.arange(6144, device="cuda", dtype=torch.bfloat16),
+    }
+
+    logical = sender_spec.make_named_buffer(dtype_spec, "cuda")
+    load_spec.copy_fromto_params(sender_spec, logical, model, src_to_dst=False)
+    reference = peer_spec.make_byte_chunk(dtype_spec, "cuda")
+    sender_spec(logical).pack_into(peer_spec, reference)
+
+    fused = peer_spec.make_byte_chunk(dtype_spec, "cuda")
+    batched_copy(
+        load_spec.fuse_copy_pairs(
+            peer_spec,
+            fused,
+            model,
+            dtype_spec,
+            src_to_dst=False,
+        )
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(reference, fused)
+
+
+if __name__ == "__main__":
+    dev = sys.argv[1] if len(sys.argv) > 1 else "cuda"
+    try:
+        ok = main(dev)
+    except Exception:
+        import traceback
+
+        traceback.print_exc()
+        ok = False
+    sys.exit(0 if ok else 1)

--- a/examples/weightbridge/tests/test_internal_consume_cuda_ipc.py
+++ b/examples/weightbridge/tests/test_internal_consume_cuda_ipc.py
@@ -1,0 +1,346 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Focused two-GPU test for the fused internal-consume data path."""
+
+from __future__ import annotations
+
+import multiprocessing.connection
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+def _ipc_source(send: multiprocessing.connection.Connection, release) -> None:
+    from torch.multiprocessing.reductions import reduce_tensor
+
+    torch.cuda.set_device(1)
+    flat_numel = 1024 * 1024
+    storage = torch.arange(flat_numel + 200, dtype=torch.int32, device="cuda:1")
+    _rebuild, args = reduce_tensor(storage)
+    metadata = {
+        "handle": bytes(args[7])[-64:],
+        "tensor_offset_bytes": int(args[9]) + int(args[3]) * storage.element_size(),
+    }
+    send.send((storage, flat_numel, metadata))
+    release.wait(timeout=60)
+
+
+def _ipc_consumer(recv: multiprocessing.connection.Connection, result, release) -> None:
+    import gc
+
+    from wbridge.backend.router import (
+        _close_cuda_ipc_mapping,
+        _enable_cuda_peer_access,
+        _open_cuda_ipc_mapping,
+    )
+    from wbridge.utils.data import CopyPlan
+
+    torch.cuda.set_device(0)
+    _enable_cuda_peer_access(0, 1)
+    storage, flat_numel, metadata = recv.recv()
+    mapped_base, allocation_base = _open_cuda_ipc_mapping(0, metadata)
+    flat = storage[:flat_numel]
+    matrix = storage[flat_numel:].reshape(20, 10)
+    dst_flat = torch.zeros_like(flat, device="cuda:0")
+    dst_transposed = torch.zeros(10, 20, dtype=torch.int32, device="cuda:0")
+    pairs = [(dst_flat, flat), (dst_transposed, matrix.t())]
+    plan = CopyPlan(
+        pairs,
+        single_kernel=True,
+        source_ptrs=[
+            mapped_base + (source.data_ptr() - storage.data_ptr())
+            for _destination, source in pairs
+        ],
+    )
+    plan.run()
+    torch.cuda.synchronize()
+    expected_transposed = (
+        torch.arange(
+            flat_numel,
+            flat_numel + 200,
+            dtype=torch.int32,
+        )
+        .reshape(20, 10)
+        .t()
+        .contiguous()
+    )
+    ok = bool(
+        torch.equal(dst_flat.cpu(), torch.arange(dst_flat.numel(), dtype=torch.int32))
+        and torch.equal(dst_transposed.cpu(), expected_transposed)
+    )
+    source_device = str(flat.device)
+    _close_cuda_ipc_mapping(0, allocation_base)
+    launches = plan.launch_count
+    del pairs, plan, flat, matrix, storage
+    gc.collect()
+    result.send((ok, launches, source_device))
+    release.set()
+
+
+def _mixed_ipc_source(send: multiprocessing.connection.Connection, release) -> None:
+    """Export one allocation containing both BF16 and FP32 source views."""
+    from torch.multiprocessing.reductions import reduce_tensor
+
+    torch.cuda.set_device(1)
+    bf16_numel = 1024 * 1024
+    fp32_shape = (20, 10)
+    bf16_nbytes = bf16_numel * torch.empty((), dtype=torch.bfloat16).element_size()
+    fp32_nbytes = (
+        fp32_shape[0]
+        * fp32_shape[1]
+        * torch.empty((), dtype=torch.float32).element_size()
+    )
+    storage = torch.empty(bf16_nbytes + fp32_nbytes, dtype=torch.uint8, device="cuda:1")
+    bf16 = storage[:bf16_nbytes].view(torch.bfloat16)
+    fp32 = storage[bf16_nbytes:].view(torch.float32).reshape(fp32_shape)
+    bf16.copy_(
+        torch.arange(bf16_numel, dtype=torch.int32, device="cuda:1").remainder(251)
+    )
+    fp32.copy_(
+        torch.arange(fp32.numel(), dtype=torch.float32, device="cuda:1").reshape(
+            fp32_shape
+        )
+        + 0.25
+    )
+    _rebuild, args = reduce_tensor(storage)
+    metadata = {
+        "handle": bytes(args[7])[-64:],
+        "tensor_offset_bytes": int(args[9]) + int(args[3]) * storage.element_size(),
+    }
+    send.send((storage, bf16_numel, fp32_shape, metadata))
+    release.wait(timeout=60)
+
+
+def _mixed_ipc_consumer(
+    recv: multiprocessing.connection.Connection, result, release
+) -> None:
+    """Read mixed-dtype peer views with the production unified-dtype plan."""
+    import gc
+
+    from wbridge.backend.router import (
+        _close_cuda_ipc_mapping,
+        _enable_cuda_peer_access,
+        _open_cuda_ipc_mapping,
+    )
+    from wbridge.utils.data import CopyPlan
+
+    torch.cuda.set_device(0)
+    _enable_cuda_peer_access(0, 1)
+    storage, bf16_numel, fp32_shape, metadata = recv.recv()
+    mapped_base, allocation_base = _open_cuda_ipc_mapping(0, metadata)
+    bf16_nbytes = bf16_numel * torch.empty((), dtype=torch.bfloat16).element_size()
+    bf16 = storage[:bf16_nbytes].view(torch.bfloat16)
+    fp32 = storage[bf16_nbytes:].view(torch.float32).reshape(fp32_shape)
+    dst_bf16 = torch.zeros_like(bf16, device="cuda:0")
+    dst_fp32 = torch.zeros(
+        fp32_shape[1], fp32_shape[0], dtype=torch.float32, device="cuda:0"
+    )
+    pairs = [(dst_bf16, bf16), (dst_fp32, fp32.t())]
+    plan = CopyPlan(
+        pairs,
+        unified_dtype_kernels=True,
+        source_ptrs=[
+            mapped_base + (source.data_ptr() - storage.data_ptr())
+            for _destination, source in pairs
+        ],
+    )
+    plan.run()
+    torch.cuda.synchronize()
+    ok = bool(
+        torch.equal(dst_bf16.cpu(), bf16.cpu())
+        and torch.equal(dst_fp32.cpu(), fp32.t().contiguous().cpu())
+    )
+    source_device = str(bf16.device)
+    _close_cuda_ipc_mapping(0, allocation_base)
+    launches = plan.launch_count
+    del pairs, plan, bf16, fp32, storage
+    gc.collect()
+    result.send((ok, launches, source_device))
+    release.set()
+
+
+def _event_ipc_source(
+    send: multiprocessing.connection.Connection,
+    go,
+    published,
+    release,
+) -> None:
+    """Publish a peer allocation only after a delayed copy and reusable IPC event record."""
+    from torch.multiprocessing.reductions import reduce_tensor
+
+    torch.cuda.set_device(1)
+    flat_numel = 1024 * 1024
+    storage = torch.zeros(flat_numel, dtype=torch.int32, device="cuda:1")
+    _rebuild, args = reduce_tensor(storage)
+    metadata = {
+        "handle": bytes(args[7])[-64:],
+        "tensor_offset_bytes": int(args[9]) + int(args[3]) * storage.element_size(),
+    }
+    ready_event = torch.cuda.Event(interprocess=True)
+    ready_event.record()
+    torch.cuda.synchronize()
+    send.send((storage, flat_numel, metadata, ready_event.ipc_handle()))
+    if not go.wait(timeout=60):
+        raise TimeoutError("consumer did not import CUDA IPC event")
+
+    stream = torch.cuda.Stream(device=1)
+    with torch.cuda.stream(stream):
+        # Ensure a consumer that does not truly wait the imported event observes zeros.
+        torch.cuda._sleep(100_000_000)
+        storage.copy_(torch.arange(flat_numel, dtype=torch.int32, device="cuda:1"))
+        ready_event.record(stream)
+    # Match production: the CPU sequence is published after event.record() is enqueued,
+    # without synchronizing the producer stream.
+    published.set()
+    release.wait(timeout=60)
+
+
+def _event_ipc_consumer(
+    recv: multiprocessing.connection.Connection,
+    result,
+    go,
+    published,
+    release,
+) -> None:
+    """Wait an event imported on the reader device before dereferencing peer memory."""
+    import gc
+
+    from wbridge.backend.router import (
+        _close_cuda_ipc_mapping,
+        _enable_cuda_peer_access,
+        _open_cuda_ipc_mapping,
+    )
+    from wbridge.utils.data import CopyPlan
+
+    torch.cuda.set_device(0)
+    _enable_cuda_peer_access(0, 1)
+    storage, flat_numel, metadata, event_handle = recv.recv()
+    mapped_base, allocation_base = _open_cuda_ipc_mapping(0, metadata)
+    ready_event = torch.cuda.Event.from_ipc_handle(0, event_handle)
+    go.set()
+    if not published.wait(timeout=60):
+        raise TimeoutError("producer did not publish CUDA IPC event")
+
+    source = storage[:flat_numel]
+    destination = torch.zeros_like(source, device="cuda:0")
+    plan = CopyPlan([(destination, source)], source_ptrs=[mapped_base])
+    stream = torch.cuda.Stream(device=0)
+    with torch.cuda.stream(stream):
+        stream.wait_event(ready_event)
+        plan.run()
+    stream.synchronize()
+    ok = bool(
+        torch.equal(destination.cpu(), torch.arange(flat_numel, dtype=torch.int32))
+    )
+    _close_cuda_ipc_mapping(0, allocation_base)
+    del plan, source, destination, storage
+    gc.collect()
+    result.send(ok)
+    release.set()
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="internal consume CUDA-IPC test needs 2 GPUs"
+)
+def test_internal_consume_reads_peer_ipc_memory_in_one_kernel() -> None:
+    """A consumer process directly reads an IPC-exported peer allocation over NVLink."""
+    ctx = torch.multiprocessing.get_context("spawn")
+    source_recv, source_send = ctx.Pipe(duplex=False)
+    result_recv, result_send = ctx.Pipe(duplex=False)
+    release = ctx.Event()
+    source = ctx.Process(target=_ipc_source, args=(source_send, release))
+    consumer = ctx.Process(
+        target=_ipc_consumer, args=(source_recv, result_send, release)
+    )
+    source.start()
+    consumer.start()
+    try:
+        assert result_recv.poll(90), "CUDA-IPC internal consume timed out"
+        ok, launches, source_device = result_recv.recv()
+        assert ok
+        assert launches == 1
+        assert source_device == "cuda:1"
+    finally:
+        release.set()
+        source.join(timeout=30)
+        consumer.join(timeout=30)
+        if source.is_alive():
+            source.terminate()
+        if consumer.is_alive():
+            consumer.terminate()
+    assert source.exitcode == 0
+    assert consumer.exitcode == 0
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="internal consume CUDA-IPC test needs 2 GPUs"
+)
+def test_internal_consume_reads_mixed_dtype_peer_ipc_memory() -> None:
+    """A BF16/FP32 lane reads peer IPC memory once per dtype without byte corruption."""
+    ctx = torch.multiprocessing.get_context("spawn")
+    source_recv, source_send = ctx.Pipe(duplex=False)
+    result_recv, result_send = ctx.Pipe(duplex=False)
+    release = ctx.Event()
+    source = ctx.Process(target=_mixed_ipc_source, args=(source_send, release))
+    consumer = ctx.Process(
+        target=_mixed_ipc_consumer, args=(source_recv, result_send, release)
+    )
+    source.start()
+    consumer.start()
+    try:
+        assert result_recv.poll(90), "mixed-dtype CUDA-IPC internal consume timed out"
+        ok, launches, source_device = result_recv.recv()
+        assert ok
+        assert launches == 2
+        assert source_device == "cuda:1"
+    finally:
+        release.set()
+        source.join(timeout=30)
+        consumer.join(timeout=30)
+        if source.is_alive():
+            source.terminate()
+        if consumer.is_alive():
+            consumer.terminate()
+    assert source.exitcode == 0
+    assert consumer.exitcode == 0
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="internal consume CUDA-IPC test needs 2 GPUs"
+)
+def test_internal_consume_waits_reused_peer_ipc_event() -> None:
+    """The reader-device IPC event import orders a delayed producer copy before peer reads."""
+    ctx = torch.multiprocessing.get_context("spawn")
+    source_recv, source_send = ctx.Pipe(duplex=False)
+    result_recv, result_send = ctx.Pipe(duplex=False)
+    go = ctx.Event()
+    published = ctx.Event()
+    release = ctx.Event()
+    source = ctx.Process(
+        target=_event_ipc_source,
+        args=(source_send, go, published, release),
+    )
+    consumer = ctx.Process(
+        target=_event_ipc_consumer,
+        args=(source_recv, result_send, go, published, release),
+    )
+    source.start()
+    consumer.start()
+    try:
+        assert result_recv.poll(90), "CUDA-IPC event ordering test timed out"
+        assert result_recv.recv()
+    finally:
+        release.set()
+        source.join(timeout=30)
+        consumer.join(timeout=30)
+        if source.is_alive():
+            source.terminate()
+        if consumer.is_alive():
+            consumer.terminate()
+    assert source.exitcode == 0
+    assert consumer.exitcode == 0

--- a/examples/weightbridge/tests/test_local_repl_flags.py
+++ b/examples/weightbridge/tests/test_local_repl_flags.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CPU-only coverage for the same-node replica ready/consumed sequence bank."""
+
+import os
+
+from wbridge.backend.router import _LocalReplFlagBank, WBEndpoint
+
+
+class _FakeEvent:
+    def __init__(self):
+        self.records = 0
+
+    def record(self):
+        self.records += 1
+
+
+def test_local_repl_flag_bank_is_bidirectionally_visible_and_unlinked():
+    owner = _LocalReplFlagBank.create(3)
+    path = owner.path
+    peer = _LocalReplFlagBank.open(path)
+    try:
+        assert peer.ready() == 0
+        owner.publish_ready(11)
+        assert peer.ready() == 11
+
+        assert owner.consumed(2) == 0
+        peer.publish_consumed(2, 9)
+        assert owner.consumed(2) == 9
+    finally:
+        peer.close()
+        owner.close()
+    assert not os.path.exists(path)
+
+
+def test_local_repl_flag_bank_channels_are_independent():
+    owner = _LocalReplFlagBank.create(2, channels=3)
+    path = owner.path
+    peer = _LocalReplFlagBank.open(path, slots=2, channels=3)
+    try:
+        owner.publish_ready(7, 1)
+        owner.publish_ready(9, 2)
+        assert [peer.ready(channel) for channel in range(3)] == [0, 7, 9]
+
+        peer.publish_consumed(0, 11, 1)
+        peer.publish_consumed(1, 13, 2)
+        assert owner.consumed(0, 1) == 11
+        assert owner.consumed(1, 2) == 13
+        assert owner.consumed(0, 2) == 0
+    finally:
+        peer.close()
+        owner.close()
+    assert not os.path.exists(path)
+
+
+def test_topology_grecv_parities_use_independent_ready_and_consumed_channels():
+    owner_bank = _LocalReplFlagBank.create(1, channels=3)
+    reader_bank = _LocalReplFlagBank.open(owner_bank.path, slots=1, channels=3)
+    owner = WBEndpoint.__new__(WBEndpoint)
+    reader = WBEndpoint.__new__(WBEndpoint)
+    source, owner_rank, reader_rank = 16, 8, 9
+    channels = {(source, 0): 1, (source, 1): 2}
+    events = {(source, slot): {reader_rank: _FakeEvent()} for slot in range(2)}
+    owner._repl_local_flags = owner_bank
+    owner._topo_local_slot_channel = channels
+    owner._topo_slot_ready_event = events
+    owner._repl_flag_slot_of = {reader_rank: 0}
+    reader._repl_peer_local_flags = {owner_rank: reader_bank}
+    reader._topo_peer_slot_channel = {owner_rank: channels}
+    reader._repl_peer_slot_of_me = {owner_rank: 0}
+    try:
+        owner._publish_topo_slot_ready(source, 0, (reader_rank,), 11)
+        assert reader._topo_slot_ready_reached(owner_rank, source, 0, 11)
+        assert not reader._topo_slot_ready_reached(owner_rank, source, 1, 12)
+        assert events[(source, 0)][reader_rank].records == 1
+        assert events[(source, 1)][reader_rank].records == 0
+
+        owner._publish_topo_slot_ready(source, 1, (reader_rank,), 12)
+        assert reader._topo_slot_ready_reached(owner_rank, source, 1, 12)
+        assert events[(source, 1)][reader_rank].records == 1
+
+        reader._write_topo_slot_cons_flag(owner_rank, source, 1, 12)
+        assert owner._topo_slot_cons_flag_reached(reader_rank, source, 1, 12)
+        assert not owner._topo_slot_cons_flag_reached(reader_rank, source, 0, 11)
+        reader._write_topo_slot_cons_flag(owner_rank, source, 0, 11)
+        assert owner._topo_slot_cons_flag_reached(reader_rank, source, 0, 11)
+    finally:
+        reader_bank.close()
+        owner_bank.close()

--- a/examples/weightbridge/tests/test_local_staging.py
+++ b/examples/weightbridge/tests/test_local_staging.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for :class:`~wbridge.backend.rdma.local.LocalStagingEngine`.
+
+Exercises the register_buffer + interval-map ``_view`` reconstruction and the copy path behind the
+``RdmaEngine`` interface. Runs on CPU (no GPU needed): where CUDA is unavailable the engine copies
+synchronously and ``write_async`` returns ``None`` (the ABC no-op-handle convention). Skipped without torch.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from wbridge.backend.rdma.local import LocalStagingEngine  # noqa: E402
+
+
+def _u8(n: int, fill: int = 0) -> "torch.Tensor":
+    return torch.full((n,), fill, dtype=torch.uint8)
+
+
+def _engine() -> LocalStagingEngine:
+    eng = LocalStagingEngine()
+    eng.init("localhost", "tcp")
+    return eng
+
+
+def test_whole_buffer_roundtrip():
+    eng = _engine()
+    src = torch.arange(256, dtype=torch.uint8)
+    dst = _u8(256)
+    eng.register_buffer(src)
+    eng.register_buffer(dst)
+    eng.write(eng.session_id(), [src.data_ptr()], [dst.data_ptr()], [256])
+    assert torch.equal(dst, src)
+
+
+def test_offset_slice_view():
+    eng = _engine()
+    src = torch.arange(256, dtype=torch.uint8)
+    dst = _u8(256)
+    eng.register_buffer(src)
+    eng.register_buffer(dst)
+    # src[64:192] -> dst[0:128] via raw offset pointers (interval-map reconstruction).
+    eng.write(eng.session_id(), [src.data_ptr() + 64], [dst.data_ptr()], [128])
+    assert torch.equal(dst[:128], src[64:192])
+    assert torch.equal(dst[128:], _u8(128))  # remainder untouched
+
+
+def test_multi_segment_batch():
+    eng = _engine()
+    src = torch.arange(64, dtype=torch.uint8)
+    a = _u8(32)
+    b = _u8(32)
+    for t in (src, a, b):
+        eng.register_buffer(t)
+    eng.write(
+        eng.session_id(),
+        [src.data_ptr(), src.data_ptr() + 32],
+        [a.data_ptr(), b.data_ptr()],
+        [32, 32],
+    )
+    assert torch.equal(a, src[:32]) and torch.equal(b, src[32:])
+
+
+def test_unregistered_ptr_raises():
+    eng = _engine()
+    t = _u8(16)
+    eng.register_buffer(t)
+    with pytest.raises(KeyError):
+        eng.write(eng.session_id(), [t.data_ptr() + 4096], [t.data_ptr()], [8])
+
+
+def test_write_async_then_wait():
+    eng = _engine()
+    a = torch.arange(64, dtype=torch.uint8)
+    b = _u8(64)
+    eng.register_buffer(a)
+    eng.register_buffer(b)
+    h = eng.write_async(eng.session_id(), [a.data_ptr()], [b.data_ptr()], [64])
+    eng.wait([h])  # a torch.cuda.Event on GPU, or a None no-op on CPU
+    assert torch.equal(b, a)
+
+
+def test_register_buffer_rejects_non_uint8():
+    eng = _engine()
+    with pytest.raises(AssertionError):
+        eng.register_buffer(torch.zeros(8, dtype=torch.float32))
+
+
+if __name__ == "__main__":
+    for fn in [
+        test_whole_buffer_roundtrip,
+        test_offset_slice_view,
+        test_multi_segment_batch,
+        test_unregistered_ptr_raises,
+        test_write_async_then_wait,
+        test_register_buffer_rejects_non_uint8,
+    ]:
+        fn()
+    print("LocalStagingEngine tests passed")

--- a/examples/weightbridge/tests/test_logical_tensor_split.py
+++ b/examples/weightbridge/tests/test_logical_tensor_split.py
@@ -1,0 +1,257 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from wbridge.utils.data import (
+    batched_copy,
+    LoadSpec,
+    logical_tensor_name,
+    parse_logical_tensor_name,
+    ShardSpec,
+    split_large_load_spec_sources,
+    validate_logical_tensor_partitions,
+)
+
+
+def _mapping(source_shape, destination_shape=None, *, transpose=False):
+    destination_shape = destination_shape or source_shape
+    source = [
+        (0, extent, -extent if transpose and dim == 0 else extent)
+        for dim, extent in enumerate(source_shape)
+    ]
+    destination = [(0, extent, extent) for extent in destination_shape]
+    return source, destination
+
+
+def test_split_large_source_is_row_aligned_and_bounded():
+    source, destination = _mapping((10, 4))
+    load = LoadSpec({"weight": {"model.weight": [(source, destination)]}})
+
+    translated, dtypes, report = split_large_load_spec_sources(
+        load,
+        {"weight": torch.float32},
+        max_bytes=64,
+    )
+
+    assert len(report) == 1
+    assert report[0]["full_bytes"] == 160
+    assert report[0]["max_piece_bytes"] == 64
+    assert list(translated.entries) == [
+        logical_tensor_name("weight", 0, 4),
+        logical_tensor_name("weight", 4, 8),
+        logical_tensor_name("weight", 8, 10),
+    ]
+    assert set(dtypes) == set(translated.entries)
+    assert [spec[0][0][:2] for _name, spec in translated.src_shard_spec] == [
+        (0, 4),
+        (4, 8),
+        (8, 10),
+    ]
+    assert all(
+        translated.src_shard_spec.subset({name}).nbytes(dtypes) <= 64
+        for name in translated.entries
+    )
+
+
+def test_partial_mapping_roundtrips_through_logical_buffers():
+    # This worker owns physical checkpoint rows [3, 9), so its first/last logical pieces are partial.
+    source = [(3, 9, 10), (0, 4, 4)]
+    destination = [(0, 6, 6), (0, 4, 4)]
+    load = LoadSpec({"weight": {"model.weight": [(source, destination)]}})
+    translated, dtypes, _report = split_large_load_spec_sources(
+        load,
+        {"weight": torch.float32},
+        max_bytes=64,
+    )
+    spec = translated.src_shard_spec
+
+    model = {"model.weight": torch.arange(24, dtype=torch.float32).reshape(6, 4)}
+    logical = spec.make_named_buffer(dtypes, "cpu")
+    translated.copy_fromto_params(spec, logical, model, src_to_dst=False)
+
+    restored = {"model.weight": torch.zeros_like(model["model.weight"])}
+    translated.copy_fromto_params(spec, logical, restored, src_to_dst=True)
+    assert torch.equal(restored["model.weight"], model["model.weight"])
+
+
+@pytest.mark.parametrize("start,end", [(0, 8), (8, 16)])
+def test_normal_deduplicated_partial_mapping_roundtrips(start, end):
+    """The two-stage fallback must support strict sub-shards created by sender de-duplication.
+
+    These are ordinary checkpoint names, not the explicitly split logical names covered by the tests above.
+    GLM-5 hits this path when its BF16 trainer k_norm is converted into an FP32 rollout wire tensor.
+    """
+    source, destination = _mapping((16,))
+    load = LoadSpec({"weight": {"model.weight": [(source, destination)]}})
+    partial = ShardSpec({"weight": [[(start, end, 16)]]})
+    dtypes = {"weight": torch.float32}
+    model = {"model.weight": torch.arange(16, dtype=torch.bfloat16)}
+
+    logical = partial.make_named_buffer(dtypes, "cpu")
+    load.copy_fromto_params(partial, logical, model, src_to_dst=False)
+    assert torch.equal(logical["weight"], model["model.weight"][start:end].float())
+
+    restored = {"model.weight": torch.zeros_like(model["model.weight"])}
+    load.copy_fromto_params(partial, logical, restored, src_to_dst=True)
+    expected = torch.zeros_like(model["model.weight"])
+    expected[start:end] = model["model.weight"][start:end]
+    assert torch.equal(restored["model.weight"], expected)
+
+
+def test_transposed_mapping_roundtrips_after_dim0_split():
+    source, destination = _mapping((6, 4), (4, 6), transpose=True)
+    load = LoadSpec({"weight": {"model.weight": [(source, destination)]}})
+    translated, dtypes, _report = split_large_load_spec_sources(
+        load,
+        {"weight": torch.float32},
+        max_bytes=32,
+    )
+    spec = translated.src_shard_spec
+
+    model = {"model.weight": torch.arange(24, dtype=torch.float32).reshape(4, 6)}
+    logical = spec.make_named_buffer(dtypes, "cpu")
+    translated.copy_fromto_params(spec, logical, model, src_to_dst=False)
+    restored = {"model.weight": torch.zeros_like(model["model.weight"])}
+    translated.copy_fromto_params(spec, logical, restored, src_to_dst=True)
+    assert torch.equal(restored["model.weight"], model["model.weight"])
+
+
+def test_translated_load_from_full_uses_physical_source_once():
+    source, destination = _mapping((10, 4))
+    load = LoadSpec({"weight": {"model.weight": [(source, destination)]}})
+    translated, _dtypes, _report = split_large_load_spec_sources(
+        load,
+        {"weight": torch.float32},
+        max_bytes=64,
+    )
+    calls = 0
+    checkpoint = torch.arange(40, dtype=torch.float32).reshape(10, 4)
+
+    def fetch():
+        nonlocal calls
+        calls += 1
+        return checkpoint.clone()
+
+    restored = {"model.weight": torch.zeros_like(checkpoint)}
+    translated.load_from_full({"weight": fetch}, restored)
+    assert calls == 1
+    assert torch.equal(restored["model.weight"], checkpoint)
+
+
+def test_split_is_idempotent_and_names_are_reversible():
+    source, destination = _mapping((10, 4))
+    load = LoadSpec({"weight": {"model.weight": [(source, destination)]}})
+    once, dtypes, _report = split_large_load_spec_sources(
+        load,
+        {"weight": torch.float32},
+        max_bytes=64,
+    )
+    twice, twice_dtypes, second_report = split_large_load_spec_sources(
+        once,
+        dtypes,
+        max_bytes=64,
+    )
+    assert second_report == []
+    assert twice.entries == once.entries
+    assert twice_dtypes == dtypes
+    for name in twice.entries:
+        physical, start, end = parse_logical_tensor_name(name)
+        assert physical == "weight"
+        assert 0 <= start < end <= 10
+
+
+def test_row_larger_than_cap_is_rejected():
+    source, destination = _mapping((2, 64))
+    load = LoadSpec({"weight": {"model.weight": [(source, destination)]}})
+    try:
+        split_large_load_spec_sources(load, {"weight": torch.float32}, max_bytes=128)
+    except ValueError as exc:
+        assert "one row is 256 bytes" in str(exc)
+    else:
+        raise AssertionError("expected unsplittable first dimension to be rejected")
+
+
+def _logical_spec(*intervals):
+    return ShardSpec(
+        {
+            logical_tensor_name("weight", start, end): [[(start, end, 16)]]
+            for start, end in intervals
+        }
+    )
+
+
+def test_partition_validation_allows_duplicate_and_disjoint_pieces():
+    validate_logical_tensor_partitions(
+        [
+            _logical_spec((0, 4), (4, 8)),
+            _logical_spec((0, 4), (8, 12)),
+            _logical_spec((12, 16)),
+        ]
+    )
+
+
+def test_partition_validation_rejects_mismatched_split_grids():
+    with pytest.raises(ValueError, match="overlaps"):
+        validate_logical_tensor_partitions(
+            [
+                _logical_spec((0, 8)),
+                _logical_spec((0, 4), (4, 8)),
+            ]
+        )
+
+
+def test_partition_validation_rejects_split_and_unsplit_names():
+    unsplit = ShardSpec({"weight": [[(0, 16, 16)]]})
+    with pytest.raises(ValueError, match="physical and logical names coexist"):
+        validate_logical_tensor_partitions([unsplit, _logical_spec((0, 16))])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="fused copy requires CUDA")
+@pytest.mark.parametrize("transpose", [False, True])
+def test_fused_model_wire_copy_with_logical_names(transpose):
+    source_shape = (6, 4)
+    destination_shape = (4, 6) if transpose else source_shape
+    source, destination = _mapping(
+        source_shape,
+        destination_shape,
+        transpose=transpose,
+    )
+    load = LoadSpec({"weight": {"model.weight": [(source, destination)]}})
+    translated, dtypes, _report = split_large_load_spec_sources(
+        load,
+        {"weight": torch.float32},
+        max_bytes=32,
+    )
+    spec = translated.src_shard_spec
+    model = {
+        "model.weight": torch.arange(24, dtype=torch.float32, device="cuda").reshape(
+            destination_shape
+        ),
+    }
+
+    wire = spec.make_byte_chunk(dtypes, "cuda")
+    batched_copy(
+        translated.fuse_copy_pairs(
+            spec,
+            wire,
+            model,
+            dtypes,
+            src_to_dst=False,
+        )
+    )
+    restored = {"model.weight": torch.zeros_like(model["model.weight"])}
+    batched_copy(
+        translated.fuse_copy_pairs(
+            spec,
+            wire,
+            restored,
+            dtypes,
+            src_to_dst=True,
+        )
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(restored["model.weight"], model["model.weight"])

--- a/examples/weightbridge/tests/test_monarch_engine.py
+++ b/examples/weightbridge/tests/test_monarch_engine.py
@@ -1,0 +1,455 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Offline tests for :class:`~wbridge.backend.rdma.monarch.MonarchEngine`.
+
+No Monarch install and no fabric: a fake ``monarch.*`` is injected into ``sys.modules`` so the parts of
+the engine that are pure bookkeeping can be tested on any box with torch. What that covers is exactly the
+logic Monarch's API forced on us, and each case here stands for a failure that is invisible or
+catastrophic on real hardware:
+
+* **region -> handle mapping.** ``RDMABuffer`` has no remote offset, so a write is addressed by looking up
+  a handle published for that exact ``(addr, size)``. A tiling mismatch between publisher and writer
+  silently addresses the wrong tile, or raises deep inside the data path mid-transfer.
+* **the configurable tiling itself**, which must be byte-exact and identical on both sides. Tests use a
+  small 4 MiB tile to keep their CPU-memory footprint low; production defaults to 64 MiB.
+* **the threaded actor context.** WeightBridge calls ``write`` from daemon threads that start with an
+  empty context; getting this wrong is an *uncatchable Rust panic* that poisons the actor. The concurrent
+  case is here because the obvious implementation (one shared ``contextvars.Context`` + ``ctx.run``) works
+  single-threaded and fails only under concurrency, with ``cannot enter context: already entered``.
+* **the event-loop guard**, which turns an actor-loop deadlock (an unbounded hang with nothing in the log) into
+  an immediate error.
+
+Run in-container:  python -m pytest tests/test_monarch_engine.py -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import types
+
+import pytest
+import torch
+
+CHUNK = 4 * 1024 * 1024
+
+
+# --------------------------------------------------------------------------- fake monarch
+class FakeRDMABuffer:
+    """Stands in for ``monarch.rdma.RDMABuffer``: an opaque handle over one tensor view."""
+
+    def __init__(self, view) -> None:
+        self.view = view
+        self.nbytes = view.numel() * view.element_size()
+
+
+class FakeRDMAAction:
+    def __init__(self) -> None:
+        self.ops: list[tuple[FakeRDMABuffer, object]] = []
+
+    def write_remote(self, dst, src):
+        self.ops.append((dst, src))
+        return self
+
+    def submit(self, *, timeout: int = 60):
+        # Perform the copies eagerly so tests can assert on delivered bytes, and hand back a Future-alike.
+        for dst, src in self.ops:
+            dst.view.copy_(src)
+        return FakeFuture(len(self.ops))
+
+
+class FakeFuture:
+    def __init__(self, n_ops: int) -> None:
+        self.n_ops = n_ops
+        self.got = False
+
+    def get(self):
+        self.got = True
+        return None
+
+
+class FakeContext:
+    """Stands in for a monarch ``Context``; identity is all the engine needs."""
+
+    def __init__(self, tag: str = "actor") -> None:
+        self.tag = tag
+
+
+@pytest.fixture
+def fake_monarch(monkeypatch):
+    """Install a fake ``monarch`` package and return its mutable state.
+
+    ``_context`` is a real :class:`contextvars.ContextVar` so the threading tests exercise genuine
+    contextvar semantics (empty in a fresh thread) rather than a mock's.
+    """
+    import contextvars
+
+    ctxvar = contextvars.ContextVar("fake_monarch_context", default=None)
+    state = types.SimpleNamespace(
+        ctx=FakeContext(), ctxvar=ctxvar, backend="ibverbs", set_calls=[], buffers=[]
+    )
+
+    def _make(name: str, **attrs):
+        m = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        monkeypatch.setitem(sys.modules, name, m)
+        # `from monarch.rdma import X` resolves the leaf as an attribute of its parent package, so the
+        # sys.modules entry alone is not enough.
+        parent, _, leaf = name.rpartition(".")
+        if parent:
+            setattr(sys.modules[parent], leaf, m)
+        return m
+
+    def _rdma_buffer(view):
+        b = FakeRDMABuffer(view)
+        state.buffers.append(b)
+        return b
+
+    def _set_context(c):
+        state.set_calls.append((threading.current_thread().name, c))
+        return ctxvar.set(c)
+
+    _make("monarch")
+    _make(
+        "monarch.rdma",
+        RDMABuffer=_rdma_buffer,
+        RDMAAction=FakeRDMAAction,
+        get_rdma_backend=lambda: state.backend,
+    )
+    _make("monarch.actor", context=lambda: ctxvar.get() or state.ctx)
+    _make("monarch._src")
+    _make("monarch._src.actor")
+    _make("monarch._src.actor.actor_mesh", _context=ctxvar, _set_context=_set_context)
+    return state
+
+
+@pytest.fixture
+def engine(fake_monarch):
+    from wbridge.backend.rdma.monarch import MonarchEngine
+
+    eng = MonarchEngine()
+    eng._chunk = CHUNK  # test-sized override; production's documented default is 64 MiB
+    fake_monarch.ctxvar.set(fake_monarch.ctx)  # pretend this is the actor's own thread
+    eng.init("10.0.0.1", "rdma")
+    return eng
+
+
+def _buf(nbytes: int, fill: int = 0) -> torch.Tensor:
+    return torch.full((nbytes,), fill, dtype=torch.uint8)
+
+
+# --------------------------------------------------------------------------- tiling
+@pytest.mark.parametrize(
+    "size,expect",
+    [
+        (0, []),
+        (1, [(0x1000, 1)]),
+        (CHUNK, [(0x1000, CHUNK)]),
+        (CHUNK + 1, [(0x1000, CHUNK), (0x1000 + CHUNK, 1)]),
+        (
+            3 * CHUNK,
+            [(0x1000, CHUNK), (0x1000 + CHUNK, CHUNK), (0x1000 + 2 * CHUNK, CHUNK)],
+        ),
+    ],
+)
+def test_tile_is_exact_and_covers(size, expect):
+    from wbridge.backend.rdma.monarch import _tile
+
+    got = list(_tile(0x1000, size, CHUNK))
+    assert got == expect
+    assert sum(n for _, n in got) == size, (
+        "tiling must cover the region exactly, no gaps or overlap"
+    )
+
+
+# --------------------------------------------------------------------------- registration / lookup
+def test_register_requires_the_owning_tensor(engine):
+    with pytest.raises(RuntimeError, match="needs the owning tensor"):
+        engine.register(0x1000, 64)
+
+
+def test_local_view_resolves_an_interior_pointer(engine):
+    t = _buf(1024)
+    engine.register(t.data_ptr(), 1024, tensor=t)
+    v = engine._local_view(t.data_ptr() + 256, 128)
+    assert v.numel() == 128
+    assert v.data_ptr() == t.data_ptr() + 256
+
+
+def test_local_view_rejects_an_unregistered_pointer(engine):
+    t = _buf(1024)
+    engine.register(t.data_ptr(), 1024, tensor=t)
+    with pytest.raises(KeyError, match="not in any registered buffer"):
+        engine._local_view(t.data_ptr() + 1024, 8)  # one byte past the end
+
+
+def test_publish_tiles_large_regions(engine, fake_monarch):
+    t = _buf(3 * CHUNK)
+    engine.register(t.data_ptr(), 3 * CHUNK, tensor=t)
+    engine.publish_regions([(t.data_ptr(), 3 * CHUNK)])
+
+    assert len(engine._published) == 3, (
+        "a 12 MiB region must publish three 4 MiB handles"
+    )
+    assert set(engine._published) == {
+        (t.data_ptr() + i * CHUNK, CHUNK) for i in range(3)
+    }
+    assert all(b.nbytes == CHUNK for b in fake_monarch.buffers)
+
+
+def test_publish_skips_empty_and_dedupes(engine):
+    t = _buf(4096)
+    engine.register(t.data_ptr(), 4096, tensor=t)
+    engine.publish_regions(
+        [(t.data_ptr(), 0), (t.data_ptr(), 512), (t.data_ptr(), 512)]
+    )
+    assert set(engine._published) == {(t.data_ptr(), 512)}
+
+
+def test_write_to_an_unpublished_region_names_the_region(engine):
+    """The failure mode this guards is a publisher/writer disagreement; the error must be diagnosable."""
+    src = _buf(64, fill=7)
+    engine.register(src.data_ptr(), 64, tensor=src)
+    engine.attach_peer("peer:1", {"regions": {}})
+    with pytest.raises(KeyError, match="published no region"):
+        engine.write("peer:1", [src.data_ptr()], [0xDEAD000], [64])
+
+
+# --------------------------------------------------------------------------- data path
+def _pair(fake_monarch):
+    """Two engines sharing the fake fabric: ``a`` writes into ``b``'s published regions."""
+    from wbridge.backend.rdma.monarch import MonarchEngine
+
+    a, b = MonarchEngine(), MonarchEngine()
+    a._chunk = b._chunk = CHUNK
+    a.init("10.0.0.1", "rdma")
+    b.init("10.0.0.2", "rdma")
+    return a, b
+
+
+def test_write_delivers_bytes_through_the_handle_map(fake_monarch):
+    a, b = _pair(fake_monarch)
+    src = torch.arange(8192, dtype=torch.int32).view(torch.uint8).clone()
+    dst = _buf(src.numel())
+
+    a.register(src.data_ptr(), src.numel(), tensor=src)
+    b.register(dst.data_ptr(), dst.numel(), tensor=dst)
+    b.publish_regions([(dst.data_ptr(), dst.numel())])
+    a.attach_peer(b.session_id(), b.publish_payload())
+
+    a.write(b.session_id(), [src.data_ptr()], [dst.data_ptr()], [src.numel()])
+    assert torch.equal(dst, src)
+
+
+def test_write_of_a_multi_tile_region_reassembles_in_order(fake_monarch):
+    """A >4 MiB write is split; a mismatch between the two tilings would scramble or drop a tile."""
+    a, b = _pair(fake_monarch)
+    n = 2 * CHUNK + 12345
+    src = torch.randint(0, 256, (n,), dtype=torch.uint8)
+    dst = _buf(n)
+
+    a.register(src.data_ptr(), n, tensor=src)
+    b.register(dst.data_ptr(), n, tensor=dst)
+    b.publish_regions([(dst.data_ptr(), n)])
+    a.attach_peer(b.session_id(), b.publish_payload())
+
+    h = a.write_async(b.session_id(), [src.data_ptr()], [dst.data_ptr()], [n])
+    assert h.n_ops == 3, "two full tiles plus a tail must share one action"
+    a.wait([h])
+    assert h.got
+    assert torch.equal(dst, src)
+
+
+def test_write_batches_every_op_into_one_action(fake_monarch):
+    a, b = _pair(fake_monarch)
+    src = torch.randint(0, 256, (3 * 1024,), dtype=torch.uint8)
+    dst = _buf(3 * 1024)
+    a.register(src.data_ptr(), src.numel(), tensor=src)
+    b.register(dst.data_ptr(), dst.numel(), tensor=dst)
+    offs = [(dst.data_ptr() + i * 1024, 1024) for i in range(3)]
+    b.publish_regions(offs)
+    a.attach_peer(b.session_id(), b.publish_payload())
+
+    h = a.write_async(
+        b.session_id(),
+        [src.data_ptr() + i * 1024 for i in range(3)],
+        [o for o, _ in offs],
+        [1024, 1024, 1024],
+    )
+    assert h.n_ops == 3
+    a.wait([h])
+    assert torch.equal(dst, src)
+
+
+def test_write_async_of_nothing_is_a_no_op(engine):
+    assert engine.write_async("peer:1", [], [], []) is None
+    engine.wait([None])  # must tolerate the None handle write() would hand back
+
+
+def test_write_rejects_mismatched_lengths(engine):
+    with pytest.raises(AssertionError, match="length mismatch"):
+        engine.write_async("peer:1", [1, 2], [3], [4])
+
+
+# --------------------------------------------------------------------------- threading
+def test_write_from_a_bare_thread_installs_the_actor_context(fake_monarch):
+    """WeightBridge's sender Stage-2 thread starts with an empty context.
+
+    Without the install this is a Rust panic that poisons the actor, not a catchable error — so the check
+    is that the engine set the context *on that thread*, not merely that the call returned.
+    """
+    a, b = _pair(fake_monarch)
+    src = torch.randint(0, 256, (2048,), dtype=torch.uint8)
+    dst = _buf(2048)
+    a.register(src.data_ptr(), 2048, tensor=src)
+    b.register(dst.data_ptr(), 2048, tensor=dst)
+    b.publish_regions([(dst.data_ptr(), 2048)])
+    a.attach_peer(b.session_id(), b.publish_payload())
+
+    seen = {}
+
+    def worker():
+        assert fake_monarch.ctxvar.get() is None, (
+            "a fresh thread must start with no context"
+        )
+        a.write(b.session_id(), [src.data_ptr()], [dst.data_ptr()], [2048])
+        seen["ctx"] = fake_monarch.ctxvar.get()
+
+    t = threading.Thread(target=worker, name="wb-stage2")
+    t.start()
+    t.join()
+
+    assert seen["ctx"] is fake_monarch.ctx, (
+        "the actor context must be live on the worker thread"
+    )
+    assert any(name == "wb-stage2" for name, _ in fake_monarch.set_calls)
+    assert torch.equal(dst, src)
+
+
+def test_concurrent_threads_can_write(fake_monarch):
+    """The regression guard for a shared ``contextvars.Context``.
+
+    ``ctx.run()`` raises ``cannot enter context: already entered`` when a second thread enters a Context
+    the first is still inside — which only ever shows up under concurrency, on real hardware, mid-run.
+    """
+    a, b = _pair(fake_monarch)
+    n_threads, sz = 8, 4096
+    src = torch.randint(0, 256, (n_threads * sz,), dtype=torch.uint8)
+    dst = _buf(n_threads * sz)
+    a.register(src.data_ptr(), src.numel(), tensor=src)
+    b.register(dst.data_ptr(), dst.numel(), tensor=dst)
+    b.publish_regions([(dst.data_ptr() + i * sz, sz) for i in range(n_threads)])
+    a.attach_peer(b.session_id(), b.publish_payload())
+
+    start = threading.Barrier(
+        n_threads
+    )  # maximise the overlap the shared-Context bug needs
+    errors: list[BaseException] = []
+
+    def worker(i):
+        try:
+            start.wait(timeout=10)
+            a.write(
+                b.session_id(),
+                [src.data_ptr() + i * sz],
+                [dst.data_ptr() + i * sz],
+                [sz],
+            )
+        except BaseException as e:  # noqa: BLE001 — the Context error is what we are hunting
+            errors.append(e)
+
+    threads = [
+        threading.Thread(target=worker, args=(i,), name=f"wb-w{i}")
+        for i in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent writes raised: {errors!r}"
+    assert torch.equal(dst, src)
+
+
+def test_an_existing_foreign_context_is_left_alone(fake_monarch):
+    """A thread that already carries a context (the actor's own) must not be re-pointed."""
+    a, b = _pair(fake_monarch)
+    src, dst = _buf(64, fill=3), _buf(64)
+    a.register(src.data_ptr(), 64, tensor=src)
+    b.register(dst.data_ptr(), 64, tensor=dst)
+    b.publish_regions([(dst.data_ptr(), 64)])
+    a.attach_peer(b.session_id(), b.publish_payload())
+
+    other = FakeContext("other")
+    fake_monarch.ctxvar.set(other)
+    a.write(b.session_id(), [src.data_ptr()], [dst.data_ptr()], [64])
+    assert fake_monarch.ctxvar.get() is other
+
+
+def test_wait_on_a_live_event_loop_raises_instead_of_hanging(fake_monarch):
+    """Guard against blocking the actor loop on its own completion message.
+
+    Blocking an actor's loop on a completion that only that loop can deliver is an unbounded hang with no
+    log line. It must fail immediately, and the message must say where the work belongs.
+    """
+    a, b = _pair(fake_monarch)
+    src, dst = _buf(64, fill=5), _buf(64)
+    a.register(src.data_ptr(), 64, tensor=src)
+    b.register(dst.data_ptr(), 64, tensor=dst)
+    b.publish_regions([(dst.data_ptr(), 64)])
+    a.attach_peer(b.session_id(), b.publish_payload())
+
+    async def on_the_loop():
+        h = a.write_async(b.session_id(), [src.data_ptr()], [dst.data_ptr()], [64])
+        with pytest.raises(RuntimeError, match="would deadlock"):
+            a.wait([h])
+
+    asyncio.run(on_the_loop())
+
+
+# --------------------------------------------------------------------------- lifecycle
+def test_init_refuses_the_tcp_fallback(fake_monarch):
+    """A silent TCP fallback measures the wrong thing while looking like success."""
+    from wbridge.backend.rdma.monarch import MonarchEngine
+
+    fake_monarch.backend = "tcp"
+    with pytest.raises(RuntimeError, match="not 'ibverbs'"):
+        MonarchEngine().init("10.0.0.1", "rdma")
+
+    fake_monarch.backend = "none"
+    with pytest.raises(RuntimeError, match="no RDMA backend"):
+        MonarchEngine().init("10.0.0.1", "rdma")
+
+
+def test_session_id_stays_host_shaped(engine):
+    """router._setup_rdma_buffers parses the session to detect co-located peers, so it cannot be a blob."""
+    host, _, pid = engine.session_id().partition(":")
+    assert host == "10.0.0.1"
+    assert pid.isdigit()
+
+
+def test_calls_before_init_do_not_reach_monarch(fake_monarch):
+    from wbridge.backend.rdma.monarch import MonarchEngine
+
+    eng = MonarchEngine()
+    with pytest.raises(AssertionError, match="init not called"):
+        eng.publish_regions([(0x1000, 64)])
+
+
+def test_close_drops_every_handle(engine):
+    t = _buf(4096)
+    engine.register(t.data_ptr(), 4096, tensor=t)
+    engine.publish_regions([(t.data_ptr(), 4096)])
+    engine.attach_peer("peer:1", {"regions": {(1, 2): object()}})
+    engine.close()
+    assert not engine._published and not engine._peer and not engine._bufs
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/examples/weightbridge/tests/test_mooncake_engine.py
+++ b/examples/weightbridge/tests/test_mooncake_engine.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Smoke test for :class:`~wbridge.backend.rdma.mooncake.MooncakeEngine` (register + one-sided write).
+
+Two processes on the same node exchange (session_id, dst_ptr, size) over a spawn ``Queue``; the sender
+RDMA-writes a known byte pattern into the receiver's registered buffer over Mooncake ``tcp``; the receiver
+verifies the bytes. Runs both a **host-pinned** and a **CUDA (VRAM)** buffer variant — the CUDA variant
+settles whether the ``tcp`` transport can register+write GPU memory (the data-plane design depends on it).
+
+Needs a GPU + ``mooncake`` (skipped otherwise), so run in-container:
+
+    python tests/test_mooncake_engine.py            # both variants
+    python tests/test_mooncake_engine.py host        # host-pinned only
+    python tests/test_mooncake_engine.py cuda        # CUDA/VRAM only
+"""
+
+import multiprocessing as mp
+import sys
+
+import pytest
+
+N = 256 * 1024  # bytes to transfer
+
+
+def _pattern(torch):
+    """Deterministic uint8 pattern of length N (0,1,2,...,255,0,...)."""
+    return (torch.arange(N) % 256).to(torch.uint8)
+
+
+def _alloc(torch, mode):
+    if mode == "cuda":
+        return torch.zeros(N, dtype=torch.uint8, device="cuda")
+    return torch.zeros(N, dtype=torch.uint8).pin_memory()
+
+
+def _receiver(mode, q_info, q_done, out_q) -> None:
+    import torch
+    from wbridge.backend.rdma import MooncakeEngine
+    from wbridge.utils.distributed import get_local_ip
+
+    eng = MooncakeEngine()
+    eng.init(get_local_ip(), "tcp", "")
+    buf = _alloc(torch, mode)  # zero-initialised destination
+    eng.register(buf.data_ptr(), N)
+    q_info.put((eng.session_id(), buf.data_ptr(), N))
+
+    q_done.get()  # block until the sender reports the write is done
+    got = buf.detach().to("cpu")
+    ok = bool(torch.equal(got, _pattern(torch)))
+    out_q.put(("receiver", mode, ok, got[:4].tolist(), got[-4:].tolist()))
+    eng.close()
+
+
+def _sender(mode, q_info, q_done) -> None:
+    import torch
+    from wbridge.backend.rdma import MooncakeEngine
+    from wbridge.utils.distributed import get_local_ip
+
+    eng = MooncakeEngine()
+    eng.init(get_local_ip(), "tcp", "")
+    session, dst_ptr, size = q_info.get()
+
+    src = _pattern(torch)
+    src = src.cuda() if mode == "cuda" else src.pin_memory()
+    eng.register(src.data_ptr(), N)
+    eng.write(session, [src.data_ptr()], [dst_ptr], [size])  # blocking one-sided write
+    q_done.put("done")
+    eng.close()
+
+
+def run_once(mode: str) -> None:
+    ctx = mp.get_context("spawn")  # CUDA-safe; avoids fork+CUDA issues
+    q_info, q_done, out_q = ctx.Queue(), ctx.Queue(), ctx.Queue()
+    recv = ctx.Process(target=_receiver, args=(mode, q_info, q_done, out_q))
+    send = ctx.Process(target=_sender, args=(mode, q_info, q_done))
+    recv.start()
+    send.start()
+    try:
+        result = out_q.get(timeout=120)
+    finally:
+        send.join(timeout=15)
+        recv.join(timeout=15)
+        for p in (send, recv):
+            if p.is_alive():
+                p.terminate()
+    print(f"[mooncake-smoke] {result}", flush=True)
+    assert result[2], f"{mode}: received bytes != sent pattern ({result})"
+
+
+@pytest.mark.parametrize("mode", ["host", "cuda"])
+def test_mooncake_write(mode):
+    pytest.importorskip("mooncake")
+    torch = pytest.importorskip("torch")
+    if mode == "cuda" and not torch.cuda.is_available():
+        pytest.skip("no CUDA")
+    run_once(mode)
+
+
+if __name__ == "__main__":
+    modes = sys.argv[1:] or ["host", "cuda"]
+    for m in modes:
+        print(f"=== mooncake smoke: {m} ===", flush=True)
+        run_once(m)
+        print(f"PASS {m}", flush=True)
+    print("ALL MOONCAKE SMOKE TESTS PASSED", flush=True)

--- a/examples/weightbridge/tests/test_multinode_control_hub.py
+++ b/examples/weightbridge/tests/test_multinode_control_hub.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Regression tests for the cross-host receiver control hub."""
+
+import multiprocessing as mp
+import socket
+import time
+
+import pytest
+
+pytest.importorskip("zmq")
+
+from wbridge.backend.control_channel import (
+    ControlChannel,
+    coordinator_ipc,
+    multi_node_hub_addr,
+)
+
+
+_UNUSED_CONTROLLER = coordinator_ipc(39999)
+
+
+def _free_tcp_endpoint() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return f"tcp://127.0.0.1:{sock.getsockname()[1]}"
+
+
+def _peer(endpoint: str, output) -> None:
+    channel = ControlChannel(
+        _UNUSED_CONTROLLER,
+        1,
+        2,
+        hub_endpoint=endpoint,
+        reg_timeout_s=5.0,
+    )
+    output.put(channel.poll_decision(timeout_ms=5000))
+    channel.close()
+
+
+def _idle_then_delayed_peer(endpoint: str, output) -> None:
+    channel = ControlChannel(
+        _UNUSED_CONTROLLER,
+        1,
+        2,
+        hub_endpoint=endpoint,
+        reg_timeout_s=5.0,
+    )
+    output.put(channel.poll_decision(timeout_ms=200))
+    time.sleep(0.4)
+    output.put(channel.poll_decision(timeout_ms=5000))
+    channel.close()
+
+
+def test_multinode_hub_address_derivation() -> None:
+    assert multi_node_hub_addr(15000, "10.1.2.3:15003", 1) is None
+    assert multi_node_hub_addr(15000, "10.1.2.3:15003", 2) == "tcp://10.1.2.3:16718"
+    assert (
+        multi_node_hub_addr(15000, "[2001:db8::1]:15003", 2)
+        == "tcp://[2001:db8::1]:16718"
+    )
+
+
+def test_coordinator_ipc_uses_configured_directory(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("WBRIDGE_COORDINATOR_IPC_DIR", str(tmp_path))
+    assert coordinator_ipc(15000) == f"ipc://{tmp_path}/wbridge_coord_15000.sock"
+
+
+def test_tcp_hub_registers_remote_peer_and_broadcasts() -> None:
+    endpoint = _free_tcp_endpoint()
+    spawn = mp.get_context("spawn")
+    output = spawn.Queue()
+    peer = spawn.Process(target=_peer, args=(endpoint, output))
+    peer.start()
+
+    rank0 = ControlChannel(
+        _UNUSED_CONTROLLER,
+        0,
+        2,
+        hub_endpoint=endpoint,
+        reg_timeout_s=5.0,
+    )
+    decision = {"type": "connect_request", "epoch": 7}
+    rank0.broadcast(decision)
+    assert output.get(timeout=10) == decision
+
+    rank0.close()
+    peer.join(timeout=10)
+    assert peer.exitcode == 0
+
+
+def test_idle_is_barriered_and_action_waits_for_peer_quiescence() -> None:
+    endpoint = _free_tcp_endpoint()
+    spawn = mp.get_context("spawn")
+    output = spawn.Queue()
+    peer = spawn.Process(target=_idle_then_delayed_peer, args=(endpoint, output))
+    peer.start()
+
+    rank0 = ControlChannel(
+        _UNUSED_CONTROLLER,
+        0,
+        2,
+        hub_endpoint=endpoint,
+        reg_timeout_s=5.0,
+    )
+    idle = {"type": "empty"}
+    rank0.broadcast(idle)
+    assert output.get(timeout=5) == idle
+
+    decision = {"type": "connect_request", "epoch": 7}
+    started = time.monotonic()
+    rank0.broadcast(decision)
+    elapsed = time.monotonic() - started
+    assert elapsed >= 0.3
+    assert output.get(timeout=10) == decision
+
+    rank0.close()
+    peer.join(timeout=10)
+    assert peer.exitcode == 0

--- a/examples/weightbridge/tests/test_persistent_topo_waiter.py
+++ b/examples/weightbridge/tests/test_persistent_topo_waiter.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CPU-only coverage for endpoint-lifetime topology completion waiters."""
+
+import queue
+import time
+
+from wbridge.backend.receiver import WeightReceiver
+
+
+class _FakeEngine:
+    def __init__(self):
+        self.waited = []
+
+    def wait(self, bids):
+        self.waited.extend(bids)
+
+
+def test_topology_outbound_waiter_is_reused_and_preserves_peer_generation_order():
+    receiver = WeightReceiver.__new__(WeightReceiver)
+    receiver._rank = 8
+    receiver.engine = _FakeEngine()
+    receiver._trace_state = lambda *_args, **_kwargs: None
+    flags = []
+    receiver._flag_emit = lambda kind, peer, seq: flags.append((kind, peer, seq))
+
+    peer = 16
+    receiver._ensure_topo_out_waiters({peer})
+    thread = receiver._topo_out_wait_threads[peer]
+    results = queue.Queue()
+    for ri, seq, bid in ((0, 11, "round-0"), (1, 12, "round-1")):
+        receiver._topo_out_wait_queues[peer].put(
+            (3, ri, seq, bid, time.time(), results)
+        )
+
+    assert results.get(timeout=1) == (0, peer, None)
+    assert results.get(timeout=1) == (1, peer, None)
+    assert receiver.engine.waited == ["round-0", "round-1"]
+    assert flags == [(1, peer, 11), (1, peer, 12)]
+
+    receiver._ensure_topo_out_waiters({peer})
+    assert receiver._topo_out_wait_threads[peer] is thread
+    receiver._topo_out_wait_queues[peer].put(None)
+    thread.join(timeout=1)
+    assert not thread.is_alive()

--- a/examples/weightbridge/tests/test_query_receivers_metadata.py
+++ b/examples/weightbridge/tests/test_query_receivers_metadata.py
@@ -1,0 +1,94 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""ZMQ coordinator relay (:class:`~wbridge.backend.coordinator.WeightReceiverController`).
+
+Torch/GPU-free: drives the coordinator's relay loop in-process with a mock receiver rank 0 and a mock
+Trainer, over IPC (the trainer-facing ROUTER binds any endpoint string, so no TCP port is needed here).
+Covers: rank 0's WORKER_REGISTER -> world query, and connect/receive forwarding + ack round-trip.
+"""
+
+import json
+import tempfile
+import threading
+
+import pytest
+
+pytest.importorskip("zmq")
+import zmq  # noqa: E402
+from wbridge.backend.control_channel import (  # noqa: E402
+    CONNECT,
+    CONNECT_REQUEST,
+    RECEIVE,
+    RECEIVE_REQUEST,
+    WORKER_REGISTER,
+    WORLD_QUERY,
+)
+from wbridge.backend.coordinator import (  # noqa: E402
+    _coordinator_register_timeout_s,
+    COORDINATOR_REGISTER_TIMEOUT_ENV,
+    WeightReceiverController,
+)
+
+
+def _ipc(suffix: str) -> str:
+    return f"ipc://{tempfile.NamedTemporaryFile(delete=False, suffix=suffix).name}"
+
+
+def test_coordinator_register_timeout_env(monkeypatch):
+    monkeypatch.delenv(COORDINATOR_REGISTER_TIMEOUT_ENV, raising=False)
+    assert _coordinator_register_timeout_s() == 600.0
+
+    monkeypatch.setenv(COORDINATOR_REGISTER_TIMEOUT_ENV, "7200")
+    assert _coordinator_register_timeout_s() == 7200.0
+
+    monkeypatch.setenv(COORDINATOR_REGISTER_TIMEOUT_ENV, "0")
+    with pytest.raises(ValueError, match="must be positive"):
+        _coordinator_register_timeout_s()
+
+
+def test_coordinator_relay():
+    ctx = zmq.Context.instance()
+    wrc = WeightReceiverController(
+        ipc_name=_ipc("_r0"), tcp_endpoint=_ipc("_tr"), ctx=ctx
+    )
+
+    # Mock receiver rank 0: DEALER (identity worker-0). Registers its worker count, then acks every
+    # forwarded control message — mimicking ControlChannel.step's drain+ack.
+    rank0 = ctx.socket(zmq.DEALER)
+    rank0.setsockopt_string(zmq.IDENTITY, "worker-0")
+    rank0.connect(wrc.ipc_name)
+    rank0.send_string(json.dumps({"type": WORKER_REGISTER, "num_workers": 2}))
+
+    def _rank0_acker():
+        while True:
+            msg = json.loads(rank0.recv().decode())
+            if msg.get("type") in (CONNECT_REQUEST, RECEIVE_REQUEST):
+                rank0.send_string(json.dumps({"status": "ack"}))
+
+    threading.Thread(target=_rank0_acker, daemon=True).start()
+    threading.Thread(target=wrc.serve, daemon=True).start()
+
+    tr = ctx.socket(zmq.DEALER)
+    tr.connect(wrc._tcp_endpoint)
+
+    def _req(obj: dict) -> dict:
+        tr.send_string(json.dumps(obj))
+        assert tr.poll(5000), f"no coordinator reply to {obj}"
+        return json.loads(tr.recv().decode())
+
+    assert _req({"type": WORLD_QUERY}) == {"status": "success", "world_size": 2}
+    assert _req({"type": CONNECT, "rank": 8, "world_size": 12})["status"] == "success"
+    assert _req({"type": RECEIVE})["status"] == "success"
+
+    tr.close(linger=0)
+    rank0.close(linger=0)
+    wrc.close()
+
+
+if __name__ == "__main__":
+    test_coordinator_relay()
+    print("test_coordinator_relay passed")

--- a/examples/weightbridge/tests/test_rdma_protocol.py
+++ b/examples/weightbridge/tests/test_rdma_protocol.py
@@ -1,0 +1,445 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for the RDMA data-plane logic that does not need a GPU or Mooncake.
+
+Covers the two pieces of new pure logic:
+
+* :meth:`~wbridge.utils.data.BoundShardSpec.pack_into` matches the allocating ``__getitem__`` path.
+* The flag ping-pong wiring on :class:`~wbridge.backend.router.WBEndpoint` (``_seq`` monotonicity across
+  update epochs, exclusive per-message addressing, and direct async publication) using in-process
+  loopback engines over real same-process addresses.
+
+Run: ``python tests/test_rdma_protocol.py`` or ``pytest tests/test_rdma_protocol.py``.
+"""
+
+import ctypes
+import queue
+import threading
+import time
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from wbridge.backend.rdma.base import RdmaEngine  # noqa: E402
+from wbridge.backend.router import WBEndpoint  # noqa: E402
+from wbridge.backend.sender import _recv_lane_predecessors, WeightSender  # noqa: E402
+from wbridge.utils.data import ShardSpec  # noqa: E402
+
+
+# --------------------------------------------------------------------------- pack_into
+def test_pack_into_matches_getitem():
+    """pack_into writes the same wire bytes as the allocating ``full[{r: dst}][r]`` path."""
+    full = ShardSpec({"a": [[(0, 10, 10)]], "b": [[(0, 6, 6)]]})
+    tensors = {
+        "a": torch.arange(10, dtype=torch.float32),
+        "b": torch.arange(6, dtype=torch.float32) + 100.0,
+    }
+    dst = ShardSpec({"a": [[(2, 6, 10)]], "b": [[(1, 4, 6)]]})  # sub-regions of each
+
+    ref = full(tensors)[{0: dst}][0]  # allocating reference
+
+    nbytes = dst.nbytes({"a": torch.float32, "b": torch.float32})
+    out = torch.zeros(nbytes + 8, dtype=torch.uint8)  # deliberately oversized
+    n = full(tensors).pack_into(dst, out)
+
+    assert n == nbytes
+    assert torch.equal(out[:n], ref)
+
+
+# --------------------------------------------------------------------------- loopback engine
+def test_single_recv_slot_requires_previous_round_ack_per_destination():
+    """Depth one makes each destination's immediately previous contributing round its RECV reuse gate."""
+    pred, final = _recv_lane_predecessors(
+        [[8, 9], [8], [9], [8, 9]],
+        depth=1,
+    )
+    assert pred == [
+        {8: None, 9: None},
+        {8: 0},
+        {9: 0},
+        {8: 1, 9: 2},
+    ]
+    assert final == {(8, 0): 3, (9, 0): 3}
+
+
+class LoopbackEngine(RdmaEngine):
+    """One-sided ``write`` == ``ctypes.memmove`` between same-process addresses (for tests only)."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def init(self, local_host: str, protocol: str, device: str = "") -> None:  # noqa: D401
+        pass
+
+    def session_id(self) -> str:
+        return self._name
+
+    def register(self, ptr: int, size: int) -> None:
+        pass
+
+    def write(self, dst_session, src_ptrs, dst_ptrs, sizes) -> None:
+        for s, d, n in zip(src_ptrs, dst_ptrs, sizes):
+            ctypes.memmove(int(d), int(s), int(n))
+
+    def close(self) -> None:
+        pass
+
+
+class DeferredFlagEngine(LoopbackEngine):
+    """Async loopback whose source bytes are read only by ``wait``.
+
+    Deferring the memcpy makes source-slot reuse observable: the control worker must wait handle N before
+    writing sequence N+1 into the same scratch slot, or both remote writes would incorrectly carry N+1.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self.landed = []
+        self.sync_writes = 0
+
+    def write(self, dst_session, src_ptrs, dst_ptrs, sizes) -> None:
+        self.sync_writes += 1
+        super().write(dst_session, src_ptrs, dst_ptrs, sizes)
+
+    def write_async(self, dst_session, src_ptrs, dst_ptrs, sizes):
+        return tuple(zip(map(int, src_ptrs), map(int, dst_ptrs), map(int, sizes)))
+
+    def wait(self, handles) -> None:
+        for handle in handles:
+            if handle is None:
+                continue
+            for src, dst, size in handle:
+                value = ctypes.c_int64.from_address(src).value
+                ctypes.memmove(dst, src, size)
+                self.landed.append(value)
+
+
+class IndependentCompletionEngine(LoopbackEngine):
+    """Opaque handles are events, allowing a test to complete destinations out of order."""
+
+    def wait(self, handles) -> None:
+        for handle in handles:
+            if handle is not None and not handle.wait(timeout=2.0):
+                raise TimeoutError("test completion was never released")
+
+
+def _make_endpoint(
+    rank: int, peer: int, num_rounds: int, engine: RdmaEngine
+) -> WBEndpoint:
+    ep = WBEndpoint()
+    ep.engine = engine
+    ep._rank = rank
+    ep.num_rounds = num_rounds
+    ep._epoch = 0
+    ep.peers = [peer]
+    ep.flag_slot_of = {peer: 0}
+    ep._flag_buf = torch.zeros(num_rounds, dtype=WBEndpoint._FLAG_DTYPE)
+    ep._flag_src = torch.zeros(num_rounds, dtype=WBEndpoint._FLAG_DTYPE)
+    ep.peer_session = {peer: f"sess-{peer}"}
+    ep._ctlp = False
+    return ep
+
+
+def test_seq_monotonic_across_epochs():
+    ep = WBEndpoint()
+    ep.num_rounds = 3
+    ep._epoch = 0
+    assert [ep._seq(ri) for ri in range(3)] == [1, 2, 3]
+    ep._epoch = 1
+    assert [ep._seq(ri) for ri in range(3)] == [4, 5, 6]
+    # Strictly increasing across the epoch boundary → a stale prior-epoch flag never satisfies a later poll.
+    seqs = []
+    for e in range(3):
+        ep._epoch = e
+        seqs.extend(ep._seq(ri) for ri in range(3))
+    assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs)
+
+
+def test_flag_pingpong_and_data_ordering():
+    """Drive the sender/receiver flag protocol sequentially over a loopback engine, 2 rounds x 2 epochs.
+
+    Because the loopback ``write`` is synchronous, this deterministically exercises the flag addressing,
+    the data-before-flag ordering, and ``_poll_flag``'s ``>=`` comparison across the epoch boundary.
+    """
+    num_rounds = 2
+    eng = LoopbackEngine("shared")
+    sender = _make_endpoint(rank=0, peer=1, num_rounds=num_rounds, engine=eng)
+    receiver = _make_endpoint(rank=1, peer=0, num_rounds=num_rounds, engine=eng)
+
+    # Cross-wire the flag destinations (each writes into the other's incoming slot 0).
+    sender._flag_dst = {1: receiver._flag_buf.data_ptr()}
+    receiver._flag_dst = {0: sender._flag_buf.data_ptr()}
+
+    # A small data buffer per side: sender source, receiver destination (like a 1-peer round).
+    payload_bytes = 16
+    sender._data_buf = {1: torch.zeros(payload_bytes, dtype=torch.uint8)}
+    receiver._data_buf = {0: torch.zeros(payload_bytes, dtype=torch.uint8)}
+    sender._data_dst = {1: receiver._data_buf[0].data_ptr()}
+
+    for epoch in range(2):
+        for ri in range(num_rounds):
+            seq = sender._seq(ri)
+            assert seq == receiver._seq(ri)
+
+            # ---- sender: write data, THEN done flag (ordering guaranteed by sync write) ----
+            pattern = torch.arange(payload_bytes, dtype=torch.uint8) + (
+                epoch * num_rounds + ri
+            )
+            sender._data_buf[1].copy_(pattern)
+            eng.write(
+                "sess-1",
+                [sender._data_buf[1].data_ptr()],
+                [sender._data_dst[1]],
+                [payload_bytes],
+            )
+            sender._write_flag(1, seq)
+
+            # ---- receiver: poll done, consume (data already landed), ack ----
+            receiver._poll_flag(0, seq, timeout_s=5.0)
+            assert torch.equal(receiver._data_buf[0], pattern), (
+                f"data not landed before flag @e{epoch}r{ri}"
+            )
+            receiver._write_flag(0, seq)
+
+            # ---- sender: poll consumed ----
+            sender._poll_flag(1, seq, timeout_s=5.0)
+        sender._epoch += 1
+        receiver._epoch += 1
+
+    assert sender._flag_buf.tolist() == [3, 4]
+    assert receiver._flag_buf.tolist() == [3, 4]
+    sender._flag_reaper_stop()
+    receiver._flag_reaper_stop()
+
+
+def test_async_flags_use_exclusive_round_slots():
+    """Two messages use immutable source/destination words and no shared writer queue."""
+    eng = DeferredFlagEngine("deferred")
+    sender = _make_endpoint(rank=0, peer=1, num_rounds=2, engine=eng)
+    receiver = _make_endpoint(rank=1, peer=0, num_rounds=2, engine=eng)
+    sender._flag_dst = {1: receiver._flag_buf.data_ptr()}
+    try:
+        sender._flag_emit(0, 1, 1)
+        sender._flag_emit(0, 1, 2)
+        deadline = time.time() + 2.0
+        while receiver._flag_buf.tolist() != [1, 2] and time.time() < deadline:
+            time.sleep(0.001)
+        assert eng.landed == [1, 2]
+        assert eng.sync_writes == 0
+        assert sender._flag_src.tolist() == [1, 2]
+        assert receiver._flag_buf.tolist() == [1, 2]
+        assert not hasattr(sender, "_ctl_thread")
+    finally:
+        sender._flag_reaper_stop()
+
+
+def test_async_flag_reaper_delivers_without_a_later_write_or_epoch_flush():
+    """A peer may block on the first flag; the off-path reaper must retire it independently."""
+    eng = DeferredFlagEngine("first-flag")
+    sender = _make_endpoint(rank=0, peer=1, num_rounds=1, engine=eng)
+    receiver = _make_endpoint(rank=1, peer=0, num_rounds=1, engine=eng)
+    sender._flag_dst = {1: receiver._flag_buf.data_ptr()}
+    try:
+        sender._flag_emit(0, 1, 1)
+        deadline = time.time() + 2.0
+        while int(receiver._flag_buf[0].item()) < 1 and time.time() < deadline:
+            time.sleep(0.001)
+        assert int(receiver._flag_buf[0].item()) == 1
+        assert eng.landed == [1]
+        assert eng.sync_writes == 0
+    finally:
+        sender._flag_reaper_stop()
+
+
+def test_sender_peer_waiters_publish_data_ready_independently():
+    """A blocked peer completion must not delay another peer's DATA-ready publication."""
+    sender = WeightSender.__new__(WeightSender)
+    sender._rank = 0
+    sender.engine = IndependentCompletionEngine("independent")
+    sender._wire_wait_queues = {}
+    sender._wire_wait_threads = {}
+    sender._wire_wait_lock = threading.Lock()
+    sender._trace_state = lambda *args, **kwargs: None
+    published = []
+    publish_cv = threading.Condition()
+
+    def publish(kind, peer, seq):
+        with publish_cv:
+            published.append((peer, seq, time.perf_counter()))
+            publish_cv.notify_all()
+
+    sender._flag_emit = publish
+    result_q = queue.Queue()
+    slow = threading.Event()
+    fast = threading.Event()
+    sender._ensure_wire_waiters({8, 9})
+    now = time.time()
+    try:
+        sender._wire_wait_queues[8].put((0, 2, 3, slow, now, now, False, result_q))
+        sender._wire_wait_queues[9].put((0, 2, 3, fast, now, now, False, result_q))
+        released_at = time.perf_counter()
+        fast.set()
+        with publish_cv:
+            publish_cv.wait_for(
+                lambda: any(peer == 9 for peer, _seq, _t in published), timeout=1.0
+            )
+        assert any(peer == 9 for peer, _seq, _t in published)
+        assert not any(peer == 8 for peer, _seq, _t in published)
+        fast_published_at = next(t for peer, _seq, t in published if peer == 9)
+        assert fast_published_at - released_at < 0.1
+
+        slow.set()
+        with publish_cv:
+            publish_cv.wait_for(
+                lambda: any(peer == 8 for peer, _seq, _t in published), timeout=1.0
+            )
+        assert {result_q.get(timeout=1.0)[0] for _ in range(2)} == {8, 9}
+    finally:
+        slow.set()
+        fast.set()
+        sender._stop_wire_waiters()
+
+
+def test_direct_async_ready_flag_addressing():
+    """Kind-1 writes must use the replica-ready source/destination rather than the sender ACK channel."""
+    eng = DeferredFlagEngine("ready")
+    ep = _make_endpoint(rank=1, peer=2, num_rounds=1, engine=eng)
+    remote_ready = torch.zeros(1, dtype=WBEndpoint._FLAG_DTYPE)
+    ep._repl_flag_slot_of = {2: 0}
+    ep._repl_flag_src = torch.zeros(ep.num_rounds, dtype=WBEndpoint._FLAG_DTYPE)
+    ep._repl_peer_session = {2: "sess-2"}
+    ep._repl_flag_dst = {2: remote_ready.data_ptr()}
+    try:
+        ep._flag_emit(1, 2, 7)
+        deadline = time.time() + 2.0
+        while int(remote_ready[0].item()) != 7 and time.time() < deadline:
+            time.sleep(0.001)
+        assert eng.landed == [7]
+        assert eng.sync_writes == 0
+        assert int(remote_ready[0].item()) == 7
+    finally:
+        ep._flag_reaper_stop()
+
+
+def test_copyplan_reuse():
+    """A cached CopyPlan re-reads current source data on each run() (incl. a transposed segment)."""
+    from wbridge.utils.data import CopyPlan
+
+    d = "cuda"
+    src = torch.randn(64, 32, device=d)
+    dst = torch.zeros(64, 32, device=d)
+    src_t = torch.randn(20, 10, device=d)  # transposed segment: src_t.t() -> dst_t
+    dst_t = torch.zeros(10, 20, device=d)
+    plan = CopyPlan([(dst, src), (dst_t, src_t.t())])
+    plan.run()
+    torch.cuda.synchronize()
+    assert torch.equal(dst, src) and torch.equal(dst_t, src_t.t().contiguous()), (
+        "first run wrong"
+    )
+    # mutate sources IN PLACE, replay the SAME plan: dst must reflect the new values (reuse invariant)
+    src.copy_(torch.randn(64, 32, device=d))
+    src_t.copy_(torch.randn(20, 10, device=d))
+    plan.run()
+    torch.cuda.synchronize()
+    assert torch.equal(dst, src) and torch.equal(dst_t, src_t.t().contiguous()), (
+        "reuse run wrong"
+    )
+
+
+def test_copyplan_single_kernel_mixes_flat_and_transposed_segments():
+    """Internal consume must preserve one launch per peer even when its model mappings mix layouts."""
+    from wbridge.utils.data import CopyPlan
+
+    d = "cuda"
+    src = torch.randn(64, 32, device=d)
+    dst = torch.zeros_like(src)
+    src_t = torch.randn(20, 10, device=d)
+    dst_t = torch.zeros(10, 20, device=d)
+    plan = CopyPlan([(dst, src), (dst_t, src_t.t())], single_kernel=True)
+    assert plan.launch_count == 1
+    plan.run()
+    torch.cuda.synchronize()
+    assert torch.equal(dst, src)
+    assert torch.equal(dst_t, src_t.t().contiguous())
+
+
+def test_copyplan_unifies_mixed_layouts_once_per_dtype():
+    """A consume lane with BF16 weights and FP32 norms needs exactly two unified launches."""
+    from wbridge.utils.data import CopyPlan
+
+    src_bf16 = torch.randn(64, 32, device="cuda", dtype=torch.bfloat16)
+    dst_bf16 = torch.zeros_like(src_bf16)
+    src_f32 = torch.randn(20, 10, device="cuda", dtype=torch.float32)
+    dst_f32 = torch.zeros(10, 20, device="cuda", dtype=torch.float32)
+    plan = CopyPlan(
+        [(dst_bf16, src_bf16), (dst_f32, src_f32.t())],
+        unified_dtype_kernels=True,
+    )
+
+    assert plan.launch_count == 2
+    plan.run()
+    torch.cuda.synchronize()
+    assert torch.equal(dst_bf16, src_bf16)
+    assert torch.equal(dst_f32, src_f32.t().contiguous())
+
+
+def test_copyplan_locally_converts_dtype():
+    """The two-stage sender fallback casts BF16 model values into an FP32 wire view."""
+    from wbridge.utils.data import CopyPlan
+
+    src_bf16 = torch.randn(128, device="cuda", dtype=torch.bfloat16)
+    dst_f32 = torch.zeros(128, device="cuda", dtype=torch.float32)
+    src_f32 = torch.randn(128, device="cuda", dtype=torch.float32)
+    dst_bf16 = torch.zeros(128, device="cuda", dtype=torch.bfloat16)
+    plan = CopyPlan([(dst_f32, src_bf16), (dst_bf16, src_f32)])
+
+    assert plan.launch_count == 2
+    plan.run()
+    torch.cuda.synchronize()
+    assert torch.equal(dst_f32, src_bf16.float())
+    assert torch.equal(dst_bf16, src_f32.bfloat16())
+
+
+def test_copyplan_rebinds_epoch_scratch_source():
+    """A cached A+R descriptor plan may follow a newly allocated non-RDMA scratch base each epoch."""
+    from wbridge.utils.data import CopyPlan
+
+    template = torch.zeros(1024, dtype=torch.uint8, device="cuda")
+    actual = (
+        torch.arange(1024, dtype=torch.int32, device="cuda")
+        .remainder(251)
+        .to(torch.uint8)
+    )
+    dst = torch.zeros_like(actual)
+    plan = CopyPlan(
+        [(dst, template)],
+        source_region=(template.data_ptr(), template.numel()),
+    )
+    plan.rebase_sources(actual.data_ptr())
+    plan.run()
+    torch.cuda.synchronize()
+    assert torch.equal(dst, actual)
+
+
+if __name__ == "__main__":
+    test_pack_into_matches_getitem()
+    print("PASS test_pack_into_matches_getitem")
+    test_seq_monotonic_across_epochs()
+    print("PASS test_seq_monotonic_across_epochs")
+    test_flag_pingpong_and_data_ordering()
+    print("PASS test_flag_pingpong_and_data_ordering")
+    test_async_flags_use_exclusive_round_slots()
+    print("PASS test_async_flags_use_exclusive_round_slots")
+    test_direct_async_ready_flag_addressing()
+    print("PASS test_direct_async_ready_flag_addressing")
+    if torch.cuda.is_available():
+        test_copyplan_reuse()
+        print("PASS test_copyplan_reuse")
+    else:
+        print("SKIP test_copyplan_reuse (no CUDA)")
+    print("ALL RDMA PROTOCOL UNIT TESTS PASSED")

--- a/examples/weightbridge/tests/test_receive_trigger.py
+++ b/examples/weightbridge/tests/test_receive_trigger.py
@@ -1,0 +1,142 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""CPU-only state-machine tests for the data-driven receiver KICK/GO protocol."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from wbridge.backend.control_channel import (  # noqa: E402
+    EMPTY,
+    RECEIVE_KICK,
+    RECEIVE_REQUEST,
+)
+from wbridge.backend.receiver import WeightReceiver  # noqa: E402
+from wbridge.backend.sender import _receiver_rank_has_input  # noqa: E402
+from wbridge.utils.data import ShardSpec  # noqa: E402
+
+
+def _receiver(round_peers: list[list[int]]) -> WeightReceiver:
+    r = WeightReceiver.__new__(WeightReceiver)
+    r.router = SimpleNamespace(
+        local_rounds=[(None, {p: object() for p in peers}) for peers in round_peers]
+    )
+    r.num_rounds = len(round_peers)
+    r._epoch = 0
+    peers = sorted({p for ps in round_peers for p in ps})
+    r.flag_slot_of = {p: i for i, p in enumerate(peers)}
+    r._flag_buf = torch.zeros(max(len(peers), 1) * r.num_rounds, dtype=torch.int64)
+    r._connected = True
+    r._rs_cv = threading.Condition()
+    r._rs_err = None
+    r._rs_kicked = -1
+    r._rs_staged = -1
+    r._rs_gpu_ready = -1
+    return r
+
+
+def test_first_active_input_requires_every_contributing_sender():
+    r = _receiver([[], [3, 5]])
+    assert r._first_active_round() == 1
+    assert not r._sender_input_ready(0)
+
+    # epoch 0, global round 1 => sequence 2. One contributor is not sufficient.
+    slot3, _ = r._flag_message_slot(r.flag_slot_of[3], 2)
+    slot5, _ = r._flag_message_slot(r.flag_slot_of[5], 2)
+    r._flag_buf[slot3] = 2
+    assert not r._sender_input_ready(0)
+    r._flag_buf[slot5] = 2
+    assert r._sender_input_ready(0)
+
+    # A prior epoch's sequence cannot wake the next update (epoch 1 wants sequence 4).
+    assert not r._sender_input_ready(1)
+    r._flag_buf[:] = 4
+    assert r._sender_input_ready(1)
+
+
+def test_direct_rank0_go_is_driven_by_gpu_ingress_flag():
+    r = _receiver([[2]])
+    assert r._rank0_decision(None, staged=False)["type"] == EMPTY
+    slot, _ = r._flag_message_slot(r.flag_slot_of[2], 1)
+    r._flag_buf[slot] = 1
+    decision = r._rank0_decision(None, staged=False)
+    assert decision == {"type": RECEIVE_REQUEST, "epoch": 0}
+
+
+def test_rs_cpu_flag_kicks_then_local_gpu_flag_goes():
+    r = _receiver([[2]])
+    assert r._rank0_decision(None, staged=True)["type"] == EMPTY
+
+    # Trainer->CPU data-before-flag starts the background receive, but is not GO.
+    slot, _ = r._flag_message_slot(r.flag_slot_of[2], 1)
+    r._flag_buf[slot] = 1
+    assert r._rank0_decision(None, staged=True) == {"type": RECEIVE_KICK, "epoch": 0}
+    assert r._rank0_decision(None, staged=True)["type"] == EMPTY
+
+    # Only the completed CPU->GPU first-round flag authorizes rank 0's GO.
+    r._rs_staged = 0
+    assert r._rank0_decision(None, staged=True)["type"] == EMPTY
+    r._rs_gpu_ready = 0
+    assert r._rank0_decision(None, staged=True) == {"type": RECEIVE_REQUEST, "epoch": 0}
+
+
+def test_zero_input_rank_accepts_legacy_doorbell_only_as_fallback():
+    r = _receiver([[], []])
+    fallback = {"type": RECEIVE_REQUEST}
+    assert r._rank0_decision(None, staged=False)["type"] == EMPTY
+    assert r._rank0_decision(fallback, staged=False) == {
+        "type": RECEIVE_REQUEST,
+        "epoch": 0,
+    }
+    assert r._rank0_decision(fallback, staged=True) == {
+        "type": RECEIVE_KICK,
+        "epoch": 0,
+    }
+
+
+def test_rs_worker_finishes_all_cpu_receive_before_first_h2d():
+    r = _receiver([[2]])
+    r._rank = 9
+    r._stop = False
+    r._rs_go = 0
+    order: list[str] = []
+
+    def receive_all(epoch: int) -> None:
+        assert epoch == 0
+        order.append("cpu_all")
+
+    def stage_first(epoch: int) -> None:
+        assert epoch == 0
+        assert order == ["cpu_all"]
+        order.append("first_h2d")
+        r._stop = True
+
+    r._receive_to_cpu = receive_all
+    r._rs_stage_first_to_gpu = stage_first
+    r._trace_state = lambda *_args, **_kwargs: None
+
+    th = threading.Thread(target=r._recv_worker)
+    th.start()
+    th.join(timeout=5)
+    assert not th.is_alive()
+    assert order == ["cpu_all", "first_h2d"]
+    assert r._rs_staged == 0
+    assert r._rs_gpu_ready == 0
+
+
+def test_zero_input_fallback_classification_uses_deduplicated_specs():
+    src = ShardSpec({"a": [[(0, 8, 8)]]})
+    hit = ShardSpec({"a": [[(2, 4, 8)]]})
+    miss = ShardSpec({"b": [[(0, 1, 1)]]})
+    router = SimpleNamespace(send_specs=[src], recv_specs=[hit, miss])
+    assert _receiver_rank_has_input(router, 0)
+    assert not _receiver_rank_has_input(router, 1)

--- a/examples/weightbridge/tests/test_receiver_poll_requests.py
+++ b/examples/weightbridge/tests/test_receiver_poll_requests.py
@@ -1,0 +1,74 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from types import MethodType, SimpleNamespace
+
+from wbridge.backend.control_channel import CONNECT_REQUEST, RECEIVE_REQUEST
+from wbridge.backend.receiver import WeightReceiver
+from wbridge.frontend.adapters import ReceiverAdapter
+
+
+def _receiver_for(decision: dict | None, calls: list[object]) -> WeightReceiver:
+    receiver = WeightReceiver.__new__(WeightReceiver)
+    receiver._pending = None
+
+    def is_update_ready(self) -> bool:
+        calls.append("poll")
+        self._pending = decision
+        return decision is not None
+
+    def request_update(self) -> bool:
+        calls.append("execute")
+        current = self._pending
+        self._pending = None
+        return current is not None and current.get("type") == RECEIVE_REQUEST
+
+    receiver.is_update_ready = MethodType(is_update_ready, receiver)
+    receiver.request_update = MethodType(request_update, receiver)
+    return receiver
+
+
+def test_empty_poll_returns_false_without_executing_or_calling_hook() -> None:
+    calls: list[object] = []
+    receiver = _receiver_for(None, calls)
+
+    assert receiver.poll_requests(lambda epoch: calls.append(("hook", epoch))) is False
+    assert calls == ["poll"]
+
+
+def test_connect_executes_without_calling_receive_hook() -> None:
+    calls: list[object] = []
+    receiver = _receiver_for({"type": CONNECT_REQUEST}, calls)
+
+    assert receiver.poll_requests(lambda epoch: calls.append(("hook", epoch))) is False
+    assert calls == ["poll", "execute"]
+
+
+def test_receive_calls_hook_before_execution_and_returns_true() -> None:
+    calls: list[object] = []
+    receiver = _receiver_for({"type": RECEIVE_REQUEST, "epoch": 7}, calls)
+
+    assert receiver.poll_requests(lambda epoch: calls.append(("hook", epoch))) is True
+    assert calls == ["poll", ("hook", 7), "execute"]
+
+
+def test_receiver_adapter_exposes_only_the_unified_poll_surface() -> None:
+    calls: list[object] = []
+    adapter = ReceiverAdapter.__new__(ReceiverAdapter)
+    adapter.receiver = SimpleNamespace(
+        poll_requests=lambda before_receive=None: (
+            calls.append(before_receive),
+            True,
+        )[1]
+    )
+    hook = lambda _epoch: None
+
+    assert adapter.poll_requests(before_receive=hook) is True
+    assert calls == [hook]
+    assert not hasattr(ReceiverAdapter, "is_update_ready")
+    assert not hasattr(ReceiverAdapter, "request_update")

--- a/examples/weightbridge/tests/test_replica_relay.py
+++ b/examples/weightbridge/tests/test_replica_relay.py
@@ -1,0 +1,299 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import threading
+import time
+
+import torch
+from wbridge.backend.receiver import WeightReceiver
+from wbridge.backend.router import _relay_round_predecessors, WBEndpoint, WeightRouter
+from wbridge.utils.data import ShardSpec
+
+
+def _spec(**entries):
+    return ShardSpec(
+        {
+            name: [[(left, right, width), (0, 4, 4)]]
+            for name, (left, right, width) in entries.items()
+        }
+    )
+
+
+def test_relay_selects_one_owner_per_node_and_preserves_full_group(monkeypatch):
+    monkeypatch.setenv("WBRIDGE_DEDUP_PAIR_BYTES", "0")
+    senders = [
+        _spec(weight=(0, 4, 8)),
+        _spec(weight=(4, 8, 8)),
+    ]
+    receivers = [_spec(weight=(0, 8, 8)) for _ in range(4)]
+    router = WeightRouter(
+        0,
+        2,
+        senders + receivers,
+        {"weight": torch.float32},
+        global_rounds=[{"weight"}],
+    )
+    placement = {
+        0: "trainer",
+        1: "trainer",
+        2: "node-a",
+        3: "node-a",
+        4: "node-b",
+        5: "node-b",
+    }
+
+    assert router.configure_relay(placement)
+    assert len(router._relay_groups) == 1
+    group = router.relay_group(0)
+    assert group["members"] == (0, 1, 2, 3)
+    assert group["owners"] == (0, 2)
+    assert group["chain"] == (2, 4)
+    assert group["owner_of"] == {0: 0, 1: 0, 2: 2, 3: 2}
+    assert group["local_readers"] == {0: (0, 1), 2: (2, 3)}
+    assert group["round_specs"][0].nbytes(router.dtype_spec) == 8 * 4 * 4
+    assert {
+        rank: spec.nbytes(router.dtype_spec)
+        for rank, spec in group["trainer_specs"][0].items()
+    } == {0: 4 * 4 * 4, 1: 4 * 4 * 4}
+
+
+def test_relay_coalesces_names_by_replica_membership(monkeypatch):
+    monkeypatch.setenv("WBRIDGE_DEDUP_PAIR_BYTES", "0")
+    sender = _spec(a=(0, 4, 4), b=(0, 4, 4))
+    receivers = [
+        _spec(a=(0, 4, 4), b=(0, 4, 4)),
+        _spec(a=(0, 4, 4)),
+        _spec(a=(0, 4, 4), b=(0, 4, 4)),
+        _spec(a=(0, 4, 4)),
+    ]
+    router = WeightRouter(
+        0,
+        1,
+        [sender] + receivers,
+        {"a": torch.float32, "b": torch.float32},
+        global_rounds=[{"a"}, {"b"}],
+    )
+    placement = {0: "trainer", 1: "node-a", 2: "node-a", 3: "node-b", 4: "node-b"}
+
+    assert router.configure_relay(placement)
+    by_members = {group["members"]: group for group in router._relay_groups}
+    assert set(by_members) == {(0, 1, 2, 3), (0, 2)}
+    assert by_members[(0, 1, 2, 3)]["names"] == ("a",)
+    assert by_members[(0, 2)]["names"] == ("b",)
+    assert by_members[(0, 2)]["chain"] == (1, 3)
+    assert not by_members[(0, 2)]["round_specs"][0].entries
+    assert by_members[(0, 2)]["round_specs"][1].entries
+
+
+def test_relay_inf_piggybacks_wide_group_onto_existing_replica_groups(monkeypatch):
+    monkeypatch.setenv("WBRIDGE_DEDUP_PAIR_BYTES", "inf")
+    sender = _spec(a=(0, 4, 4), b=(0, 4, 4), c=(0, 4, 4))
+    receivers = [
+        _spec(a=(0, 4, 4), b=(0, 4, 4)),
+        _spec(a=(0, 4, 4), c=(0, 4, 4)),
+        _spec(a=(0, 4, 4), b=(0, 4, 4)),
+        _spec(a=(0, 4, 4), c=(0, 4, 4)),
+    ]
+    router = WeightRouter(
+        0,
+        1,
+        [sender] + receivers,
+        {"a": torch.float32, "b": torch.float32, "c": torch.float32},
+        global_rounds=[{"a", "b", "c"}],
+    )
+    placement = {
+        0: "trainer",
+        1: "node-a",
+        2: "node-a",
+        3: "node-b",
+        4: "node-b",
+    }
+
+    assert router.configure_relay(placement)
+    by_members = {group["members"]: group for group in router._relay_groups}
+    assert set(by_members) == {(0, 2), (1, 3)}
+    assert set(by_members[(0, 2)]["names"]) == {"a", "b"}
+    assert set(by_members[(1, 3)]["names"]) == {"a", "c"}
+
+
+def test_relay_control_token_roundtrip_and_slot():
+    endpoint = WBEndpoint.__new__(WBEndpoint)
+    endpoint._relay_num_groups = 9
+    endpoint.num_rounds = 16
+    endpoint.world_size = 24
+
+    token = endpoint._encode_relay_token(7, 12345)
+    assert endpoint._decode_relay_token(token) == (7, 12345)
+    assert endpoint._relay_flag_slot(11, 7, 12345) == (
+        (11 * 9 + 7) * 16 + (12345 - 1) % 16
+    )
+
+
+def test_relay_round_dependencies_order_operations_and_reuse_exact_parity():
+    assert _relay_round_predecessors([0, 1, 2, 4, 5, 8], depth=2) == {
+        0: (None, None),
+        1: (0, None),
+        2: (1, 0),
+        4: (2, 2),
+        5: (4, 1),
+        8: (5, 4),
+    }
+
+
+def test_relay_rollout_rdma_bytes_matches_depth2_owner_layout(monkeypatch):
+    monkeypatch.setenv("WBRIDGE_DEDUP_PAIR_BYTES", "0")
+    senders = [
+        _spec(weight=(0, 4, 8)),
+        _spec(weight=(4, 8, 8)),
+    ]
+    receivers = [_spec(weight=(0, 8, 8)) for _ in range(4)]
+    router = WeightRouter(
+        0,
+        2,
+        senders + receivers,
+        {"weight": torch.float32},
+        global_rounds=[{"weight"}],
+    )
+    placement = {
+        0: "trainer",
+        1: "trainer",
+        2: "node-a",
+        3: "node-a",
+        4: "node-b",
+        5: "node-b",
+    }
+
+    # One 128-byte canonical payload. Each node owner now registers only depth-2 PREP: 128+1 bytes because
+    # the unused parity retains the implementation's one-byte allocation. DOFF is non-RDMA. Every rollout
+    # worker registers four 6-rank x 1-group x 1-round int64 control banks (192 bytes).
+    assert router.relay_rollout_rdma_bytes(placement) == [321, 192, 321, 192]
+
+
+def test_relay_downstream_engine_bootstraps_from_predecessor_data():
+    spec = _spec(weight=(0, 8, 8))
+    group = {
+        "chain": (8, 16),
+        "round_specs": [spec, ShardSpec({})],
+        "trainer_specs": [{0: spec}, {}],
+    }
+
+    class _Router:
+        @staticmethod
+        def relay_group(gid):
+            assert gid == 3
+            return group
+
+    receiver = WeightReceiver.__new__(WeightReceiver)
+    receiver._relay_enabled = True
+    receiver._relay_owned_gids = (3,)
+    receiver.router = _Router()
+    receiver._rank = 16
+    receiver.num_rounds = 2
+    observed = []
+
+    def reached(kind, peer, gid, seq):
+        observed.append((kind, peer, gid, seq))
+        return True
+
+    receiver._relay_flag_reached = reached
+
+    assert receiver._sender_input_ready(epoch=4)
+    assert observed == [(receiver._RELAY_DATA_KIND, 8, 3, 9)]
+
+
+def test_relay_local_exit_ignores_downstream_and_other_local_readers():
+    owner_states = {
+        (0, 0): {
+            "relay_done": True,
+            "local_consumed": False,
+            "prep_free": False,
+            "upstream_done": False,
+        },
+    }
+    consume_states = {(0, 0): {"done": True}}
+
+    assert WeightReceiver._relay_local_exit_ready(owner_states, consume_states)
+    owner_states[(0, 0)]["relay_done"] = False
+    assert not WeightReceiver._relay_local_exit_ready(owner_states, consume_states)
+    owner_states[(0, 0)]["relay_done"] = True
+    consume_states[(0, 0)]["done"] = False
+    assert not WeightReceiver._relay_local_exit_ready(owner_states, consume_states)
+
+
+def test_relay_retirement_polls_tasks_independently_and_preserves_delivery():
+    receiver = WeightReceiver.__new__(WeightReceiver)
+    receiver._rank = 10
+    receiver._relay_local_readers = {}
+    receiver._relay_local_channel = {}
+    receiver._relay_local_slot_of = {}
+    receiver._relay_retire_lock = threading.Lock()
+    receiver._relay_retire_q = None
+    receiver._relay_retire_thread = None
+    receiver._relay_retire_errors = []
+    receiver._relay_prep_released = {}
+    receiver._relay_doff_released = {}
+    receiver._relay_doff_depth = 1
+
+    ready = {(21, 1, 8)}
+    observed = []
+    observed_cv = threading.Condition()
+
+    def reached(_kind, peer, gid, seq):
+        return (peer, gid, seq) in ready
+
+    def emit(kind, peer, gid, seq):
+        with observed_cv:
+            observed.append((kind, peer, gid, seq))
+            observed_cv.notify_all()
+
+    receiver._relay_flag_reached = reached
+    receiver._relay_emit = emit
+    receiver._trace_state = lambda *_args, **_kwargs: None
+
+    def wait_for(count):
+        deadline = time.monotonic() + 2.0
+        with observed_cv:
+            while len(observed) < count:
+                remaining = deadline - time.monotonic()
+                assert remaining > 0
+                observed_cv.wait(remaining)
+
+    try:
+        receiver._defer_relay_retirement(
+            [
+                {
+                    "wt": 0,
+                    "gid": 0,
+                    "ri": 0,
+                    "seq": 7,
+                    "succ": 20,
+                    "upstream_peers": (3,),
+                    "doff_released": False,
+                },
+                {
+                    "wt": 0,
+                    "gid": 1,
+                    "ri": 1,
+                    "seq": 8,
+                    "succ": 21,
+                    "upstream_peers": (4, 5),
+                    "doff_released": False,
+                },
+            ]
+        )
+        wait_for(2)
+        assert observed == [
+            (receiver._RELAY_DATA_KIND, 4, 1, 8),
+            (receiver._RELAY_DATA_KIND, 5, 1, 8),
+        ]
+        assert receiver._relay_doff_was_released(0, 0, 7)
+        assert receiver._relay_doff_was_released(1, 1, 8)
+
+        ready.add((20, 0, 7))
+        wait_for(3)
+        assert observed[-1] == (receiver._RELAY_DATA_KIND, 3, 0, 7)
+    finally:
+        receiver._stop_relay_retire_worker()

--- a/examples/weightbridge/tests/test_shard_compatibility.py
+++ b/examples/weightbridge/tests/test_shard_compatibility.py
@@ -1,0 +1,400 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for _check_shard_compatibility, ShardSpec.compute_overlap, and BoundShardSpec pack/unpack."""
+
+import torch
+from wbridge.utils.data import _check_shard_compatibility, ShardSpec
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_shard_spec(shard):
+    """Single-entry :class:`~wbridge.utils.data.ShardSpec` (one tensor name)."""
+    return ShardSpec(
+        {
+            "weight": [shard],
+        }
+    )
+
+
+def _tensor_for_shard(shard, dtype=torch.float32):  # torch dtype for tensors
+    numel = 1
+    for l, r, w in shard:
+        numel *= r - l
+    return torch.arange(numel, dtype=dtype).reshape(tuple(r - l for l, r, w in shard))
+
+
+def _alignment_shards(alignment):
+    """Split the production alignment tuples into the two equivalent shard views used in assertions."""
+    return (
+        [(sl, sr, width) for sl, sr, _rl, _rr, width in alignment],
+        [(rl, rr, width) for _sl, _sr, rl, rr, width in alignment],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _check_shard_compatibility tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckShardCompatibility:
+    """Unit tests for _check_shard_compatibility."""
+
+    def test_same_dims(self):
+        """Identical dimensionality and widths — returned as-is."""
+        s = [(0, 4, 4), (0, 6, 6)]
+        r = [(2, 3, 4), (1, 5, 6)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert aligned_s == [(0, 4, 4), (0, 6, 6)]
+        assert aligned_r == [(2, 3, 4), (1, 5, 6)]
+
+    def test_sender_flat_receiver_split(self):
+        """Sender has 1 dim, receiver has 2 — sender gets split."""
+        s = [(0, 24, 24)]
+        r = [(0, 4, 4), (0, 6, 6)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [4, 6]
+        assert [w for _, _, w in aligned_r] == [4, 6]
+        assert aligned_s == [(0, 4, 4), (0, 6, 6)]
+        assert aligned_r == [(0, 4, 4), (0, 6, 6)]
+
+    def test_receiver_flat_sender_split(self):
+        """Receiver has 1 dim, sender has 2 — receiver gets split."""
+        s = [(0, 4, 4), (0, 6, 6)]
+        r = [(0, 24, 24)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert aligned_s == [(0, 4, 4), (0, 6, 6)]
+        assert aligned_r == [(0, 4, 4), (0, 6, 6)]
+
+    def test_sender_flat_partial_full_inner(self):
+        """Sender 1D range spans full rows — splits cleanly."""
+        s = [(6, 12, 24)]
+        r = [(0, 4, 4), (0, 6, 6)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert aligned_s == [(1, 2, 4), (0, 6, 6)]
+        assert aligned_r == [(0, 4, 4), (0, 6, 6)]
+
+    def test_sender_flat_single_row(self):
+        """Sender 1D range fits within one row — single-row split."""
+        s = [(1, 5, 24)]
+        r = [(0, 4, 4), (0, 6, 6)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert aligned_s == [(0, 1, 4), (1, 5, 6)]
+        assert aligned_r == [(0, 4, 4), (0, 6, 6)]
+
+    def test_receiver_flat_single_row(self):
+        """Receiver 1D range fits within one row — single-row split."""
+        s = [(0, 4, 4), (0, 6, 6)]
+        r = [(7, 11, 24)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert aligned_s == [(0, 4, 4), (0, 6, 6)]
+        assert aligned_r == [(1, 2, 4), (1, 5, 6)]
+
+    def test_multi_level_split(self):
+        """Sender 1D, receiver 3D — requires cascaded splitting."""
+        s = [(4, 8, 24)]
+        r = [(0, 2, 2), (0, 3, 3), (0, 4, 4)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [2, 3, 4]
+        assert aligned_s == [(0, 1, 2), (1, 2, 3), (0, 4, 4)]
+        assert aligned_r == [(0, 2, 2), (0, 3, 3), (0, 4, 4)]
+
+    def test_incompatible_spans_multiple_rows(self):
+        """Range spans multiple non-complete rows — not a rectangle."""
+        s = [(5, 13, 24)]
+        r = [(0, 4, 4), (0, 6, 6)]
+        assert _check_shard_compatibility(s, r) is None
+
+    def test_incompatible_not_divisible(self):
+        """Width not divisible — no valid split."""
+        s = [(0, 10, 12)]
+        r = [(0, 3, 3), (0, 4, 4)]
+        assert _check_shard_compatibility(s, r) is None
+
+    def test_both_partial(self):
+        """Both sides have partial ranges, same dims."""
+        s = [(1, 3, 4), (2, 5, 6)]
+        r = [(2, 4, 4), (0, 4, 6)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert aligned_s == [(1, 3, 4), (2, 5, 6)]
+        assert aligned_r == [(2, 4, 4), (0, 4, 6)]
+
+    def test_sender_3d_receiver_1d(self):
+        """Sender 3D, receiver 1D — receiver gets fully split."""
+        s = [(0, 2, 2), (0, 3, 3), (0, 4, 4)]
+        r = [(0, 24, 24)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert aligned_s == [(0, 2, 2), (0, 3, 3), (0, 4, 4)]
+        assert aligned_r == [(0, 2, 2), (0, 3, 3), (0, 4, 4)]
+
+    def test_single_dim_identical(self):
+        """Single dimension on both sides."""
+        s = [(2, 7, 10)]
+        r = [(4, 9, 10)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert aligned_s == [(2, 7, 10)]
+        assert aligned_r == [(4, 9, 10)]
+
+    # --- alignment failures ---
+
+    def test_fail_transposed_dims(self):
+        """4×3 vs 3×4 — coprime first widths, incompatible."""
+        s = [(0, 4, 4), (0, 3, 3)]
+        r = [(0, 3, 3), (0, 4, 4)]
+        assert _check_shard_compatibility(s, r) is None
+
+    def test_fail_coprime_first_dims(self):
+        """3×8 vs 4×6 — first widths 3 and 4 share no factor."""
+        s = [(0, 3, 3), (0, 8, 8)]
+        r = [(0, 4, 4), (0, 6, 6)]
+        assert _check_shard_compatibility(s, r) is None
+
+    def test_fail_receiver_spans_multiple_rows(self):
+        """Receiver 1D range crosses row boundaries non-rectangularly."""
+        s = [(0, 3, 3), (0, 4, 4)]
+        r = [(1, 11, 12)]
+        assert _check_shard_compatibility(s, r) is None
+
+    def test_fail_inner_range_not_rectangular(self):
+        """Outer split succeeds but the inner remainder can't align."""
+        s = [(2, 6, 8), (0, 3, 3)]
+        r = [(0, 4, 4), (1, 5, 6)]
+        assert _check_shard_compatibility(s, r) is None
+
+    def test_fail_sender_nonrect_in_3d(self):
+        """1D range [10,20) can't form a rectangle in a 2×3×4 grid."""
+        s = [(10, 20, 24)]
+        r = [(0, 2, 2), (0, 3, 3), (0, 4, 4)]
+        assert _check_shard_compatibility(s, r) is None
+
+    def test_fail_width_not_divisible_deep(self):
+        """Sender 10×3 vs receiver 6×5 — 10%6≠0."""
+        s = [(0, 10, 10), (0, 3, 3)]
+        r = [(0, 6, 6), (0, 5, 5)]
+        assert _check_shard_compatibility(s, r) is None
+
+    def test_fail_partial_receiver_in_complex_split(self):
+        """3×2×4 vs 6×4 — receiver partial range [2,5) on dim0."""
+        s = [(1, 3, 3), (0, 2, 2), (1, 3, 4)]
+        r = [(2, 5, 6), (0, 4, 4)]
+        assert _check_shard_compatibility(s, r) is None
+
+    # --- complex multi-dimensional alignment ---
+
+    def test_4x6_vs_2x4x3(self):
+        """4×6 and 2×4×3 — common refinement is 2×2×2×3."""
+        s = [(0, 4, 4), (0, 6, 6)]
+        r = [(0, 2, 2), (0, 4, 4), (0, 3, 3)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [2, 2, 2, 3]
+        assert [w for _, _, w in aligned_r] == [2, 2, 2, 3]
+        assert aligned_s == [(0, 2, 2), (0, 2, 2), (0, 2, 2), (0, 3, 3)]
+        assert aligned_r == [(0, 2, 2), (0, 2, 2), (0, 2, 2), (0, 3, 3)]
+
+    def test_4x6_vs_2x12(self):
+        """4×6 and 2×12 — common refinement is 2×2×6."""
+        s = [(0, 4, 4), (0, 6, 6)]
+        r = [(0, 2, 2), (0, 12, 12)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [2, 2, 6]
+        assert aligned_s == [(0, 2, 2), (0, 2, 2), (0, 6, 6)]
+        assert aligned_r == [(0, 2, 2), (0, 2, 2), (0, 6, 6)]
+
+    def test_3x2x4_vs_6x4(self):
+        """3×2×4 and 6×4 — receiver dim0 (6) splits into 3×2."""
+        s = [(0, 3, 3), (0, 2, 2), (0, 4, 4)]
+        r = [(0, 6, 6), (0, 4, 4)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [3, 2, 4]
+        assert aligned_s == [(0, 3, 3), (0, 2, 2), (0, 4, 4)]
+        assert aligned_r == [(0, 3, 3), (0, 2, 2), (0, 4, 4)]
+
+    def test_3x2x4_vs_6x4_partial(self):
+        """3×2×4 vs 6×4 with partial ranges — aligned to 3×2×4."""
+        s = [(1, 3, 3), (0, 2, 2), (1, 3, 4)]
+        r = [(2, 4, 6), (0, 4, 4)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [3, 2, 4]
+        assert aligned_s == [(1, 3, 3), (0, 2, 2), (1, 3, 4)]
+        assert aligned_r == [(1, 2, 3), (0, 2, 2), (0, 4, 4)]
+
+    def test_8x3_vs_4x6_full_range(self):
+        """8×3 vs 4×6 with full receiver — common refinement 4×2×3."""
+        s = [(2, 6, 8), (0, 3, 3)]
+        r = [(0, 4, 4), (0, 6, 6)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [4, 2, 3]
+        assert aligned_s == [(1, 3, 4), (0, 2, 2), (0, 3, 3)]
+        assert aligned_r == [(0, 4, 4), (0, 2, 2), (0, 3, 3)]
+
+    def test_2x2x6_vs_4x3x2(self):
+        """2×2×6 vs 4×3×2 — common refinement 2×2×3×2."""
+        s = [(0, 2, 2), (0, 2, 2), (0, 6, 6)]
+        r = [(0, 4, 4), (0, 3, 3), (0, 2, 2)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [2, 2, 3, 2]
+        assert aligned_s == [(0, 2, 2), (0, 2, 2), (0, 3, 3), (0, 2, 2)]
+        assert aligned_r == [(0, 2, 2), (0, 2, 2), (0, 3, 3), (0, 2, 2)]
+
+    def test_1d_vs_4d_cascade(self):
+        """1D (48) vs 2×3×2×4 — deep cascading split."""
+        s = [(0, 48, 48)]
+        r = [(0, 2, 2), (0, 3, 3), (0, 2, 2), (0, 4, 4)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [2, 3, 2, 4]
+        assert aligned_s == [(0, 2, 2), (0, 3, 3), (0, 2, 2), (0, 4, 4)]
+
+    def test_1d_partial_vs_4d(self):
+        """Partial 1D range in 48 vs 2×3×2×4."""
+        s = [(0, 24, 48)]
+        r = [(0, 2, 2), (0, 3, 3), (0, 2, 2), (0, 4, 4)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [2, 3, 2, 4]
+        assert aligned_s == [(0, 1, 2), (0, 3, 3), (0, 2, 2), (0, 4, 4)]
+
+    def test_4x6_vs_2x4x3_partial_receiver(self):
+        """4×6 vs 2×4×3 with partial range in receiver dim1."""
+        s = [(0, 4, 4), (0, 6, 6)]
+        r = [(0, 2, 2), (2, 4, 4), (0, 3, 3)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [2, 2, 2, 3]
+        assert aligned_s == [(0, 2, 2), (0, 2, 2), (0, 2, 2), (0, 3, 3)]
+        assert aligned_r == [(0, 2, 2), (1, 2, 2), (0, 2, 2), (0, 3, 3)]
+
+    def test_mixed_partial_and_full(self):
+        """Sender [0,4)×[0,6) vs receiver [0,2)×[6,12)."""
+        s = [(0, 4, 4), (0, 6, 6)]
+        r = [(0, 2, 2), (6, 12, 12)]
+        result = _check_shard_compatibility(s, r)
+        assert result is not None
+        aligned_s, aligned_r = _alignment_shards(result)
+        assert [w for _, _, w in aligned_s] == [2, 2, 6]
+        assert aligned_s == [(0, 2, 2), (0, 2, 2), (0, 6, 6)]
+        assert aligned_r == [(0, 2, 2), (1, 2, 2), (0, 6, 6)]
+
+
+# ---------------------------------------------------------------------------
+# compute_overlap (spec only)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeOverlap:
+    def test_same_dims_partial_overlap(self):
+        s_shard = [(1, 3, 4), (0, 6, 6)]
+        r_shard = [(2, 4, 4), (2, 5, 6)]
+        sender = _make_shard_spec(s_shard)
+        receiver = _make_shard_spec(r_shard)
+        overlap = ShardSpec.compute_overlap(sender, receiver)
+        assert "weight" in overlap.entries
+        o_shard = overlap["weight"]
+        assert o_shard == [[(2, 3, 4), (2, 5, 6)]]
+
+    def test_no_overlap(self):
+        """Disjoint shards produce an empty result."""
+        s_shard = [(0, 2, 4), (0, 6, 6)]
+        r_shard = [(2, 4, 4), (0, 6, 6)]
+        sender = _make_shard_spec(s_shard)
+        receiver = _make_shard_spec(r_shard)
+        overlap = ShardSpec.compute_overlap(sender, receiver)
+        assert len(overlap.entries) == 0
+
+    def test_explicit_names_limit_work_and_ignore_missing_names(self):
+        sender = ShardSpec(
+            {
+                "keep": [[(0, 4, 4)]],
+                "skip": [[(0, 4, 4)]],
+            }
+        )
+        receiver = ShardSpec(
+            {
+                "keep": [[(2, 4, 4)]],
+                "skip": [[(0, 4, 4)]],
+            }
+        )
+        overlap = ShardSpec.compute_overlap(sender, receiver, iter(("missing", "keep")))
+        assert overlap.entries == {"keep": [[(2, 4, 4)]]}
+
+
+# ---------------------------------------------------------------------------
+# BoundShardSpec pack / unpack via __getitem__ / __setitem__
+# ---------------------------------------------------------------------------
+
+
+class TestPackFor:
+    def test_full_shard_roundtrip(self):
+        shard = [(0, 4, 4), (0, 6, 6)]
+        sender = _make_shard_spec(shard)
+        receiver = _make_shard_spec(shard)
+        overlap = ShardSpec.compute_overlap(sender, receiver)
+        t = _tensor_for_shard(shard).reshape(-1)
+        packed = sender({"weight": t})[{0: overlap}][0]
+        t_out = torch.zeros_like(t)
+        receiver({"weight": t_out})[{0: overlap}] = {0: packed}
+        assert torch.equal(t_out, t)
+
+    def test_setitem_named_pairs_filters_without_rebasing_wire_names(self):
+        """A fused destination may select B from an original [A,B] wire layout; B must not read A's bytes."""
+        full = ShardSpec(
+            {
+                "a": [[(0, 4, 4)]],
+                "b": [[(0, 3, 3)]],
+            }
+        )
+        selected = full.subset({"b"})
+        named_source = {
+            "a": torch.arange(4, dtype=torch.float32) + 10,
+            "b": torch.arange(3, dtype=torch.float32) + 100,
+        }
+        out = torch.zeros(3, dtype=torch.float32)
+        pairs = selected({"b": out}).setitem_named_pairs(
+            {0: selected},
+            {0: named_source},
+        )
+        for dst, src in pairs:
+            dst.copy_(src)
+        assert torch.equal(out, named_source["b"])

--- a/examples/weightbridge/tests/test_specgen.py
+++ b/examples/weightbridge/tests/test_specgen.py
@@ -1,0 +1,919 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for :func:`wbridge.utils.specgen.infer_load_spec` with a composite ``lw``."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Iterable
+
+import pytest
+import torch
+import wbridge.utils.specgen as specgen_module
+from wbridge.utils.data import LoadSpec, Shards
+from wbridge.utils.specgen import (
+    _diff2_inplace,
+    _plan_logical_sources,
+    _plan_worker_slices,
+    _prefix_sum_2d,
+    _select_probe_build_device,
+    DEFAULT_MAX_HF_BYTES,
+    HFWeightFetcher,
+    infer_load_spec,
+    SPECGEN_PROBE_DEVICE_ENV,
+    verify_load_spec,
+)
+
+
+@pytest.fixture(scope="module")
+def device() -> torch.device:
+    if not torch.cuda.is_available():
+        pytest.skip("infer_load_spec requires CUDA worker tensors")
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+def _hfsd_to_fetcher(
+    hfsd: dict[str, torch.Tensor],
+) -> tuple[HFWeightFetcher, dict[str, tuple[int, ...]]]:
+    """Convert a test HF state dict to (fetcher, shapes)."""
+    return (
+        {name: (lambda t=t: t) for name, t in hfsd.items()},
+        {name: tuple(t.shape) for name, t in hfsd.items()},
+    )
+
+
+def test_plan_logical_sources_caps_encoded_i64_not_checkpoint_dtype() -> None:
+    shape = (17, 11)
+    row_i64_bytes = shape[1] * 8
+
+    unsplit, unsplit_shapes = _plan_logical_sources({"weight": shape}, math.inf)
+    assert [(piece.start, piece.end) for piece in unsplit["weight"]] == [(0, 17)]
+    assert unsplit_shapes == {"weight": shape}
+
+    pieces, logical_shapes = _plan_logical_sources(
+        {"weight": shape},
+        5 * row_i64_bytes,
+    )
+    assert [(piece.start, piece.end) for piece in pieces["weight"]] == [
+        (0, 5),
+        (5, 10),
+        (10, 15),
+        (15, 17),
+    ]
+    assert all(
+        (piece.end - piece.start) * row_i64_bytes <= 5 * row_i64_bytes
+        for piece in pieces["weight"]
+    )
+    assert set(logical_shapes) == {piece.logical_name for piece in pieces["weight"]}
+
+
+def test_plan_worker_slices_flattens_fused_leading_dimensions() -> None:
+    shape = (12, 4096, 7168)
+    cap = 64 * 1024**2
+    rows_per_slice = cap // (shape[-1] * 8)
+    slices = _plan_worker_slices(shape, cap)
+
+    assert slices[0] == (0, rows_per_slice, (rows_per_slice, shape[-1]))
+    assert slices[-1][1] == shape[0] * shape[1]
+    assert all(math.prod(slice_shape) * 8 <= cap for _, _, slice_shape in slices)
+    assert sum(end - start for start, end, _ in slices) == shape[0] * shape[1]
+
+
+def test_diff2_strided_diff1_round_trip() -> None:
+    original = torch.arange(35, dtype=torch.int64).reshape(5, 7) ** 2
+    expected = original.clone()
+    expected[:, 2:] = original[:, 2:] - 2 * original[:, 1:-1] + original[:, :-2]
+    expected[:, 1] = original[:, 1] - 2 * original[:, 0]
+    column_diff = expected.clone()
+    expected[2:, :] = (
+        column_diff[2:, :] - 2 * column_diff[1:-1, :] + column_diff[:-2, :]
+    )
+    expected[1, :] = column_diff[1, :] - 2 * column_diff[0, :]
+
+    actual = _diff2_inplace(original.clone())
+    assert torch.equal(actual, expected)
+    assert torch.equal(_prefix_sum_2d(actual.clone()), original)
+
+
+def test_infer_load_spec_i64_caps_are_canonical(device: torch.device) -> None:
+    """INF and small caps produce the same physical LoadSpec after merging.
+
+    Transpose makes source dim-0 cuts land on destination dim 1, while the
+    small cap independently cuts the worker on destination dim 0.  Thus this
+    also exercises two-dimensional coalescing of the resulting shard grid.
+    """
+    # Small caps create enough logical ids that the encoded index spans two
+    # fp16 chunks, exercising carry propagation as well as canonicalisation.
+    rows, cols = 65, 17
+    hfsd = {
+        "model.weight": torch.randn(rows, cols, dtype=torch.float16),
+    }
+    wksd = {
+        "weight": torch.zeros(cols, rows, dtype=torch.float16, device=device),
+    }
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            if name == "model.weight":
+                wksd["weight"].copy_(fn().T)
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    row_i64_bytes = cols * 8
+    specs = [
+        infer_load_spec(
+            hf_weights,
+            hf_shapes,
+            lambda: wksd,
+            lw,
+            i64_cap_bytes=cap,
+        )
+        for cap in (math.inf, 5 * row_i64_bytes, 4 * row_i64_bytes)
+    ]
+
+    assert specs[1].entries == specs[0].entries
+    assert specs[2].entries == specs[0].entries
+    assert set(specs[2].entries) == {"model.weight"}
+    assert all(".__wbridge_dim0_" not in name for name in specs[2].entries)
+    lw(hf_weights)
+    verify_load_spec(hf_weights, lambda: wksd, specs[2])
+
+
+def test_infer_load_spec_i64_caps_fused_3d_worker(device: torch.device) -> None:
+    """Flattened-row slicing preserves separately loaded transposed experts."""
+    experts, source_rows, source_cols = 4, 7, 5
+    hfsd = {
+        f"model.experts.{index}.weight": torch.randn(
+            source_rows,
+            source_cols,
+            dtype=torch.float16,
+        )
+        for index in range(experts)
+    }
+    wksd = {
+        "experts.weight": torch.zeros(
+            experts,
+            source_cols,
+            source_rows,
+            dtype=torch.float16,
+            device=device,
+        ),
+    }
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            if name.startswith("model.experts."):
+                index = int(name.split(".")[2])
+                wksd["experts.weight"][index].copy_(fn().T)
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    dim0_row_i64_bytes = source_rows * source_cols * 8
+    flattened_row_i64_bytes = source_rows * 8
+    specs = [
+        infer_load_spec(
+            hf_weights,
+            hf_shapes,
+            lambda: wksd,
+            lw,
+            i64_cap_bytes=cap,
+        )
+        for cap in (
+            math.inf,
+            2 * dim0_row_i64_bytes,
+            dim0_row_i64_bytes,
+            flattened_row_i64_bytes,
+        )
+    ]
+    assert specs[1].entries == specs[0].entries
+    assert specs[2].entries == specs[0].entries
+    assert specs[3].entries == specs[0].entries
+    lw(hf_weights)
+    verify_load_spec(hf_weights, lambda: wksd, specs[3])
+
+
+def test_infer_load_spec_cuda_row_staged_cpu_placeholders(
+    device: torch.device,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Oversized CPU placeholders are populated only by CUDA row tiles."""
+    monkeypatch.setenv(SPECGEN_PROBE_DEVICE_ENV, "cpu")
+    tile_bytes = 64
+    monkeypatch.setattr(specgen_module, "_SPECGEN_CUDA_ROW_TILE_BYTES", tile_bytes)
+    hfsd = {
+        "model.weight": torch.randn(11, 7, dtype=torch.float32),
+    }
+    wksd = {
+        "weight": torch.zeros(7, 11, dtype=torch.float32, device=device),
+    }
+    probe_devices: list[str] = []
+    build_devices: list[str] = []
+    build_intervals: list[tuple[int, int]] = []
+    original_build_chunk = specgen_module._build_chunk_gpu
+
+    def recording_build_chunk(*args, **kwargs) -> torch.Tensor:
+        build_devices.append(args[6].type)
+        build_intervals.append((kwargs["dim0_start"], kwargs["dim0_end"]))
+        return original_build_chunk(*args, **kwargs)
+
+    monkeypatch.setattr(specgen_module, "_build_chunk_gpu", recording_build_chunk)
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        source = hf_weights["model.weight"]()
+        probe_devices.append(source.device.type)
+        wksd["weight"].copy_(source.T)
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, lw)
+
+    assert probe_devices
+    assert set(probe_devices) == {"cpu"}
+    assert build_devices and set(build_devices) == {"cuda"}
+    assert len(build_intervals) > 1
+    assert all(
+        (end - start) * 7 * torch.float32.itemsize <= tile_bytes
+        for start, end in build_intervals
+    )
+    lw(hf_weights)
+    verify_load_spec(hf_weights, lambda: wksd, spec)
+
+
+def test_cpu_fallback_keeps_bounded_probe_on_cuda(
+    device: torch.device,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CPU fallback mode does not move bounded probes off CUDA."""
+    del device  # CUDA availability is the relevant fixture precondition.
+    shape = (3, 4)
+    pieces, _logical_shapes = _plan_logical_sources({"weight": shape}, math.inf)
+    monkeypatch.setattr(specgen_module, "_SPECGEN_CUDA_ROW_TILE_BYTES", 1024)
+
+    probe = specgen_module._build_physical_chunk(
+        pieces["weight"],
+        {"weight": 0},
+        0,
+        0,
+        32,
+        torch.float32,
+        torch.device("cpu"),
+    )
+
+    assert probe.is_cuda
+    assert probe.shape == shape
+
+
+def test_auto_probe_device_budgets_two_live_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto placement covers loaders that retain one source during fetch."""
+    gib = 1024**3
+    monkeypatch.delenv(SPECGEN_PROBE_DEVICE_ENV, raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        torch.cuda,
+        "mem_get_info",
+        lambda: (int(5.8 * gib), 80 * gib),
+    )
+
+    # This reproduces Kimi's expanded FP32 expert source: one 4.38-GiB
+    # tensor appears to fit in 5.8 GiB, but two loader-live sources do not.
+    shape = (1, int(4.38 * gib) // torch.float32.itemsize)
+    pieces, _logical_shapes = _plan_logical_sources({"weight": shape}, math.inf)
+    assert (
+        _select_probe_build_device(
+            ["weight"],
+            pieces,
+            torch.float32,
+        ).type
+        == "cpu"
+    )
+
+    small_shape = (1, 128 * 1024**2 // torch.float32.itemsize)
+    small_pieces, _ = _plan_logical_sources(
+        {"weight": small_shape},
+        math.inf,
+    )
+    assert (
+        _select_probe_build_device(
+            ["weight"],
+            small_pieces,
+            torch.float32,
+        ).type
+        == "cuda"
+    )
+
+
+def _complex_sglang_like_lw(
+    wksd: dict[str, torch.Tensor],
+    *,
+    V: int,
+    H: int,
+    INTER: int,
+    tp_rank: int,
+    q_dim: int,
+    kv_dim: int,
+) -> Callable[[HFWeightFetcher], None]:
+    """Mimics several SGLang / vLLM-style load paths (PP skip, padding, QKV merge, TP, transpose, tie).
+
+    * **PP:** names prefixed with ``pp_skip.`` are ignored (weights not on this pipeline stage).
+    * **Padded vocab:** ``embed_tokens`` / ``lm_head`` HF tensors are wider than the runtime vocab;
+      only ``[:V, :]`` is copied (extra rows mirror padded ``lm_head`` in large checkpoints).
+    * **QKV merge:** three HF matrices are written into non-overlapping row blocks of ``qkv_proj``
+      (like ``stacked_params_mapping`` merging ``q_proj`` / ``k_proj`` / ``v_proj`` into ``qkv_proj``).
+    * **TP column-parallel:** ``gate_proj`` shards along dim 0 (output features).
+    * **TP row-parallel:** ``o_proj`` shards along dim 1 (input features split across ranks).
+    * **Tied embeddings:** after the first full pass, iterate weights again and copy
+      ``model.embed_tokens.weight`` into ``lm_head.weight`` (``qwen2``-style second scan).
+    """
+
+    half = H // 2
+    assert tp_rank in (0, 1)
+    qkv_rows = q_dim + 2 * kv_dim
+
+    def _dispatch(name: str, t: torch.Tensor) -> None:
+        if name.startswith("pp_skip."):
+            return
+        if name == "model.embed_tokens.weight":
+            wksd["embed_tokens.weight"].copy_(t[:V, :])
+            wksd["lm_head.weight"].copy_(t[:V, :])
+            return
+        if name.endswith("self_attn.q_proj.weight"):
+            wksd["layers.1.self_attn.qkv_proj.weight"][:q_dim, :].copy_(t)
+            return
+        if name.endswith("self_attn.k_proj.weight"):
+            wksd["layers.1.self_attn.qkv_proj.weight"][q_dim : q_dim + kv_dim, :].copy_(
+                t
+            )
+            return
+        if name.endswith("self_attn.v_proj.weight"):
+            wksd["layers.1.self_attn.qkv_proj.weight"][
+                q_dim + kv_dim : qkv_rows, :
+            ].copy_(t)
+            return
+        if name.endswith("self_attn.o_proj.weight"):
+            wksd["layers.1.self_attn.o_proj.weight"].copy_(
+                t[:, tp_rank * half : (tp_rank + 1) * half]
+            )
+            return
+        if name.endswith("mlp.gate_proj.weight"):
+            wksd["layers.1.mlp.gate_proj.weight"].copy_(
+                t[tp_rank * half : (tp_rank + 1) * half, :]
+            )
+            return
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            _dispatch(name, fn())
+        # Second pass for tied embeddings
+        for name, fn in hf_weights.items():
+            if name == "model.embed_tokens.weight":
+                wksd["lm_head.weight"].copy_(fn()[:V, :])
+                break
+
+    return lw
+
+
+def test_infer_load_spec_complex_load_weights(device: torch.device) -> None:
+    # V, V_PAD, H, INTER = 256, 32, 64, 128
+    V, V_PAD, H, INTER = 8, 1, 4, 8
+    tp_rank = 1
+    q_dim, kv_dim = 64, 16
+    qkv_rows = q_dim + 2 * kv_dim
+    half = H // 2
+
+    hfsd = {
+        "pp_skip.model.layers.0.mlp.fc.weight": torch.randn(3, 3),
+        "model.embed_tokens.weight": torch.randn(V + V_PAD, H),
+        "model.layers.1.self_attn.q_proj.weight": torch.randn(q_dim, H),
+        "model.layers.1.self_attn.k_proj.weight": torch.randn(kv_dim, H),
+        "model.layers.1.self_attn.v_proj.weight": torch.randn(kv_dim, H),
+        "model.layers.1.self_attn.o_proj.weight": torch.randn(H, H),
+        "model.layers.1.mlp.gate_proj.weight": torch.randn(H, INTER),
+    }
+    for t in hfsd.values():
+        assert t.device.type == "cpu"
+
+    wksd = {
+        "embed_tokens.weight": torch.zeros(V, H, device=device),
+        "lm_head.weight": torch.zeros(V, H, device=device),
+        "layers.1.self_attn.qkv_proj.weight": torch.zeros(qkv_rows, H, device=device),
+        "layers.1.self_attn.o_proj.weight": torch.zeros(H, half, device=device),
+        "layers.1.mlp.gate_proj.weight": torch.zeros(half, INTER, device=device),
+    }
+
+    lw = _complex_sglang_like_lw(
+        wksd,
+        V=V,
+        H=H,
+        INTER=INTER,
+        tp_rank=tp_rank,
+        q_dim=q_dim,
+        kv_dim=kv_dim,
+    )
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    load_spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, lw)
+    spec = load_spec.src_shard_spec
+
+    assert "pp_skip.model.layers.0.mlp.fc.weight" not in spec.entries
+
+    def _shard(name: str) -> Shards:
+        return spec[name]
+
+    assert _shard("model.embed_tokens.weight") == [[(0, V, V + V_PAD), (0, H, H)]]
+    assert _shard("model.layers.1.self_attn.q_proj.weight") == [
+        [(0, q_dim, q_dim), (0, H, H)]
+    ]
+    assert _shard("model.layers.1.self_attn.k_proj.weight") == [
+        [(0, kv_dim, kv_dim), (0, H, H)]
+    ]
+    assert _shard("model.layers.1.self_attn.v_proj.weight") == [
+        [(0, kv_dim, kv_dim), (0, H, H)]
+    ]
+    assert _shard("model.layers.1.self_attn.o_proj.weight") == [
+        [(0, H, H), (tp_rank * half, (tp_rank + 1) * half, H)]
+    ]
+    assert _shard("model.layers.1.mlp.gate_proj.weight") == [
+        [(tp_rank * half, (tp_rank + 1) * half, H), (0, INTER, INTER)]
+    ]
+
+
+def test_infer_load_spec_batched_merge_matches_single(device: torch.device) -> None:
+    """Small max_hf_bytes forces multiple batches; merged spec matches one-shot."""
+    V, H = 8, 4
+    hfsd = {
+        "a.weight": torch.randn(H, H),
+        "b.weight": torch.randn(H, H),
+        "c.weight": torch.randn(H, H),
+    }
+    wksd = {
+        "a.weight": torch.zeros(H, H, device=device),
+        "b.weight": torch.zeros(H, H, device=device),
+        "c.weight": torch.zeros(H, H, device=device),
+    }
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            short = name.replace("model.", "") if name.startswith("model.") else name
+            if short in wksd:
+                wksd[short].copy_(fn())
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    full = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, lw).src_shard_spec
+
+    assert set(full.entries.keys()) == {"a.weight", "b.weight", "c.weight"}
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not torch.cuda.is_bf16_supported(),
+    reason="needs CUDA with bfloat16",
+)
+def test_infer_load_spec_hf_worker_dtype_mismatch(device: torch.device) -> None:
+    """HF tensor bf16, worker fp32 (like SGLang e_score_correction_bias); infer + verify."""
+    hfsd = {
+        "model.layers.0.mlp.gate.e_score_correction_bias": torch.randn(
+            8, dtype=torch.bfloat16, device="cpu"
+        ),
+    }
+    wksd = {
+        "layers.0.mlp.gate.e_score_correction_bias": torch.zeros(
+            8, dtype=torch.float32, device=device
+        ),
+    }
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            if name.endswith("e_score_correction_bias"):
+                wksd["layers.0.mlp.gate.e_score_correction_bias"].copy_(fn())
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    load_spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, lw)
+    spec = load_spec.src_shard_spec
+    name = "model.layers.0.mlp.gate.e_score_correction_bias"
+    assert spec[name] == [[(0, 8, 8)]]
+
+    lw(hf_weights)
+    verify_load_spec(hf_weights, lambda: wksd, load_spec)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not torch.cuda.is_bf16_supported(),
+    reason="needs CUDA with bfloat16",
+)
+def test_infer_load_spec_bfloat16(device: torch.device) -> None:
+    """``infer_load_spec`` with bf16 HF + worker tensors at production-like sizes."""
+    dt = torch.bfloat16
+
+    # Large square weight (e.g. attention projection): 1024×1024, row-parallel TP2 on dim 1.
+    H = 1024
+    half_w = H // 2
+    tp_rank_o = 0
+    hfsd_o = {
+        "model.layers.0.self_attn.o_proj.weight": torch.randn(
+            H, H, dtype=dt, device="cpu"
+        ),
+    }
+    wksd_o = {
+        "layers.0.self_attn.o_proj.weight": torch.zeros(
+            H, half_w, dtype=dt, device=device
+        ),
+    }
+
+    def lw_o(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            if name.endswith("o_proj.weight"):
+                wksd_o["layers.0.self_attn.o_proj.weight"].copy_(
+                    fn()[:, tp_rank_o * half_w : (tp_rank_o + 1) * half_w]
+                )
+
+    hf_w_o, hf_s_o = _hfsd_to_fetcher(hfsd_o)
+    spec_o = infer_load_spec(hf_w_o, hf_s_o, lambda: wksd_o, lw_o).src_shard_spec
+    assert spec_o["model.layers.0.self_attn.o_proj.weight"] == [
+        [(0, H, H), (tp_rank_o * half_w, (tp_rank_o + 1) * half_w, H)]
+    ]
+
+    # Wide matrix 16×151936 (vocab-scale last dim): column-parallel TP2 on dim 1.
+    rows, cols = 16, 151_936
+    half_c = cols // 2
+    tp_rank_e = 1
+    hfsd_e = {
+        "model.embed_tokens.weight": torch.randn(rows, cols, dtype=dt, device="cpu"),
+    }
+    wksd_e = {
+        "model.embed_tokens.weight": torch.zeros(rows, half_c, dtype=dt, device=device),
+    }
+
+    def lw_e(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            if name.endswith("embed_tokens.weight"):
+                wksd_e["model.embed_tokens.weight"].copy_(
+                    fn()[:, tp_rank_e * half_c : (tp_rank_e + 1) * half_c]
+                )
+
+    hf_w_e, hf_s_e = _hfsd_to_fetcher(hfsd_e)
+    spec_e = infer_load_spec(hf_w_e, hf_s_e, lambda: wksd_e, lw_e).src_shard_spec
+    assert spec_e["model.embed_tokens.weight"] == [
+        [(0, rows, rows), (tp_rank_e * half_c, (tp_rank_e + 1) * half_c, cols)]
+    ]
+
+
+def test_verify_load_spec_1to1(device: torch.device) -> None:
+    """After load, :func:`verify_load_spec` matches HF slices to worker slices from the LoadSpec."""
+    H = 4
+    hfsd = {
+        "a.weight": torch.randn(H, H),
+        "b.weight": torch.randn(H, H),
+    }
+    wksd = {
+        "a.weight": torch.zeros(H, H, device=device),
+        "b.weight": torch.zeros(H, H, device=device),
+    }
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            wksd[name].copy_(fn())
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    lw(hf_weights)
+    load_spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, lw)
+    verify_load_spec(hf_weights, lambda: wksd, load_spec)
+
+
+def test_load_spec_src_shard_spec_multi_mapping_merge_and_split() -> None:
+    """Multiple :class:`ShardMapping` for one (src, dst) pair; :attr:`LoadSpec.src_shard_spec` lists source shards.
+
+    Cases 1–4 use **2D** tensors (axis-aligned boxes). Cases 5–6 are separate **1D** tensors with scattered
+    index ranges.
+    """
+    H, C = 4, 16
+
+    # --- Case 1 (2D): full row span, two non-adjacent column windows → two src shards ---
+    split_entries = {
+        "hf_split": {
+            "wk_split": [
+                ([(0, H, H), (0, 4, C)], [(0, H, H), (0, 4, C)]),
+                ([(0, H, H), (8, 12, C)], [(0, H, H), (4, 8, C)]),
+            ]
+        }
+    }
+    spec_split = LoadSpec(split_entries).src_shard_spec
+    assert sorted(spec_split["hf_split"], key=lambda s: (s[1][0], s[1][1])) == [
+        [(0, H, H), (0, 4, C)],
+        [(0, H, H), (8, 12, C)],
+    ]
+
+    # --- Case 2 (2D): full rows, two column bands separated by a gap (distinct from case 1) ---
+    gap_entries = {
+        "hf_gap": {
+            "wk_gap": [
+                ([(0, H, H), (0, 3, C)], [(0, H, H), (0, 3, C)]),
+                ([(0, H, H), (10, 14, C)], [(0, H, H), (3, 7, C)]),
+            ]
+        }
+    }
+    spec_gap = LoadSpec(gap_entries).src_shard_spec
+    assert sorted(spec_gap["hf_gap"], key=lambda s: (s[1][0], s[1][1])) == [
+        [(0, H, H), (0, 3, C)],
+        [(0, H, H), (10, 14, C)],
+    ]
+
+    # --- Case 3 (2D): scattered column intervals (gaps), three src shards ---
+    scattered_entries = {
+        "hf_scatter": {
+            "wk_scatter": [
+                ([(0, H, H), (0, 2, C)], [(0, H, H), (0, 2, C)]),
+                ([(0, H, H), (5, 7, C)], [(0, H, H), (2, 4, C)]),
+                ([(0, H, H), (10, 12, C)], [(0, H, H), (4, 6, C)]),
+            ]
+        }
+    }
+    spec_scatter = LoadSpec(scattered_entries).src_shard_spec
+    assert sorted(spec_scatter["hf_scatter"], key=lambda s: s[1][0]) == [
+        [(0, H, H), (0, 2, C)],
+        [(0, H, H), (5, 7, C)],
+        [(0, H, H), (10, 12, C)],
+    ]
+
+    # --- Case 4 (2D): two disjoint rectangles (different row *and* column ranges), no overlap ---
+    disjoint_entries = {
+        "hf_disjoint": {
+            "wk_disjoint": [
+                ([(0, 2, H), (0, 4, C)], [(0, 2, H), (0, 4, C)]),
+                ([(2, H, H), (8, 12, C)], [(2, H, H), (4, 8, C)]),
+            ]
+        }
+    }
+    spec_disjoint = LoadSpec(disjoint_entries).src_shard_spec
+    assert sorted(spec_disjoint["hf_disjoint"], key=lambda s: (s[0][0], s[1][0])) == [
+        [(0, 2, H), (0, 4, C)],
+        [(2, H, H), (8, 12, C)],
+    ]
+
+    # --- Case 5 (1D): pseudo-random non-adjacent intervals on one axis ---
+    W1 = 32
+    random_1d = {
+        "hf_rand1d": {
+            "wk_rand1d": [
+                ([(1, 3, W1)], [(0, 2, W1)]),
+                ([(11, 15, W1)], [(2, 6, W1)]),
+                ([(20, 24, W1)], [(6, 10, W1)]),
+            ]
+        }
+    }
+    spec_1d = LoadSpec(random_1d).src_shard_spec
+    assert sorted(spec_1d["hf_rand1d"], key=lambda s: s[0][0]) == [
+        [(1, 3, W1)],
+        [(11, 15, W1)],
+        [(20, 24, W1)],
+    ]
+
+    # --- Case 6 (1D): second 1D tensor, different width and scattered ranges ---
+    W2 = 48
+    random_1d_b = {
+        "hf_rand1d_b": {
+            "wk_rand1d_b": [
+                ([(0, 5, W2)], [(0, 5, W2)]),
+                ([(7, 11, W2)], [(5, 9, W2)]),
+                ([(30, 36, W2)], [(9, 15, W2)]),
+            ]
+        }
+    }
+    spec_1d_b = LoadSpec(random_1d_b).src_shard_spec
+    assert sorted(spec_1d_b["hf_rand1d_b"], key=lambda s: s[0][0]) == [
+        [(0, 5, W2)],
+        [(7, 11, W2)],
+        [(30, 36, W2)],
+    ]
+
+
+def test_infer_load_spec_transpose(device: torch.device) -> None:
+    """Transpose mapping: HF (A, B) → wk (B, A) via t.T.contiguous()."""
+    A, B = 6, 4
+    hfsd = {
+        "model.linear.weight": torch.randn(A, B),
+    }
+    wksd = {
+        "linear.weight": torch.zeros(B, A, device=device),
+    }
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            if name == "model.linear.weight":
+                wksd["linear.weight"].copy_(fn().T.contiguous())
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    load_spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, lw)
+
+    # Verify the LoadSpec can reproduce the weights
+    lw(hf_weights)
+    verify_load_spec(hf_weights, lambda: wksd, load_spec)
+
+
+def test_infer_load_spec_single_row_col(device: torch.device) -> None:
+    """Single-row and single-column shards (width-1 or height-1 boxes)."""
+    H, W = 8, 4
+    hfsd = {
+        "model.row_weight": torch.randn(1, W),
+        "model.col_weight": torch.randn(H, 1),
+    }
+    wksd = {
+        "row_weight": torch.zeros(1, W, device=device),
+        "col_weight": torch.zeros(H, 1, device=device),
+    }
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            if name == "model.row_weight":
+                wksd["row_weight"].copy_(fn())
+            elif name == "model.col_weight":
+                wksd["col_weight"].copy_(fn())
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    load_spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, lw)
+    spec = load_spec.src_shard_spec
+    assert "model.row_weight" in spec.entries
+    assert "model.col_weight" in spec.entries
+
+    # Verify correctness
+    lw(hf_weights)
+    verify_load_spec(hf_weights, lambda: wksd, load_spec)
+
+
+def test_infer_load_spec_l_shape(device: torch.device) -> None:
+    """L-shaped mapping: two rectangular regions from same HF tensor with different spans."""
+    H, W = 8, 8
+    hfsd = {
+        "model.weight": torch.randn(H, W),
+    }
+    # Worker tensor is 6×4 — top 4 rows get cols [0:4], bottom 2 rows get cols [4:8]
+    wksd = {
+        "weight": torch.zeros(6, 4, device=device),
+    }
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            if name == "model.weight":
+                t = fn()
+                # Top 4 rows: copy cols [0:4] from HF rows [0:4]
+                wksd["weight"][:4, :].copy_(t[:4, :4])
+                # Bottom 2 rows: copy cols [4:8] from HF rows [4:6]
+                wksd["weight"][4:, :].copy_(t[4:6, 4:8])
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    load_spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, lw)
+
+    # Should decompose into 2 mappings
+    wk_mappings = load_spec.entries.get("model.weight", {}).get("weight", [])
+    assert len(wk_mappings) == 2, (
+        f"Expected 2 mappings for L-shape, got {len(wk_mappings)}"
+    )
+
+    # Verify correctness
+    lw(hf_weights)
+    verify_load_spec(hf_weights, lambda: wksd, load_spec)
+
+
+def test_infer_load_spec_moe_many_names_overflow(device: torch.device) -> None:
+    """MoE-like: many HF tensors → one fused 3D wksd tensor.
+
+    With many HF names, n_bits is large (≥15) so the first coordinate's
+    bit offset ≥ ele_bits (16 for bf16).  The structured-index stride
+    when moving right through the wksd tensor wraps in int16, which
+    previously caused diff2 to produce O(numel) nonzeros instead of O(1).
+    """
+    N_EXPERTS = 8
+    EXPERT_H, EXPERT_W = 4, 6
+
+    # Create enough HF tensors to push n_bits high.
+    # n_bits = ceil(log2(N)), so N ≥ 2^14 = 16384 → n_bits = 15.
+    N_PAD = 16384
+    hfsd = {}
+    for i in range(N_EXPERTS):
+        hfsd[f"model.experts.{i}.weight"] = torch.randn(EXPERT_H, EXPERT_W)
+    for i in range(N_PAD):
+        hfsd[f"model.pad.{i}.weight"] = torch.randn(1, 1)
+
+    wksd = {
+        "experts.weight": torch.zeros(N_EXPERTS, EXPERT_H, EXPERT_W, device=device),
+    }
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            if name.startswith("model.experts."):
+                idx = int(name.split(".")[2])
+                if idx < N_EXPERTS:
+                    wksd["experts.weight"][idx].copy_(fn())
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    load_spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, lw)
+
+    expert_count = 0
+    for hf_name, wk_map in load_spec.entries.items():
+        if "experts.weight" in wk_map:
+            expert_count += len(wk_map["experts.weight"])
+    assert expert_count == N_EXPERTS, (
+        f"Expected {N_EXPERTS} expert mappings, got {expert_count}"
+    )
+
+    lw(hf_weights)
+    verify_load_spec(hf_weights, lambda: wksd, load_spec)
+
+
+def test_infer_load_spec_moe_transpose_overflow(device: torch.device) -> None:
+    """MoE + transpose: HF (H, W) → wksd[i] = (W, H) via .T.
+
+    Combines the overflow scenario (many names → large n_bits) with
+    transpose — the exact pattern causing 30M diff2 nonzeros in
+    Qwen3-30B-A3B before the fix.
+    """
+    N_EXPERTS = 4
+    EXPERT_H, EXPERT_W = 4, 6
+    N_PAD = 16384
+
+    hfsd = {}
+    for i in range(N_EXPERTS):
+        hfsd[f"model.experts.{i}.down_proj"] = torch.randn(EXPERT_H, EXPERT_W)
+    for i in range(N_PAD):
+        hfsd[f"model.pad.{i}.w"] = torch.randn(1, 1)
+
+    wksd = {
+        "experts.w2_weight": torch.zeros(N_EXPERTS, EXPERT_W, EXPERT_H, device=device),
+    }
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            if name.startswith("model.experts.") and "down_proj" in name:
+                idx = int(name.split(".")[2])
+                if idx < N_EXPERTS:
+                    wksd["experts.w2_weight"][idx].copy_(fn().T)
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    load_spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, lw)
+
+    lw(hf_weights)
+    verify_load_spec(hf_weights, lambda: wksd, load_spec)
+
+
+def test_carry_aware_moe_down_proj(device: torch.device) -> None:
+    """Carry-aware diff2 with realistic MoE down_proj dimensions.
+
+    Simplified Qwen3-30B-A3B down_proj:
+      HF: model.experts.{i}.down_proj → (768, 256) per expert
+      Worker: experts.w2_weight → (8, 256, 768) — transposed!
+      lw: wksd[idx].copy_(fn().T)
+
+    With 16K+ pad names, compact n_bits = 15.  For bf16 (ele_bits=16):
+      Total bits: 15 + 10 + 8 = 33 → 3 chunks of 16 bits
+      Chunk 0 [0,16): name(15) + 1 bit of x_0 → carries
+      Chunk 1 [16,32): 9 bits of x_0 + 7 bits of x_1 → carries
+      Chunk 2 [32,48): 1 bit of x_1 + sign
+
+    Without carry-aware probing, chunks 0 and 1 would produce O(dim) nnz.
+    With carry propagation, each chunk's remainder has O(N_EXPERTS) nnz.
+    """
+    N_EXPERTS = 8
+    EXPERT_H, EXPERT_W = 768, 256  # real 30B dims (HF shape)
+
+    # 16K pad names → n_bits = ceil(log2(16K + 8 + 1)) = 15
+    N_PAD = 16384
+    hfsd: dict[str, torch.Tensor] = {}
+    for i in range(N_EXPERTS):
+        hfsd[f"model.experts.{i}.down_proj"] = torch.randn(EXPERT_H, EXPERT_W)
+    for i in range(N_PAD):
+        hfsd[f"model.pad.{i}.w"] = torch.randn(1, 1)
+
+    wksd = {
+        "experts.w2_weight": torch.zeros(
+            N_EXPERTS,
+            EXPERT_W,
+            EXPERT_H,
+            device=device,
+            dtype=torch.bfloat16,
+        ),
+    }
+
+    def lw(hf_weights: HFWeightFetcher) -> None:
+        for name, fn in hf_weights.items():
+            if name.startswith("model.experts.") and "down_proj" in name:
+                idx = int(name.split(".")[2])
+                if idx < N_EXPERTS:
+                    wksd["experts.w2_weight"][idx].copy_(fn().T)
+
+    hf_weights, hf_shapes = _hfsd_to_fetcher(hfsd)
+    load_spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, lw)
+
+    # Verify correctness
+    lw(hf_weights)
+    verify_load_spec(hf_weights, lambda: wksd, load_spec)
+
+    # Verify we found all expert mappings
+    expert_count = 0
+    for hf_name, wk_map in load_spec.entries.items():
+        if "experts.w2_weight" in wk_map:
+            expert_count += len(wk_map["experts.w2_weight"])
+    assert expert_count == N_EXPERTS, (
+        f"Expected {N_EXPERTS} expert mappings, got {expert_count}"
+    )

--- a/examples/weightbridge/tests/test_specgen_orig.py
+++ b/examples/weightbridge/tests/test_specgen_orig.py
@@ -1,0 +1,303 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Run the original test_specgen.py test cases without pytest."""
+
+import importlib
+import importlib.util
+import logging
+import os
+import sys
+import types
+from pathlib import Path
+
+LIB_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(LIB_ROOT))
+logging.basicConfig(level=logging.INFO)
+
+import torch
+
+# Stub wbridge package
+wbridge_pkg = types.ModuleType("wbridge")
+wbridge_pkg.__path__ = [str(LIB_ROOT / "wbridge")]
+wbridge_pkg.__package__ = "wbridge"
+sys.modules["wbridge"] = wbridge_pkg
+
+wbridge_utils = types.ModuleType("wbridge.utils")
+wbridge_utils.__path__ = [os.path.join(wbridge_pkg.__path__[0], "utils")]
+wbridge_utils.__package__ = "wbridge.utils"
+sys.modules["wbridge.utils"] = wbridge_utils
+
+for mod_name, file_name in [
+    ("wbridge.utils.data", "data.py"),
+    ("wbridge.utils.specgen", "specgen.py"),
+]:
+    spec = importlib.util.spec_from_file_location(
+        mod_name, os.path.join(wbridge_utils.__path__[0], file_name)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+
+from collections.abc import Callable, Iterable
+
+from wbridge.utils.data import LoadSpec, Shards
+from wbridge.utils.specgen import (
+    DEFAULT_MAX_HF_BYTES,
+    infer_load_spec,
+    verify_load_spec,
+)
+
+device = torch.device("cuda", 0)
+
+
+def _hfsd_to_fetcher(hfsd):
+    """Convert a plain dict of tensors to (HFWeightFetcher, shapes)."""
+    fetcher = {name: (lambda t=t: t) for name, t in hfsd.items()}
+    shapes = {name: tuple(t.shape) for name, t in hfsd.items()}
+    return fetcher, shapes
+
+
+# ---- Reproduce _complex_sglang_like_lw from test_specgen.py ----
+def _complex_sglang_like_lw(wksd, *, V, H, INTER, tp_rank, q_dim, kv_dim):
+    half = H // 2
+    assert tp_rank in (0, 1)
+    qkv_rows = q_dim + 2 * kv_dim
+
+    def _dispatch(name, t):
+        if name.startswith("pp_skip."):
+            return
+        if name == "model.embed_tokens.weight":
+            wksd["embed_tokens.weight"].copy_(t[:V, :])
+            wksd["lm_head.weight"].copy_(t[:V, :])
+            return
+        if name.endswith("self_attn.q_proj.weight"):
+            wksd["layers.1.self_attn.qkv_proj.weight"][:q_dim, :].copy_(t)
+            return
+        if name.endswith("self_attn.k_proj.weight"):
+            wksd["layers.1.self_attn.qkv_proj.weight"][q_dim : q_dim + kv_dim, :].copy_(
+                t
+            )
+            return
+        if name.endswith("self_attn.v_proj.weight"):
+            wksd["layers.1.self_attn.qkv_proj.weight"][
+                q_dim + kv_dim : qkv_rows, :
+            ].copy_(t)
+            return
+        if name.endswith("self_attn.o_proj.weight"):
+            wksd["layers.1.self_attn.o_proj.weight"].copy_(
+                t[:, tp_rank * half : (tp_rank + 1) * half]
+            )
+            return
+        if name.endswith("mlp.gate_proj.weight"):
+            wksd["layers.1.mlp.gate_proj.weight"].copy_(
+                t[tp_rank * half : (tp_rank + 1) * half, :]
+            )
+            return
+
+    def lw(hf_weights):
+        for name, fn in hf_weights.items():
+            _dispatch(name, fn())
+        for name, fn in hf_weights.items():
+            if name == "model.embed_tokens.weight":
+                wksd["lm_head.weight"].copy_(fn()[:V, :])
+                break
+
+    return lw
+
+
+# ---- test_infer_load_spec_complex_load_weights ----
+print("Running test_infer_load_spec_complex_load_weights...")
+V, V_PAD, H, INTER = 8, 1, 4, 8
+tp_rank = 1
+q_dim, kv_dim = 64, 16
+qkv_rows = q_dim + 2 * kv_dim
+half = H // 2
+
+hfsd = {
+    "pp_skip.model.layers.0.mlp.fc.weight": torch.randn(3, 3),
+    "model.embed_tokens.weight": torch.randn(V + V_PAD, H),
+    "model.layers.1.self_attn.q_proj.weight": torch.randn(q_dim, H),
+    "model.layers.1.self_attn.k_proj.weight": torch.randn(kv_dim, H),
+    "model.layers.1.self_attn.v_proj.weight": torch.randn(kv_dim, H),
+    "model.layers.1.self_attn.o_proj.weight": torch.randn(H, H),
+    "model.layers.1.mlp.gate_proj.weight": torch.randn(H, INTER),
+}
+wksd = {
+    "embed_tokens.weight": torch.zeros(V, H, device=device),
+    "lm_head.weight": torch.zeros(V, H, device=device),
+    "layers.1.self_attn.qkv_proj.weight": torch.zeros(qkv_rows, H, device=device),
+    "layers.1.self_attn.o_proj.weight": torch.zeros(H, half, device=device),
+    "layers.1.mlp.gate_proj.weight": torch.zeros(half, INTER, device=device),
+}
+
+lw = _complex_sglang_like_lw(
+    wksd, V=V, H=H, INTER=INTER, tp_rank=tp_rank, q_dim=q_dim, kv_dim=kv_dim
+)
+fetcher, shapes = _hfsd_to_fetcher(hfsd)
+load_spec = infer_load_spec(fetcher, shapes, lambda: wksd, lw)
+spec = load_spec.src_shard_spec
+
+assert "pp_skip.model.layers.0.mlp.fc.weight" not in spec.entries
+assert spec["model.embed_tokens.weight"] == [[(0, V, V + V_PAD), (0, H, H)]]
+assert spec["model.layers.1.self_attn.q_proj.weight"] == [
+    [(0, q_dim, q_dim), (0, H, H)]
+]
+assert spec["model.layers.1.self_attn.k_proj.weight"] == [
+    [(0, kv_dim, kv_dim), (0, H, H)]
+]
+assert spec["model.layers.1.self_attn.v_proj.weight"] == [
+    [(0, kv_dim, kv_dim), (0, H, H)]
+]
+assert spec["model.layers.1.self_attn.o_proj.weight"] == [
+    [(0, H, H), (tp_rank * half, (tp_rank + 1) * half, H)]
+]
+assert spec["model.layers.1.mlp.gate_proj.weight"] == [
+    [(tp_rank * half, (tp_rank + 1) * half, H), (0, INTER, INTER)]
+]
+print("  PASS")
+
+# ---- test_infer_load_spec_batched_merge_matches_single ----
+print("Running test_infer_load_spec_batched_merge_matches_single...")
+H = 4
+hfsd_b = {
+    "a.weight": torch.randn(H, H),
+    "b.weight": torch.randn(H, H),
+    "c.weight": torch.randn(H, H),
+}
+wksd_b = {
+    "a.weight": torch.zeros(H, H, device=device),
+    "b.weight": torch.zeros(H, H, device=device),
+    "c.weight": torch.zeros(H, H, device=device),
+}
+
+
+def lw_b(hf_weights):
+    for name, fn in hf_weights.items():
+        short = name.replace("model.", "") if name.startswith("model.") else name
+        if short in wksd_b:
+            wksd_b[short].copy_(fn())
+
+
+fetcher_b, shapes_b = _hfsd_to_fetcher(hfsd_b)
+full = infer_load_spec(fetcher_b, shapes_b, lambda: wksd_b, lw_b).src_shard_spec
+batched = infer_load_spec(fetcher_b, shapes_b, lambda: wksd_b, lw_b).src_shard_spec
+assert set(full.entries.keys()) == set(batched.entries.keys())
+for name in full.entries:
+    assert full[name] == batched[name], (
+        f"mismatch on {name}: {full[name]} vs {batched[name]}"
+    )
+print("  PASS")
+
+# ---- test_infer_load_spec_hf_worker_dtype_mismatch ----
+print("Running test_infer_load_spec_hf_worker_dtype_mismatch...")
+hfsd_d = {
+    "model.layers.0.mlp.gate.e_score_correction_bias": torch.randn(
+        8, dtype=torch.bfloat16, device="cpu"
+    )
+}
+wksd_d = {
+    "layers.0.mlp.gate.e_score_correction_bias": torch.zeros(
+        8, dtype=torch.float32, device=device
+    )
+}
+
+
+def lw_d(hf_weights):
+    for name, fn in hf_weights.items():
+        if name.endswith("e_score_correction_bias"):
+            wksd_d["layers.0.mlp.gate.e_score_correction_bias"].copy_(fn())
+
+
+fetcher_d, shapes_d = _hfsd_to_fetcher(hfsd_d)
+load_spec_d = infer_load_spec(fetcher_d, shapes_d, lambda: wksd_d, lw_d)
+spec_d = load_spec_d.src_shard_spec
+name_d = "model.layers.0.mlp.gate.e_score_correction_bias"
+assert spec_d[name_d] == [[(0, 8, 8)]]
+
+lw_d(fetcher_d)
+verify_load_spec(fetcher_d, lambda: wksd_d, load_spec_d)
+print("  PASS")
+
+# ---- test_infer_load_spec_bfloat16 ----
+print("Running test_infer_load_spec_bfloat16...")
+dt = torch.bfloat16
+
+# Large square weight
+H = 1024
+half_w = H // 2
+tp_rank_o = 0
+hfsd_o = {
+    "model.layers.0.self_attn.o_proj.weight": torch.randn(H, H, dtype=dt, device="cpu")
+}
+wksd_o = {
+    "layers.0.self_attn.o_proj.weight": torch.zeros(H, half_w, dtype=dt, device=device)
+}
+
+
+def lw_o(hf_weights):
+    for name, fn in hf_weights.items():
+        if name.endswith("o_proj.weight"):
+            t = fn()
+            wksd_o["layers.0.self_attn.o_proj.weight"].copy_(
+                t[:, tp_rank_o * half_w : (tp_rank_o + 1) * half_w]
+            )
+
+
+fetcher_o, shapes_o = _hfsd_to_fetcher(hfsd_o)
+spec_o = infer_load_spec(fetcher_o, shapes_o, lambda: wksd_o, lw_o).src_shard_spec
+assert spec_o["model.layers.0.self_attn.o_proj.weight"] == [
+    [(0, H, H), (tp_rank_o * half_w, (tp_rank_o + 1) * half_w, H)]
+]
+
+# Wide matrix (vocab-scale)
+rows, cols = 16, 151_936
+half_c = cols // 2
+tp_rank_e = 1
+hfsd_e = {"model.embed_tokens.weight": torch.randn(rows, cols, dtype=dt, device="cpu")}
+wksd_e = {
+    "model.embed_tokens.weight": torch.zeros(rows, half_c, dtype=dt, device=device)
+}
+
+
+def lw_e(hf_weights):
+    for name, fn in hf_weights.items():
+        if name.endswith("embed_tokens.weight"):
+            t = fn()
+            wksd_e["model.embed_tokens.weight"].copy_(
+                t[:, tp_rank_e * half_c : (tp_rank_e + 1) * half_c]
+            )
+
+
+fetcher_e, shapes_e = _hfsd_to_fetcher(hfsd_e)
+spec_e = infer_load_spec(fetcher_e, shapes_e, lambda: wksd_e, lw_e).src_shard_spec
+assert spec_e["model.embed_tokens.weight"] == [
+    [(0, rows, rows), (tp_rank_e * half_c, (tp_rank_e + 1) * half_c, cols)]
+]
+print("  PASS")
+
+# ---- test_verify_load_spec_1to1 ----
+print("Running test_verify_load_spec_1to1...")
+H = 4
+hfsd_v = {"a.weight": torch.randn(H, H), "b.weight": torch.randn(H, H)}
+wksd_v = {
+    "a.weight": torch.zeros(H, H, device=device),
+    "b.weight": torch.zeros(H, H, device=device),
+}
+
+
+def lw_v(hf_weights):
+    for name, fn in hf_weights.items():
+        wksd_v[name].copy_(fn())
+
+
+fetcher_v, shapes_v = _hfsd_to_fetcher(hfsd_v)
+lw_v(fetcher_v)
+load_spec_v = infer_load_spec(fetcher_v, shapes_v, lambda: wksd_v, lw_v)
+verify_load_spec(fetcher_v, lambda: wksd_v, load_spec_v)
+print("  PASS")
+
+print("\n=== ALL ORIGINAL test_specgen.py TESTS PASSED ===")

--- a/examples/weightbridge/tests/test_specgen_quick.py
+++ b/examples/weightbridge/tests/test_specgen_quick.py
@@ -1,0 +1,414 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Quick GPU test of the new specgen algorithm."""
+
+import importlib
+import logging
+import os
+import sys
+import types
+from pathlib import Path
+
+LIB_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(LIB_ROOT))
+logging.basicConfig(level=logging.INFO)
+
+import torch
+
+print(
+    f"torch {torch.__version__}, CUDA: {torch.cuda.is_available()}, devices: {torch.cuda.device_count()}"
+)
+
+# Stub wbridge package to avoid importing backend (which needs fastapi/pyzmq)
+wbridge_pkg = types.ModuleType("wbridge")
+wbridge_pkg.__path__ = [str(LIB_ROOT / "wbridge")]
+wbridge_pkg.__package__ = "wbridge"
+sys.modules["wbridge"] = wbridge_pkg
+
+wbridge_utils = types.ModuleType("wbridge.utils")
+wbridge_utils.__path__ = [os.path.join(wbridge_pkg.__path__[0], "utils")]
+wbridge_utils.__package__ = "wbridge.utils"
+sys.modules["wbridge.utils"] = wbridge_utils
+
+# Now import the actual modules
+import importlib.util
+
+for mod_name, file_name in [
+    ("wbridge.utils.data", "data.py"),
+    ("wbridge.utils.specgen", "specgen.py"),
+]:
+    spec = importlib.util.spec_from_file_location(
+        mod_name, os.path.join(wbridge_utils.__path__[0], file_name)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+
+from wbridge.utils.data import LoadSpec
+from wbridge.utils.specgen import infer_load_spec, verify_load_spec
+
+device = torch.device("cuda", 0)
+
+
+def _hfsd_to_fetcher(hfsd):
+    """Convert a plain dict of tensors to (HFWeightFetcher, shapes)."""
+    fetcher = {name: (lambda t=t: t) for name, t in hfsd.items()}
+    shapes = {name: tuple(t.shape) for name, t in hfsd.items()}
+    return fetcher, shapes
+
+
+# ---- Test 1: trivial 1:1 copy ----
+H = 4
+hfsd = {"a.weight": torch.randn(H, H), "b.weight": torch.randn(H, H)}
+wksd = {
+    "a.weight": torch.zeros(H, H, device=device),
+    "b.weight": torch.zeros(H, H, device=device),
+}
+
+
+def lw1(hf_weights):
+    for name, fn in hf_weights.items():
+        if name in wksd:
+            wksd[name].copy_(fn())
+
+
+fetcher, shapes = _hfsd_to_fetcher(hfsd)
+spec = infer_load_spec(fetcher, shapes, lambda: wksd, lw1)
+ss = spec.src_shard_spec
+assert ss["a.weight"] == [[(0, H, H), (0, H, H)]]
+assert ss["b.weight"] == [[(0, H, H), (0, H, H)]]
+print("PASS test_1to1_copy")
+
+# ---- Test 2: TP column-parallel ----
+H = 8
+half = H // 2
+tp_rank = 1
+hfsd2 = {"gate.weight": torch.randn(H, H)}
+wksd2 = {"gate.weight": torch.zeros(half, H, device=device)}
+
+
+def lw2(hf_weights):
+    for name, fn in hf_weights.items():
+        if name == "gate.weight":
+            t = fn()
+            wksd2["gate.weight"].copy_(t[tp_rank * half : (tp_rank + 1) * half, :])
+
+
+fetcher2, shapes2 = _hfsd_to_fetcher(hfsd2)
+spec2 = infer_load_spec(fetcher2, shapes2, lambda: wksd2, lw2)
+ss2 = spec2.src_shard_spec
+expected = [[(tp_rank * half, (tp_rank + 1) * half, H), (0, H, H)]]
+assert ss2["gate.weight"] == expected, f"got {ss2['gate.weight']}"
+print("PASS test_tp_column_parallel")
+
+# ---- Test 3: TP row-parallel ----
+H = 8
+half = H // 2
+tp_rank = 0
+hfsd3 = {"o.weight": torch.randn(H, H)}
+wksd3 = {"o.weight": torch.zeros(H, half, device=device)}
+
+
+def lw3(hf_weights):
+    for name, fn in hf_weights.items():
+        if name == "o.weight":
+            t = fn()
+            wksd3["o.weight"].copy_(t[:, tp_rank * half : (tp_rank + 1) * half])
+
+
+fetcher3, shapes3 = _hfsd_to_fetcher(hfsd3)
+spec3 = infer_load_spec(fetcher3, shapes3, lambda: wksd3, lw3)
+ss3 = spec3.src_shard_spec
+expected3 = [[(0, H, H), (tp_rank * half, (tp_rank + 1) * half, H)]]
+assert ss3["o.weight"] == expected3, f"got {ss3['o.weight']}"
+print("PASS test_tp_row_parallel")
+
+# ---- Test 4: QKV merge (3 HF -> 1 worker) ----
+H = 4
+q_dim, kv_dim = 8, 2
+hfsd4 = {
+    "q.weight": torch.randn(q_dim, H),
+    "k.weight": torch.randn(kv_dim, H),
+    "v.weight": torch.randn(kv_dim, H),
+}
+wksd4 = {"qkv.weight": torch.zeros(q_dim + 2 * kv_dim, H, device=device)}
+
+
+def lw4(hf_weights):
+    for name, fn in hf_weights.items():
+        t = fn()
+        if name == "q.weight":
+            wksd4["qkv.weight"][:q_dim, :].copy_(t)
+        elif name == "k.weight":
+            wksd4["qkv.weight"][q_dim : q_dim + kv_dim, :].copy_(t)
+        elif name == "v.weight":
+            wksd4["qkv.weight"][q_dim + kv_dim :, :].copy_(t)
+
+
+fetcher4, shapes4 = _hfsd_to_fetcher(hfsd4)
+spec4 = infer_load_spec(fetcher4, shapes4, lambda: wksd4, lw4)
+ss4 = spec4.src_shard_spec
+assert ss4["q.weight"] == [[(0, q_dim, q_dim), (0, H, H)]]
+assert ss4["k.weight"] == [[(0, kv_dim, kv_dim), (0, H, H)]]
+assert ss4["v.weight"] == [[(0, kv_dim, kv_dim), (0, H, H)]]
+print("PASS test_qkv_merge")
+
+# ---- Test 5: PP skip ----
+H = 4
+hfsd5 = {
+    "pp_skip.layer0.weight": torch.randn(H, H),
+    "layer1.weight": torch.randn(H, H),
+}
+wksd5 = {"layer1.weight": torch.zeros(H, H, device=device)}
+
+
+def lw5(hf_weights):
+    for name, fn in hf_weights.items():
+        if name == "layer1.weight":
+            wksd5["layer1.weight"].copy_(fn())
+
+
+fetcher5, shapes5 = _hfsd_to_fetcher(hfsd5)
+spec5 = infer_load_spec(fetcher5, shapes5, lambda: wksd5, lw5)
+assert "pp_skip.layer0.weight" not in spec5.entries
+assert "layer1.weight" in spec5.entries
+print("PASS test_pp_skip")
+
+# ---- Test 6: Padded vocab ----
+V, V_PAD, H = 8, 2, 4
+hfsd6 = {"embed.weight": torch.randn(V + V_PAD, H)}
+wksd6 = {"embed.weight": torch.zeros(V, H, device=device)}
+
+
+def lw6(hf_weights):
+    for name, fn in hf_weights.items():
+        if name == "embed.weight":
+            t = fn()
+            wksd6["embed.weight"].copy_(t[:V, :])
+
+
+fetcher6, shapes6 = _hfsd_to_fetcher(hfsd6)
+spec6 = infer_load_spec(fetcher6, shapes6, lambda: wksd6, lw6)
+ss6 = spec6.src_shard_spec
+expected6 = [[(0, V, V + V_PAD), (0, H, H)]]
+assert ss6["embed.weight"] == expected6, f"got {ss6['embed.weight']}"
+print("PASS test_padded_vocab")
+
+# ---- Test 7: Tied embeddings (double-pass lw) ----
+V, H = 8, 4
+hfsd7 = {"model.embed_tokens.weight": torch.randn(V, H)}
+wksd7 = {
+    "embed_tokens.weight": torch.zeros(V, H, device=device),
+    "lm_head.weight": torch.zeros(V, H, device=device),
+}
+
+
+def lw7(hf_weights):
+    for name, fn in hf_weights.items():
+        if name == "model.embed_tokens.weight":
+            t = fn()
+            wksd7["embed_tokens.weight"].copy_(t)
+    for name, fn in hf_weights.items():
+        if name == "model.embed_tokens.weight":
+            t = fn()
+            wksd7["lm_head.weight"].copy_(t)
+
+
+fetcher7, shapes7 = _hfsd_to_fetcher(hfsd7)
+spec7 = infer_load_spec(fetcher7, shapes7, lambda: wksd7, lw7)
+ss7 = spec7.src_shard_spec
+expected7 = [[(0, V, V), (0, H, H)]]
+assert ss7["model.embed_tokens.weight"] == expected7, (
+    f"got {ss7['model.embed_tokens.weight']}"
+)
+print("PASS test_tied_embeddings")
+
+# ---- Test 8: 1D tensor partial copy ----
+W = 16
+hfsd8 = {"bias": torch.randn(W)}
+wksd8 = {"bias": torch.zeros(8, device=device)}
+
+
+def lw8(hf_weights):
+    for name, fn in hf_weights.items():
+        if name == "bias":
+            t = fn()
+            wksd8["bias"].copy_(t[4:12])
+
+
+fetcher8, shapes8 = _hfsd_to_fetcher(hfsd8)
+spec8 = infer_load_spec(fetcher8, shapes8, lambda: wksd8, lw8)
+ss8 = spec8.src_shard_spec
+expected8 = [[(4, 12, W)]]
+assert ss8["bias"] == expected8, f"got {ss8['bias']}"
+print("PASS test_1d_tensor")
+
+# ---- Test 9: Complex SGLang-like (from test file) ----
+V, V_PAD, H, INTER = 8, 1, 4, 8
+tp_rank = 1
+q_dim, kv_dim = 64, 16
+qkv_rows = q_dim + 2 * kv_dim
+half = H // 2
+
+hfsd9 = {
+    "pp_skip.model.layers.0.mlp.fc.weight": torch.randn(3, 3),
+    "model.embed_tokens.weight": torch.randn(V + V_PAD, H),
+    "model.layers.1.self_attn.q_proj.weight": torch.randn(q_dim, H),
+    "model.layers.1.self_attn.k_proj.weight": torch.randn(kv_dim, H),
+    "model.layers.1.self_attn.v_proj.weight": torch.randn(kv_dim, H),
+    "model.layers.1.self_attn.o_proj.weight": torch.randn(H, H),
+    "model.layers.1.mlp.gate_proj.weight": torch.randn(H, INTER),
+}
+wksd9 = {
+    "embed_tokens.weight": torch.zeros(V, H, device=device),
+    "lm_head.weight": torch.zeros(V, H, device=device),
+    "layers.1.self_attn.qkv_proj.weight": torch.zeros(qkv_rows, H, device=device),
+    "layers.1.self_attn.o_proj.weight": torch.zeros(H, half, device=device),
+    "layers.1.mlp.gate_proj.weight": torch.zeros(half, INTER, device=device),
+}
+
+
+def _dispatch9(name, t):
+    if name.startswith("pp_skip."):
+        return
+    if name == "model.embed_tokens.weight":
+        wksd9["embed_tokens.weight"].copy_(t[:V, :])
+        wksd9["lm_head.weight"].copy_(t[:V, :])
+        return
+    if name.endswith("self_attn.q_proj.weight"):
+        wksd9["layers.1.self_attn.qkv_proj.weight"][:q_dim, :].copy_(t)
+        return
+    if name.endswith("self_attn.k_proj.weight"):
+        wksd9["layers.1.self_attn.qkv_proj.weight"][q_dim : q_dim + kv_dim, :].copy_(t)
+        return
+    if name.endswith("self_attn.v_proj.weight"):
+        wksd9["layers.1.self_attn.qkv_proj.weight"][q_dim + kv_dim : qkv_rows, :].copy_(
+            t
+        )
+        return
+    if name.endswith("self_attn.o_proj.weight"):
+        wksd9["layers.1.self_attn.o_proj.weight"].copy_(
+            t[:, tp_rank * half : (tp_rank + 1) * half]
+        )
+        return
+    if name.endswith("mlp.gate_proj.weight"):
+        wksd9["layers.1.mlp.gate_proj.weight"].copy_(
+            t[tp_rank * half : (tp_rank + 1) * half, :]
+        )
+        return
+
+
+def lw9(hf_weights):
+    for name, fn in hf_weights.items():
+        _dispatch9(name, fn())
+    for name, fn in hf_weights.items():
+        if name == "model.embed_tokens.weight":
+            wksd9["lm_head.weight"].copy_(fn()[:V, :])
+            break
+
+
+fetcher9, shapes9 = _hfsd_to_fetcher(hfsd9)
+spec9 = infer_load_spec(fetcher9, shapes9, lambda: wksd9, lw9)
+ss9 = spec9.src_shard_spec
+
+assert "pp_skip.model.layers.0.mlp.fc.weight" not in ss9.entries
+assert ss9["model.embed_tokens.weight"] == [[(0, V, V + V_PAD), (0, H, H)]]
+assert ss9["model.layers.1.self_attn.q_proj.weight"] == [[(0, q_dim, q_dim), (0, H, H)]]
+assert ss9["model.layers.1.self_attn.k_proj.weight"] == [
+    [(0, kv_dim, kv_dim), (0, H, H)]
+]
+assert ss9["model.layers.1.self_attn.v_proj.weight"] == [
+    [(0, kv_dim, kv_dim), (0, H, H)]
+]
+assert ss9["model.layers.1.self_attn.o_proj.weight"] == [
+    [(0, H, H), (tp_rank * half, (tp_rank + 1) * half, H)]
+]
+assert ss9["model.layers.1.mlp.gate_proj.weight"] == [
+    [(tp_rank * half, (tp_rank + 1) * half, H), (0, INTER, INTER)]
+]
+print("PASS test_complex_sglang_like")
+
+# ---- Test 10: verify_load_spec works with new algorithm ----
+H = 4
+hfsd10 = {"a.weight": torch.randn(H, H), "b.weight": torch.randn(H, H)}
+wksd10 = {
+    "a.weight": torch.zeros(H, H, device=device),
+    "b.weight": torch.zeros(H, H, device=device),
+}
+
+
+def lw10(hf_weights):
+    for name, fn in hf_weights.items():
+        if name in wksd10:
+            wksd10[name].copy_(fn())
+
+
+fetcher10, shapes10 = _hfsd_to_fetcher(hfsd10)
+lw10(fetcher10)
+spec10 = infer_load_spec(fetcher10, shapes10, lambda: wksd10, lw10)
+verify_load_spec(fetcher10, lambda: wksd10, spec10)
+print("PASS test_verify_load_spec")
+
+# ---- Test 11: dtype mismatch (bf16 HF -> fp32 wk) ----
+hfsd11 = {
+    "model.layers.0.mlp.gate.e_score_correction_bias": torch.randn(
+        8, dtype=torch.bfloat16
+    ),
+}
+wksd11 = {
+    "layers.0.mlp.gate.e_score_correction_bias": torch.zeros(
+        8, dtype=torch.float32, device=device
+    ),
+}
+
+
+def lw11(hf_weights):
+    for name, fn in hf_weights.items():
+        if name.endswith("e_score_correction_bias"):
+            wksd11["layers.0.mlp.gate.e_score_correction_bias"].copy_(fn())
+
+
+fetcher11, shapes11 = _hfsd_to_fetcher(hfsd11)
+spec11 = infer_load_spec(fetcher11, shapes11, lambda: wksd11, lw11)
+ss11 = spec11.src_shard_spec
+name11 = "model.layers.0.mlp.gate.e_score_correction_bias"
+assert ss11[name11] == [[(0, 8, 8)]], f"got {ss11[name11]}"
+
+lw11(fetcher11)
+verify_load_spec(fetcher11, lambda: wksd11, spec11)
+print("PASS test_dtype_mismatch_bf16_to_fp32")
+
+# ---- Test 12: bfloat16 production-like sizes ----
+dt = torch.bfloat16
+H = 1024
+half_w = H // 2
+tp_rank_o = 0
+
+hfsd12 = {"model.layers.0.self_attn.o_proj.weight": torch.randn(H, H, dtype=dt)}
+wksd12 = {
+    "layers.0.self_attn.o_proj.weight": torch.zeros(H, half_w, dtype=dt, device=device)
+}
+
+
+def lw12(hf_weights):
+    for name, fn in hf_weights.items():
+        if name.endswith("o_proj.weight"):
+            t = fn()
+            wksd12["layers.0.self_attn.o_proj.weight"].copy_(
+                t[:, tp_rank_o * half_w : (tp_rank_o + 1) * half_w]
+            )
+
+
+fetcher12, shapes12 = _hfsd_to_fetcher(hfsd12)
+spec12 = infer_load_spec(fetcher12, shapes12, lambda: wksd12, lw12)
+ss12 = spec12.src_shard_spec
+assert ss12["model.layers.0.self_attn.o_proj.weight"] == [
+    [(0, H, H), (tp_rank_o * half_w, (tp_rank_o + 1) * half_w, H)]
+]
+print("PASS test_bfloat16_production_size")
+
+print("\n=== ALL 12 TESTS PASSED ===")

--- a/examples/weightbridge/tests/test_tcp_control.py
+++ b/examples/weightbridge/tests/test_tcp_control.py
@@ -1,0 +1,84 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Loopback tests for the persistent host-network control transport."""
+
+import threading
+import time
+
+from wbridge.backend.tcp_control import TcpControlTransport
+
+
+def test_tcp_control_full_duplex_fixed_records():
+    landed = {0: [], 1: []}
+    cv = threading.Condition()
+
+    def callback(rank):
+        def receive(kind, peer, seq):
+            with cv:
+                landed[rank].append((kind, peer, seq))
+                cv.notify_all()
+
+        return receive
+
+    left = TcpControlTransport(0, "127.0.0.1", callback(0))
+    right = TcpControlTransport(1, "127.0.0.1", callback(1))
+    try:
+        # Rank 0 is the unique connector. Rank 1's accept loop is live before
+        # configure(), so setup does not require an auxiliary controller thread.
+        left.configure({1}, {1: right.endpoint}, timeout_s=2.0)
+        right.configure({0}, {0: left.endpoint}, timeout_s=2.0)
+
+        left.send(0, 1, 17)
+        right.send(1, 0, 19)
+        left.send(2, 1, 23)
+        with cv:
+            cv.wait_for(
+                lambda: len(landed[0]) == 1 and len(landed[1]) == 2,
+                timeout=2.0,
+            )
+        assert landed[0] == [(1, 1, 19)]
+        assert landed[1] == [(0, 0, 17), (2, 0, 23)]
+        left.check()
+        right.check()
+    finally:
+        left.close()
+        right.close()
+
+
+def test_tcp_control_peers_do_not_share_send_lock():
+    received = []
+    cv = threading.Condition()
+
+    def callback(kind, peer, seq):
+        with cv:
+            received.append((kind, peer, seq, time.perf_counter()))
+            cv.notify_all()
+
+    root = TcpControlTransport(0, "127.0.0.1", lambda *_args: None)
+    one = TcpControlTransport(1, "127.0.0.1", callback)
+    two = TcpControlTransport(2, "127.0.0.1", callback)
+    try:
+        root.configure({1, 2}, {1: one.endpoint, 2: two.endpoint}, timeout_s=2.0)
+        one.configure({0}, {0: root.endpoint}, timeout_s=2.0)
+        two.configure({0}, {0: root.endpoint}, timeout_s=2.0)
+
+        a = threading.Thread(target=root.send, args=(0, 1, 31))
+        b = threading.Thread(target=root.send, args=(0, 2, 37))
+        a.start()
+        b.start()
+        a.join(timeout=2.0)
+        b.join(timeout=2.0)
+        with cv:
+            cv.wait_for(lambda: len(received) == 2, timeout=2.0)
+        assert {(kind, peer, seq) for kind, peer, seq, _t in received} == {
+            (0, 0, 31),
+            (0, 0, 37),
+        }
+    finally:
+        root.close()
+        one.close()
+        two.close()

--- a/examples/weightbridge/tests/test_topo_subgroups.py
+++ b/examples/weightbridge/tests/test_topo_subgroups.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for WeightRouter.topo_subgroups (topology-aware 1-worker-per-node partition)."""
+
+from wbridge.backend.router import WeightRouter
+
+
+def test_equal_n_two_nodes():
+    subs, ok = WeightRouter.topo_subgroups(
+        [4, 5, 6, 7], {4: "A", 5: "A", 6: "B", 7: "B"}
+    )
+    assert ok
+    assert subs == [[4, 6], [5, 7]]  # subgroup j = j-th worker (by rank) on each node
+
+
+def test_three_nodes():
+    ip = {0: "A", 1: "A", 2: "B", 3: "B", 4: "C", 5: "C"}
+    subs, ok = WeightRouter.topo_subgroups([0, 1, 2, 3, 4, 5], ip)
+    assert ok
+    assert subs == [[0, 2, 4], [1, 3, 5]]
+
+
+def test_unequal_n_fails():
+    subs, ok = WeightRouter.topo_subgroups([4, 5, 6], {4: "A", 5: "A", 6: "B"})
+    assert not ok and subs == []
+
+
+def test_missing_ip_fails():
+    subs, ok = WeightRouter.topo_subgroups(
+        [4, 5, 6, 7], {4: "A", 5: "A", 6: "B"}
+    )  # 7's ip missing
+    assert not ok
+
+
+def test_one_per_node_ok():
+    # n=1 is the external-only topology used by two one-node rollout replicas.
+    subs, ok = WeightRouter.topo_subgroups([4, 6], {4: "A", 6: "B"})
+    assert ok and subs == [[4, 6]]
+
+
+def test_determinism_order_independent():
+    ip = {4: "A", 5: "A", 6: "B", 7: "B"}
+    a, _ = WeightRouter.topo_subgroups([7, 6, 5, 4], ip)  # unsorted input
+    b, _ = WeightRouter.topo_subgroups([4, 5, 6, 7], ip)
+    assert a == b == [[4, 6], [5, 7]]

--- a/examples/weightbridge/tests/test_transpose_copy.py
+++ b/examples/weightbridge/tests/test_transpose_copy.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""test_transpose_copy.py — demonstrate the transpose gap in the transfer path, then (after fix) verify.
+
+Uses the toy builders (qwen_tiny) with the now-transposed rollout down_proj. Runs specgen to get the
+trainer/rollout LoadSpecs, then simulates the stage-1 transfer round-trip:
+    trainer wksd --(save)--> HF comm buffer --(load)--> fresh rollout wksd
+and checks the round-tripped rollout params equal the reference rollout layout. With the current
+copy_fromto_params (ignores the w sign) the transposed down_proj must FAIL; after the Triton fix it
+must PASS.
+
+Run in-container:  python tests/test_transpose_copy.py
+"""
+
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "examples"))
+
+from qwen_tiny import (  # noqa: E402
+    build_qwen_tiny_hf_checkpoint,
+    build_rollout_wksd,
+    build_trainer_wksd,
+    DEFAULT_QWEN_TINY_CONFIG,
+    make_rollout_load_weights,
+    make_trainer_load_weights,
+)
+from utils import make_hf_weights  # noqa: E402
+from wbridge.utils.specgen import infer_load_spec  # noqa: E402
+
+
+def _side(build_wksd, make_lw, cfg, hf_weights, hf_shapes, device, dtype):
+    wksd = build_wksd(cfg, device=device, dtype=dtype, tp_rank=0, tp_size=1)
+    lw_raw = make_lw(wksd, cfg, device=device, dtype=dtype, tp_rank=0, tp_size=1)
+
+    def load_weights(fetcher):
+        lw_raw((name, fn()) for name, fn in fetcher.items())
+
+    load_spec = infer_load_spec(hf_weights, hf_shapes, lambda: wksd, load_weights)
+    dtype_spec = {
+        hf: max((wksd[wk].dtype for wk in entry), key=lambda d: d.itemsize)
+        for hf, entry in load_spec.entries.items()
+    }
+    return wksd, load_spec, dtype_spec, load_weights
+
+
+def main(device="cpu"):
+    cfg = DEFAULT_QWEN_TINY_CONFIG
+    dtype = torch.float32
+    hf_cpu = build_qwen_tiny_hf_checkpoint(cfg, dtype=dtype, seed=1, device=device)
+    hf_weights, hf_shapes = make_hf_weights(hf_cpu)
+
+    tr_wksd, tr_spec, tr_dt, tr_lw = _side(
+        build_trainer_wksd,
+        make_trainer_load_weights,
+        cfg,
+        hf_weights,
+        hf_shapes,
+        device,
+        dtype,
+    )
+    ro_wksd, ro_spec, ro_dt, ro_lw = _side(
+        build_rollout_wksd,
+        make_rollout_load_weights,
+        cfg,
+        hf_weights,
+        hf_shapes,
+        device,
+        dtype,
+    )
+
+    # reference correct layouts: load HF into each side directly
+    tr_lw(hf_weights)
+    ro_lw(hf_weights)
+
+    # report whether the rollout LoadSpec carries a transpose (negative w) for down_proj
+    neg = {}
+    for sname, shards in ro_spec.src_shard_spec:
+        if any(w < 0 for shard in shards for (_, _, w) in shard):
+            neg[sname] = True
+    print(f"rollout LoadSpec transposed HF names: {sorted(neg)}")
+
+    # ---- stage-1 round-trip: trainer wksd -> HF comm -> fresh rollout wksd ----
+    tr_src = tr_spec.src_shard_spec
+    ro_src = ro_spec.src_shard_spec
+    comm = tr_src.make_named_buffer(tr_dt, device)  # per-HF-name 1D buffers (HF layout)
+    tr_spec.copy_fromto_params(
+        tr_src, comm, tr_wksd, src_to_dst=False
+    )  # comm <- trainer worker
+    ro_new = build_rollout_wksd(cfg, device=device, dtype=dtype, tp_rank=0, tp_size=1)
+    for t in ro_new.values():
+        t.zero_()
+    ro_spec.copy_fromto_params(
+        ro_src, comm, ro_new, src_to_dst=True
+    )  # rollout worker <- comm
+
+    ok = True
+    for name in ro_wksd:
+        a, b = ro_new[name], ro_wksd[name]
+        match = a.shape == b.shape and torch.allclose(a, b)
+        if not match:
+            ok = False
+            print(
+                f"  MISMATCH {name}: new{tuple(a.shape)} vs ref{tuple(b.shape)} allclose={a.shape == b.shape and torch.allclose(a, b)}"
+            )
+        else:
+            print(f"  ok {name} {tuple(a.shape)}")
+    print("ROUND-TRIP:", "PASS" if ok else "FAIL")
+    return ok
+
+
+if __name__ == "__main__":
+    dev = sys.argv[1] if len(sys.argv) > 1 else "cpu"
+    try:
+        ok = main(dev)
+    except Exception as e:
+        import traceback
+
+        traceback.print_exc()
+        print("ROUND-TRIP: FAIL (exception)")
+        ok = False
+    sys.exit(0 if ok else 1)

--- a/examples/weightbridge/wbridge/__init__.py
+++ b/examples/weightbridge/wbridge/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""WeightBridge - RL weight transfer between Trainer Workers and Rollout Workers."""
+
+from wbridge.backend import (
+    SenderArgs,
+    WeightReceiver,
+    WeightReceiverController,
+    WeightSender,
+)
+from wbridge.utils.data import BoundShardSpec, ShardSpec
+
+__all__ = [
+    "BoundShardSpec",
+    "SenderArgs",
+    "ShardSpec",
+    "WeightReceiver",
+    "WeightReceiverController",
+    "WeightSender",
+]

--- a/examples/weightbridge/wbridge/backend/__init__.py
+++ b/examples/weightbridge/wbridge/backend/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Backend Data Plane transport and Control Plane ZMQ coordination."""
+
+from wbridge.backend.coordinator import WeightReceiverController
+from wbridge.backend.receiver import WeightReceiver
+from wbridge.backend.sender import SenderArgs, WeightSender
+
+__all__ = ["SenderArgs", "WeightReceiver", "WeightReceiverController", "WeightSender"]

--- a/examples/weightbridge/wbridge/backend/control_channel.py
+++ b/examples/weightbridge/wbridge/backend/control_channel.py
@@ -1,0 +1,371 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Torch-free per-engine control star for WeightBridge receivers.
+
+Two pieces, split by which thread owns their ZMQ sockets (sockets are NOT thread-safe):
+
+* :class:`CoordinatorClient` — rank0's trainer-facing intake (the ``worker-0`` DEALER to the coordinator).
+  Owned by rank0's **receiving thread**; normally it carries connect only, plus the zero-input update
+  fallback, independently of the scheduler tick.
+* :class:`ControlChannel` — the rank0<->peers **hub star**, used on the **main (scheduler) thread**. Every
+  scheduler tick uses a prepare/ack/commit barrier, so all of an engine's TP ranks have reached the hook
+  before any rank proceeds. This includes ``empty`` ticks: the barrier bounds the queue to one decision and
+  avoids making peer ranks sleep until a long polling timeout.
+
+rank0's main thread reads the state the receiving thread posted and feeds it into
+:meth:`ControlChannel.broadcast`. This module imports only ``zmq`` (no torch/fastapi) so it is unit-testable
+without a GPU.
+"""
+
+import json
+import logging
+import os
+import tempfile
+import time
+from typing import Any, Optional
+
+import zmq
+
+logger = logging.getLogger(__name__)
+
+# Message types for coordinator <-> rank0 and rank0 <-> peers.
+CONNECT_REQUEST = "connect_request"
+RECEIVE_REQUEST = "receive_request"
+RECEIVE_KICK = (
+    "receive_kick"  # rank0 -> peers (RS-on phase 1): start the receive-to-CPU worker
+)
+EMPTY = "empty"
+REGISTER = "register"  # peer -> rank0 hub startup registration
+WORKER_REGISTER = (
+    "worker_register"  # rank0 -> coordinator: reports this engine's receiver count
+)
+
+# Internal rank0 <-> peer synchronization fields.  They stay private to this module and are stripped before
+# a decision is returned to WeightReceiver.
+_SYNC_SEQ = "_wbridge_control_seq"
+_SYNC_PHASE = "_wbridge_control_phase"
+_SYNC_PREPARE = "prepare"
+_SYNC_COMMIT = "commit"
+_SYNC_ACK = "ack"
+
+# Message types for trainer <-> coordinator (external, over the coordinator's TCP ROUTER).
+WORLD_QUERY = "world_query"  # -> {status, world_size}
+CONNECT = "connect"  # + process-group args -> {status}
+RECEIVE = "receive"  # -> {status}
+
+# The coordinator's trainer-facing TCP port is derived deterministically from SGLang's HTTP server port,
+# so every process (all TP ranks + the trainer's discovery) computes the same endpoint with no handoff.
+WBRIDGE_PORT_OFFSET = 1717
+WBRIDGE_HUB_PORT_OFFSET = WBRIDGE_PORT_OFFSET + 1
+
+# This startup guard covers both registration hops: receiver rank 0 joining
+# the standalone coordinator and the remaining model-parallel ranks joining
+# rank 0's hub.  Large-model LoadSpec construction can stagger those ranks by
+# many minutes, so launchers need one consistent knob for both waits.
+STARTUP_REGISTER_TIMEOUT_ENV = "WBRIDGE_COORDINATOR_REGISTER_TIMEOUT_S"
+
+
+def startup_register_timeout_s() -> float:
+    """Return the startup-only receiver registration timeout."""
+    raw = os.environ.get(STARTUP_REGISTER_TIMEOUT_ENV, "600").strip()
+    try:
+        timeout_s = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{STARTUP_REGISTER_TIMEOUT_ENV} must be a positive number, got {raw!r}"
+        ) from exc
+    if timeout_s <= 0:
+        raise ValueError(
+            f"{STARTUP_REGISTER_TIMEOUT_ENV} must be positive, got {raw!r}"
+        )
+    return timeout_s
+
+
+def coordinator_ipc(server_port: int) -> str:
+    """Deterministic rank0-facing IPC path for the coordinator, derived from the engine's server port."""
+    ipc_dir = os.path.abspath(
+        os.path.expanduser(
+            os.environ.get("WBRIDGE_COORDINATOR_IPC_DIR", tempfile.gettempdir())
+        )
+    )
+    return f"ipc://{os.path.join(ipc_dir, f'wbridge_coord_{server_port}.sock')}"
+
+
+def coordinator_tcp_port(server_port: int) -> int:
+    """Deterministic trainer-facing TCP port for the coordinator, derived from the engine's server port."""
+    return server_port + WBRIDGE_PORT_OFFSET
+
+
+def multi_node_hub_addr(
+    server_port: int,
+    dist_init_addr: str | None,
+    nnodes: int,
+) -> str | None:
+    """Return a rank-0-hosted TCP hub for a multi-node model-parallel engine.
+
+    A filesystem IPC endpoint is visible only to processes on one host.  For a
+    multi-node SGLang engine, all ranks already agree on ``dist_init_addr``;
+    reuse its rank-0 host with a deterministic, coordinator-adjacent port.
+    Single-node engines return ``None`` and retain the lower-overhead IPC hub.
+    """
+    if nnodes <= 1:
+        return None
+    if not dist_init_addr:
+        raise ValueError("multi-node receiver hub requires dist_init_addr")
+    address = dist_init_addr.strip()
+    if address.startswith("["):
+        close = address.find("]")
+        if close <= 1:
+            raise ValueError(f"invalid bracketed dist_init_addr: {dist_init_addr!r}")
+        host = address[1:close]
+        host_for_zmq = f"[{host}]"
+    else:
+        if ":" not in address:
+            raise ValueError(f"dist_init_addr has no port: {dist_init_addr!r}")
+        host_for_zmq = address.rsplit(":", 1)[0]
+    return f"tcp://{host_for_zmq}:{server_port + WBRIDGE_HUB_PORT_OFFSET}"
+
+
+def hub_addr(controller_ipc_name: str) -> str:
+    """The rank0 hub reuses the coordinator IPC path with a distinct suffix, so every worker
+    (which all know the coordinator IPC) can derive the same address without extra discovery."""
+    return f"{controller_ipc_name}.hub"
+
+
+class CoordinatorClient:
+    """rank0's trainer-facing coordinator intake (the ``worker-0`` DEALER). Owned by the receiving thread.
+
+    Sends :data:`WORKER_REGISTER` on creation (so the coordinator can answer the trainer's world query
+    without a separate config path), then blocks on coordinator requests, acking each so the trainer can
+    proceed. Normal updates are flag-driven; ``receive`` is only a zero-input fallback. All socket ops happen
+    on the one thread that creates it.
+    """
+
+    def __init__(
+        self,
+        controller_ipc_name: str,
+        num_workers: int,
+        *,
+        ctx: Optional[zmq.Context] = None,
+    ) -> None:
+        self._ctx = ctx if ctx is not None else zmq.Context()
+        self._owns_ctx = ctx is None
+        self._sock = self._ctx.socket(zmq.DEALER)
+        self._sock.setsockopt_string(zmq.IDENTITY, "worker-0")
+        self._sock.connect(controller_ipc_name)
+        # ZMQ queues this if the coordinator has not bound yet (lazy connect).
+        self._sock.send_string(
+            json.dumps({"type": WORKER_REGISTER, "num_workers": num_workers})
+        )
+        self._poller = zmq.Poller()
+        self._poller.register(self._sock, zmq.POLLIN)
+
+    def poll(self, timeout_ms: int = 1000) -> Optional[dict[str, Any]]:
+        """Block up to *timeout_ms* for the next trainer request; return it or ``None`` on timeout."""
+        if not dict(self._poller.poll(timeout_ms)):
+            return None
+        return json.loads(self._sock.recv_string())
+
+    def ack(self) -> None:
+        """Ack the current request (lets the coordinator reply to the trainer)."""
+        self._sock.send_string(json.dumps({"status": "ack"}))
+
+    def close(self) -> None:
+        try:
+            self._sock.close(linger=0)
+            if self._owns_ctx:
+                self._ctx.term()
+        except Exception:
+            pass
+
+
+class ControlChannel:
+    """rank0<->peers hub star (ZMQ only), used on the MAIN thread to keep TP ranks in lockstep.
+
+    Topology per engine::
+
+        rank0 --ROUTER hub / DEALER--> peer-1 .. peer-{N-1}
+
+    Every decision is sent in two phases. Every peer acknowledges ``prepare`` from its scheduler thread and
+    waits for ``commit``; rank 0 sends ``commit`` only after every peer has acknowledged. Thus no receiver can
+    leave an in-flight SGLang collective for a blocking WeightBridge collective while another receiver is
+    still participating in it. Applying the same barrier to ``empty`` decisions prevents both an idle FIFO
+    backlog and the multi-second peer polling stalls that would otherwise desynchronize TP ranks. The
+    trainer-facing intake is a separate :class:`CoordinatorClient` (rank0's receiving thread).
+    """
+
+    def __init__(
+        self,
+        controller_ipc_name: str,
+        rank: int,
+        num_workers: int,
+        *,
+        hub_endpoint: str | None = None,
+        ctx: Optional[zmq.Context] = None,
+        reg_timeout_s: float | None = None,
+    ) -> None:
+        self.rank = rank
+        self.num_workers = num_workers
+        self._ctx = ctx if ctx is not None else zmq.Context()
+        self._owns_ctx = ctx is None
+        hub = (
+            hub_endpoint if hub_endpoint is not None else hub_addr(controller_ipc_name)
+        )
+
+        if rank == 0:
+            self._hub = self._ctx.socket(zmq.ROUTER)
+            self._hub.bind(hub)
+            self._peer_ids: list[bytes] = []
+            self._decision_seq = 0
+            self._await_registration(
+                startup_register_timeout_s() if reg_timeout_s is None else reg_timeout_s
+            )
+        else:
+            self._peer = self._ctx.socket(zmq.DEALER)
+            self._peer.setsockopt_string(zmq.IDENTITY, f"peer-{rank}")
+            self._peer.connect(hub)
+            self._poller = zmq.Poller()
+            self._poller.register(self._peer, zmq.POLLIN)
+            self._peer.send_string(json.dumps({"type": REGISTER, "rank": rank}))
+
+    def _await_registration(self, timeout_s: float) -> None:
+        """rank0: block until all ``num_workers-1`` peers have registered on the hub."""
+        expected = self.num_workers - 1
+        if expected <= 0:
+            return
+        poller = zmq.Poller()
+        poller.register(self._hub, zmq.POLLIN)
+        deadline = time.time() + timeout_s
+        while len(self._peer_ids) < expected:
+            if dict(poller.poll(1000)):
+                ident, _payload = self._hub.recv_multipart()
+                if ident not in self._peer_ids:
+                    self._peer_ids.append(ident)
+            elif time.time() > deadline:
+                raise TimeoutError(
+                    f"receiver rank0 hub: only {len(self._peer_ids)}/{expected} peers registered"
+                )
+        logger.info(
+            "wbridge receiver rank0: %d peers registered on hub", len(self._peer_ids)
+        )
+
+    @staticmethod
+    def _public_decision(decision: dict[str, Any]) -> dict[str, Any]:
+        """Remove synchronization metadata before exposing a decision to WeightReceiver."""
+        return {k: v for k, v in decision.items() if k not in (_SYNC_SEQ, _SYNC_PHASE)}
+
+    def broadcast(self, decision: dict[str, Any]) -> None:
+        """Rank 0: barrier-broadcast one scheduler-tick decision.
+
+        Peers acknowledge the prepare from the scheduler thread and wait for a commit. Rank 0 returns only
+        after all peers are quiescent and the commit has been published. ``EMPTY`` follows the same bounded
+        handshake, so it cannot accumulate in front of an actionable decision or leave peers waiting for the
+        polling timeout.
+        """
+
+        self._decision_seq += 1
+        seq = self._decision_seq
+        prepare = {**decision, _SYNC_SEQ: seq, _SYNC_PHASE: _SYNC_PREPARE}
+        payload = json.dumps(prepare).encode("utf-8")
+        for ident in self._peer_ids:
+            self._hub.send_multipart([ident, payload])
+
+        pending = set(self._peer_ids)
+        if pending:
+            poller = zmq.Poller()
+            poller.register(self._hub, zmq.POLLIN)
+            timeout_s = startup_register_timeout_s()
+            deadline = time.time() + timeout_s
+            while pending:
+                remaining_ms = max(1, min(1000, int((deadline - time.time()) * 1000)))
+                if not dict(poller.poll(remaining_ms)):
+                    if time.time() >= deadline:
+                        missing = sorted(
+                            ident.decode("utf-8", "replace") for ident in pending
+                        )
+                        raise TimeoutError(
+                            f"receiver rank0 control barrier seq={seq}: "
+                            f"only {len(self._peer_ids) - len(pending)}/{len(self._peer_ids)} peers acked; "
+                            f"missing={missing}"
+                        )
+                    continue
+                frames = self._hub.recv_multipart()
+                if len(frames) != 2:
+                    logger.warning(
+                        "receiver rank0 control barrier: ignoring malformed frames=%d",
+                        len(frames),
+                    )
+                    continue
+                ident, raw = frames
+                try:
+                    message = json.loads(raw.decode("utf-8"))
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    logger.warning(
+                        "receiver rank0 control barrier: ignoring malformed peer payload"
+                    )
+                    continue
+                if (
+                    message.get(_SYNC_PHASE) == _SYNC_ACK
+                    and message.get(_SYNC_SEQ) == seq
+                ):
+                    pending.discard(ident)
+                else:
+                    logger.warning(
+                        "receiver rank0 control barrier seq=%d: ignoring unexpected message from %r: %r",
+                        seq,
+                        ident,
+                        message,
+                    )
+
+        commit = {**decision, _SYNC_SEQ: seq, _SYNC_PHASE: _SYNC_COMMIT}
+        payload = json.dumps(commit).encode("utf-8")
+        for ident in self._peer_ids:
+            self._hub.send_multipart([ident, payload])
+
+    def poll_decision(self, timeout_ms: int = 5000) -> Optional[dict[str, Any]]:
+        """Peer scheduler thread: wait for rank 0's next scheduler-tick decision.
+
+        The initial prepare wait is bounded by *timeout_ms* so idle schedulers continue normally.  Once a
+        prepare arrives, this rank acknowledges that it is quiescent and waits for the matching commit; no
+        WeightBridge action is visible to the caller before every peer has acknowledged.
+        """
+        if not dict(self._poller.poll(timeout_ms)):
+            return None
+        decision = json.loads(self._peer.recv_string())
+        if decision.get(_SYNC_PHASE) != _SYNC_PREPARE:
+            # Compatibility with a pre-barrier rank 0, useful during rolling tests.  Production snapshots
+            # keep sender and receiver sources identical, so this path is not used in a campaign.
+            return self._public_decision(decision)
+
+        seq = decision.get(_SYNC_SEQ)
+        self._peer.send_string(json.dumps({_SYNC_SEQ: seq, _SYNC_PHASE: _SYNC_ACK}))
+        deadline = time.time() + startup_register_timeout_s()
+        while True:
+            remaining_ms = max(1, min(1000, int((deadline - time.time()) * 1000)))
+            if not dict(self._poller.poll(remaining_ms)):
+                if time.time() >= deadline:
+                    raise TimeoutError(
+                        f"receiver peer {self.rank} timed out waiting for control commit seq={seq}"
+                    )
+                continue
+            commit = json.loads(self._peer.recv_string())
+            if commit.get(_SYNC_PHASE) == _SYNC_COMMIT and commit.get(_SYNC_SEQ) == seq:
+                return self._public_decision(commit)
+            raise RuntimeError(
+                f"receiver peer {self.rank} expected control commit seq={seq}, got {commit!r}"
+            )
+
+    def close(self) -> None:
+        try:
+            if self.rank == 0:
+                self._hub.close(linger=0)
+            else:
+                self._peer.close(linger=0)
+            if self._owns_ctx:
+                self._ctx.term()
+        except Exception:
+            pass

--- a/examples/weightbridge/wbridge/backend/coordinator.py
+++ b/examples/weightbridge/wbridge/backend/coordinator.py
@@ -1,0 +1,208 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Standalone per-engine ZMQ control-plane coordinator for WeightBridge.
+
+Replaces the former FastAPI ``WeightReceiverController``. Runs as its OWN process (spawned once per
+rollout engine) so external control requests from the Trainer are serviced continuously, independent of
+any rollout worker's scheduler tick. Pure ``zmq`` + JSON — no torch, no FastAPI.
+
+**Thin relay.** It forwards the Trainer's one-time ``connect`` (and rare zero-input ``receive`` fallback)
+to receiver rank 0 over the node-local IPC ROUTER and routes rank 0's ack back over the Trainer-facing TCP
+ROUTER; it answers the Trainer's
+``world_query`` locally from the count rank 0 reports at startup (:data:`WORKER_REGISTER`). rank 0 keeps
+its own peer fan-out hub (see :mod:`wbridge.backend.control_channel`) — the coordinator never talks to the
+peers, so the lockstep rendezvous is unchanged.
+
+Run as ``python -m wbridge.backend.coordinator --ipc <addr> --tcp-port <n>`` (usually via :func:`spawn`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from typing import Any, Optional
+
+import zmq
+from wbridge.backend.control_channel import (
+    CONNECT,
+    CONNECT_REQUEST,
+    RECEIVE,
+    RECEIVE_REQUEST,
+    STARTUP_REGISTER_TIMEOUT_ENV,
+    startup_register_timeout_s,
+    WORKER_REGISTER,
+    WORLD_QUERY,
+)
+
+logger = logging.getLogger(__name__)
+
+COORDINATOR_REGISTER_TIMEOUT_ENV = STARTUP_REGISTER_TIMEOUT_ENV
+
+
+def _coordinator_register_timeout_s() -> float:
+    """Backward-compatible wrapper for the shared startup registration guard."""
+    return startup_register_timeout_s()
+
+
+class WeightReceiverController:
+    """ZMQ control-plane relay between Trainer rank 0 and one rollout engine's receiver rank 0.
+
+    Binds two ROUTERs: ``tcp_endpoint`` (Trainer-facing) and ``ipc_name`` (rank0-facing; the same address
+    receiver rank 0 connects its ``worker-0`` DEALER to). Call :meth:`serve` to run the relay loop.
+    """
+
+    def __init__(
+        self, ipc_name: str, tcp_endpoint: str, *, ctx: Optional[zmq.Context] = None
+    ) -> None:
+        self._ipc_name = ipc_name
+        self._tcp_endpoint = tcp_endpoint
+        self._ctx = ctx if ctx is not None else zmq.Context.instance()
+        self._rank0 = self._ctx.socket(
+            zmq.ROUTER
+        )  # receiver rank 0 connects here (identity worker-0)
+        self._rank0.bind(ipc_name)
+        self._trainer = self._ctx.socket(
+            zmq.ROUTER
+        )  # Trainer rank 0 connects here (over TCP)
+        self._trainer.bind(tcp_endpoint)
+        self._worker_num: Optional[int] = None
+
+    @property
+    def ipc_name(self) -> str:
+        return self._ipc_name
+
+    # ---- rank0-facing IPC (same wire protocol as the former controller) ----
+    def _send_to_rank0(self, payload: dict[str, Any]) -> None:
+        self._rank0.send_multipart([b"worker-0", json.dumps(payload).encode("utf-8")])
+
+    def _gather_ack(self, *, timeout_s: float = 600.0) -> bool:
+        """Block until receiver rank 0 replies on the IPC ROUTER; return whether it acked."""
+        if not self._rank0.poll(int(timeout_s * 1000)):
+            raise TimeoutError(
+                f"wbridge coordinator: no ack from receiver rank 0 within {timeout_s:.0f}s"
+            )
+        msg = self._rank0.recv_multipart()[1]
+        return json.loads(msg.decode("utf-8")).get("status") == "ack"
+
+    def _await_register(self, *, timeout_s: float = 600.0) -> None:
+        """Block until receiver rank 0 reports its worker count (:data:`WORKER_REGISTER`)."""
+        if not self._rank0.poll(int(timeout_s * 1000)):
+            raise TimeoutError(
+                f"wbridge coordinator: receiver rank 0 did not register within {timeout_s:.0f}s"
+            )
+        msg = json.loads(self._rank0.recv_multipart()[1].decode("utf-8"))
+        assert msg.get("type") == WORKER_REGISTER, (
+            f"expected WORKER_REGISTER, got {msg.get('type')!r}"
+        )
+        self._worker_num = int(msg["num_workers"])
+        logger.info(
+            "wbridge coordinator: receiver rank 0 registered (world_size=%d)",
+            self._worker_num,
+        )
+
+    # ---- relay loop ----
+    def serve(self) -> None:
+        """Block: wait for rank 0's registration, then relay Trainer requests until killed."""
+        self._await_register(timeout_s=_coordinator_register_timeout_s())
+        logger.info("wbridge coordinator: serving Trainer on %s", self._tcp_endpoint)
+        while True:
+            ident, payload = self._trainer.recv_multipart()
+            try:
+                reply = self._handle(json.loads(payload.decode("utf-8")))
+            except Exception as e:  # noqa: BLE001 — one bad request must not kill the relay
+                logger.warning("wbridge coordinator: request failed: %s", e)
+                reply = {"status": "error", "error": str(e)}
+            self._trainer.send_multipart([ident, json.dumps(reply).encode("utf-8")])
+
+    def _handle(self, req: dict[str, Any]) -> dict[str, Any]:
+        t = req.get("type")
+        if t == WORLD_QUERY:
+            return {"status": "success", "world_size": self._worker_num}
+        if t == CONNECT:
+            self._send_to_rank0(
+                {
+                    "type": CONNECT_REQUEST,
+                    **{k: v for k, v in req.items() if k != "type"},
+                }
+            )
+            return {"status": "success" if self._gather_ack() else "error"}
+        if t == RECEIVE:
+            self._send_to_rank0({"type": RECEIVE_REQUEST})
+            return {"status": "success" if self._gather_ack() else "error"}
+        return {"status": "error", "error": f"unknown request type {t!r}"}
+
+    def close(self) -> None:
+        self._rank0.close(linger=0)
+        self._trainer.close(linger=0)
+
+
+def spawn(ipc_name: str, tcp_port: int) -> "subprocess.Popen":
+    """Launch the coordinator as a detached child process. Returns the ``Popen`` for teardown.
+
+    The child imports only ``zmq`` + :mod:`wbridge.backend.control_channel` (no torch), so startup is
+    cheap. It self-exits if this parent dies (see :func:`_parent_death_watchdog`).
+    """
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "wbridge.backend.coordinator",
+            "--ipc",
+            ipc_name,
+            "--tcp-port",
+            str(tcp_port),
+        ]
+    )
+
+
+def _parent_death_watchdog() -> None:
+    """Exit if our parent (the spawning rank-0 process) dies — avoids leaking coordinators across runs."""
+    ppid = os.getppid()
+    while True:
+        time.sleep(2.0)
+        if os.getppid() != ppid:
+            logger.warning("wbridge coordinator: parent %d gone, exiting", ppid)
+            os._exit(0)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[wbridge-coord] %(message)s")
+    ap = argparse.ArgumentParser(
+        description="WeightBridge standalone control-plane coordinator"
+    )
+    ap.add_argument(
+        "--ipc",
+        required=True,
+        help="rank0-facing IPC address produced by coordinator_ipc(port)",
+    )
+    ap.add_argument(
+        "--tcp-port", type=int, required=True, help="Trainer-facing TCP port"
+    )
+    args = ap.parse_args()
+    threading.Thread(
+        target=_parent_death_watchdog, name="wbridge-coord-watchdog", daemon=True
+    ).start()
+    wrc = WeightReceiverController(
+        ipc_name=args.ipc, tcp_endpoint=f"tcp://*:{args.tcp_port}"
+    )
+    logger.info("wbridge coordinator: up (ipc=%s, tcp=*:%d)", args.ipc, args.tcp_port)
+    try:
+        wrc.serve()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        wrc.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/weightbridge/wbridge/backend/gantt.py
+++ b/examples/weightbridge/wbridge/backend/gantt.py
@@ -1,0 +1,191 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Wall-clock event recorder for building a per-component weight-transfer Gantt (gated WBRIDGE_GANTT=1),
+plus optional torch.profiler labels for the same regions.
+
+Records ``(role, rank, wt, op, round, t0, t1)`` with ``time.time()`` — wall clock, so sender-node and
+receiver-node events share one timeline (modulo NTP skew across nodes). Adds no cuda syncs, so it does not
+perturb the pipeline being measured. RDMA waits/polls/drain bracket blocking calls, so those intervals are
+exact — which is what reveals the pipeline fill/drain bubble.
+
+Output: one JSONL file per process under ``$WBRIDGE_GANTT_DIR``. We write files rather than log lines
+because Ray's log forwarding dedups/rate-limits the high-frequency events (collapsing many rounds into
+one). Falls back to the logger when no directory is configured or writable.
+
+Torch profiler labels: every :func:`span` also opens ``torch.profiler.record_function("wbridge::"+op)``
+when profiling is enabled (``WBRIDGE_PROFILE=1``, or inside :func:`capture`), so a chrome trace attributes
+CUDA kernels to wbridge phases. The two switches are independent — the wall-clock recorder needs no
+profiler, and the label needs no ``WBRIDGE_GANTT`` — so one ``with span(...)`` at each call site covers
+both. Each is a true no-op (shared ``nullcontext``, zero allocation) when its switch is off.
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+from contextlib import contextmanager, nullcontext
+
+ON = os.environ.get("WBRIDGE_GANTT") == "1"
+_prof = os.environ.get("WBRIDGE_PROFILE") == "1"
+_events: list = []  # (role, rank, wt, op, round, t0, t1)
+_events_lock = threading.Lock()
+_dump_lock = threading.Lock()
+_logger = logging.getLogger("wbridge.gantt")
+_NULL = nullcontext()
+
+
+def _record_function(op: str):
+    """``torch.profiler.record_function("wbridge::"+op)`` when profiling is on, else a no-op context."""
+    if _prof:
+        import torch
+
+        return torch.profiler.record_function(f"wbridge::{op}")
+    return _NULL
+
+
+@contextmanager
+def capture():
+    """Force torch.profiler labels on for the duration, restoring the prior state afterward.
+
+    Wrap the region where a profiler is actively recording (a targeted capture) so the :func:`span`
+    labels appear in the trace regardless of the ``WBRIDGE_PROFILE`` env. Independent of ``WBRIDGE_GANTT``.
+    """
+    global _prof
+    prev = _prof
+    _prof = True
+    try:
+        yield
+    finally:
+        _prof = prev
+
+
+def _outdir() -> str | None:
+    path = os.environ.get("WBRIDGE_GANTT_DIR")
+    return os.path.abspath(os.path.expanduser(path)) if path else None
+
+
+def rec(role: str, rank: int, wt: int, op: str, rnd: int, t0: float, t1: float) -> None:
+    if ON:
+        with _events_lock:
+            _events.append((role, rank, wt, op, rnd, t0, t1))
+
+
+class _Span:
+    """Times its ``with`` block (records a Gantt span on exit) and, when profiling, also opens a
+    ``record_function`` label around it. Created only when :data:`ON`."""
+
+    __slots__ = ("_meta", "_t0", "_rf")
+
+    def __init__(self, meta: tuple) -> None:
+        self._meta = meta
+
+    def __enter__(self) -> "_Span":
+        self._t0 = time.time()
+        self._rf = (
+            _record_function(self._meta[3]) if _prof else None
+        )  # op label; only when profiling
+        if self._rf is not None:
+            self._rf.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if self._rf is not None:
+            self._rf.__exit__(exc_type, exc, tb)
+        if (
+            exc_type is None
+        ):  # skip on exception (matches recording only after the work completes)
+            rec(*self._meta, self._t0, time.time())
+        return False
+
+
+def span(role: str, rank: int, wt: int, op: str, rnd: int):
+    """Context manager: time the wrapped block, record it as a Gantt span, and (when profiling) label
+    it ``wbridge::<op>`` in the torch profiler trace.
+
+    A no-op (shared ``nullcontext``, zero allocation) unless ``WBRIDGE_GANTT=1`` or profiling is on.
+    Replaces the ``t0 = now(); <work>; rec(..., t0, now())`` idiom with ``with span(...):  <work>``.
+    """
+    if ON:
+        return _Span((role, rank, wt, op, rnd))
+    if _prof:
+        return _record_function(
+            op
+        )  # profiler label only (no wall-clock record when gantt is off)
+    return _NULL
+
+
+def take() -> list:
+    """Atomically detach the events recorded so far, without performing any output.
+
+    WeightBridge uses this at the end of an epoch while all of that epoch's producer threads are
+    quiescent.  The immutable snapshot can then be written only after the caller has recorded its
+    externally visible ``block_end`` metric, without accidentally taking events from the next epoch.
+    """
+    global _events
+    if not ON:
+        return []
+    with _events_lock:
+        events = _events
+        _events = []
+    return events
+
+
+def dump(events: list | None = None) -> None:
+    """Write an event snapshot.
+
+    With no argument this retains the legacy drain-and-write behavior.  Passing a snapshot returned by
+    :func:`take` separates event collection from file/log output, which is required to keep profiling I/O
+    outside an application's reported blocking interval.
+    """
+    if events is None:
+        events = take()
+    if not events:
+        return
+    # A process normally has one endpoint, but the explicit lock also keeps fallback/direct users from
+    # interleaving two JSONL appends when post-block emission races an asynchronous sender completion.
+    with _dump_lock:
+        d = _outdir()
+        if d:
+            try:
+                os.makedirs(d, exist_ok=True)
+                # The Gantt directory is commonly shared by several physical nodes. Include the
+                # hostname so equal container PIDs cannot interleave records into the same file.
+                host = os.uname().nodename
+                path = os.path.join(d, f"gantt_pid{os.getpid()}_{host}.jsonl")
+                with open(path, "a") as f:
+                    for role, rank, wt, op, rnd, t0, t1 in events:
+                        f.write(
+                            json.dumps(
+                                {
+                                    "role": role,
+                                    "rank": rank,
+                                    "wt": wt,
+                                    "op": op,
+                                    "round": rnd,
+                                    "t0": t0,
+                                    "t1": t1,
+                                    "host": host,
+                                    "pid": os.getpid(),
+                                }
+                            )
+                            + "\n"
+                        )
+                return
+            except OSError:
+                pass  # fall through to logger
+        for role, rank, wt, op, rnd, t0, t1 in events:
+            _logger.info(
+                "wbridge-gantt role=%s rank=%d wt=%d op=%s round=%d t0=%.6f t1=%.6f",
+                role,
+                rank,
+                wt,
+                op,
+                rnd,
+                t0,
+                t1,
+            )

--- a/examples/weightbridge/wbridge/backend/rdma/__init__.py
+++ b/examples/weightbridge/wbridge/backend/rdma/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""One-sided RDMA transport for the WeightBridge data plane (register + write only)."""
+
+from wbridge.backend.rdma.base import RdmaEngine
+from wbridge.backend.rdma.dual import DualMooncakeEngine
+from wbridge.backend.rdma.local import LocalStagingEngine
+from wbridge.backend.rdma.mooncake import MooncakeEngine
+
+# MonarchEngine is imported lazily (router._init_engine): importing monarch pulls a large
+# native extension and is only needed when protocol="monarch".
+__all__ = ["RdmaEngine", "MooncakeEngine", "DualMooncakeEngine", "LocalStagingEngine"]

--- a/examples/weightbridge/wbridge/backend/rdma/base.py
+++ b/examples/weightbridge/wbridge/backend/rdma/base.py
@@ -1,0 +1,160 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Abstract one-sided RDMA transport for the WeightBridge data plane.
+
+WeightBridge transfers weights with **exactly two RDMA primitives** — ``register`` (pin a local GPU or
+CPU-pinned buffer so a peer may write into it) and ``write`` (a blocking one-sided write into a peer's
+*already-registered* buffer). There is deliberately no send/recv or notify primitive: "finish" and "ack"
+signals are themselves tiny :meth:`RdmaEngine.write` calls into a flag buffer the peer polls.
+
+Concrete implementations include :class:`~wbridge.backend.rdma.mooncake.MooncakeEngine` and
+:class:`~wbridge.backend.rdma.monarch.MonarchEngine`. Composite and local-staging implementations use
+the same interface, keeping backend selection out of the data-plane protocol.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+
+class RdmaEngine(ABC):
+    """One-sided RDMA transport: ``register`` + ``write`` plus lifecycle.
+
+    Lifecycle: :meth:`init` once, then :meth:`register` every local buffer a peer will write into (and
+    every local buffer used as a write *source*), exchange :meth:`session_id` and registered addresses
+    out of band (WeightBridge uses a one-time Gloo ``all_gather_object``), then :meth:`write` repeatedly,
+    and :meth:`close` at teardown.
+    """
+
+    @abstractmethod
+    def init(
+        self,
+        local_host: str,
+        protocol: str,
+        device: str = "",
+        pin_local_nic: bool = False,
+    ) -> None:
+        """Bring up the transport on ``local_host``.
+
+        ``protocol`` selects the transport (``"tcp"`` for the local toy, ``"rdma"`` for RDMA fabrics).
+        ``device`` is an optional device filter passed through to the backend. ``pin_local_nic`` asks a
+        host-RDMA backend to pin this rank to its GPU's local NIC (staging bandwidth fix; see
+        :meth:`MooncakeEngine._local_gpu_nic`) — backends without a NIC notion ignore it.
+        """
+
+    @abstractmethod
+    def session_id(self) -> str:
+        """Return this engine's session id (``"host:port"``); peers pass it to :meth:`write`."""
+
+    @abstractmethod
+    def register(
+        self, ptr: int, size: int, is_flag: bool = False, tensor: "object | None" = None
+    ) -> None:
+        """Pin a local buffer at ``ptr`` (a ``tensor.data_ptr()``) of ``size`` bytes for RDMA.
+
+        The buffer may be GPU (VRAM) or CPU-pinned; the backend classifies it. Raises on failure.
+        ``is_flag`` marks the tiny host-pinned sync buffers (the ``_write_flag`` ping-pong): a multi-engine
+        backend may route these over a *separate* transport from bulk data (see :class:`DualMooncakeEngine`,
+        which keeps flags off the bandwidth-pinned NIC so a saturating bulk write can't starve a flag). Single-
+        engine backends ignore it.
+
+        ``tensor`` is the owning tensor, passed by callers that have it. Pointer-based backends (Mooncake)
+        ignore it; :class:`~wbridge.backend.rdma.monarch.MonarchEngine` requires it, because Monarch's API
+        registers tensors/memoryviews rather than raw addresses.
+        """
+
+    # ----- optional connect-time metadata exchange (default: nothing to exchange) -----
+    def publish_regions(self, regions: "Sequence[tuple[int, int]]") -> None:
+        """Declare every ``(addr, size)`` a peer may write into, before the metadata exchange.
+
+        Backends whose remote addressing is a raw pointer (Mooncake) need nothing here. Monarch's
+        ``RDMABuffer`` has no remote offset, so each destination region must be exported as its own
+        handle; this is where the router hands over the exact list.
+        """
+        return
+
+    def publish_payload(self) -> object | None:
+        """Backend-specific blob to include in the connect-time ``all_gather_object``, or ``None``."""
+        return None
+
+    def attach_peer(self, session: str, payload: object) -> None:
+        """Receive a peer's :meth:`publish_payload` after the gather. Default: ignore."""
+        return
+
+    @abstractmethod
+    def write(
+        self,
+        dst_session: str,
+        src_ptrs: Sequence[int],
+        dst_ptrs: Sequence[int],
+        sizes: Sequence[int],
+    ) -> None:
+        """Blocking one-sided batch write of local ``src_ptrs`` into remote ``dst_ptrs`` on ``dst_session``.
+
+        ``src_ptrs[i]`` (local, registered) is copied into ``dst_ptrs[i]`` (remote, registered by that
+        peer) for ``sizes[i]`` bytes. Returns only after every write has landed remotely (synchronous),
+        which is what lets a subsequent flag write safely signal "data arrived". Raises on failure.
+        """
+
+    # ----- optional async write (default: fall back to the blocking write) -----
+    def write_async(
+        self,
+        dst_session: str,
+        src_ptrs: Sequence[int],
+        dst_ptrs: Sequence[int],
+        sizes: Sequence[int],
+    ) -> object | None:
+        """Submit a **non-blocking** one-sided batch write; return an opaque handle for :meth:`wait`.
+
+        Same semantics as :meth:`write` except it returns immediately (data has *not* landed yet), so a
+        caller can submit writes to many peers concurrently and then :meth:`wait` on all handles at once —
+        hiding per-write latency. The default performs the blocking :meth:`write` and returns ``None`` so
+        backends without an async path (and test loopbacks) keep working unchanged.
+
+        The handle is opaque and backend-specific (a Mooncake batch id, a ``(engine, id)`` tuple, or a
+        :class:`torch.cuda.Event` for :class:`~wbridge.backend.rdma.local.LocalStagingEngine`). Handles must
+        be passed to :meth:`wait` on the **same engine** that produced them — do not mix engines in one
+        ``wait`` list.
+        """
+        self.write(dst_session, src_ptrs, dst_ptrs, sizes)
+        return None
+
+    def write_batch(
+        self, items: Sequence[tuple[str, Sequence[int], Sequence[int], Sequence[int]]]
+    ):
+        """Submit writes to *several* destinations as one unit; return handles for :meth:`wait`.
+
+        Semantically identical to calling :meth:`write_async` per item, and that is exactly the default —
+        backends with no notion of a cross-destination batch keep their existing behaviour. It exists
+        because a backend can be much faster when it knows the whole round up front: Monarch's completion
+        is an actor message per submitted action, and issuing one action per peer leaves the per-peer
+        completions to be observed one after another, which shows up as a wide straggler spread. Focused
+        testing found little change in median throughput but a material improvement for the slowest rank
+        when the peers shared a single action.
+
+        The progressive sender path deliberately uses :meth:`write_async` per destination: each receiver's
+        slot-reuse ACK independently enables its write, and its DATA-ready flag must follow that exact
+        completion. ``write_batch`` remains available to synchronized callers/backends for which a whole
+        fan-out really does share one dependency and one completion boundary. The control plane likewise
+        keeps :meth:`write_async` per flag.
+        """
+        return [self.write_async(s, sp, dp, sz) for s, sp, dp, sz in items]
+
+    def wait(self, handles: Sequence[object]) -> None:
+        """Block until every handle returned by :meth:`write_async` has completed. ``None`` handles are
+        no-ops (already landed via the default sync fallback). Raises on failure.
+
+        Calls for disjoint handles may run concurrently. Receiver external exchange and trainer bulk sends
+        use that property to publish each destination's READY/DATA-ready independently instead of waiting
+        for the round's slowest peer.
+        """
+        return
+
+    @abstractmethod
+    def close(self) -> None:
+        """Unregister buffers and tear down the transport. Idempotent."""

--- a/examples/weightbridge/wbridge/backend/rdma/dual.py
+++ b/examples/weightbridge/wbridge/backend/rdma/dual.py
@@ -1,0 +1,225 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Dual-engine facade routing each write to NVLink or the configured Mooncake network transport.
+
+Mooncake selects a transport by the *target segment's protocol*, and the high-bandwidth intra-node NVLink
+transport (``nvlink_intra``, CUDA-IPC / GPU-P2P) only works between GPUs on the SAME node, while the
+configured network transport handles cross-node peers. To exploit NVLink wherever peers happen to be
+co-located — without assuming any particular placement — each rank runs a ``nvlink_intra`` engine and one
+or two network engines, and this facade picks per destination:
+
+  * same-node peer AND a device (NVLink-registered) source   -> NVLink engine
+  * a tiny host-pinned FLAG buffer                            -> the network *flag* engine
+  * otherwise (cross-node bulk, device or host)              -> the network *bulk* engine
+
+Why two network engines under EFA staging: host RDMA is pinned to one NIC per rank for bandwidth (see
+``MooncakeEngine._local_gpu_nic``). But the latency-bound same-node flag ping-pong must not ride the same NIC
+as bulk — a saturating multi-GiB bulk write starves the flag's connection handshake on that one NIC, which
+surfaced as ``batch_transfer_sync_write rc=-1`` ("malformed handshake") and an AGH deadlock. So when pinning,
+bulk takes the switch's primary NIC (index 0) and flags a secondary NIC (index 1) — same switch, disjoint
+from every rank's bulk NIC. Without a pin (the both-OFF GPUDirect path), one network engine carries both.
+
+Full registration overlap holds for **device** memory (registered in the bulk network engine AND NVLink, same
+``data_ptr`` as the one-sided-write destination on either); **host-pinned** memory cannot register with the
+NVLink transport (CUDA IPC needs device memory), so those transfers use the configured network transport —
+flags through the flag engine and staging arenas through the bulk engine.
+
+NOTE on the NVLink engine's role: same-node **bulk** normally never reaches this facade at all. Co-located
+trainer->rollout and rollout<->rollout pairs move their bytes with a direct CUDA-IPC copy that skips Mooncake
+entirely (``router.SAME_NODE_IPC``); the ``nvlink_intra`` engine here is the fallback for the cases that
+bypass can't cover — a staging endpoint (host DRAM is not IPC-mappable), an allocator that cannot export IPC
+handles, or ``WBRIDGE_SAME_NODE_IPC=0``. Consequently a Mooncake wheel without the nvlink_intra patch is not
+fatal: :meth:`DualMooncakeEngine.init` logs and leaves ``_nvl`` as ``None``, and those writes take the
+configured network transport.
+
+Because the routing lives entirely here, the sender/receiver/router code is unchanged: it holds one engine,
+calls ``register``/``write``/``write_async``/``wait`` as before (marking flag buffers with ``is_flag=True``),
+and passes around the composite :meth:`session_id`. This is the sole RDMA engine (``router._init_engine``);
+it transparently uses the configured network transport for every cross-node peer.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+from wbridge.backend.rdma.base import RdmaEngine
+from wbridge.backend.rdma.mooncake import MooncakeEngine
+
+logger = logging.getLogger(__name__)
+
+_SEP = "|"  # composite session = "<network_flags>|<nvl>|<network_bulk>"; ip:port tokens never contain '|'
+
+
+class DualMooncakeEngine(RdmaEngine):
+    """Route writes over same-node NVLink or the configured Mooncake network engines."""
+
+    def __init__(self) -> None:
+        self._efa = MooncakeEngine()  # flags always; also bulk when not split (no pin)
+        self._efa_bulk: MooncakeEngine = (
+            self._efa
+        )  # separate PINNED bulk engine when staging (set in init)
+        self._nvl: MooncakeEngine | None = (
+            MooncakeEngine()
+        )  # None if the wheel has no nvlink_intra
+        self._ip = ""
+        self._nvl_ranges: list[
+            tuple[int, int]
+        ] = []  # (base, base+size) device regions registered in nvl
+        self._flag_ranges: list[
+            tuple[int, int]
+        ] = []  # host flag buffers -> routed over the un-pinned _efa
+
+    def init(
+        self,
+        local_host: str,
+        protocol: str,
+        device: str = "",
+        pin_local_nic: bool = False,
+    ) -> None:
+        self._ip = local_host
+        if pin_local_nic:
+            # Split: bulk on the switch's primary NIC (index 0), flags on a secondary NIC (index 1) so a
+            # saturating bulk write can't starve a same-node flag handshake on the same NIC.
+            self._efa.init(
+                local_host, protocol, device, pin_local_nic=True, nic_index=1
+            )  # flags
+            self._efa_bulk = MooncakeEngine()
+            self._efa_bulk.init(
+                local_host, protocol, device, pin_local_nic=True, nic_index=0
+            )  # bulk data
+        else:
+            # Both-OFF (GPUDirect) path: one network engine carries flags and bulk.
+            self._efa.init(local_host, protocol, device)
+            self._efa_bulk = self._efa
+        # NVLink is same-node only; it keys off the buffer's GPU, so no NIC device string / no pin. This
+        # transport is now a FALLBACK: same-node bulk normally bypasses Mooncake altogether via the direct
+        # CUDA-IPC pull (``router.SAME_NODE_IPC``), and only lands here when that is off or unavailable
+        # (staging, a non-exportable allocator). So a wheel without the nvlink_intra patch is no longer fatal
+        # — we log it and route every same-node write that does reach us over the network transport instead.
+        try:
+            self._nvl.init(local_host, "nvlink_intra", "")
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "DualMooncakeEngine: nvlink_intra transport unavailable (%s); same-node writes "
+                "that do not take the CUDA-IPC bypass will use the network transport",
+                e,
+            )
+            self._nvl = None
+        logger.info(
+            "DualMooncakeEngine up: network(flags)=%s network_bulk=%s nvl=%s",
+            self._efa.session_id(),
+            self._efa_bulk.session_id(),
+            self._nvl.session_id() if self._nvl is not None else "-",
+        )
+
+    def session_id(self) -> str:
+        # "<network_flags>|<nvl>|<network_bulk>"; bulk == flags when not split (peers parse three tokens).
+        # An empty nvl token means "no NVLink transport here" — _use_nvl already treats that as cross-node.
+        nvl = self._nvl.session_id() if self._nvl is not None else ""
+        return f"{self._efa.session_id()}{_SEP}{nvl}{_SEP}{self._efa_bulk.session_id()}"
+
+    def bulk_numa_node(self) -> int:
+        """NUMA node of the bulk NIC, so callers can allocate host staging buffers NUMA-local to it. -1 if
+        unpinned/unknown."""
+        return self._efa_bulk.pinned_numa_node()
+
+    @staticmethod
+    def _split(session: str) -> tuple[str, str, str]:
+        """Return ``(network_flags, nvl, network_bulk)`` from a composite or legacy plain session."""
+        parts = session.split(_SEP)
+        efa = parts[0]
+        nvl = parts[1] if len(parts) > 1 else ""
+        bulk = parts[2] if len(parts) > 2 else efa
+        return efa, nvl, bulk
+
+    @staticmethod
+    def _ip_of(session: str) -> str:
+        return session.rsplit(":", 1)[0]
+
+    def register(self, ptr: int, size: int, is_flag: bool = False, tensor=None) -> None:
+        if is_flag:
+            # Tiny host sync buffer -> the un-pinned flag engine ONLY (kept off the bandwidth-pinned bulk NIC).
+            self._efa.register(ptr, size, is_flag=True)
+            self._flag_ranges.append((int(ptr), int(ptr) + int(size)))
+            return
+        # Bulk: the bulk engine handles cross-node landing/reads over the pinned NIC. Device memory ALSO
+        # registers in NVLink (same-node peers); host-pinned bulk cannot, so it stays on the network engine.
+        self._efa_bulk.register(ptr, size)
+        if self._nvl is None:
+            return  # no NVLink transport: everything routes to the network engine below
+        try:
+            self._nvl.register(ptr, size)
+            self._nvl_ranges.append((int(ptr), int(ptr) + int(size)))
+        except RuntimeError:
+            pass  # host-pinned bulk buffer: network-only, routed to the bulk engine below
+
+    def _nvl_covers(self, ptr: int, size: int) -> bool:
+        p, end = int(ptr), int(ptr) + int(size)
+        return any(base <= p and end <= lim for base, lim in self._nvl_ranges)
+
+    def _in_flag_range(self, ptr: int) -> bool:
+        p = int(ptr)
+        return any(base <= p < end for base, end in self._flag_ranges)
+
+    def _use_nvl(self, peer_session: str, src_ptrs, sizes) -> bool:
+        if self._nvl is None:
+            return False  # no local NVLink transport (unpatched wheel)
+        efa_sess, nvl_sess, _bulk = self._split(peer_session)
+        if not nvl_sess or self._ip_of(efa_sess) != self._ip:
+            return False  # cross-node peer (or peer has no nvl engine)
+        # All sources must be NVLink-registered device memory (excludes the host flag buffers).
+        return all(self._nvl_covers(s, z) for s, z in zip(src_ptrs, sizes))
+
+    def _target(self, peer_session: str, src_ptrs, sizes):
+        efa_sess, nvl_sess, bulk_sess = self._split(peer_session)
+        # Flags (never batched with bulk) -> un-pinned flag engine.
+        if any(self._in_flag_range(s) for s in src_ptrs):
+            return self._efa, efa_sess
+        # Same-node device bulk -> NVLink.
+        if self._use_nvl(peer_session, src_ptrs, sizes):
+            return self._nvl, nvl_sess
+        # Cross-node bulk (device or host) -> pinned bulk engine.
+        return self._efa_bulk, bulk_sess
+
+    def write(
+        self,
+        dst_session: str,
+        src_ptrs: Sequence[int],
+        dst_ptrs: Sequence[int],
+        sizes: Sequence[int],
+    ) -> None:
+        eng, sess = self._target(dst_session, src_ptrs, sizes)
+        eng.write(sess, src_ptrs, dst_ptrs, sizes)
+
+    def write_async(
+        self,
+        dst_session: str,
+        src_ptrs: Sequence[int],
+        dst_ptrs: Sequence[int],
+        sizes: Sequence[int],
+    ):
+        eng, sess = self._target(dst_session, src_ptrs, sizes)
+        bid = eng.write_async(sess, src_ptrs, dst_ptrs, sizes)
+        return None if bid is None else (eng, bid)
+
+    def wait(self, handles: Sequence[object]) -> None:
+        groups: dict[int, tuple[RdmaEngine, list]] = {}
+        for h in handles:
+            if h is None:
+                continue
+            eng, bid = h  # type: ignore[misc]
+            groups.setdefault(id(eng), (eng, []))[1].append(bid)
+        for eng, bids in groups.values():
+            eng.wait(bids)
+
+    def close(self) -> None:
+        self._efa.close()
+        if self._efa_bulk is not self._efa:
+            self._efa_bulk.close()
+        if self._nvl is not None:
+            self._nvl.close()

--- a/examples/weightbridge/wbridge/backend/rdma/local.py
+++ b/examples/weightbridge/wbridge/backend/rdma/local.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""In-process staging "engine": GPU<->CPU copies behind the :class:`RdmaEngine` interface.
+
+WeightBridge's staging modes (sender-staging / receiver-staging) offload the packed wire bytes to CPU
+before the RDMA write (SS) or land them in CPU before the GPU load (RS). To keep the four modes a single
+parameterized data path — rather than four branches — the GPU<->CPU hop is expressed as *one more*
+:class:`RdmaEngine` so every movement in the pipeline is the same ``write_async``/``wait`` protocol,
+whether the hop is trainer-GPU->trainer-CPU, CPU->remote, or rollout-CPU->rollout-GPU.
+
+Unlike a real transport, a local copy needs the *tensors* (torch ``.copy_``), not just raw addresses. So
+callers register buffers with :meth:`register_buffer` (which keeps the tensor); :meth:`write`/:meth:`write_async`
+reconstruct contiguous ``uint8`` views from the raw ``src_ptrs``/``dst_ptrs`` via an interval map (mirrors
+:meth:`DualMooncakeEngine._nvl_covers`). Copies run on a private CUDA stream and ``write_async`` returns a
+recorded :class:`torch.cuda.Event`; ``wait`` synchronizes it. A ``torch.cuda.Event`` recorded on one thread
+may be waited from another, which is exactly the sender/receiver adapter-thread handoff.
+
+On a host without CUDA (offline unit tests on the login node) the copies run synchronously and
+``write_async`` returns ``None`` (the ABC's no-op-handle convention), so register/classify/copy logic is
+testable with CPU tensors.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+import torch
+from wbridge.backend.rdma.base import RdmaEngine
+
+logger = logging.getLogger(__name__)
+
+
+class LocalStagingEngine(RdmaEngine):
+    """Single-process loopback engine: ``write`` is a local ``cudaMemcpyAsync`` (GPU<->CPU / D2D)."""
+
+    def __init__(self) -> None:
+        self._session = ""
+        self._stream: torch.cuda.Stream | None = None
+        # (base_ptr, end_ptr, flat uint8 tensor) for every register_buffer'd buffer.
+        self._bufs: list[tuple[int, int, torch.Tensor]] = []
+
+    def init(
+        self,
+        local_host: str,
+        protocol: str,
+        device: str = "",
+        pin_local_nic: bool = False,
+    ) -> None:
+        # pin_local_nic is a NIC-level knob (see MooncakeEngine); the local GPU<->CPU copy engine has no NIC.
+        self._session = f"local://{id(self):#x}"
+        self._stream = torch.cuda.Stream() if torch.cuda.is_available() else None
+
+    def session_id(self) -> str:
+        return self._session or f"local://{id(self):#x}"
+
+    def register_buffer(self, t: torch.Tensor) -> None:
+        """Register a contiguous 1-D ``uint8`` buffer so its bytes can be a staging src/dst.
+
+        This is the real registration for local staging (it keeps the tensor for ``.copy_``); the ABC's
+        :meth:`register` is a no-op because local memory needs no pinning for a torch copy.
+        """
+        assert t.dtype == torch.uint8 and t.dim() == 1 and t.is_contiguous(), (
+            "LocalStagingEngine expects a contiguous 1-D uint8 buffer"
+        )
+        base = t.data_ptr()
+        self._bufs.append((base, base + t.numel(), t))
+
+    def register(self, ptr: int, size: int, is_flag: bool = False, tensor=None) -> None:
+        # Local memory needs no RDMA pinning; buffers are supplied via register_buffer (which keeps the
+        # tensor). A no-op keeps LocalStagingEngine drop-in wherever engine.register(ptr, size) is called.
+        # is_flag is a NIC-routing hint (see DualMooncakeEngine); the local copy engine has no NIC.
+        return
+
+    def _view(self, ptr: int, size: int) -> torch.Tensor:
+        p, n = int(ptr), int(size)
+        for base, end, t in self._bufs:
+            if base <= p and p + n <= end:
+                off = p - base
+                return t[off : off + n]
+        raise KeyError(
+            f"LocalStagingEngine: ptr {p:#x} size {n} not covered by any register_buffer"
+        )
+
+    def write(
+        self,
+        dst_session: str,
+        src_ptrs: Sequence[int],
+        dst_ptrs: Sequence[int],
+        sizes: Sequence[int],
+    ) -> None:
+        self.wait([self.write_async(dst_session, src_ptrs, dst_ptrs, sizes)])
+
+    def write_async(
+        self,
+        dst_session: str,
+        src_ptrs: Sequence[int],
+        dst_ptrs: Sequence[int],
+        sizes: Sequence[int],
+    ) -> object | None:
+        if not src_ptrs:
+            return None
+        if self._stream is None:  # no CUDA (offline): synchronous copy, no-op handle
+            for s, d, n in zip(src_ptrs, dst_ptrs, sizes):
+                self._view(d, n).copy_(self._view(s, n))
+            return None
+        # Order after whatever produced the source (pack / RDMA landing) on the caller's current stream,
+        # then copy on the private stream so the returned event is a precise "staging done" marker.
+        self._stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self._stream):
+            for s, d, n in zip(src_ptrs, dst_ptrs, sizes):
+                self._view(d, n).copy_(self._view(s, n), non_blocking=True)
+            ev = torch.cuda.Event()
+            ev.record()
+        return ev
+
+    def wait(self, handles: Sequence[object]) -> None:
+        for h in handles:
+            if h is not None:
+                h.synchronize()  # torch.cuda.Event
+
+    def close(self) -> None:
+        self._bufs.clear()
+        self._stream = None

--- a/examples/weightbridge/wbridge/backend/rdma/monarch.py
+++ b/examples/weightbridge/wbridge/backend/rdma/monarch.py
@@ -1,0 +1,426 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Monarch backend for :class:`~wbridge.backend.rdma.base.RdmaEngine` — one-sided RDMA over libibverbs.
+
+A second transport alongside Mooncake, using `Monarch <https://github.com/meta-pytorch/monarch>`_'s RDMA
+layer. Six properties of that layer shape everything here; each was established with focused transport
+microbenchmarks on an RDMA cluster:
+
+1. **An ``RDMABuffer`` has no remote offset.** ``write_from``/``read_into`` always target the buffer's
+   base, so a peer cannot address "arena + 3 MiB". The buffer *can* wrap a tensor view, though, and every
+   region WeightBridge writes into is fixed and enumerable at connect (per-(sender,round) RECV slots, flag
+   slots, per-peer ``grecv`` slots). So the owner publishes one buffer per exact destination region and
+   the writer looks it up — see :meth:`publish_regions`.
+
+2. **Regions are tiled** into ``_chunk``-sized pieces on both the publish and the write side, using the
+   same deterministic tiling so lookups match exactly — the direct analogue of
+   :meth:`MooncakeEngine._stripe`. Tiling is required by point 1 (it is what makes an offset addressable
+   at all); the tile *size* is only a tuning knob. It is not a correctness ceiling: the
+   ``IBV_WC_REM_ACCESS_ERR`` / ``IBV_WC_LOC_PROT_ERR`` failures that once looked like a small per-op
+   limit were an artifact of ``expandable_segments`` (point 6). With stock ``cudaMalloc``, much larger
+   operations are clean; steady-state transfer time was insensitive across the tested tile sizes, while
+   larger tiles reduced connect overhead by publishing fewer ``RDMABuffer`` handles.
+
+3. **Every call needs a live Monarch actor context**, and it is a ``contextvar``, so it does not reach the
+   threads WeightBridge writes from (the sender's Stage-2 daemon thread, the receiver's RS/ctl threads).
+   Calling without it is not a catchable error — it trips a Rust panic that poisons the actor's dispatch
+   loop. :meth:`init` captures the ``Context`` object and :meth:`_in_ctx` installs it on whatever thread
+   makes a call. Note it installs the *value* rather than running inside a captured
+   ``contextvars.Context``: a ``Context`` cannot be entered twice, so a shared one would raise
+   ``cannot enter context: already entered`` the moment two WeightBridge threads submit concurrently.
+
+4. **Nothing may block the actor's event loop.** An RDMA completion comes back as a message to the
+   submitting actor (``RDMAAction.submit`` passes ``context().actor_instance`` to Rust), so an endpoint
+   that blocks its own loop on ``Future.get()`` can never observe it — the transfer wedges forever. All
+   WeightBridge work therefore runs on a dedicated thread off the loop; :meth:`wait` refuses to run on a
+   live loop rather than hang.
+
+5. **One NIC per GPU.** Monarch selects a NIC per memory region: device memory gets the NIC co-located
+   with its GPU, host memory is hash-spread. Nothing to configure here, but it means per-rank bandwidth is
+   limited to one NIC rather than Mooncake's multi-path striping.
+
+6. **Do NOT enable ``PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True``**, despite Monarch warning at
+   import that it is "required to maximize RDMA performance with CUDA tensors". A CUDA VMM segment is
+   mapped from physical granules piecewise, and one ibverbs MR cannot span such a range: large writes
+   failed in a repeatable periodic pattern with ``IBV_WC_REM_ACCESS_ERR`` /
+   ``IBV_WC_LOC_PROT_ERR``. The same workload is clean with stock ``cudaMalloc``. Small transfers (the toy
+   example) do not trip it, which is why it survived early testing.
+
+Handles reach peers through the connect-time metadata exchange (:meth:`publish_payload` /
+:meth:`attach_peer`), NOT through :meth:`session_id` — the router parses the session string to decide
+co-location, so it has to stay an ``ip:port``-shaped string.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Sequence
+
+import torch
+from wbridge.backend.rdma.base import RdmaEngine
+
+logger = logging.getLogger(__name__)
+
+# Largest single RDMA op. Not a reliability limit (see docstring point 2) — 64 MiB is chosen because
+# steady-state transfer time was insensitive across tested sizes while larger tiles reduced the number of
+# published handles, and it stays clear of sizes that were only problematic under expandable_segments.
+DEFAULT_CHUNK_BYTES = int(
+    os.environ.get("WBRIDGE_MONARCH_CHUNK_BYTES", str(64 * 1024 * 1024))
+)
+
+
+def _tile(addr: int, size: int, chunk: int):
+    """Deterministic tiling of ``[addr, addr+size)`` into <= ``chunk`` pieces.
+
+    Publisher and writer both call this, so a writer's ``(offset, length)`` always matches a published
+    buffer exactly. Any change here must change both sides at once.
+    """
+    off = 0
+    while off < size:
+        n = min(chunk, size - off)
+        yield addr + off, n
+        off += n
+
+
+class _Submission:
+    """The in-flight handle: a Monarch ``Future`` plus the op table that produced it.
+
+    Monarch reports a submit failure as ``N/M ops failed`` with bare op *indices*, which say nothing about
+    which region went wrong. Keeping the table lets :meth:`MonarchEngine.wait` translate those indices back
+    into ``src -> dst+len`` and makes an addressing bug diagnosable from one log line.
+    """
+
+    __slots__ = ("fut", "ops", "dst")
+
+    def __init__(self, fut, ops, dst: str) -> None:
+        self.fut, self.ops, self.dst = fut, ops, dst
+
+    def __getattr__(
+        self, name: str
+    ):  # transparently expose the underlying Future's attributes
+        return getattr(self.fut, name)
+
+    def get(self):
+        return self.fut.get()
+
+    def describe(self, indices: Sequence[int]) -> str:
+        rows = [
+            f"    op {i}: src {self.ops[i][0]:#x} -> dst {self.ops[i][1]:#x} + {self.ops[i][2]}"
+            for i in indices
+            if 0 <= i < len(self.ops)
+        ]
+        return f"  to {self.dst}, {len(self.ops)} ops:\n" + "\n".join(rows)
+
+
+def _failed_op_indices(msg: str) -> list[int]:
+    """Op indices out of a Monarch submit error ('  op 12: send completion failed ...')."""
+    out = []
+    for line in msg.splitlines():
+        line = line.strip()
+        if line.startswith("op ") and ":" in line:
+            try:
+                out.append(int(line[3 : line.index(":")]))
+            except ValueError:
+                pass
+    return out
+
+
+class MonarchEngine(RdmaEngine):
+    """:class:`RdmaEngine` over ``monarch.rdma``. Must be constructed inside a Monarch actor."""
+
+    def __init__(self) -> None:
+        self._actor_ctx: object | None = None  # monarch Context, captured at init
+        self._session = ""
+        # (base, end, tensor) for every locally registered buffer, so a raw (ptr, size) from the router
+        # can be turned back into the 1-D uint8 view Monarch's API needs.
+        self._bufs: list[tuple[int, int, torch.Tensor]] = []
+        self._published: dict[tuple[int, int], object] = {}  # our regions -> RDMABuffer
+        self._peer: dict[
+            str, dict[tuple[int, int], object]
+        ] = {}  # peer session -> their regions
+        self._chunk = DEFAULT_CHUNK_BYTES
+
+    # ----------------------------------------------------------------- lifecycle
+    def init(
+        self,
+        local_host: str,
+        protocol: str,
+        device: str = "",
+        pin_local_nic: bool = False,
+    ) -> None:
+        from monarch.rdma import get_rdma_backend
+
+        backend = get_rdma_backend()
+        if backend == "none":
+            raise RuntimeError(
+                "MonarchEngine: no RDMA backend available in this process"
+            )
+        if backend != "ibverbs":
+            # A silent TCP fallback would look like it works while measuring the wrong thing — the same
+            # trap that can produce a bogus peer-to-peer number. Refuse rather than mislead.
+            raise RuntimeError(
+                f"MonarchEngine: Monarch reports backend {backend!r}, not 'ibverbs'. Refusing to run on "
+                "the TCP fallback; set MONARCH_RDMA_ALLOW_TCP_FALLBACK=false to diagnose."
+            )
+        # Captured on the actor's thread. _in_ctx replays it onto WeightBridge's worker threads, which
+        # start with an empty context and would otherwise trip the Rust panic (see docstring point 3).
+        from monarch.actor import context
+
+        # A completion is an actor message, so Python must run for this process to observe that a transfer
+        # finished. CPython hands the GIL between threads only every sys.getswitchinterval() (default
+        # 5 ms), so competing Python work can delay each completion by a full handoff. The synthetic
+        # ladder showed a severe throughput loss and recovered most of it with a shorter interval. It is
+        # handoff latency, not CPU starvation.
+        #
+        # The representative workload showed no meaningful improvement when this was applied across all
+        # ranks, so it was not GIL-bound. This knob only matters for a process that really does run
+        # competing Python during transfers.
+        # Off by default: process-global, and shortening it costs context switches in compute-heavy Python.
+        sw = float(os.environ.get("WBRIDGE_MONARCH_SWITCH_INTERVAL", "0"))
+        if sw > 0:
+            import sys
+
+            sys.setswitchinterval(sw)
+            logger.warning("MonarchEngine: sys.setswitchinterval(%g) applied", sw)
+        self._actor_ctx = context()
+        # Session stays ip:port-shaped: router._setup_rdma_buffers parses it to detect co-located peers.
+        self._session = f"{local_host}:{os.getpid()}"
+        logger.info(
+            "MonarchEngine up: session=%s backend=%s chunk=%d B",
+            self._session,
+            backend,
+            self._chunk,
+        )
+
+    def _in_ctx(self, fn):
+        """Run *fn* with this engine's actor context installed on the calling thread.
+
+        The install is sticky: WeightBridge's worker threads are long-lived and each one only needs the
+        contextvar set once. A thread that already carries a context (the actor's own, or one inherited
+        via ``asyncio.to_thread``) is left alone.
+        """
+        assert self._actor_ctx is not None, "MonarchEngine.init not called"
+        from monarch._src.actor.actor_mesh import _context, _set_context
+
+        if _context.get() is None:
+            _set_context(self._actor_ctx)  # type: ignore[arg-type]
+        return fn()
+
+    def session_id(self) -> str:
+        assert self._session, "MonarchEngine.init not called"
+        return self._session
+
+    def close(self) -> None:
+        self._published.clear()
+        self._peer.clear()
+        self._bufs.clear()
+        self._actor_ctx = None
+
+    # ----------------------------------------------------------------- registration
+    def register(
+        self,
+        ptr: int,
+        size: int,
+        is_flag: bool = False,
+        tensor: torch.Tensor | None = None,
+    ) -> None:
+        """Record a local buffer. Monarch has no separate pin step — registration happens when an
+        ``RDMABuffer`` is created — so this only keeps the tensor needed to build views later."""
+        if tensor is None:
+            raise RuntimeError(
+                "MonarchEngine.register needs the owning tensor (pass tensor=...); Monarch's API takes "
+                "tensors/memoryviews, not raw pointers"
+            )
+        base = int(ptr)
+        self._bufs.append(
+            (base, base + int(size), tensor.view(torch.uint8).reshape(-1))
+        )
+
+    def _local_view(self, ptr: int, size: int) -> torch.Tensor:
+        p, n = int(ptr), int(size)
+        for base, end, t in self._bufs:
+            if base <= p and p + n <= end:
+                off = p - base
+                return t[off : off + n]
+        raise KeyError(
+            f"MonarchEngine: local ptr {p:#x} size {n} is not in any registered buffer"
+        )
+
+    def publish_regions(self, regions: Sequence[tuple[int, int]]) -> None:
+        """Export every region a peer will write into, tiled to the per-op ceiling.
+
+        Called once at connect, before the metadata exchange. Tiling here (rather than only on the write
+        side) is what makes an offset addressable at all: the writer targets the tile whose base is the
+        offset it wants.
+        """
+        from monarch.rdma import RDMABuffer
+
+        def _publish() -> None:
+            for addr, size in regions:
+                if size <= 0:
+                    continue
+                for c_addr, c_size in _tile(int(addr), int(size), self._chunk):
+                    key = (c_addr, c_size)
+                    if key not in self._published:
+                        self._published[key] = RDMABuffer(
+                            self._local_view(c_addr, c_size)
+                        )
+
+        self._in_ctx(_publish)
+        logger.info(
+            "MonarchEngine %s: published %d RDMA regions (%d requested, chunk=%d B)",
+            self._session,
+            len(self._published),
+            len(regions),
+            self._chunk,
+        )
+
+    def publish_payload(self) -> object:
+        """What goes into the connect-time metadata exchange: our region -> handle map."""
+        return {"session": self._session, "regions": dict(self._published)}
+
+    def attach_peer(self, session: str, payload: object) -> None:
+        if not payload:
+            return
+        self._peer[session] = dict(payload["regions"])  # type: ignore[index]
+        logger.debug(
+            "MonarchEngine %s: attached %d regions from peer %s",
+            self._session,
+            len(self._peer[session]),
+            session,
+        )
+
+    def _peer_buf(self, session: str, addr: int, size: int):
+        try:
+            return self._peer[session][(int(addr), int(size))]
+        except KeyError:
+            raise KeyError(
+                f"MonarchEngine: peer {session} published no region at {int(addr):#x}+{size}. Every "
+                "destination must be declared via publish_regions() at connect."
+            ) from None
+
+    # ----------------------------------------------------------------- data path
+    def _build_action(self, dst_session: str, src_ptrs, dst_ptrs, sizes):
+        from monarch.rdma import RDMAAction
+
+        act = RDMAAction()
+        ops: list[
+            tuple[int, int, int]
+        ] = []  # (src_addr, dst_addr, n), positionally = Monarch's op index
+        for s, d, size in zip(src_ptrs, dst_ptrs, sizes):
+            s, d, size = int(s), int(d), int(size)
+            # Walk source and destination in lockstep through the SAME tiling the publisher used.
+            for (d_addr, n), (s_addr, _n) in zip(
+                _tile(d, size, self._chunk), _tile(s, size, self._chunk)
+            ):
+                act.write_remote(
+                    self._peer_buf(dst_session, d_addr, n), self._local_view(s_addr, n)
+                )
+                ops.append((s_addr, d_addr, n))
+        return act, ops
+
+    def write(
+        self,
+        dst_session: str,
+        src_ptrs: Sequence[int],
+        dst_ptrs: Sequence[int],
+        sizes: Sequence[int],
+    ) -> None:
+        h = self.write_async(dst_session, src_ptrs, dst_ptrs, sizes)
+        self.wait([h])
+
+    def write_async(
+        self,
+        dst_session: str,
+        src_ptrs: Sequence[int],
+        dst_ptrs: Sequence[int],
+        sizes: Sequence[int],
+    ):
+        """Stage the whole batch into one :class:`RDMAAction` and submit it.
+
+        One action per call, not one per chunk: ``RDMAAction`` exists to dispatch its ops together, which
+        is what keeps a multi-MiB transfer from paying per-op latency serially.
+        """
+        if not src_ptrs:
+            return None
+        assert len(src_ptrs) == len(dst_ptrs) == len(sizes), (
+            f"ptr/size length mismatch: {len(src_ptrs)}/{len(dst_ptrs)}/{len(sizes)}"
+        )
+
+        def _submit():
+            act, ops = self._build_action(dst_session, src_ptrs, dst_ptrs, sizes)
+            return _Submission(act.submit(timeout=300), ops, dst_session)
+
+        # Submitting inside the captured context starts the transfer; the returned Future is completed
+        # later by wait(), also inside the context.
+        return self._in_ctx(_submit)
+
+    def write_batch(self, items):
+        """Every destination's ops in ONE :class:`RDMAAction` — one submit, one Future, one completion.
+
+        An action's ops may target different peers, so a whole round's fan-out fits in a single action.
+        See :meth:`RdmaEngine.write_batch` for why this matters (straggler spread, not median bandwidth).
+        """
+        from monarch.rdma import RDMAAction
+
+        live = [(s, sp, dp, sz) for s, sp, dp, sz in items if sp]
+        if not live:
+            return []
+
+        def _submit():
+            act = RDMAAction()
+            ops: list[tuple[int, int, int]] = []
+            sessions = []
+            for dst_session, src_ptrs, dst_ptrs, sizes in live:
+                sessions.append(dst_session)
+                for s, d, size in zip(src_ptrs, dst_ptrs, sizes):
+                    s, d, size = int(s), int(d), int(size)
+                    for (d_addr, n), (s_addr, _n) in zip(
+                        _tile(d, size, self._chunk), _tile(s, size, self._chunk)
+                    ):
+                        act.write_remote(
+                            self._peer_buf(dst_session, d_addr, n),
+                            self._local_view(s_addr, n),
+                        )
+                        ops.append((s_addr, d_addr, n))
+            return _Submission(
+                act.submit(timeout=300), ops, "+".join(sorted(set(sessions)))
+            )
+
+        return [self._in_ctx(_submit)]
+
+    def wait(self, handles: Sequence[object]) -> None:
+        live = [h for h in handles if h is not None]
+        if not live:
+            return
+        if asyncio._get_running_loop() is not None:
+            # Monarch delivers the completion as a message to this actor, which only its event loop can
+            # process; blocking that loop here means the Future never resolves. Fail loudly — the silent
+            # version of this is an unbounded hang with no error in the log (see docstring point 4).
+            raise RuntimeError(
+                "MonarchEngine.wait() called on a live asyncio event loop, which would deadlock: the "
+                "actor cannot process the RDMA completion while blocked here. Run WeightBridge work on a "
+                "dedicated thread off the actor's loop (see examples/workers_monarch.py::_ActorThread)."
+            )
+
+        def _get() -> None:
+            for h in live:
+                try:
+                    h.get()  # type: ignore[attr-defined]
+                except Exception as e:  # noqa: BLE001 — re-raised, annotated with the offending regions
+                    if isinstance(h, _Submission):
+                        idx = _failed_op_indices(str(e))
+                        raise RuntimeError(
+                            f"MonarchEngine.wait: submit failed ({len(idx)} bad ops)\n"
+                            f"  bad op indices: {idx}\n"
+                            f"{h.describe(idx[:64])}\n{e}"
+                        ) from e
+                    raise
+
+        self._in_ctx(_get)

--- a/examples/weightbridge/wbridge/backend/rdma/mooncake.py
+++ b/examples/weightbridge/wbridge/backend/rdma/mooncake.py
@@ -1,0 +1,299 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Mooncake backend for :class:`~wbridge.backend.rdma.base.RdmaEngine`.
+
+Wraps ``mooncake.engine.TransferEngine`` for engine initialization, local-memory registration,
+synchronous batched writes, and rollout-side session discovery. Mooncake's return-code conventions are
+``initialize``/``register_memory`` using ``!= 0`` for error and ``batch_transfer_sync_write`` using
+``< 0`` for error.
+
+Protocols:
+
+* ``"tcp"`` — TCP transport (the local toy). Stock Mooncake auto-installs an RDMA (RC-QP) transport that
+  fails on EFA, so :meth:`MooncakeEngine.init` forces ``MC_FORCE_TCP=1``.
+* ``"efa"`` — AWS EFA transport. Requires Mooncake built with ``-DUSE_EFA=ON``, a compatible system
+  ``libfabric``/``libefa`` visible to the dynamic linker, and ``FI_EFA_ENABLE_SHM_TRANSFER=0``. The
+  installation and loader paths belong to the deployment environment rather than this library.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Sequence
+
+from wbridge.backend.rdma.base import RdmaEngine
+
+logger = logging.getLogger(__name__)
+
+# Mooncake's built-in peer-to-peer metadata handshake (no external etcd/redis metadata server).
+_METADATA_MODE = "P2PHANDSHAKE"
+
+
+class MooncakeEngine(RdmaEngine):
+    """:class:`RdmaEngine` backed by ``mooncake.engine.TransferEngine``."""
+
+    def __init__(self) -> None:
+        self._te = None
+        self._session = ""
+        self._regions: list[int] = []  # registered base ptrs, for unregister on close
+        self._pinned_nic = (
+            ""  # NIC this engine pinned to (for NUMA-local staging alloc); "" if none
+        )
+        # EFA round-robins one NIC per transfer request, so a single large write can ride only one path.
+        # Striping each write into contiguous sub-transfers (see _stripe) lets the engine spread them across
+        # available NICs. The default 16 MiB was selected empirically and remains configurable; 0 disables.
+        # WBRIDGE_-prefixed (not MC_) on purpose: wbridge reads this itself, HERE — it is NOT consumed by the
+        # Mooncake/libfabric C layer (unlike MC_PATH_ROUNDROBIN / MC_NUM_QP_PER_EP, which that layer reads).
+        self._subslice = int(
+            os.environ.get("WBRIDGE_EFA_SUBSLICE_BYTES", str(16 * 1024 * 1024))
+        )
+
+    def init(
+        self,
+        local_host: str,
+        protocol: str,
+        device: str = "",
+        pin_local_nic: bool = False,
+        nic_index: int = 0,
+    ) -> None:
+        # Nudge transport env vars before importing the extension (``setdefault`` so explicit overrides
+        # win). See the module docstring for the EFA deployment requirements not settable from here
+        # (EFA wheel + libfabric symlink).
+        if protocol == "tcp":
+            # Stock Mooncake auto-installs an RC-QP RDMA transport that fails on EFA ("Failed to create
+            # QP: Operation not supported"); MC_FORCE_TCP=1 keeps it on TCP. Verified on EFA (host+VRAM).
+            os.environ.setdefault("MC_FORCE_TCP", "1")
+        elif protocol == "efa":
+            os.environ.setdefault("FI_EFA_ENABLE_SHM_TRANSFER", "0")
+            # Stripe each transfer across the GPU's affinity NICs. Mooncake discovers the available EFA
+            # paths; round-robin paths plus multiple QPs per endpoint spread one write across them.
+            # Sweep MC_NUM_QP_PER_EP for the target fabric if needed.
+            os.environ.setdefault("MC_PATH_ROUNDROBIN", "1")
+            os.environ.setdefault("MC_NUM_QP_PER_EP", "4")
+            # Host-memory staging: pin this rank to a NIC local to its GPU. Host DRAM has no per-GPU NIC
+            # affinity, so leaving every rank on the same first NIC can create a bottleneck. ``nic_index``
+            # selects among the local NICs: DualMooncakeEngine uses separate indices for bulk and flags so a
+            # saturating bulk write cannot starve a flag. GPUDirect transfers carry their own GPU-to-NIC
+            # affinity, so pin only when the caller (a staging endpoint) requests it.
+            if pin_local_nic and not device:
+                nic = self._local_gpu_nic(nic_index)
+                if nic:
+                    device = nic
+                    logger.info(
+                        "MooncakeEngine: pinning host-RDMA to local NIC %s (staging, nic_index=%d)",
+                        nic,
+                        nic_index,
+                    )
+                else:
+                    logger.warning(
+                        "MooncakeEngine: pin_local_nic requested but no local NIC found; "
+                        "falling back to default (multi-NIC) selection"
+                    )
+
+        self._pinned_nic = (
+            device if protocol == "efa" else ""
+        )  # a NIC name when pinned; drives NUMA-local alloc
+
+        from mooncake.engine import TransferEngine
+
+        self._te = TransferEngine()
+        rc = self._te.initialize(local_host, _METADATA_MODE, protocol, device)
+        if rc != 0:
+            raise RuntimeError(
+                f"Mooncake initialize failed (rc={rc}) host={local_host!r} protocol={protocol!r} device={device!r}"
+            )
+        self._session = f"{local_host}:{self._te.get_rpc_port()}"
+        logger.info(
+            "MooncakeEngine up: session=%s protocol=%s", self._session, protocol
+        )
+
+    # ----- local NIC selection for host-memory pinning (below the RdmaEngine ABC, like _stripe) -----
+    def _local_gpu_nic(self, index: int = 0) -> str:
+        """The ``index``-th EFA NIC on the same PCIe switch as this rank's current CUDA device.
+
+        Index 0 selects the first NIC in the GPU's PCIe locality group, and higher indices select the
+        remaining local NICs (used to keep the flag channel disjoint from bulk traffic). ``index`` is
+        clamped to the discovered group size.
+        Returns ``""`` if it can't be determined, in which case the caller leaves ``device`` empty and
+        Mooncake falls back to its default selection.
+        """
+        try:
+            import glob
+
+            import torch
+
+            bus = self._gpu_pci_bus(torch.cuda.current_device())
+            if bus is None:
+                return ""
+            groups: dict[
+                int, list[str]
+            ] = {}  # PCIe-root-domain -> NIC names sharing it
+            for d in sorted(glob.glob("/sys/class/infiniband/*")):
+                real = os.path.realpath(os.path.join(d, "device"))
+                seg = [p for p in real.split("/") if p.startswith("pci0000:")]
+                if seg:
+                    groups.setdefault(int(seg[0].split(":")[1], 16), []).append(
+                        os.path.basename(d)
+                    )
+            if not groups:
+                return ""
+            dom = max((r for r in groups if r <= bus), default=min(groups))
+            nics = groups.get(dom, [])
+            return nics[min(index, len(nics) - 1)] if nics else ""
+        except Exception:  # noqa: BLE001 — best-effort; empty -> default multi-NIC selection
+            return ""
+
+    @staticmethod
+    def _gpu_pci_bus(dev: int) -> "int | None":
+        """Physical PCIe bus number (e.g. 0x53) of CUDA device *dev*.
+
+        Uses ``cudaDeviceGetPCIBusId`` (CUDA runtime) so it is CUDA_VISIBLE_DEVICES-safe — SGLang/Ray set
+        CVD per worker, so ``current_device()`` is a *visible* index that would NOT match a physical NIC/
+        nvidia-smi index; the CUDA API maps it to the real device and returns the physical bus. None on error.
+        """
+        try:
+            import ctypes
+
+            lib = ctypes.CDLL("libcudart.so")
+            buf = ctypes.create_string_buffer(64)
+            if (
+                lib.cudaDeviceGetPCIBusId(buf, ctypes.c_int(64), ctypes.c_int(int(dev)))
+                != 0
+            ):
+                return None
+            return int(buf.value.decode().split(":")[1], 16)  # "0000:53:00.0" -> 0x53
+        except Exception:  # noqa: BLE001
+            return None
+
+    def pinned_numa_node(self) -> int:
+        """NUMA node of the NIC this engine pinned to, or -1 if not pinned / unknown.
+
+        Used to allocate the host staging buffers NUMA-local to the NIC that DMAs them — a cross-NUMA
+        DRAM<->NIC path materially reduces host-RDMA bandwidth, while NUMA-local first-touch closed most of
+        that gap in isolated testing.
+        """
+        nic = self._pinned_nic
+        if not nic:
+            return -1
+        try:
+            return int(open(f"/sys/class/infiniband/{nic}/device/numa_node").read())
+        except (OSError, ValueError):
+            return -1
+
+    def session_id(self) -> str:
+        assert self._session, "MooncakeEngine.init not called"
+        return self._session
+
+    def register(self, ptr: int, size: int, is_flag: bool = False, tensor=None) -> None:
+        # is_flag is a routing hint for multi-engine backends; a single Mooncake engine registers all the same.
+        # tensor is for tensor-based backends (MonarchEngine); Mooncake registers by address.
+        assert self._te is not None, "MooncakeEngine.init not called"
+        rc = self._te.register_memory(int(ptr), int(size))
+        if rc != 0:
+            raise RuntimeError(
+                f"Mooncake register_memory failed (rc={rc}) ptr={int(ptr):#x} size={size}"
+            )
+        self._regions.append(int(ptr))
+
+    def _stripe(self, src_ptrs, dst_ptrs, sizes):
+        """Split each (src,dst,size) transfer into contiguous sub-transfers of <= ``_subslice`` bytes.
+
+        EFA assigns one NIC per transfer request; many sub-transfers let the engine round-robin them
+        across all NICs, which produced a large multi-path throughput gain. Transfers already <= _subslice pass through unchanged, so
+        tiny writes (e.g. 8-byte flags) and the TCP toy are unaffected. ``_subslice<=0`` disables.
+        """
+        ss = self._subslice
+        if ss <= 0:
+            return (
+                [int(p) for p in src_ptrs],
+                [int(p) for p in dst_ptrs],
+                [int(s) for s in sizes],
+            )
+        s2: list[int] = []
+        d2: list[int] = []
+        z2: list[int] = []
+        for s, d, n in zip(src_ptrs, dst_ptrs, sizes):
+            s, d, n = int(s), int(d), int(n)
+            off = 0
+            while off < n:
+                c = ss if n - off > ss else n - off
+                s2.append(s + off)
+                d2.append(d + off)
+                z2.append(c)
+                off += c
+        return s2, d2, z2
+
+    def write(
+        self,
+        dst_session: str,
+        src_ptrs: Sequence[int],
+        dst_ptrs: Sequence[int],
+        sizes: Sequence[int],
+    ) -> None:
+        assert self._te is not None, "MooncakeEngine.init not called"
+        if not src_ptrs:
+            return
+        assert len(src_ptrs) == len(dst_ptrs) == len(sizes), (
+            f"ptr/size length mismatch: {len(src_ptrs)}/{len(dst_ptrs)}/{len(sizes)}"
+        )
+        s2, d2, z2 = self._stripe(src_ptrs, dst_ptrs, sizes)
+        rc = self._te.batch_transfer_sync_write(dst_session, s2, d2, z2)
+        if rc < 0:
+            raise RuntimeError(
+                f"Mooncake batch_transfer_sync_write failed (rc={rc}) dst_session={dst_session!r}"
+            )
+
+    def write_async(self, dst_session, src_ptrs, dst_ptrs, sizes):
+        """Submit a non-blocking batch write; returns a batch handle to pass to :meth:`wait`.
+
+        ``batch_transfer_async_write`` returns a batch id promptly; the data lands later. This lets the
+        sender submit writes to all peers concurrently and
+        :meth:`wait` on all handles at once. Each transfer is striped into sub-transfers (:meth:`_stripe`)
+        so a single large write fans out across all EFA NICs instead of riding one.
+        """
+        assert self._te is not None, "MooncakeEngine.init not called"
+        if not src_ptrs:
+            return None
+        s2, d2, z2 = self._stripe(src_ptrs, dst_ptrs, sizes)
+        bid = self._te.batch_transfer_async_write(dst_session, s2, d2, z2)
+        if bid < 0:
+            raise RuntimeError(
+                f"Mooncake batch_transfer_async_write failed (rc={bid}) dst_session={dst_session!r}"
+            )
+        return bid
+
+    def wait(self, handles) -> None:
+        """Block until all *handles* (batch ids from :meth:`write_async`) have completed.
+
+        ``get_batch_transfer_status(ids)`` blocks until every batch in the list finishes and returns 0 on
+        success; focused testing confirmed that it does not return before the transfer lands.
+        """
+        assert self._te is not None, "MooncakeEngine.init not called"
+        ids = [int(h) for h in handles if h is not None]
+        if not ids:
+            return
+        rc = self._te.get_batch_transfer_status(ids)
+        if rc != 0:
+            raise RuntimeError(
+                f"Mooncake get_batch_transfer_status failed (rc={rc}) for {len(ids)} batches"
+            )
+
+    def close(self) -> None:
+        te = self._te
+        if te is None:
+            return
+        for ptr in self._regions:
+            try:
+                te.unregister_memory(ptr)
+            except Exception:  # best-effort teardown
+                logger.debug(
+                    "unregister_memory(%#x) failed during close", ptr, exc_info=True
+                )
+        self._regions.clear()
+        self._te = None
+        self._session = ""

--- a/examples/weightbridge/wbridge/backend/receiver.py
+++ b/examples/weightbridge/wbridge/backend/receiver.py
@@ -1,0 +1,3619 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Rollout Worker side of WeightBridge: the per-worker :class:`WeightReceiver`.
+
+Control-plane model (per rollout engine):
+
+* A standalone **coordinator** process (:mod:`wbridge.backend.coordinator`) handles discovery and relays the
+  one-time ``connect`` request over ZMQ to **only receiver rank 0** (identity ``worker-0``). Per-update
+  readiness normally comes from the data plane itself: a sender completion sequence in pinned CPU memory.
+* **Receiver rank 0** is the sole decision maker. Each :meth:`WeightReceiver.poll_requests` round it peeks
+  its first active input round and forwards one ``empty|kick|receive`` decision to the other TP ranks over a
+  ZMQ **star** (IPC for single-node engines, TCP for multi-node engines; see
+  :class:`~wbridge.backend.control_channel.ControlChannel`).
+* **Every other rank joins** the same :meth:`WeightReceiver.poll_requests` round and waits for rank 0's
+  decision, so all TP ranks act in lockstep. Connect and the weight transfer both run on the **main
+  thread, blocking**, inside that call.
+
+The data plane is one-sided RDMA writes (see :class:`~wbridge.backend.router.WBEndpoint`), not a process
+group. :meth:`WeightReceiver.poll_requests` drives the transfer from the main thread.  The default
+receiver schedule is serial; the opt-in depth-2 three-stage schedule moves external exchange + internal
+consume onto a cross-round progress worker so sender landing, fused prepare, and two independently-gated E+C
+rounds can occupy the parity slots concurrently. External completion waiters persist across updates; the
+per-update progress worker is joined before ``poll_requests`` returns. There is no ``cpu_direct`` mode.
+Replica-group relay is the exception: the main thread returns after its own model consumes and successor
+writes finish. A persistent retirement worker keeps PREP lifetime accounting and recursive full-delivery
+notification off that blocking path.
+"""
+
+import logging
+import os
+import queue
+import threading
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Optional
+
+import torch
+from wbridge.backend import gantt
+from wbridge.backend.control_channel import (
+    CONNECT_REQUEST,
+    ControlChannel,
+    CoordinatorClient,
+    EMPTY,
+    RECEIVE_KICK,
+    RECEIVE_REQUEST,
+)
+from wbridge.backend.router import (
+    _arena_peer_predecessors,
+    _arena_slot_offset,
+    _arena_slot_predecessors,
+    _relay_round_predecessors,
+    WBEndpoint,
+)
+from wbridge.utils.data import LoadSpec, ShardSpec
+
+logger = logging.getLogger(__name__)
+
+
+def _doff_source_predecessors(
+    active_rounds: list[int],
+    ext_recv_by_round: list[tuple[int, ...]],
+    depth: int,
+    rank: int,
+) -> list[dict[int, tuple[int, int]]]:
+    """Return cyclic reuse predecessors for each fixed ``(source, DOFF slot)``.
+
+    This is topology-pipeline metadata.  Callers on the generic serial path must
+    not build it because that path intentionally has no topology round tables.
+    """
+    if depth <= 0:
+        raise ValueError(f"DOFF depth must be positive, got {depth}")
+    predecessors: list[dict[int, tuple[int, int]]] = [{} for _ in ext_recv_by_round]
+    final: dict[tuple[int, int], int] = {}
+    for ri in active_rounds:
+        for source in {rank, *ext_recv_by_round[ri]}:
+            final[(source, ri % depth)] = ri
+    previous: dict[tuple[int, int], int] = {}
+    for ri in active_rounds:
+        for source in {rank, *ext_recv_by_round[ri]}:
+            key = (source, ri % depth)
+            predecessors[ri][source] = (
+                (0, previous[key]) if key in previous else (-1, final[key])
+            )
+            previous[key] = ri
+    return predecessors
+
+
+class WeightReceiver(WBEndpoint):
+    """One receiver per rollout TP rank.
+
+    Rank 0 mediates the control plane via :class:`~wbridge.backend.control_channel.ControlChannel`; all
+    ranks perform ``connect`` / ``_receive_weights`` on the main thread inside :meth:`poll_requests`.
+    """
+
+    def __init__(
+        self,
+        controller_ipc_name: str,
+        rank: int,
+        shard_spec: ShardSpec,
+        dtype_spec: dict[str, torch.dtype],
+        load_spec: LoadSpec,
+        wksd: dict[str, torch.Tensor],
+        *,
+        num_workers: int,
+        control_hub_name: str | None = None,
+        receiver_staging: bool = False,
+    ) -> None:
+        self.cuda_device = f"cuda:{torch.cuda.current_device()}"
+
+        self.rank = rank
+        self.num_workers = num_workers
+        self.shard_spec = shard_spec
+        self.dtype_spec = dtype_spec
+        # HF<->worker mapping + live params; the fused wire->model CopyPlan is built once at connect.
+        self.load_spec = load_spec
+        self.wksd = wksd
+        self.receiver_staging = (
+            receiver_staging  # WBEndpoint switch (read by router._init_engine/_setup)
+        )
+
+        self._connected = False
+        self._recv_count = (
+            0  # RECEIVE_REQUESTs handled (for WBRIDGE_RECV_PROFILE_WT targeting)
+        )
+        # Internal two-phase state used by poll_requests: readiness selects a decision, then the same
+        # scheduler-thread call executes it.
+        self._pending: Optional[dict[str, Any]] = None
+
+        # Hub star (MAIN thread, all ranks): rank0 broadcasts one decision per tick, peers block for it. This
+        # per-tick rendezvous keeps the engine's TP ranks in lockstep, so a blocking collective (the connect
+        # rendezvous, the receiver<->receiver all-gather) is entered by all ranks together — never with one
+        # rank stuck in an unrelated collective (which is what deadlocked when this was decoupled). Created +
+        # used only on the main thread.
+        self._chan = ControlChannel(
+            controller_ipc_name,
+            rank,
+            num_workers,
+            hub_endpoint=control_hub_name,
+        )
+
+        # rank0 ONLY: a receiving thread owns the trainer-facing coordinator intake. In normal operation it
+        # carries discovery/connect only; RECEIVE is retained as a zero-input-rank fallback. It sets _ext_req;
+        # the main thread reads it during poll_requests and broadcasts decisions via the hub (notification stays
+        # on the main thread — that is what preserves TP lockstep).
+        self._controller_ipc_name = controller_ipc_name
+        self._ext_req: Optional[dict[str, Any]] = None
+        self._ext_lock = threading.Lock()
+        self._ext_cv = threading.Condition(self._ext_lock)
+        self._stop = False
+        self._ctrl_thread: Optional[threading.Thread] = None
+        # External bulk completions use one persistent waiter per destination.  The transport exposes a
+        # blocking wait rather than wait-any, so a single waiter would reintroduce head-of-line blocking when
+        # overlapping groups send to several destinations.  These daemon workers span every transfer epoch;
+        # individual E+C rounds only enqueue completed submissions and never call Thread.start().
+        self._topo_out_wait_queues: dict[int, queue.Queue] = {}
+        self._topo_out_wait_threads: dict[int, threading.Thread] = {}
+        self._topo_out_wait_lock = threading.Lock()
+        # Exact protocol generations observed/completed by the cross-round internal-consume dispatcher.
+        self._topo_lane_seen: dict[tuple[int, int | None], int] = {}
+        self._topo_lane_consumed: dict[tuple[int, int | None], int] = {}
+        # Relay completion has two lifetimes. The scheduler-visible receive ends once this worker has
+        # consumed its model data and every successor write has completed. PREP may still be read by a
+        # same-node peer, and full-delivery DATA still has to propagate back through the chain. One persistent
+        # retirement worker handles both without keeping the rollout engine blocked. PREP is released on the
+        # foreground path after forwarding + offload; `_relay_doff_released` is the cross-epoch fence that
+        # prevents an epoch-retired DOFF slot from being overwritten while a local reader still consumes it.
+        self._relay_retire_lock = threading.Lock()
+        self._relay_retire_q: queue.Queue | None = None
+        self._relay_retire_thread: threading.Thread | None = None
+        self._relay_retire_errors: list[BaseException] = []
+        self._relay_prep_released: dict[tuple[int, int], int] = {}
+        self._relay_doff_released: dict[tuple[int, int], int] = {}
+        self._relay_group_executor = None
+        if rank == 0:
+            self._ctrl_thread = threading.Thread(
+                target=self._coordinator_worker,
+                name="wbridge-recv-adapter",
+                daemon=True,
+            )
+            self._ctrl_thread.start()
+
+        # RS-on: a per-rank receive-worker lands ALL sender writes into the full-depth CPU arena while the
+        # scheduler keeps generating. Only after the complete local epoch is in CPU does it H2D the first
+        # active round into the isolated GPU ingress arena and publish _rs_gpu_ready. Rank 0's local GPU-ready
+        # flag causes GO; peers quiesce on that GO and wait for their own flag before assemble/repack.
+        self._rs_cv = threading.Condition()
+        self._rs_go: Optional[int] = (
+            None  # epoch the main thread asked the worker to receive
+        )
+        self._rs_receiving = (
+            -1
+        )  # epoch currently in flight (avoids re-signaling every tick)
+        self._rs_staged = -1  # epoch the worker has fully landed in CPU
+        self._rs_gpu_ready = (
+            -1
+        )  # epoch whose first active round is fully landed in GPU RECV
+        self._rs_kicked = -1  # epoch rank0 has broadcast a KICK for (phase-1 latch)
+        self._rs_err: Optional[BaseException] = None
+        self._recv_thread: Optional[threading.Thread] = None
+        if receiver_staging:
+            self._recv_thread = threading.Thread(
+                target=self._recv_worker, name="wbridge-recv-cpu", daemon=True
+            )
+            self._recv_thread.start()
+
+    def stop(self) -> None:
+        """Stop rank0's coordinator thread + the RS receive-worker, and close the hub star."""
+        self._stop = True
+        self._stop_relay_retire_worker()
+        self._stop_relay_bulk_waiters()
+        executor = getattr(self, "_relay_group_executor", None)
+        self._relay_group_executor = None
+        if executor is not None:
+            executor.shutdown(wait=True, cancel_futures=True)
+        with self._ext_cv:
+            self._ext_cv.notify_all()
+        with self._rs_cv:
+            self._rs_cv.notify_all()
+        with self._topo_out_wait_lock:
+            topo_queues = list(self._topo_out_wait_queues.values())
+            topo_threads = list(self._topo_out_wait_threads.values())
+        for work_q in topo_queues:
+            work_q.put(None)
+        for th in (self._ctrl_thread, self._recv_thread, *topo_threads):
+            if th is not None and th.is_alive():
+                th.join(timeout=5.0)
+        self._flag_reaper_stop()
+        if self._chan is not None:
+            self._chan.close()
+
+    def _teardown(self) -> None:
+        """Retire the relay control worker before the base tears down its transports and buffers."""
+        self._stop_relay_retire_worker()
+        executor = getattr(self, "_relay_group_executor", None)
+        self._relay_group_executor = None
+        if executor is not None:
+            executor.shutdown(wait=True, cancel_futures=True)
+        super()._teardown()
+
+    def _init_relay_retire_state(self) -> None:
+        """Lazily initialize retirement state for low-level endpoints constructed with ``__new__``."""
+        if hasattr(self, "_relay_retire_lock"):
+            if not hasattr(self, "_relay_doff_released"):
+                self._relay_doff_released = {}
+            return
+        self._relay_retire_lock = threading.Lock()
+        self._relay_retire_q = None
+        self._relay_retire_thread = None
+        self._relay_retire_errors = []
+        self._relay_prep_released = {}
+        self._relay_doff_released = {}
+
+    def _relay_retire_check(self) -> None:
+        self._init_relay_retire_state()
+        with self._relay_retire_lock:
+            error = self._relay_retire_errors[0] if self._relay_retire_errors else None
+        if error is not None:
+            raise RuntimeError(
+                f"wbridge rank {self._rank}: asynchronous relay retirement failed"
+            ) from error
+
+    def _ensure_relay_retire_worker(self) -> None:
+        self._init_relay_retire_state()
+        self._relay_retire_check()
+        with self._relay_retire_lock:
+            thread = self._relay_retire_thread
+            if thread is not None:
+                if not thread.is_alive():
+                    raise RuntimeError(
+                        f"wbridge rank {self._rank}: relay retirement worker stopped unexpectedly"
+                    )
+                return
+            work_q: queue.Queue = queue.Queue()
+            thread = threading.Thread(
+                target=self._relay_retire_worker,
+                args=(work_q,),
+                name="wbridge-relay-retire",
+                daemon=True,
+            )
+            self._relay_retire_q = work_q
+            self._relay_retire_thread = thread
+            thread.start()
+
+    def _stop_relay_retire_worker(self) -> None:
+        self._init_relay_retire_state()
+        with self._relay_retire_lock:
+            work_q = self._relay_retire_q
+            thread = self._relay_retire_thread
+        if work_q is not None and thread is not None:
+            work_q.put(None)
+            thread.join(timeout=5.0)
+            if thread.is_alive():
+                raise RuntimeError(
+                    f"wbridge rank {getattr(self, '_rank', getattr(self, 'rank', -1))}: "
+                    "relay retirement worker did not stop"
+                )
+        with self._relay_retire_lock:
+            self._relay_retire_q = None
+            self._relay_retire_thread = None
+            self._relay_retire_errors = []
+            self._relay_prep_released = {}
+            self._relay_doff_released = {}
+
+    def _relay_local_readers_done(self, gid: int, ri: int, seq: int) -> bool:
+        """Return whether every other same-node member has finished reading this DOFF slot."""
+        readers = self._relay_local_readers.get(gid, ())
+        if not readers:
+            return True
+        depth = getattr(self, "_relay_doff_depth", 1)
+        channel = self._relay_local_channel[(gid, ri % depth)]
+        return all(
+            self._relay_local_flags.consumed(
+                self._relay_local_slot_of[reader],
+                channel,
+            )
+            >= seq
+            for reader in readers
+        )
+
+    def _relay_mark_prep_released(self, gid: int, ri: int, seq: int) -> None:
+        self._init_relay_retire_state()
+        key = (gid, ri % 2)
+        with self._relay_retire_lock:
+            self._relay_prep_released[key] = max(
+                seq,
+                self._relay_prep_released.get(key, 0),
+            )
+
+    def _relay_prep_was_released(self, gid: int, ri: int, seq: int) -> bool:
+        self._init_relay_retire_state()
+        with self._relay_retire_lock:
+            return self._relay_prep_released.get((gid, ri % 2), 0) >= seq
+
+    def _relay_mark_doff_released(self, gid: int, ri: int, seq: int) -> None:
+        self._init_relay_retire_state()
+        key = (gid, ri % getattr(self, "_relay_doff_depth", 1))
+        with self._relay_retire_lock:
+            self._relay_doff_released[key] = max(
+                seq,
+                self._relay_doff_released.get(key, 0),
+            )
+
+    def _relay_doff_was_released(self, gid: int, ri: int, seq: int) -> bool:
+        self._init_relay_retire_state()
+        with self._relay_retire_lock:
+            return (
+                self._relay_doff_released.get(
+                    (gid, ri % getattr(self, "_relay_doff_depth", 1)),
+                    0,
+                )
+                >= seq
+            )
+
+    @staticmethod
+    def _relay_local_exit_ready(owner_states: dict, consume_states: dict) -> bool:
+        """The worker may resume compute after its consumes and successor writes complete.
+
+        Same-node readers of an owned DOFF slot and recursive downstream delivery are deliberately absent:
+        the retirement worker owns those lifetimes after this predicate becomes true. PREP was already
+        released after its successor write and offload copy completed.
+        """
+        return all(state["done"] for state in consume_states.values()) and all(
+            state["relay_done"] for state in owner_states.values()
+        )
+
+    def _defer_relay_retirement(self, tasks: list[dict]) -> None:
+        if not tasks:
+            return
+        self._ensure_relay_retire_worker()
+        with self._relay_retire_lock:
+            work_q = self._relay_retire_q
+        assert work_q is not None
+        work_q.put(tasks)
+
+    def _relay_retire_worker(self, work_q: queue.Queue) -> None:
+        """Retire independent DOFF slots and recursively publish full delivery off-path."""
+        pending: list[dict] = []
+        try:
+            while True:
+                if not pending:
+                    batch = work_q.get()
+                    if batch is None:
+                        return
+                    pending.extend(batch)
+                while True:
+                    try:
+                        batch = work_q.get_nowait()
+                    except queue.Empty:
+                        break
+                    if batch is None:
+                        return
+                    pending.extend(batch)
+
+                progress = False
+                remaining = []
+                for task in pending:
+                    if not task["doff_released"] and self._relay_local_readers_done(
+                        task["gid"],
+                        task["ri"],
+                        task["seq"],
+                    ):
+                        task["doff_released"] = True
+                        self._relay_mark_doff_released(
+                            task["gid"],
+                            task["ri"],
+                            task["seq"],
+                        )
+                        progress = True
+
+                    successor = task["succ"]
+                    downstream_done = successor is None or self._relay_flag_reached(
+                        self._RELAY_DATA_KIND,
+                        successor,
+                        task["gid"],
+                        task["seq"],
+                    )
+                    if task["doff_released"] and downstream_done:
+                        for peer in task["upstream_peers"]:
+                            self._relay_emit(
+                                self._RELAY_DATA_KIND,
+                                peer,
+                                task["gid"],
+                                task["seq"],
+                            )
+                        self._trace_state(
+                            "relay_retired",
+                            epoch=task["wt"],
+                            group=task["gid"],
+                            round=task["ri"],
+                        )
+                        progress = True
+                    else:
+                        remaining.append(task)
+                pending = remaining
+                if pending and not progress:
+                    time.sleep(1e-4)
+        except BaseException as exc:  # noqa: BLE001 - surfaced on the next receiver interaction
+            with self._relay_retire_lock:
+                self._relay_retire_errors.append(exc)
+            logger.exception(
+                "wbridge rank %d: relay retirement worker failed", self._rank
+            )
+
+    def _ensure_topo_out_waiters(self, peers: set[int]) -> None:
+        """Create the endpoint-lifetime external-completion waiter for each destination in ``peers``."""
+        # A few low-level integration drivers construct endpoints with ``__new__`` to bypass the application
+        # control adapter. Keep this data-plane helper self-initializing for those legitimate direct users.
+        if not hasattr(self, "_topo_out_wait_lock"):
+            self._topo_out_wait_queues = {}
+            self._topo_out_wait_threads = {}
+            self._topo_out_wait_lock = threading.Lock()
+        with self._topo_out_wait_lock:
+            for peer in sorted(peers):
+                if peer in self._topo_out_wait_threads:
+                    continue
+                work_q: queue.Queue = queue.Queue()
+                thread = threading.Thread(
+                    target=self._topo_out_waiter,
+                    args=(peer, work_q),
+                    name=f"wbridge-ext-ready-{peer}",
+                    daemon=True,
+                )
+                self._topo_out_wait_queues[peer] = work_q
+                self._topo_out_wait_threads[peer] = thread
+                thread.start()
+
+    def _topo_out_waiter(self, peer: int, work_q: queue.Queue) -> None:
+        """Wait queued writes to one peer in generation order and publish their READY sequences."""
+        while True:
+            task = work_q.get()
+            if task is None:
+                return
+            wt, ri, seq, bid, submitted_at, result_q = task
+            error: BaseException | None = None
+            try:
+                with gantt.span("receiver", self._rank, wt, "ext_peer_wait", ri):
+                    self.engine.wait([bid])
+                gantt.rec(
+                    "receiver",
+                    self._rank,
+                    wt,
+                    "ext_peer_xfer",
+                    ri,
+                    submitted_at,
+                    time.time(),
+                )
+                self._trace_state(
+                    "topo_external_peer_done",
+                    epoch=wt,
+                    round=ri,
+                    peer=peer,
+                    seq=seq,
+                )
+                with gantt.span("receiver", self._rank, wt, "ext_flag", ri):
+                    self._flag_emit(1, peer, seq)
+            except BaseException as exc:  # noqa: BLE001 - delivered to the owning E+C dispatcher
+                error = exc
+            result_q.put((ri, peer, error))
+
+    # ----- rank0 coordinator intake (own thread; decoupled from the scheduler tick) -----
+    def _coordinator_worker(self) -> None:
+        """rank0: own the coordinator DEALER and post connect/fallback requests for the main thread.
+
+        Normal updates no longer traverse this socket: input sequence flags are their doorbell. One external
+        request remains in flight until the main thread consumes it.
+        """
+        cc = None
+        try:
+            cc = CoordinatorClient(self._controller_ipc_name, self.num_workers)
+            while not self._stop:
+                req = cc.poll(1000)
+                if req is None:
+                    continue
+                cc.ack()
+                with self._ext_cv:
+                    self._ext_req = req
+                    self._ext_cv.notify_all()
+                    while self._ext_req is not None and not self._stop:
+                        self._ext_cv.wait()
+        except Exception:  # noqa: BLE001
+            logger.exception("wbridge rank 0: coordinator thread failed")
+        finally:
+            if cc is not None:
+                cc.close()
+
+    # ----- RS receive-worker (per rank; lands sender writes in CPU while the scheduler keeps running) -----
+    def _recv_worker(self) -> None:
+        """On KICK, stage a complete epoch in CPU, then preload its first active GPU receive round.
+
+        Network receive and its ACK pipeline perform no GPU work, so SGLang continues throughout that long
+        leg. After *all* local rounds have landed, one isolated CPU->GPU ingress copy runs on the local staging
+        stream. Its completed CUDA event is converted to the host-side ``_rs_gpu_ready`` epoch flag that rank
+        0 uses for GO (and peers wait on after GO).
+        """
+        while not self._stop:
+            with self._rs_cv:
+                while self._rs_go is None and not self._stop:
+                    self._rs_cv.wait()
+                if self._stop:
+                    return
+                epoch = self._rs_go
+                self._rs_go = None
+            try:
+                # Background span: the sender->receiver RDMA landing into CPU, off the scheduler thread. Its
+                # duration vs the main-thread GPU consume is the rollout-side overlap (blocked << total).
+                with gantt.span("recv-cpu", self._rank, epoch, "recv_to_cpu", -1):
+                    self._receive_to_cpu(epoch)
+                with self._rs_cv:
+                    self._rs_staged = epoch
+                    self._rs_cv.notify_all()
+                first_ri = self._first_active_round()
+                with gantt.span(
+                    "recv-cpu",
+                    self._rank,
+                    epoch,
+                    "first_h2d",
+                    -1 if first_ri is None else first_ri,
+                ):
+                    self._rs_stage_first_to_gpu(epoch)
+            except BaseException as e:  # noqa: BLE001 — surfaced to the scheduler thread via poll_requests
+                with self._rs_cv:
+                    self._rs_err = e
+                    self._rs_cv.notify_all()
+                return
+            with self._rs_cv:
+                self._rs_gpu_ready = epoch
+                self._rs_cv.notify_all()
+            self._trace_state(
+                "rs_gpu_recv_ready", epoch=epoch, round=self._first_active_round()
+            )
+
+    def _first_active_round(self) -> int | None:
+        """First global round in which this receiver has at least one trainer contributor."""
+        if self.router is None:
+            return None
+        return next(
+            (ri for ri, (_fs, ov) in enumerate(self.router.local_rounds) if ov), None
+        )
+
+    def _sender_input_ready(self, epoch: int) -> bool:
+        """Non-blockingly test all trainer flags for this rank's first active input round.
+
+        Under RS this means the first round has landed in CPU and is the KICK doorbell. With RS off it means
+        the first round has landed directly in GPU (except the established same-node pull path, where it means
+        the sender's GPU pack source is ready). A monotonic sequence makes stale prior-epoch flags harmless.
+        """
+        if getattr(self, "_relay_enabled", False):
+            self._relay_retire_check()
+            # Preserve the original overlap contract: rank 0 stops generation as soon as its first complete
+            # group chunk has landed at this node's representative, not after every group/round is present.
+            # The first node observes trainer DATA at a head; later nodes observe predecessor DATA. This is
+            # essential for independent rollout engines: a non-head engine has no direct trainer flag with
+            # which to bootstrap its GO decision.
+            candidates = []
+            for gid in getattr(self, "_relay_owned_gids", ()):
+                group = self.router.relay_group(gid)
+                position = group["chain"].index(self._rank)
+                for ri, spec in enumerate(group["round_specs"]):
+                    if spec.entries:
+                        input_peers = (
+                            tuple(sorted(group["trainer_specs"][ri]))
+                            if position == 0
+                            else (group["chain"][position - 1],)
+                        )
+                        candidates.append((ri, gid, input_peers))
+                        break
+            if not candidates:
+                return False
+            ri, gid, input_peers = min(candidates)
+            seq = epoch * self.num_rounds + ri + 1
+            return all(
+                self._relay_flag_reached(self._RELAY_DATA_KIND, peer, gid, seq)
+                for peer in input_peers
+            )
+        ri = self._first_active_round()
+        if ri is None:
+            return False
+        seq = epoch * self.num_rounds + ri + 1
+        overlap_specs = self.router.local_rounds[ri][1]
+        return all(self._flag_reached(peer, seq) for peer in overlap_specs)
+
+    def _rs_stage_first_to_gpu(self, epoch: int) -> None:
+        """H2D the first active round after the complete RS CPU epoch has landed.
+
+        The local staging engine returns a CUDA event and ``wait`` synchronizes it before the worker publishes
+        ``_rs_gpu_ready``. The destination is the isolated trainer-ingress arena, never live model storage.
+        """
+        ri = self._first_active_round()
+        if ri is None:
+            return
+        assert self.local_engine is not None
+        src, dst, sz = self._rs_h2d[ri]
+        if not src:
+            return
+        with torch.cuda.device(self.cuda_device):
+            handle = self.local_engine.write_async(
+                self.local_engine.session_id(), src, dst, sz
+            )
+            self.local_engine.wait([handle])
+
+    def _receive_to_cpu(self, epoch: int) -> None:
+        """Poll every round's senders (their RDMA into our full-depth CPU arena) and landing-ack all rounds
+        EXCEPT the last, using *epoch*'s flag sequence. The last round's ack is deferred to the main thread,
+        right after its H2D (:meth:`_receive_weights`): the consume H2Ds rounds in order, so the last round's
+        consume-ack implies every CPU slot has been read -> it doubles as a whole-epoch 'consumed' barrier the
+        sender's epoch-end drain waits on, so the next epoch (which reuses these depth-1-across-epochs CPU
+        slots, and whose RECEIVE must not race our epoch advance) cannot start until we've fully consumed this
+        one. Landing-acking the earlier rounds keeps the sender's per-round pipeline flowing. No assemble here.
+
+        This is the fix for the production overlap deadlock: acking EVERY round at landing let the sender (and
+        a faster rollout engine) sprint a whole epoch ahead of a slower engine, and the depth-1 per-round flag
+        state can't represent that skew -> wedge; the last-round consume-ack paces the sender to the consume."""
+        rounds = [ri for ri, (_fs, ov) in enumerate(self.router.local_rounds) if ov]
+        last = rounds[-1] if rounds else -1
+        for ri in rounds:
+            ov = self.router.local_rounds[ri][1]
+            seq = epoch * self.num_rounds + ri + 1
+            for peer in ov:
+                self._poll_flag(
+                    peer, seq
+                )  # sender wrote round ri into our CPU RECV slot
+            if ri != last:
+                for peer in ov:
+                    self._write_flag(
+                        peer, seq
+                    )  # landing-ack: frees the sender's per-round pipeline
+
+    # ----- per-round rendezvous (MAIN thread, every scheduler iteration) -----
+    def is_update_ready(self) -> bool:
+        """Internal readiness phase used by :meth:`poll_requests`.
+
+        Runs one scheduler control round, with receiver rank 0 as the sole decision maker.
+
+        RS-off: rank 0 broadcasts GO when all senders contributing to its first active round have published
+        their data-before-flag sequences. RS-on: that same observation broadcasts KICK; every CPU worker then
+        stages the complete local epoch and preloads its first active round while SGLang continues. Rank 0
+        broadcasts GO on its host-side GPU-receive flag. Peers quiesce with rank 0 and wait for their own
+        flag before the receive phase runs, preserving TP lockstep.
+        """
+        rs = self.receiver_staging and self._connected
+        if self.rank == 0:
+            with self._ext_cv:
+                req = self._ext_req
+                self._ext_req = None
+                self._ext_cv.notify_all()  # release the coordinator thread for the next request
+            decision = self._rank0_decision(req, staged=rs)
+            if decision.get("type") == RECEIVE_REQUEST and gantt.ON:
+                # Peers consume the hub's FIFO decision stream one item per scheduler tick. Timestamp GO at
+                # its source so a queued-EMPTY backlog appears explicitly as decision_lag in the Gantt.
+                decision["_gantt_broadcast_t0"] = time.time()
+            self._chan.broadcast(decision)
+        else:
+            if rs:
+                with self._rs_cv:
+                    if self._rs_err is not None:
+                        raise self._rs_err
+            decision = self._chan.poll_decision(500 if rs else 5000)
+            if decision is None:
+                self._pending = None
+                return False  # slow rank0; retry next tick (not a hang)
+        kind = decision.get("type")
+        if kind == CONNECT_REQUEST:
+            self._pending = decision
+            return True
+        if kind == RECEIVE_KICK:
+            # RS phase 1: kick this rank's receive-worker (once per epoch); keep generating (the overlap).
+            with self._rs_cv:
+                if (
+                    self._rs_receiving != self._epoch
+                    and self._rs_gpu_ready != self._epoch
+                ):
+                    self._rs_go = self._epoch
+                    self._rs_receiving = self._epoch
+                    self._rs_cv.notify_all()
+            self._trace_state("receive_kick", epoch=self._epoch)
+            self._pending = None
+            return False
+        if kind == RECEIVE_REQUEST:
+            broadcast_t0 = decision.get("_gantt_broadcast_t0")
+            if broadcast_t0 is not None:
+                gantt.rec(
+                    "receiver",
+                    self._rank,
+                    self._epoch,
+                    "decision_lag",
+                    -1,
+                    float(broadcast_t0),
+                    time.time(),
+                )
+            # RS-off: main-thread receive. RS-on: GO quiesces every TP rank; a lagging peer waits for its own
+            # host-side GPU-receive flag before touching the fused prepare/exchange path.
+            self._pending = decision
+            return True
+        self._pending = None
+        return False
+
+    def _rank0_decision(
+        self, req: Optional[dict[str, Any]], *, staged: bool
+    ) -> dict[str, Any]:
+        """Build rank 0's data-driven KICK/GO decision for one scheduler tick."""
+        if req is not None and req.get("type") == CONNECT_REQUEST:
+            return req
+        if not self._connected:
+            return {"type": EMPTY}
+
+        # Only a rank with no input flag can use the legacy coordinator doorbell. If a mixed-version sender
+        # posts RECEIVE for a normal rank, ignore its timing and still wait for the causally stronger data flag.
+        fallback = (
+            req is not None
+            and req.get("type") == RECEIVE_REQUEST
+            and self._first_active_round() is None
+        )
+        if not staged:
+            ready = fallback or self._sender_input_ready(self._epoch)
+            return (
+                {"type": RECEIVE_REQUEST, "epoch": self._epoch}
+                if ready
+                else {"type": EMPTY}
+            )
+
+        with self._rs_cv:
+            if self._rs_err is not None:
+                raise self._rs_err
+            if self._rs_kicked != self._epoch and (
+                fallback or self._sender_input_ready(self._epoch)
+            ):
+                self._rs_kicked = self._epoch
+                return {"type": RECEIVE_KICK, "epoch": self._epoch}
+            kicked = self._rs_kicked == self._epoch
+            gpu_ready = self._rs_gpu_ready == self._epoch
+        return (
+            {"type": RECEIVE_REQUEST, "epoch": self._epoch}
+            if (kicked and gpu_ready)
+            else {"type": EMPTY}
+        )
+
+    def poll_requests(
+        self, before_receive: Callable[[int], None] | None = None
+    ) -> bool:
+        """Poll one control round and execute its pending action on the main thread.
+
+        ``before_receive`` runs on every receiver rank after a real weight-update request has been
+        selected, but before any model weight is mutated.  Its argument is the update epoch.  It is not
+        called for an empty poll, a receiver-staging KICK, or the one-time connection request.
+
+        Returns ``True`` only after a weight update has been received and loaded.  Connection setup and
+        polls without a completed update return ``False``.  Like the former two-call adapter sequence,
+        this method must be driven on every model-parallel rank on every scheduler tick.
+        """
+        if not self.is_update_ready():
+            return False
+
+        decision = self._pending
+        if (
+            before_receive is not None
+            and isinstance(decision, dict)
+            and decision.get("type") == RECEIVE_REQUEST
+        ):
+            before_receive(int(decision["epoch"]))
+        return self.request_update()
+
+    def request_update(self) -> bool:
+        """Internal execution phase used by :meth:`poll_requests`; blocks on the main thread."""
+        decision = self._pending
+        self._pending = None
+        if decision is None:
+            return False
+        kind = decision.get("type")
+        if kind == CONNECT_REQUEST:
+            self._do_connect(decision)
+            return False
+        if kind == RECEIVE_REQUEST:
+            assert self._connected and self.engine is not None, "receive before connect"
+            self._trace_state("receive_request_enter", epoch=self._epoch)
+            self._run_receive(staged=self.receiver_staging)
+            self._trace_state("receive_request_done", epoch=self._epoch - 1)
+            return True
+        return False
+
+    # ----- persistent receiving thread (owns the control channel; RS-on also lands data in CPU) ----------
+    def _run_receive(self, staged: bool = False) -> None:
+        """Run one weight receive, optionally captured by a torch profiler.
+
+        Set ``WBRIDGE_RECV_PROFILE_WT=<n>`` to profile the n-th RECEIVE (0-based; n>=1 is a warm/
+        steady-state transfer) and dump a chrome trace to ``WBRIDGE_RECV_PROFILE_DIR``. Trace serialization,
+        Gantt JSONL writes, and control-profile log output are deferred until the integration records the
+        matching rollout ``block_end``. This is the only
+        way to see the rollout-side ``recv_poll/consume/ack`` breakdown: :meth:`_receive_weights` runs on
+        the SGLang scheduler thread, so the trainer-side profiler can't reach it. The capture wraps the
+        transfer in :func:`gantt.capture` so the ``wbridge::`` span labels from :func:`gantt.span`
+        light up for just this one WT even when ``WBRIDGE_PROFILE`` is unset. Negligible overhead otherwise.
+        """
+        import os as _os
+        import tempfile as _tempfile
+
+        wt = self._epoch
+        nrounds = sum(bool(overlap) for _full, overlap in self.router.local_rounds)
+        profile_idx = self._recv_count
+        self._recv_count += 1
+        target = _os.environ.get("WBRIDGE_RECV_PROFILE_WT", "").strip()
+        if not (target.isdigit() and int(target) == profile_idx):
+            self._receive_weights(staged)
+            self._capture_profile_outputs(wt, nrounds)
+            return
+        from torch.profiler import profile as _profile, ProfilerActivity
+
+        d = _os.path.abspath(
+            _os.path.expanduser(
+                _os.environ.get("WBRIDGE_RECV_PROFILE_DIR", _tempfile.gettempdir())
+            )
+        )
+        with (
+            _profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as _p,
+            gantt.capture(),
+        ):
+            self._receive_weights(staged)
+        path = _os.path.join(
+            d, f"wbridge_recv_rank{self.rank}_pid{_os.getpid()}_wt{profile_idx}.json.gz"
+        )
+
+        def export_trace() -> None:
+            _os.makedirs(d, exist_ok=True)
+            _p.export_chrome_trace(path)
+            logger.info(
+                "wbridge rank %d receiver profile WT %d -> %s",
+                self.rank,
+                profile_idx,
+                path,
+            )
+
+        self._capture_profile_outputs(wt, nrounds, (export_trace,))
+
+    # ----- actions (main thread, blocking) ----------------------------------
+    def _do_connect(self, decision: dict[str, Any]) -> None:
+        """Set up the merged process group (blocking collective with the senders)."""
+        data = {k: v for k, v in decision.items() if k != "type"}
+        data["rank"] = data["rank"] + self.rank  # base rank -> this rank's global rank
+
+        self.set_up_connection(**data)
+        self._connected = True
+        with self._rs_cv:
+            self._rs_go = None
+            self._rs_receiving = -1
+            self._rs_staged = -1
+            self._rs_gpu_ready = -1
+            self._rs_kicked = -1
+            self._rs_err = None
+
+    def _receive_weights(self, staged: bool = False) -> None:
+        """Receive one update through isolated trainer-ingress and rollout-exchange buffers.
+
+        When ``staged`` (RS-on), the sender->receiver P2P landing already happened on the receiving thread
+        into the full-depth CPU arena; this method prepends a per-round CPU->GPU staging hop (into the same
+        parity-selected GPU arena RECV zone prepare reads) and skips the sender poll/ack. Everything else — the
+        fused prepare, external exchange, and internal consume over the GPU arena — is identical to RS-off.
+
+        When the topology-aware path is available, the three-stage schedule runs external exchange, DOFF
+        offload, and internal consume on a progress worker. With two registered slots the calling thread may
+        prepare the opposite parity concurrently. With one registered slot, ACK after A+R gates the trainer's
+        next RECV write, while the next A+R waits only for the previous SEND's external reads and SEND→DOFF
+        copy. GRECV reuse remains independently gated by OFFLOAD and DOFF reuse by local DONE.
+
+        Data lands by one-sided RDMA writes into this rank's packed arena. RECV and fused own/send prepare use
+        slot ``r % depth``; compact GRECV contains one slot per ``(direct external source, r % depth)``.
+        Same-node source columns are read directly into model tensors and allocate no local staging slot. Per round: poll
+        senders → fused prepare → external exchange → readiness-driven internal consume → aggregate CONS.
+        RS-on retains its serial GPU schedule.
+        """
+        if getattr(self, "_relay_enabled", False):
+            self._receive_weights_relay(staged)
+            return
+        if getattr(self, "_direct_same_node", False):
+            if staged:
+                raise RuntimeError(
+                    "direct same-node consume does not support receiver staging"
+                )
+            self._receive_weights_direct_same_node()
+            return
+        router = self.router
+        rounds = [ri for ri, (_fs, ov) in enumerate(router.local_rounds) if ov]
+        wt = self._epoch
+        sw = router.sender_ws
+        self._trace_state(
+            "receive_enter",
+            epoch=wt,
+            rounds=rounds,
+            topo=self._topo_ok,
+            three_stage=os.environ.get("WBRIDGE_RECV_3STAGE", "1") == "1",
+        )
+        if staged:
+            # GO is based on rank 0's GPU receive flag. A lagging peer has quiesced its scheduler and waits
+            # here for its own completed first-round H2D before entering fused prepare/exchange.
+            with self._rs_cv:
+                while self._rs_gpu_ready != wt and self._rs_err is None:
+                    self._rs_cv.wait()
+                if self._rs_err is not None:
+                    raise self._rs_err
+        if getattr(self, "_con_stream", None) is None:
+            self._con_stream = torch.cuda.Stream()
+        self._flag_reaper_ensure()  # cleanup only; producers publish flags directly with write_async()
+        three_stage_requested = os.environ.get("WBRIDGE_RECV_3STAGE", "1") == "1"
+        # The topology path records its inter-node-column visibility event from the E+C worker, in round
+        # order. The single-phase path records one reusable CUDA-IPC event during prepare; allowing prepare(r+1) to
+        # re-record it before a peer has waited for round r would reintroduce the historical visibility race.
+        # Keep the first implementation deliberately narrow until that path has per-parity IPC events.
+        three_stage = bool(three_stage_requested and not staged and self._topo_ok)
+        if self._topo_ok and not three_stage:
+            raise RuntimeError(
+                "fixed DOFF internal offload requires WBRIDGE_RECV_3STAGE=1 and receiver staging off"
+            )
+        merged_recv_prep = bool(getattr(self, "_merged_recv_prep", False))
+        if merged_recv_prep and not three_stage:
+            raise RuntimeError(
+                "WBRIDGE_MERGED_RECV_PREP=1 requires the depth-2 topology-aware 3-stage receiver"
+            )
+        if three_stage_requested and not three_stage and self._epoch == 0:
+            logger.warning(
+                "wbridge rank %d: 3-stage receiver requested but unavailable "
+                "(staged=%s topo_ok=%s); using serial receiver schedule",
+                self._rank,
+                staged,
+                self._topo_ok,
+            )
+        recv_scratch: torch.Tensor | None = None
+        scratch_lifetime_t0 = 0.0
+        if merged_recv_prep:
+            scratch_lifetime_t0 = time.time()
+            with gantt.span("receiver", self._rank, wt, "recv_scratch_alloc", -1):
+                recv_scratch = torch.empty(
+                    max(self._recv_payload_S, 1),
+                    dtype=torch.uint8,
+                    device=self._arena.device,
+                )
+                scratch_base = recv_scratch.data_ptr()
+                # The tiny descriptor updates run on the default stream, ahead of every snapshot/A+R launch.
+                for plan in self._arena_prepare:
+                    plan.rebase_sources(scratch_base)
+        # DEBUG: per-slice fingerprint cross-check. Logs a position-weighted checksum of each peer sub-slice
+        # on the SEND side (my send-staging, just after the RDMA submit) and the RECV side (peer's grecv,
+        # after the ready-flag rendezvous, before consume). Correlating SEND(i->peer=j) with RECV(j,peer=i)
+        # per (wt,ri) localizes the dedup corruption: all-match => fault in prepare/consume; any
+        # mismatch => the transfer/flag handshake delivered wrong bytes for that (round, i->j) slice.
+        xchk = os.environ.get("WBRIDGE_XCHECK") == "1"
+        if xchk and self._epoch == 0:
+            logger.warning(
+                "[wbridge] rank %d WBRIDGE_XCHECK=1 — per-slice fingerprint logging ON",
+                self._rank,
+            )
+
+        def _fp(off: int, nb: int) -> int:
+            # Allocation-light checksum (the arena is HBM-tight): fused int64 reductions over uint8 VIEWS,
+            # no widened copy and no per-slice arange (those OOM'd the transfer). A full byte-sum plus a
+            # strided byte-sum gives enough position sensitivity to catch partial/reordered corruption.
+            if nb <= 0:
+                return 0
+            s = self._arena[off : off + nb]  # uint8 view, no copy
+            total = int(s.sum(dtype=torch.int64).item())  # fused widen+reduce -> scalar
+            strided = int(
+                s[::7].sum(dtype=torch.int64).item()
+            )  # strided view sum -> scalar
+            return total * 1000003 + strided
+
+        def _consume(ri: int) -> None:
+            """Fuse own + all filled grecv slots into the model on ``_con_stream``.
+
+            This is the generic staged fallback. Topology uses per-source internal-consume kernels and never
+            calls this local GRECV fan-in plan.
+            """
+            plan = self._arena_consume[ri]
+            if plan is not None:
+                # DIAG: split the wait for peers' grecv writes (ready-events land) from the copy kernel, so
+                # the gantt separates cross-process WAIT (cons_wait) from actual WORK (consume).
+                with gantt.span("receiver", self._rank, wt, "cons_wait", ri):
+                    self._trace_state(
+                        "consume_stream_wait",
+                        epoch=wt,
+                        round=ri,
+                        internal=(
+                            self._topo_int_peers_by_round[ri] if self._topo_ok else []
+                        ),
+                    )
+                    self._con_stream.synchronize()
+                    self._trace_state("consume_stream_ready", epoch=wt, round=ri)
+                with gantt.span("receiver", self._rank, wt, "consume", ri):
+                    self._trace_state("consume_kernel", epoch=wt, round=ri)
+                    with torch.cuda.stream(self._con_stream):
+                        plan.run()  # own + peers' slices -> model
+                    # LOAD-BEARING: the consumed-flag below is written only after this host sync, so a peer's
+                    # write-after-read reuse of our grecv[peer] is safe with NO event on the reuse path. Do NOT
+                    # weaken to enqueue-only-then-flag, or a peer could clobber grecv mid-consume.
+                    self._con_stream.synchronize()  # consume done before AGH is freed
+                    self._trace_state("consume_done", epoch=wt, round=ri)
+
+        def _finish(ri: int, bids: dict) -> None:
+            seq = self._seq(ri)
+            # Cross-node peers only: they PUSH their grecv[me] slice via the selected RDMA backend, so we
+            # rendezvous on the ready/consumed flags. Same-node peers are handled by the PULL in the exchange
+            # above (we read their send[me] into our own grecv on _con_stream), and their ready-flag was set
+            # post-prepare.
+            xnode = [p for p in self._repl_peers if p not in self._repl_same_node]
+            if xnode:
+                with gantt.span("receiver", self._rank, wt, "agh_xfer", ri):
+                    with gantt.span("receiver", self._rank, wt, "agh_wait", ri):
+                        for peer in xnode:
+                            if bids.get(peer) is not None:
+                                self.engine.wait(
+                                    [bids[peer]]
+                                )  # my push landed (RDMA completion)
+                    with gantt.span("receiver", self._rank, wt, "agh_flag", ri):
+                        for peer in xnode:
+                            self._write_repl_flag(
+                                peer, seq
+                            )  # signal peers their grecv[me] is ready
+                    with gantt.span("receiver", self._rank, wt, "agh_poll", ri):
+                        for peer in xnode:
+                            self._poll_repl_flag(
+                                peer, seq
+                            )  # wait peers' push into my grecv[peer]
+            # Generic fallback only: same-node grecv[peer] was filled by our own pull-read on _con_stream, so consume
+            # (also on _con_stream) is naturally ordered after it — no cross-process visibility fence needed.
+            if xchk and self._repl_peers:
+                rd_x = self._arena_layout[ri]
+                with torch.cuda.stream(
+                    self._con_stream
+                ):  # fp AFTER the fence -> reflects consume's view
+                    for peer in self._repl_peers:
+                        go = rd_x["grecv"].get(peer - self.router.sender_ws)
+                        if go and go[1]:
+                            g_off = go[0]
+                            print(
+                                f"WXCHK RECV grank={self._rank} peer={peer} wt={wt} ri={ri} "
+                                f"off={g_off} nb={go[1]} fp={_fp(g_off, go[1])}",
+                                flush=True,
+                            )
+            _consume(ri)
+            # Round ri done. cons-flag(seq) tells each peer: same-node -> we PULLED your send[me] (you may
+            # reuse its PREP parity); cross-node -> we consumed our grecv[peer] parity (you may overwrite it
+            # two rounds later at depth 2).
+            with gantt.span(
+                "receiver", self._rank, wt, "cons_flag", ri
+            ):  # DIAG: measure the flag handshake
+                for peer in self._repl_peers:
+                    self._flag_emit(2, peer, seq)
+
+        def _sn_send_peers(rd_layout: dict) -> list[int]:
+            """Same-node peers that pull OUR send[peer] in the round with layout ``rd_layout`` (send>0)."""
+            return [
+                p
+                for p in self._repl_peers
+                if p in self._repl_same_node
+                and (p - sw) in rd_layout["send"]
+                and rd_layout["send"][p - sw][1] > 0
+            ]
+
+        def _reuse_seq(pred: tuple[int, int] | None) -> int | None:
+            """Resolve a cyclic ``(epoch_delta, round)`` predecessor for this transfer epoch."""
+            if pred is None:
+                return None
+            epoch_delta, pred_ri = pred
+            pred_epoch = wt + epoch_delta
+            return None if pred_epoch < 0 else self._seq_at(pred_epoch, pred_ri)
+
+        def _topo_round(
+            ri: int, seq: int, peer_gates: dict[int, tuple[int, int]]
+        ) -> None:
+            """Run external exchange and readiness-driven fused internal consume for one round.
+
+            Every exact external ingress slot becomes READY independently. This worker launches its matching
+            direct peer-to-model descriptor kernel as soon as that slot arrives, queries completions while
+            slower slots are still pending, and commits the slot to its same-node owner. The owner releases
+            the external writer once self and every local downstream reader have committed that exact slot.
+            """
+            ext_send_peers = self._topo_ext_send_peers_by_round[ri]
+            ext_recv_peers = self._topo_ext_recv_peers_by_round[ri]
+            int_peers = self._topo_int_peers_by_round[ri]
+            int_readers = self._topo_int_readers_by_round[ri]
+            grecv_slot = ri % self._recv_depth
+            consume_plans = self._topo_internal_consume_plan[ri]
+            lane_sort = lambda lane: (lane[0], -1 if lane[1] is None else lane[1])
+            bids: dict = {}
+            submitted_at: dict[int, float] = {}
+            _td = os.environ.get("WBRIDGE_TOPO_DEBUG") == "1"
+            self._trace_state(
+                "topo_enter",
+                epoch=wt,
+                round=ri,
+                seq=seq,
+                external_send=ext_send_peers,
+                external_recv=ext_recv_peers,
+                internal_consume=sorted(consume_plans, key=lane_sort),
+                readers=int_readers,
+            )
+            if _td:
+                print(
+                    f"TDBG r{self._rank} wt{wt} ri{ri} ENTER "
+                    f"ext_send={ext_send_peers} ext_recv={ext_recv_peers} "
+                    f"consume={sorted(consume_plans, key=lane_sort)} readers={int_readers}",
+                    flush=True,
+                )
+
+            external_started = time.time()
+            with gantt.span("receiver", self._rank, wt, "ext_submit", ri):
+                self._trace_state("topo_external_submit", epoch=wt, round=ri, seq=seq)
+                for peer in ext_send_peers:
+                    spans = self._topo_ext_xfer[peer][ri]
+                    if not spans:
+                        continue
+                    gate = peer_gates.get(peer)
+                    gate_seq = _reuse_seq(gate)
+                    if gate_seq is not None:
+                        # Target emits this generation only after every local internal-consume kernel that
+                        # read the prior generation of this GRECV parity has completed.
+                        with gantt.span(
+                            "receiver", self._rank, wt, "ext_reuse_gate", ri
+                        ):
+                            self._poll_repl_cons_flag(peer, gate_seq)
+                    src, dst, size = zip(*spans)
+                    with gantt.span("receiver", self._rank, wt, "ext_write_submit", ri):
+                        submitted_at[peer] = time.time()
+                        bids[peer] = self.engine.write_async(
+                            self._repl_peer_session[peer],
+                            list(src),
+                            list(dst),
+                            list(size),
+                        )
+                    self._tstats["agh_rdma_bytes"] += sum(size)
+
+            # Outgoing destinations become READY independently through endpoint-lifetime waiters. The
+            # synchronous debug schedule still drains them before returning, but never creates a round-local
+            # thread (and therefore has no Thread.start/GIL handoff in its READY critical path).
+            ready_result_q: queue.Queue = queue.Queue()
+            pending_ready = set(bids)
+            ready_errors: list[tuple[int, BaseException]] = []
+            self._ensure_topo_out_waiters(pending_ready)
+            for peer, bid in bids.items():
+                self._topo_out_wait_queues[peer].put(
+                    (wt, ri, seq, bid, submitted_at[peer], ready_result_q)
+                )
+
+            # ---- Per-slot internal consume. ----
+            # Channel zero advertises parity-slotted PREP/own bytes. Exact external grecv slots are published
+            # independently below as each writer's completion flag arrives.
+            with gantt.span("receiver", self._rank, wt, "internal_own_ready_flag", ri):
+                for reader in int_readers:
+                    self._repl_ready_event[reader].record()
+                if int_readers:
+                    self._repl_local_flags.publish_ready(seq)
+
+            own_lane = self._topo_internal_consume_own_lane[ri]
+            lane_bytes = self._topo_internal_consume_bytes_by_lane[ri]
+            release_deps = self._topo_ext_release_readers_by_round[ri]
+            pending_ext = set(ext_recv_peers)
+            pending_launch = set(consume_plans)
+            pending_complete: set[tuple[int, int | None]] = set()
+            completed: set[tuple[int, int | None]] = set()
+            published_slots: set[int] = set()
+            pending_releases = set(ext_recv_peers)
+            assert pending_releases == set(release_deps), (
+                f"missing external release dependencies: "
+                f"releases={sorted(pending_releases)} deps={sorted(release_deps)}"
+            )
+            observed_commits: set[tuple[int, int]] = set()
+            launch_wall: dict[tuple[int, int | None], float] = {}
+            ready_wall = {lane: time.time() for lane in pending_launch}
+            ext_wall = {peer: time.time() for peer in pending_ext}
+            slot_ready_wall: dict[int, float] = {}
+            external_recorded = False
+            deadline = time.time() + 600.0
+            warned = 0.0
+
+            def _lane_ready(lane: tuple[int, int | None]) -> bool:
+                owner, source = lane
+                if owner == self._rank:
+                    return source is None or source in published_slots
+                if source is None:
+                    return self._repl_flag_reached(owner, seq)
+                return self._topo_slot_ready_reached(owner, source, grecv_slot, seq)
+
+            with gantt.span(
+                "receiver", self._rank, wt, "internal_consume_dispatch", ri
+            ):
+                while (
+                    pending_ext
+                    or pending_launch
+                    or pending_complete
+                    or pending_releases
+                ):
+                    progress = False
+                    while True:
+                        try:
+                            _done_ri, peer, error = ready_result_q.get_nowait()
+                        except queue.Empty:
+                            break
+                        pending_ready.remove(peer)
+                        if error is not None:
+                            ready_errors.append((peer, error))
+                        progress = True
+                    error = ready_errors[0] if ready_errors else None
+                    if error is not None:
+                        peer, exc = error
+                        raise RuntimeError(
+                            f"wbridge rank {self._rank}: external completion/READY failed for peer "
+                            f"{peer} epoch {wt} round {ri}"
+                        ) from exc
+
+                    # Publish each exact ingress slot immediately, rather than waiting for the whole column.
+                    ext_done = [
+                        peer
+                        for peer in sorted(pending_ext)
+                        if self._repl_flag_reached(peer, seq)
+                    ]
+                    for peer in ext_done:
+                        now = time.time()
+                        gantt.rec(
+                            "receiver",
+                            self._rank,
+                            wt,
+                            "ext_recv_wait",
+                            ri,
+                            ext_wall[peer],
+                            now,
+                        )
+                        with gantt.span(
+                            "receiver", self._rank, wt, "internal_slot_ready_flag", ri
+                        ):
+                            self._publish_topo_slot_ready(
+                                peer,
+                                grecv_slot,
+                                release_deps.get(peer, ()),
+                                seq,
+                            )
+                        slot_ready_wall[peer] = now
+                        published_slots.add(peer)
+                        pending_ext.remove(peer)
+                        self._trace_state(
+                            "internal_slot_ready",
+                            epoch=wt,
+                            round=ri,
+                            source=peer,
+                            seq=seq,
+                        )
+                        progress = True
+
+                    if not pending_ext and not external_recorded:
+                        now = time.time()
+                        gantt.rec(
+                            "receiver",
+                            self._rank,
+                            wt,
+                            "external_exchange",
+                            ri,
+                            external_started,
+                            now,
+                        )
+                        self._trace_state(
+                            "topo_external_done", epoch=wt, round=ri, seq=seq
+                        )
+                        external_recorded = True
+                        progress = True
+
+                    # Launch every independently-ready (source-column owner, external slot) lane.
+                    ready_lanes = [
+                        lane
+                        for lane in sorted(pending_launch, key=lane_sort)
+                        if _lane_ready(lane)
+                    ]
+                    for lane in ready_lanes:
+                        owner, source = lane
+                        now = time.time()
+                        gantt.rec(
+                            "receiver",
+                            self._rank,
+                            wt,
+                            "internal_consume_ready_wait",
+                            ri,
+                            ready_wall[lane],
+                            now,
+                        )
+                        stream = self._topo_internal_consume_stream[lane]
+                        if owner != self._rank:
+                            ready_event = (
+                                self._repl_peer_ready_event[owner]
+                                if source is None
+                                else self._repl_peer_topo_slot_ready_event[owner][
+                                    (source, grecv_slot)
+                                ]
+                            )
+                            stream.wait_event(ready_event)
+                        with gantt.span(
+                            "receiver", self._rank, wt, "internal_consume_submit", ri
+                        ):
+                            launch_wall[lane] = time.time()
+                            self._trace_state(
+                                "internal_consume_launch",
+                                epoch=wt,
+                                round=ri,
+                                peer=owner,
+                                source=source,
+                                seq=seq,
+                            )
+                            with torch.cuda.stream(stream):
+                                consume_plans[lane].run()
+                                self._topo_internal_consume_event[lane].record(stream)
+                        if owner != self._rank:
+                            self._tstats["agh_ipc_bytes"] += lane_bytes[lane]
+                        pending_launch.remove(lane)
+                        pending_complete.add(lane)
+                        progress = True
+
+                    # Query completion while other slots are still waiting for READY. This is what lets a
+                    # fast slot commit instead of inheriting the slowest source column's delay.
+                    done_lanes = [
+                        lane
+                        for lane in sorted(pending_complete, key=lane_sort)
+                        if self._topo_internal_consume_event[lane].query()
+                    ]
+                    for lane in done_lanes:
+                        owner, source = lane
+                        now = time.time()
+                        gantt.rec(
+                            "receiver",
+                            self._rank,
+                            wt,
+                            "internal_consume",
+                            ri,
+                            launch_wall[lane],
+                            now,
+                        )
+                        self._trace_state(
+                            "internal_consume_done",
+                            epoch=wt,
+                            round=ri,
+                            peer=owner,
+                            source=source,
+                            seq=seq,
+                        )
+                        if owner != self._rank:
+                            # Channel zero protects the owner's PREP parity; the source/parity channel
+                            # protects only grecv[source, parity]. A lane may commit both when own is attached.
+                            if own_lane.get(owner) == lane:
+                                self._flag_emit(2, owner, seq)
+                            if source is not None:
+                                self._write_topo_slot_cons_flag(
+                                    owner, source, grecv_slot, seq
+                                )
+                        pending_complete.remove(lane)
+                        completed.add(lane)
+                        progress = True
+
+                    # Owner-side fan-in: self consume plus each exact reader commit releases one parity slot.
+                    releasable: list[int] = []
+                    for source in sorted(pending_releases):
+                        if (self._rank, source) not in completed:
+                            continue
+                        readers_done = True
+                        for reader in release_deps.get(source, ()):
+                            key = (source, reader)
+                            if key in observed_commits:
+                                continue
+                            if self._topo_slot_cons_flag_reached(
+                                reader,
+                                source,
+                                grecv_slot,
+                                seq,
+                            ):
+                                observed_commits.add(key)
+                                now = time.time()
+                                gantt.rec(
+                                    "receiver",
+                                    self._rank,
+                                    wt,
+                                    "slot_cons_peer_wait",
+                                    ri,
+                                    slot_ready_wall.get(source, external_started),
+                                    now,
+                                )
+                            else:
+                                readers_done = False
+                        if readers_done:
+                            releasable.append(source)
+                    for source in releasable:
+                        now = time.time()
+                        gantt.rec(
+                            "receiver",
+                            self._rank,
+                            wt,
+                            "external_slot_hold",
+                            ri,
+                            slot_ready_wall[source],
+                            now,
+                        )
+                        with gantt.span("receiver", self._rank, wt, "cons_flag", ri):
+                            self._flag_emit(2, source, seq)
+                        pending_releases.remove(source)
+                        self._trace_state(
+                            "external_slot_released",
+                            epoch=wt,
+                            round=ri,
+                            source=source,
+                            seq=seq,
+                        )
+                        progress = True
+
+                    if progress:
+                        continue
+                    now = time.time()
+                    if now >= deadline:
+                        raise TimeoutError(
+                            f"wbridge rank {self._rank}: waited 600s for per-slot internal consume "
+                            f"epoch={wt} round={ri} ext={sorted(pending_ext)} "
+                            f"launch={sorted(pending_launch, key=lane_sort)} "
+                            f"complete={sorted(pending_complete, key=lane_sort)} "
+                            f"release={sorted(pending_releases)} seq={seq}"
+                        )
+                    elapsed = now - (deadline - 600.0)
+                    if elapsed - warned >= 30.0:
+                        warned = elapsed
+                        logger.warning(
+                            "wbridge rank %d: waiting %.0fs for per-slot internal consume "
+                            "epoch=%d round=%d ext=%s launch=%s complete=%s release=%s seq=%d",
+                            self._rank,
+                            elapsed,
+                            wt,
+                            ri,
+                            sorted(pending_ext),
+                            sorted(pending_launch, key=lane_sort),
+                            sorted(pending_complete, key=lane_sort),
+                            sorted(pending_releases),
+                            seq,
+                        )
+                    time.sleep(1e-4)
+
+            if _td:
+                print(
+                    f"TDBG r{self._rank} wt{wt} ri{ri} SLOT_CONSUME_DONE "
+                    f"lanes={sorted(completed, key=lane_sort)}",
+                    flush=True,
+                )
+            # Outbound PREP sources remain read-only until their independent writes complete. Drain before
+            # this E+C round releases its parity slot to a later prepare.
+            with gantt.span("receiver", self._rank, wt, "ext_send_drain", ri):
+                while pending_ready:
+                    _done_ri, peer, error = ready_result_q.get()
+                    pending_ready.remove(peer)
+                    if error is not None:
+                        ready_errors.append((peer, error))
+            if ready_errors:
+                peer, exc = ready_errors[0]
+                raise RuntimeError(
+                    f"wbridge rank {self._rank}: external completion/READY failed for peer {peer} "
+                    f"epoch {wt} round {ri}"
+                ) from exc
+            if _td:
+                print(
+                    f"TDBG r{self._rank} wt{wt} ri{ri} EXT_FLAGS_DONE peers={ext_send_peers}",
+                    flush=True,
+                )
+            if _td:
+                print(f"TDBG r{self._rank} wt{wt} ri{ri} ROUND_DONE", flush=True)
+            self._trace_state("topo_round_done", epoch=wt, round=ri, seq=seq)
+
+        # Stage 3 owns SEND/external exchange plus the fixed DOFF shadow. Registered SEND/GRECV bytes are never
+        # read by internal peers: own SEND is copied to DOFF after A+R, and each incoming GRECV is copied to its
+        # source-exclusive DOFF slot as soon as DATA arrives. The GRECV writer receives OFFLOAD when that D2D
+        # copy completes; local readers receive READY for DOFF and return DONE only to release DOFF reuse.
+        ec_q: "queue.Queue[tuple[int, int, dict[int, tuple[int, int]]] | None] | None" = (
+            queue.Queue() if three_stage else None
+        )
+        ec_slot_free: set[int] = set()
+        ec_completed: set[int] = set()
+        ec_cv = threading.Condition()
+        ec_err: list[BaseException] = []
+
+        # Cyclic predecessor for each fixed (source, DOFF slot). With DOFF=1 every source has one reusable
+        # internal buffer across rounds; larger values select round%DOFF independently per source. A source's
+        # next copy waits for all readers of only its own previous generation.  The serial fallback (including
+        # receiver staging) deliberately has no topology tables and never executes the E+C worker, so do not
+        # inspect topology-only metadata on that path.
+        doff_pred: list[dict[int, tuple[int, int]]] = (
+            _doff_source_predecessors(
+                rounds,
+                self._topo_ext_recv_peers_by_round,
+                self._doff_depth,
+                self._rank,
+            )
+            if three_stage
+            else [{} for _ in router.local_rounds]
+        )
+
+        if not hasattr(self, "_doff_copy_stream"):
+            self._doff_copy_stream = {}
+            self._doff_copy_event = {}
+            self._doff_slot_released = {}
+
+        def _ec_worker() -> None:
+            assert ec_q is not None
+            lane_sort = lambda lane: (lane[0], -1 if lane[1] is None else lane[1])
+            out_result_q: queue.Queue = queue.Queue()
+            out_peers = {
+                peer for ri in rounds for peer in self._topo_ext_send_peers_by_round[ri]
+            }
+            self._ensure_topo_out_waiters(out_peers)
+            if not hasattr(self, "_topo_lane_seen"):
+                self._topo_lane_seen = {}
+                self._topo_lane_consumed = {}
+            active: dict[int, dict] = {}
+            lane_inflight: set[tuple[int, int | None]] = set()
+            stopping = False
+
+            def _register(
+                item: tuple[int, int, dict[int, tuple[int, int]], tuple[int, ...]],
+            ) -> None:
+                ri, seq, peer_gates, input_release_peers = item
+                if ri in active:
+                    raise RuntimeError(f"duplicate active topology round {ri}")
+                now = time.time()
+                ext_send_peers = self._topo_ext_send_peers_by_round[ri]
+                ext_recv_peers = self._topo_ext_recv_peers_by_round[ri]
+                consume_plans = self._topo_internal_consume_plan[ri]
+                release_deps = self._topo_ext_release_readers_by_round[ri]
+                source_readers = {
+                    self._rank: tuple(self._topo_int_readers_by_round[ri])
+                }
+                source_readers.update(
+                    {source: tuple(release_deps[source]) for source in ext_recv_peers}
+                )
+                copy_sources = set(source_readers)
+                source_lane = self._topo_internal_consume_source_lane[ri]
+                missing_lanes = [
+                    source
+                    for source in copy_sources
+                    if (self._rank, source) not in source_lane
+                ]
+                if missing_lanes:
+                    raise RuntimeError(
+                        f"missing local DOFF consume lanes round={ri} sources={sorted(missing_lanes)}"
+                    )
+                doff_gate = {
+                    source: gate_seq
+                    for source, pred in doff_pred[ri].items()
+                    if (gate_seq := _reuse_seq(pred)) is not None
+                }
+                ctx = {
+                    "ri": ri,
+                    "seq": seq,
+                    "doff_slot": ri % self._doff_depth,
+                    "peer_gates": peer_gates,
+                    "input_release_peers": input_release_peers,
+                    "ext_send_peers": ext_send_peers,
+                    "ext_recv_peers": ext_recv_peers,
+                    "int_readers": self._topo_int_readers_by_round[ri],
+                    "consume_plans": consume_plans,
+                    "lane_sources": self._topo_internal_consume_lane_sources[ri],
+                    "source_lane": source_lane,
+                    "lane_bytes": self._topo_internal_consume_bytes_by_lane[ri],
+                    "source_readers": source_readers,
+                    "doff_gate": doff_gate,
+                    "pending_out_submit": set(ext_send_peers),
+                    "pending_out_wait": set(),
+                    "out_gate_wall": {peer: now for peer in ext_send_peers},
+                    "out_submit_recorded": False,
+                    "pending_ext": set(ext_recv_peers),
+                    "data_arrived": set(),
+                    "data_arrival_wall": {},
+                    "pending_copy_submit": copy_sources,
+                    "pending_copy_complete": set(),
+                    "copy_launch_wall": {},
+                    "copy_ready_wall": {},
+                    "copy_done": set(),
+                    "published_sources": set(),
+                    "pending_launch": set(consume_plans),
+                    "pending_complete": set(),
+                    "completed": set(),
+                    "pending_doff_release": set(copy_sources),
+                    "observed_commits": set(),
+                    "launch_wall": {},
+                    "ready_wall": {lane: now for lane in consume_plans},
+                    "ext_wall": {peer: now for peer in ext_recv_peers},
+                    "external_recorded": not ext_recv_peers,
+                    "prep_free": False,
+                    "registered_wall": now,
+                    "deadline": now + 600.0,
+                    "warned": 0.0,
+                }
+                active[ri] = ctx
+                self._trace_state(
+                    "topo_enter",
+                    epoch=wt,
+                    round=ri,
+                    seq=seq,
+                    external_send=ext_send_peers,
+                    external_recv=ext_recv_peers,
+                    internal_consume=sorted(consume_plans, key=lane_sort),
+                    readers=ctx["int_readers"],
+                )
+
+            def _lane_ready(ctx: dict, lane: tuple[int, int | None]) -> bool:
+                owner, source = lane
+                sources = ctx["lane_sources"][lane]
+                if owner == self._rank:
+                    return all(item in ctx["published_sources"] for item in sources)
+                return all(
+                    self._topo_slot_ready_reached(
+                        owner,
+                        item,
+                        ctx["doff_slot"],
+                        ctx["seq"],
+                    )
+                    for item in sources
+                )
+
+            try:
+                with torch.cuda.device(self._arena.device):
+                    while True:
+                        progress = False
+
+                        # When idle, sleep on the round queue. With active rounds, drain newly prepared work
+                        # without blocking and then return to the 100-us slot/event scan.
+                        if not active and not stopping:
+                            self._trace_state("ec_worker_idle", epoch=wt)
+                            item = ec_q.get()
+                            if item is None:
+                                stopping = True
+                            else:
+                                self._trace_state(
+                                    "ec_round_dequeue",
+                                    epoch=wt,
+                                    round=item[0],
+                                    seq=item[1],
+                                )
+                                _register(item)
+                                progress = True
+                        while not stopping:
+                            try:
+                                item = ec_q.get_nowait()
+                            except queue.Empty:
+                                break
+                            if item is None:
+                                stopping = True
+                                break
+                            self._trace_state(
+                                "ec_round_dequeue",
+                                epoch=wt,
+                                round=item[0],
+                                seq=item[1],
+                            )
+                            _register(item)
+                            progress = True
+
+                        # Persistent per-destination waiters report bulk completion + READY publication here.
+                        while True:
+                            try:
+                                done_ri, peer, error = out_result_q.get_nowait()
+                            except queue.Empty:
+                                break
+                            if error is not None:
+                                raise RuntimeError(
+                                    f"wbridge rank {self._rank}: external completion/READY failed for "
+                                    f"peer {peer} epoch {wt} round {done_ri}"
+                                ) from error
+                            ctx = active.get(done_ri)
+                            if ctx is None or peer not in ctx["pending_out_wait"]:
+                                raise RuntimeError(
+                                    f"unexpected external completion round={done_ri} peer={peer}"
+                                )
+                            ctx["pending_out_wait"].remove(peer)
+                            progress = True
+
+                        finished: list[int] = []
+                        for ri in sorted(active):
+                            ctx = active[ri]
+                            seq = ctx["seq"]
+
+                            # Submit every destination whose exact prior parity slot has been released. The
+                            # scanner never blocks on one peer, so a ready r+1 transfer can pass an unrelated
+                            # r straggler. Completion is handled by the endpoint-lifetime per-peer waiter.
+                            ready_out = []
+                            for peer in sorted(ctx["pending_out_submit"]):
+                                # READY/CONS use one monotonic cross-node flag per peer. Preserve that peer's
+                                # round order even though its two GRECV parities are independent: once the
+                                # older write is submitted, this write may follow immediately (before either
+                                # completes), but a higher READY sequence must never overtake a lower one.
+                                prior_pending = any(
+                                    prior_ri < ri
+                                    and peer in prior_ctx["pending_out_submit"]
+                                    for prior_ri, prior_ctx in active.items()
+                                )
+                                if prior_pending:
+                                    continue
+                                gate_seq = _reuse_seq(ctx["peer_gates"].get(peer))
+                                if gate_seq is None or self._repl_cons_flag_reached(
+                                    peer, gate_seq
+                                ):
+                                    ready_out.append((peer, gate_seq))
+                            for peer, gate_seq in ready_out:
+                                now = time.time()
+                                if gate_seq is not None:
+                                    gantt.rec(
+                                        "receiver",
+                                        self._rank,
+                                        wt,
+                                        "ext_reuse_gate",
+                                        ri,
+                                        ctx["out_gate_wall"][peer],
+                                        now,
+                                    )
+                                spans = self._topo_ext_xfer[peer][ri]
+                                if not spans:
+                                    ctx["pending_out_submit"].remove(peer)
+                                    progress = True
+                                    continue
+                                src, dst, size = zip(*spans)
+                                with gantt.span(
+                                    "receiver", self._rank, wt, "ext_write_submit", ri
+                                ):
+                                    submitted_at = time.time()
+                                    bid = self.engine.write_async(
+                                        self._repl_peer_session[peer],
+                                        list(src),
+                                        list(dst),
+                                        list(size),
+                                    )
+                                self._tstats["agh_rdma_bytes"] += sum(size)
+                                ctx["pending_out_submit"].remove(peer)
+                                ctx["pending_out_wait"].add(peer)
+                                self._topo_out_wait_queues[peer].put(
+                                    (wt, ri, seq, bid, submitted_at, out_result_q)
+                                )
+                                self._trace_state(
+                                    "topo_external_submit",
+                                    epoch=wt,
+                                    round=ri,
+                                    peer=peer,
+                                    seq=seq,
+                                )
+                                progress = True
+                            if (
+                                not ctx["pending_out_submit"]
+                                and not ctx["out_submit_recorded"]
+                            ):
+                                gantt.rec(
+                                    "receiver",
+                                    self._rank,
+                                    wt,
+                                    "ext_submit",
+                                    ri,
+                                    ctx["registered_wall"],
+                                    time.time(),
+                                )
+                                ctx["out_submit_recorded"] = True
+
+                            # Observe every external DATA flag independently. Landing and DOFF availability are
+                            # separate: DATA may wait safely in its GRECV parity while a DOFF=1 predecessor is
+                            # still being read.
+                            ext_done = [
+                                peer
+                                for peer in sorted(ctx["pending_ext"])
+                                if self._repl_flag_reached(peer, seq)
+                            ]
+                            for peer in ext_done:
+                                now = time.time()
+                                gantt.rec(
+                                    "receiver",
+                                    self._rank,
+                                    wt,
+                                    "ext_recv_wait",
+                                    ri,
+                                    ctx["ext_wall"][peer],
+                                    now,
+                                )
+                                ctx["data_arrival_wall"][peer] = now
+                                ctx["data_arrived"].add(peer)
+                                ctx["pending_ext"].remove(peer)
+                                self._trace_state(
+                                    "external_data_arrived",
+                                    epoch=wt,
+                                    round=ri,
+                                    source=peer,
+                                    seq=seq,
+                                )
+                                progress = True
+                            if not ctx["pending_ext"] and not ctx["external_recorded"]:
+                                gantt.rec(
+                                    "receiver",
+                                    self._rank,
+                                    wt,
+                                    "external_exchange",
+                                    ri,
+                                    ctx["registered_wall"],
+                                    time.time(),
+                                )
+                                ctx["external_recorded"] = True
+                                progress = True
+
+                            # Copy each available source into its exclusive DOFF slot as soon as only that
+                            # source's prior DOFF generation is free. READY is published after the copy/event
+                            # records are enqueued; GPU readers wait those exact IPC events. OFFLOAD is delayed
+                            # until the local copy event actually completes.
+                            copy_ready = []
+                            for source in sorted(ctx["pending_copy_submit"]):
+                                if (
+                                    source != self._rank
+                                    and source not in ctx["data_arrived"]
+                                ):
+                                    continue
+                                gate_seq = ctx["doff_gate"].get(source)
+                                key = (source, ctx["doff_slot"])
+                                if (
+                                    gate_seq is None
+                                    or self._doff_slot_released.get(key, 0) >= gate_seq
+                                ):
+                                    copy_ready.append((source, gate_seq))
+                            for source, gate_seq in copy_ready:
+                                now = time.time()
+                                if gate_seq is not None:
+                                    gantt.rec(
+                                        "receiver",
+                                        self._rank,
+                                        wt,
+                                        "doff_reuse_wait",
+                                        ri,
+                                        ctx["registered_wall"],
+                                        now,
+                                    )
+                                key = (source, ctx["doff_slot"])
+                                stream = self._doff_copy_stream.setdefault(
+                                    key,
+                                    torch.cuda.Stream(device=self._arena.device),
+                                )
+                                event = self._doff_copy_event.setdefault(
+                                    key, torch.cuda.Event()
+                                )
+                                doff_rd = self._doff_layout[ri]
+                                if source == self._rank:
+                                    src_off = _arena_slot_offset(
+                                        0,
+                                        ri,
+                                        self._recv_depth,
+                                        self._arena_S,
+                                    )
+                                    dst_off, nb = doff_rd["own"]
+                                else:
+                                    source_rl = source - sw
+                                    src_off, nb = self._arena_layout[ri]["grecv"][
+                                        source_rl
+                                    ]
+                                    dst_off, dst_nb = doff_rd["grecv"][source_rl]
+                                    assert dst_nb == nb
+                                with gantt.span(
+                                    "receiver", self._rank, wt, "doff_copy_submit", ri
+                                ):
+                                    ctx["copy_launch_wall"][source] = time.time()
+                                    with torch.cuda.stream(stream):
+                                        self._doff_arena[dst_off : dst_off + nb].copy_(
+                                            self._arena[src_off : src_off + nb],
+                                            non_blocking=True,
+                                        )
+                                        event.record(stream)
+                                    self._publish_topo_slot_ready(
+                                        source,
+                                        ctx["doff_slot"],
+                                        ctx["source_readers"][source],
+                                        seq,
+                                        stream=stream,
+                                    )
+                                ctx["copy_ready_wall"][source] = now
+                                ctx["published_sources"].add(source)
+                                ctx["pending_copy_submit"].remove(source)
+                                ctx["pending_copy_complete"].add(source)
+                                self._trace_state(
+                                    "doff_copy_launch",
+                                    epoch=wt,
+                                    round=ri,
+                                    source=source,
+                                    slot=ctx["doff_slot"],
+                                    seq=seq,
+                                    bytes=nb,
+                                )
+                                progress = True
+
+                            done_copies = [
+                                source
+                                for source in sorted(ctx["pending_copy_complete"])
+                                if self._doff_copy_event[
+                                    (source, ctx["doff_slot"])
+                                ].query()
+                            ]
+                            for source in done_copies:
+                                now = time.time()
+                                gantt.rec(
+                                    "receiver",
+                                    self._rank,
+                                    wt,
+                                    "doff_copy",
+                                    ri,
+                                    ctx["copy_launch_wall"][source],
+                                    now,
+                                )
+                                ctx["pending_copy_complete"].remove(source)
+                                ctx["copy_done"].add(source)
+                                if source != self._rank:
+                                    gantt.rec(
+                                        "receiver",
+                                        self._rank,
+                                        wt,
+                                        "external_slot_hold",
+                                        ri,
+                                        ctx["data_arrival_wall"][source],
+                                        now,
+                                    )
+                                    with gantt.span(
+                                        "receiver",
+                                        self._rank,
+                                        wt,
+                                        "offload_flag",
+                                        ri,
+                                    ):
+                                        self._flag_emit(2, source, seq)
+                                    self._trace_state(
+                                        "external_slot_offloaded",
+                                        epoch=wt,
+                                        round=ri,
+                                        source=source,
+                                        seq=seq,
+                                    )
+                                progress = True
+
+                            ready_lanes = [
+                                lane
+                                for lane in sorted(ctx["pending_launch"], key=lane_sort)
+                                if lane not in lane_inflight
+                                and _lane_ready(ctx, lane)
+                                # READY may arrive out of round order across the two active parity slots.
+                                # Different lanes are independent, but one lane's local sequence/IPC event
+                                # is monotonic: never let a newer generation overtake an older live one.
+                                and not any(
+                                    prior_ctx["seq"] < seq
+                                    and (
+                                        lane in prior_ctx["pending_launch"]
+                                        or lane in prior_ctx["pending_complete"]
+                                    )
+                                    for prior_ctx in active.values()
+                                )
+                            ]
+                            for lane in ready_lanes:
+                                owner, source = lane
+                                now = time.time()
+                                gantt.rec(
+                                    "receiver",
+                                    self._rank,
+                                    wt,
+                                    "internal_consume_ready_wait",
+                                    ri,
+                                    ctx["ready_wall"][lane],
+                                    now,
+                                )
+                                prior = self._topo_lane_seen.get(lane, -1)
+                                if seq <= prior:
+                                    raise RuntimeError(
+                                        f"non-monotonic internal lane {lane}: seq={seq} prior={prior}"
+                                    )
+                                stream = self._topo_internal_consume_stream[lane]
+                                for source_key in ctx["lane_sources"][lane]:
+                                    ready_event = (
+                                        self._doff_copy_event[
+                                            (source_key, ctx["doff_slot"])
+                                        ]
+                                        if owner == self._rank
+                                        else self._repl_peer_topo_slot_ready_event[
+                                            owner
+                                        ][(source_key, ctx["doff_slot"])]
+                                    )
+                                    stream.wait_event(ready_event)
+                                with gantt.span(
+                                    "receiver",
+                                    self._rank,
+                                    wt,
+                                    "internal_consume_submit",
+                                    ri,
+                                ):
+                                    ctx["launch_wall"][lane] = time.time()
+                                    with torch.cuda.stream(stream):
+                                        ctx["consume_plans"][lane].run()
+                                        self._topo_internal_consume_event[lane].record(
+                                            stream
+                                        )
+                                if owner != self._rank:
+                                    self._tstats["agh_ipc_bytes"] += ctx["lane_bytes"][
+                                        lane
+                                    ]
+                                self._topo_lane_seen[lane] = seq
+                                lane_inflight.add(lane)
+                                ctx["pending_launch"].remove(lane)
+                                ctx["pending_complete"].add(lane)
+                                self._trace_state(
+                                    "internal_consume_launch",
+                                    epoch=wt,
+                                    round=ri,
+                                    peer=owner,
+                                    source=source,
+                                    seq=seq,
+                                )
+                                progress = True
+
+                            done_lanes = [
+                                lane
+                                for lane in sorted(
+                                    ctx["pending_complete"], key=lane_sort
+                                )
+                                if self._topo_internal_consume_event[lane].query()
+                            ]
+                            for lane in done_lanes:
+                                owner, source = lane
+                                now = time.time()
+                                gantt.rec(
+                                    "receiver",
+                                    self._rank,
+                                    wt,
+                                    "internal_consume",
+                                    ri,
+                                    ctx["launch_wall"][lane],
+                                    now,
+                                )
+                                if owner != self._rank:
+                                    for source_key in ctx["lane_sources"][lane]:
+                                        self._write_topo_slot_cons_flag(
+                                            owner,
+                                            source_key,
+                                            ctx["doff_slot"],
+                                            seq,
+                                        )
+                                self._topo_lane_consumed[lane] = seq
+                                lane_inflight.remove(lane)
+                                ctx["pending_complete"].remove(lane)
+                                ctx["completed"].add(lane)
+                                self._trace_state(
+                                    "internal_consume_done",
+                                    epoch=wt,
+                                    round=ri,
+                                    peer=owner,
+                                    source=source,
+                                    seq=seq,
+                                )
+                                progress = True
+
+                            # DONE is local-only and frees one source's DOFF generation. It never gates GRECV:
+                            # that registered slot was already released by OFFLOAD at copy completion.
+                            releasable: list[int] = []
+                            for source in sorted(ctx["pending_doff_release"]):
+                                local_lane = ctx["source_lane"][(self._rank, source)]
+                                if local_lane not in ctx["completed"]:
+                                    continue
+                                readers_done = True
+                                for reader in ctx["source_readers"][source]:
+                                    key = (source, reader)
+                                    if key in ctx["observed_commits"]:
+                                        continue
+                                    if self._topo_slot_cons_flag_reached(
+                                        reader,
+                                        source,
+                                        ctx["doff_slot"],
+                                        seq,
+                                    ):
+                                        ctx["observed_commits"].add(key)
+                                        gantt.rec(
+                                            "receiver",
+                                            self._rank,
+                                            wt,
+                                            "doff_reader_wait",
+                                            ri,
+                                            ctx["copy_ready_wall"].get(
+                                                source, ctx["registered_wall"]
+                                            ),
+                                            time.time(),
+                                        )
+                                    else:
+                                        readers_done = False
+                                if readers_done:
+                                    releasable.append(source)
+                            for source in releasable:
+                                now = time.time()
+                                gantt.rec(
+                                    "receiver",
+                                    self._rank,
+                                    wt,
+                                    "doff_slot_hold",
+                                    ri,
+                                    ctx["copy_ready_wall"][source],
+                                    now,
+                                )
+                                self._doff_slot_released[(source, ctx["doff_slot"])] = (
+                                    seq
+                                )
+                                ctx["pending_doff_release"].remove(source)
+                                self._trace_state(
+                                    "doff_slot_released",
+                                    epoch=wt,
+                                    round=ri,
+                                    source=source,
+                                    slot=ctx["doff_slot"],
+                                    seq=seq,
+                                )
+                                progress = True
+
+                            # SEND/PREP parity is free once its local DOFF copy and every outbound RDMA read
+                            # finish. Incoming GRECV processing and downstream DOFF readers are unrelated.
+                            if (
+                                not ctx["prep_free"]
+                                and self._rank in ctx["copy_done"]
+                                and not ctx["pending_out_submit"]
+                                and not ctx["pending_out_wait"]
+                            ):
+                                now = time.time()
+                                gantt.rec(
+                                    "receiver",
+                                    self._rank,
+                                    wt,
+                                    "send_slot_hold",
+                                    ri,
+                                    ctx["registered_wall"],
+                                    now,
+                                )
+                                ctx["prep_free"] = True
+                                if merged_recv_prep:
+                                    with gantt.span(
+                                        "receiver",
+                                        self._rank,
+                                        wt,
+                                        "ack_send",
+                                        ri,
+                                    ):
+                                        for peer in ctx["input_release_peers"]:
+                                            self._flag_emit(0, peer, ctx["seq"])
+                                with ec_cv:
+                                    ec_slot_free.add(ri)
+                                    ec_cv.notify_all()
+                                progress = True
+
+                            if (
+                                ctx["prep_free"]
+                                and not ctx["pending_ext"]
+                                and not ctx["pending_copy_submit"]
+                                and not ctx["pending_copy_complete"]
+                                and not ctx["pending_launch"]
+                                and not ctx["pending_complete"]
+                                and not ctx["pending_doff_release"]
+                            ):
+                                now = time.time()
+                                gantt.rec(
+                                    "receiver",
+                                    self._rank,
+                                    wt,
+                                    "internal_consume_dispatch",
+                                    ri,
+                                    ctx["registered_wall"],
+                                    now,
+                                )
+                                gantt.rec(
+                                    "recv-ec",
+                                    self._rank,
+                                    wt,
+                                    "exchange_consume",
+                                    ri,
+                                    ctx["registered_wall"],
+                                    now,
+                                )
+                                finished.append(ri)
+                                progress = True
+                                continue
+
+                            now = time.time()
+                            if now >= ctx["deadline"]:
+                                raise TimeoutError(
+                                    f"wbridge rank {self._rank}: waited 600s for cross-round slot "
+                                    f"progress epoch={wt} round={ri} "
+                                    f"out_submit={sorted(ctx['pending_out_submit'])} "
+                                    f"out_wait={sorted(ctx['pending_out_wait'])} "
+                                    f"ext={sorted(ctx['pending_ext'])} "
+                                    f"copy_submit={sorted(ctx['pending_copy_submit'])} "
+                                    f"copy_complete={sorted(ctx['pending_copy_complete'])} "
+                                    f"launch={sorted(ctx['pending_launch'], key=lane_sort)} "
+                                    f"complete={sorted(ctx['pending_complete'], key=lane_sort)} "
+                                    f"doff_release={sorted(ctx['pending_doff_release'])} seq={seq}"
+                                )
+                            elapsed = now - ctx["registered_wall"]
+                            if elapsed - ctx["warned"] >= 30.0:
+                                ctx["warned"] = elapsed
+                                logger.warning(
+                                    "wbridge rank %d: waiting %.0fs for cross-round slot progress "
+                                    "epoch=%d round=%d out_submit=%s out_wait=%s ext=%s "
+                                    "copy_submit=%s copy_complete=%s launch=%s complete=%s "
+                                    "doff_release=%s seq=%d",
+                                    self._rank,
+                                    elapsed,
+                                    wt,
+                                    ri,
+                                    sorted(ctx["pending_out_submit"]),
+                                    sorted(ctx["pending_out_wait"]),
+                                    sorted(ctx["pending_ext"]),
+                                    sorted(ctx["pending_copy_submit"]),
+                                    sorted(ctx["pending_copy_complete"]),
+                                    sorted(ctx["pending_launch"], key=lane_sort),
+                                    sorted(ctx["pending_complete"], key=lane_sort),
+                                    sorted(ctx["pending_doff_release"]),
+                                    seq,
+                                )
+
+                        for ri in finished:
+                            ctx = active.pop(ri)
+                            with ec_cv:
+                                ec_completed.add(ri)
+                                ec_cv.notify_all()
+                            self._trace_state(
+                                "ec_round_done",
+                                epoch=wt,
+                                round=ri,
+                                seq=ctx["seq"],
+                            )
+
+                        if stopping and not active:
+                            self._trace_state("ec_worker_stop", epoch=wt)
+                            return
+                        if not progress:
+                            time.sleep(1e-4)
+            except BaseException as e:  # noqa: BLE001 — re-raised on the poll_requests thread
+                with ec_cv:
+                    ec_err.append(e)
+                    ec_cv.notify_all()
+
+        def _wait_ec(ri: int) -> None:
+            self._trace_state("ec_slot_wait", epoch=wt, round=ri)
+            with ec_cv:
+                while ri not in ec_slot_free and not ec_err:
+                    ec_cv.wait()
+                if ec_err:
+                    raise ec_err[0]
+            self._trace_state("ec_slot_done", epoch=wt, round=ri)
+
+        ec_thread: threading.Thread | None = None
+        if three_stage:
+            ec_thread = threading.Thread(
+                target=_ec_worker, name="wbridge-recv-ec", daemon=True
+            )
+            ec_thread.start()
+
+        slot_pred = _arena_slot_predecessors(rounds, self._recv_depth)
+        peer_pred = (
+            self._topo_peer_predecessors
+            if self._topo_ok
+            else _arena_peer_predecessors(
+                self._arena_layout,
+                depth=self._recv_depth,
+            )
+        )
+        for ri in rounds:
+            seq = self._seq(ri)
+            overlap_specs = router.local_rounds[ri][1]
+            self._trace_state(
+                "round_enter",
+                epoch=wt,
+                round=ri,
+                seq=seq,
+                senders=sorted(overlap_specs),
+            )
+            # The previous active round in this *global-round parity slot* owns the PREP bytes that assemble(ri)
+            # will reuse.  Active-list position is not parity when this receiver skips a global round.
+            slot_gate = slot_pred[ri]
+            peer_gates = peer_pred[ri]
+            if not staged:
+                # RS-off: poll senders' done-flags for round ri. A cross-node sender RDMA-filled RECV(ri)
+                # during external+internal-consume(prev) (RECV∩PREP(prev)=∅), so its flag means "bytes landed"; a
+                # SAME-NODE sender wrote nothing — its flag means "my pack buffer holds round ri" and we pull.
+                with gantt.span("receiver", self._rank, wt, "poll", ri):
+                    for peer in overlap_specs:
+                        self._poll_flag(peer, seq)
+                self._trace_state("round_input_ready", epoch=wt, round=ri, seq=seq)
+                if os.environ.get("WBRIDGE_TOPO_DEBUG") == "1":
+                    print(
+                        f"TDBG r{self._rank} wt{wt} ri{ri} INPUT_DONE senders={list(overlap_specs)}",
+                        flush=True,
+                    )
+                # Same-node senders bypass RDMA: read round ri straight out of the sender's pack buffer
+                # over NVLink (CUDA-IPC) into the RECV slot assemble is about to read. Issued on the DEFAULT
+                # stream, so the existing post-assemble event sync below covers it and the ack we send after
+                # it truthfully means "your pack buffer is free". Same direction as the dedup exchange's
+                # pull: reading peer IPC memory is substantially faster than writing it.
+                recv = self._arena_layout[ri]["recv"]
+                sn = [p for p in overlap_specs if p in self._sn_senders]
+                self._tstats["wire_rdma_bytes"] += sum(
+                    recv[p][1] for p in overlap_specs if p not in self._sn_senders
+                )
+                if sn:
+                    with gantt.span("receiver", self._rank, wt, "ipc_pull", ri):
+                        for peer in sn:
+                            off, nb = recv[peer]
+                            if nb == 0:
+                                continue
+                            # Our RECV slot lives in this round's arena parity (what the assemble plan reads);
+                            # the sender packed round ri at offset 0 of its parity-(ri % its _NUM_BUF) buffer.
+                            a_off = _arena_slot_offset(
+                                off, ri, self._recv_depth, self._recv_S
+                            )
+                            src = self._peer_pack_buf[peer][
+                                ri % self._peer_pack_num_buf[peer]
+                            ]
+                            torch.cuda.current_stream().wait_event(
+                                self._peer_pack_event[peer]
+                            )
+                            self._recv_arena[a_off : a_off + nb].copy_(src[:nb])
+                            self._tstats["wire_ipc_bytes"] += nb
+            else:
+                # RS-on: the receive-worker POLLED this round into the full-depth CPU arena and landing-acked
+                # every round but the LAST. Stage this round's per-sender slices CPU->GPU RECV zone (Triton
+                # needs GPU); for the last round, ack AFTER the H2D. That consume-ack (H2Ds run in round order,
+                # so it means every CPU slot has been read) is the whole-epoch 'consumed' barrier the sender's
+                # epoch-end drain waits on: it paces the sender to our consume, keeps the engines in lockstep,
+                # and stops epoch N+1's RECEIVE racing our epoch advance (the production overlap deadlock).
+                # RS keeps the sender on RDMA (host DRAM can't be CUDA-IPC mapped), so every byte of
+                # this round arrived over the fabric.
+                self._tstats["wire_rdma_bytes"] += sum(
+                    self._arena_layout[ri]["recv"][p][1] for p in overlap_specs
+                )
+                src, dst, sz = self._rs_h2d[ri]
+                preloaded = ri == rounds[0] and self._rs_gpu_ready == wt
+                if src and not preloaded:
+                    with gantt.span("receiver", self._rank, wt, "h2d", ri):
+                        self.local_engine.wait(
+                            [
+                                self.local_engine.write_async(
+                                    self.local_engine.session_id(), src, dst, sz
+                                )
+                            ]
+                        )
+                if ri == rounds[-1]:
+                    for peer in overlap_specs:
+                        self._write_flag(
+                            peer, seq
+                        )  # last round H2D'd -> whole epoch consumed
+            # Before prepare overwrites this SEND parity, wait only for its prior outbound RDMA reads and local
+            # SEND->DOFF copy. Topology readers consume DOFF and therefore do not participate in this gate.
+            if slot_gate is not None:
+                # RECV(ri) may land beside E+C(slot_gate); prepare writes SEND/PREP and waits for that physical
+                # parity's narrow send-slot-free condition.
+                # Put this AFTER the sender poll: waiting for RECV(ri) is useful work overlapped with E+C.
+                if three_stage:
+                    with gantt.span(
+                        "receiver", self._rank, wt, "ec_slot_gate", slot_gate
+                    ):
+                        _wait_ec(slot_gate)
+                if not self._topo_ok:
+                    sn_gate = _sn_send_peers(self._arena_layout[slot_gate])
+                    if sn_gate:
+                        with gantt.span("receiver", self._rank, wt, "reuse_gate", ri):
+                            for peer in sn_gate:
+                                self._poll_repl_cons_flag(peer, self._seq(slot_gate))
+            # Prepare remains ordered on the calling thread. E+C may overlap adjacent prepared rounds;
+            # slotted source readers are covered by slot_gate and remote GRECV parity destinations by their
+            # exact per-peer/parity generation gates.
+            with gantt.span("receiver", self._rank, wt, "assemble", ri):
+                if merged_recv_prep:
+                    assert recv_scratch is not None
+                    # Snapshot the complete stable trainer-lane prefix before PREP overwrites this merged
+                    # parity slot. The following A+R plan reads the same offsets from scratch on this stream.
+                    slot_base = _arena_slot_offset(
+                        0,
+                        ri,
+                        self._recv_depth,
+                        self._recv_S,
+                    )
+                    with gantt.span(
+                        "receiver",
+                        self._rank,
+                        wt,
+                        "recv_snapshot_submit",
+                        ri,
+                    ):
+                        recv_scratch[: self._recv_payload_S].copy_(
+                            self._arena[slot_base : slot_base + self._recv_payload_S],
+                            non_blocking=True,
+                        )
+                # One kernel: RECV -> own plus any unique partial send payload. A full send aliases own, so
+                # the common one-group case writes only the canonical bytes and has no repack destination.
+                self._trace_state("assemble_kernel", epoch=wt, round=ri, seq=seq)
+                self._arena_prepare[ri].run()
+                # PULL: capture prepare completion so same-node peers get a GPU-visible fence before they read
+                # our send[peer]. Recorded on the default stream BEFORE the ready-flag below.
+                # (Topo 2-phase records its own-visibility event later, in _topo_round's phase 1.5.)
+                if not self._topo_ok:
+                    for peer in _sn_send_peers(self._arena_layout[ri]):
+                        self._repl_ready_event[peer].record()
+                self._trace_state("assemble_stream_wait", epoch=wt, round=ri, seq=seq)
+                ev = torch.cuda.Event()
+                ev.record()
+                ev.synchronize()  # fused prepare landed in HBM
+                self._trace_state("assemble_done", epoch=wt, round=ri, seq=seq)
+            if merged_recv_prep and ri == rounds[-1]:
+                # The final A+R synchronization proves no prepare descriptor still reads scratch. Dropping
+                # the tensor returns its block to PyTorch's allocator; it is not retained by WeightBridge.
+                recv_scratch = None
+                gantt.rec(
+                    "receiver",
+                    self._rank,
+                    wt,
+                    "recv_scratch_lifetime",
+                    -1,
+                    scratch_lifetime_t0,
+                    time.time(),
+                )
+            # PULL: my send-staging is now in HBM — flag each same-node peer that it may pull it (event recorded
+            # above precedes this flag, so the reader's wait_event observes THIS round's record once it sees it).
+            # (Topo 2-phase emits its column-ready flag later, in _topo_round's phase 1.5.)
+            if not self._topo_ok:
+                with gantt.span(
+                    "receiver", self._rank, wt, "ready_flag", ri
+                ):  # DIAG: measure the flag handshake
+                    for peer in _sn_send_peers(self._arena_layout[ri]):
+                        self._flag_emit(1, peer, seq)
+                if xchk:
+                    for peer in _sn_send_peers(self._arena_layout[ri]):
+                        s_off, s_nb = self._arena_layout[ri]["send"][peer - sw]
+                        s_off = _arena_slot_offset(
+                            s_off, ri, self._recv_depth, self._arena_S
+                        )
+                        print(
+                            f"WXCHK SEND grank={self._rank} peer={peer} wt={wt} ri={ri} "
+                            f"off={s_off} nb={s_nb} fp={_fp(s_off, s_nb)}",
+                            flush=True,
+                        )
+            # A+R completion is the only local prerequisite for topology E+C. Publish the prepared round to
+            # its progress worker before trainer ACKs: ACK submission is independent RECV-lane bookkeeping,
+            # and host scheduling jitter there must not delay rollout external exchange.
+            if self._topo_ok and three_stage:
+                assert ec_q is not None
+                self._trace_state("ec_round_enqueue", epoch=wt, round=ri, seq=seq)
+                ec_q.put((ri, seq, peer_gates, tuple(self.peers)))
+            # Ack actual source senders: their RECV(ri) lane is drained, so each may reuse this receiver/parity
+            # on its next contributing round. (RS-on already acked right after the H2D above — earliest point
+            # the CPU slot is free — so skip here.)
+            if not staged and not merged_recv_prep:
+                with gantt.span(
+                    "receiver", self._rank, wt, "ack_send", ri
+                ):  # DIAG: serial synchronous acks
+                    for peer in overlap_specs:
+                        self._flag_emit(0, peer, seq)
+                self._trace_state("sender_acks_done", epoch=wt, round=ri, seq=seq)
+                if os.environ.get("WBRIDGE_TOPO_DEBUG") == "1":
+                    print(
+                        f"TDBG r{self._rank} wt{wt} ri{ri} ACK_DONE senders={list(overlap_specs)}",
+                        flush=True,
+                    )
+            if self._topo_ok:
+                # Topology-aware multi-group all-gather: packed cross-node columns then possibly multi-span
+                # same-node pulls, consume + cons handshake — all inside _topo_round. Nothing else in the
+                # round body applies, so skip the single-phase exchange below.
+                if not three_stage:
+                    _topo_round(ri, seq, peer_gates)
+                continue
+            # Exchange: fill my grecv[peer] for each shared peer. Same-node -> PULL peer's send[me] over NVLink
+            # (a fast IPC READ; the reverse-direction WRITE is substantially slower). Cross-node -> keep
+            # the RDMA push of my send[peer] into the peer's grecv[me] (RDMA is direction-agnostic).
+            bids: dict = {}
+            if self._repl_peers:
+                with gantt.span("receiver", self._rank, wt, "agh_submit", ri):
+                    rd = self._arena_layout[ri]
+                    for peer in self._repl_peers:
+                        p_rl = peer - sw
+                        if peer in self._repl_same_node:
+                            # PULL: read the peer's send[me] slice from its arena straight into our grecv[peer].
+                            # Gated on the peer's ready-flag (it produced send[me]) + its production event (GPU
+                            # visibility). We fill our OWN grecv on _con_stream, so consume needs no extra fence.
+                            g = rd["grecv"].get(p_rl)
+                            ps_off = self._repl_peer_send_off[peer][ri]
+                            if not g or g[1] == 0 or ps_off is None:
+                                continue
+                            # Our GRECV offset already selects this round's shared-bank parity; ps_off is
+                            # parity-baked into the peer's arena because its send source is part of PREP.
+                            g_off = g[0]
+                            g_nb = g[1]
+                            self._poll_repl_flag(
+                                peer, seq
+                            )  # peer produced its send[me]
+                            self._con_stream.wait_event(
+                                self._repl_peer_ready_event[peer]
+                            )  # GPU-visible prepare
+                            with torch.cuda.stream(self._con_stream):
+                                self._arena[g_off : g_off + g_nb].copy_(
+                                    self._repl_peer_arena[peer][ps_off : ps_off + g_nb]
+                                )
+                            self._tstats["agh_ipc_bytes"] += g_nb
+                            if xchk:
+                                print(
+                                    f"WXCHK PULL grank={self._rank} peer={peer} wt={wt} ri={ri} "
+                                    f"g_off={g_off} nb={g_nb} ps_off={ps_off}",
+                                    flush=True,
+                                )
+                        else:
+                            # Cross-node PUSH: gate on the peer freeing its shared grecv[me] slot, then
+                            # Cross-node RDMA write (completion implies remote landing/visibility).
+                            dst = self._arena_peer_dst[peer][ri]
+                            if (
+                                dst is None
+                                or p_rl not in rd["send"]
+                                or rd["send"][p_rl][1] == 0
+                            ):
+                                continue
+                            gate = peer_gates.get(p_rl)
+                            gate_seq = _reuse_seq(gate)
+                            if gate_seq is not None:
+                                with gantt.span(
+                                    "receiver", self._rank, wt, "reuse_gate", ri
+                                ):
+                                    self._poll_repl_cons_flag(peer, gate_seq)
+                            s_off, s_nb = rd["send"][p_rl]
+                            s_off = _arena_slot_offset(
+                                s_off, ri, self._recv_depth, self._arena_S
+                            )
+                            bids[peer] = self.engine.write_async(
+                                self._repl_peer_session[peer],
+                                [self._arena.data_ptr() + s_off],
+                                [dst],
+                                [s_nb],
+                            )
+                            self._tstats["agh_rdma_bytes"] += s_nb
+                            if xchk:
+                                print(
+                                    f"WXCHK SEND grank={self._rank} peer={peer} wt={wt} ri={ri} "
+                                    f"off={s_off} nb={s_nb} fp={_fp(s_off, s_nb)}",
+                                    flush=True,
+                                )
+            # Consume + rendezvous + consumed-flag for this round, inline (serial). The flag releases each
+            # peer's next write to the same parity destination in our shared GRECV bank.
+            _finish(ri, bids)
+        if three_stage:
+            assert ec_q is not None and ec_thread is not None
+            self._trace_state("ec_drain_wait", epoch=wt)
+            ec_q.put(None)
+            ec_thread.join()
+            self._trace_state("ec_drain_done", epoch=wt)
+            if ec_err:
+                raise ec_err[0]
+        # Do not wait for flag completions at epoch close. Exclusive message slots remain immutable until
+        # causal protocol progress makes their next-epoch reuse safe; the reaper retires handles off-path.
+        self._flag_reaper_check()
+        self._trace_state("receive_final_cuda_wait", epoch=wt)
+        torch.cuda.synchronize()
+        self._epoch += 1
+        self._trace_state("receive_done", epoch=wt)
+
+    def _receive_weights_direct_same_node(self) -> None:
+        """Consume each round directly from co-located trainer pack buffers.
+
+        The sender's DATA-ready sequence is published only after its pack event has been recorded.  Once all
+        contributing senders are ready, one fused plan waits those imported events and reads their CUDA-IPC
+        mappings directly into the live rollout parameters.  ACK is emitted only after that model-copy kernel
+        finishes, making it the pack-buffer lifetime fence.  No receiver exchange or staging allocation
+        participates in the update.
+        """
+        router = self.router
+        assert router is not None
+        wt = self._epoch
+        rounds = [
+            ri for ri, (_full, overlaps) in enumerate(router.local_rounds) if overlaps
+        ]
+        self._trace_state("direct_receive_enter", epoch=wt, rounds=rounds)
+        self._flag_reaper_ensure()
+        for ri in rounds:
+            seq = self._seq(ri)
+            overlap_specs = router.local_rounds[ri][1]
+            with gantt.span("receiver", self._rank, wt, "direct_ready_wait", ri):
+                for peer in overlap_specs:
+                    self._poll_flag(peer, seq)
+            plan = self._direct_consume_plan[ri]
+            if plan is None:
+                raise RuntimeError(
+                    f"missing direct same-node consume plan for active round {ri}"
+                )
+            with gantt.span("receiver", self._rank, wt, "direct_consume", ri):
+                stream = torch.cuda.current_stream()
+                for peer in overlap_specs:
+                    stream.wait_event(self._peer_pack_event[peer])
+                plan.run()
+                completed = torch.cuda.Event()
+                completed.record(stream)
+                completed.synchronize()
+            self._tstats["wire_ipc_bytes"] += sum(
+                spec.nbytes(self.dtype_spec) for spec in overlap_specs.values()
+            )
+            with gantt.span("receiver", self._rank, wt, "direct_done", ri):
+                for peer in overlap_specs:
+                    self._flag_emit(0, peer, seq)
+            self._trace_state(
+                "direct_round_done",
+                epoch=wt,
+                round=ri,
+                seq=seq,
+                senders=sorted(overlap_specs),
+                launches=plan.launch_count,
+            )
+        self._flag_reaper_check()
+        torch.cuda.synchronize()
+        self._epoch += 1
+        self._trace_state("direct_receive_done", epoch=wt)
+
+    def _receive_weights_relay_legacy(self, staged: bool = False) -> None:
+        """Drive one depth-2 replica-group head/relay/consume epoch.
+
+        Every ``(group, round)`` is an independent state machine. Heads wait for their trainer lanes and
+        assemble directly into canonical PREP; later node representatives copy their predecessor's canonical
+        RECV into PREP. PREP simultaneously feeds the next RDMA hop and same-node CUDA-IPC consumers. Its
+        parity is released only after both those readers finish. Within one group, assemble, relay-write, and
+        internal-consume each advance in round order; different groups remain independent. The blocking call
+        ends after this worker's consumes and successor writes. A persistent retirement worker subsequently
+        releases any PREP slots still held by same-node readers and recursively reports full downstream
+        consumption, preserving the trainer's ``wait_send_complete`` contract without blocking rollout.
+        """
+        if staged:
+            raise RuntimeError("replica-group relay does not support receiver staging")
+        router = self.router
+        assert router is not None
+        wt = self._epoch
+        sw = router.sender_ws
+        seq_of = lambda ri: wt * self.num_rounds + ri + 1
+        self._flag_reaper_ensure()
+        self._relay_retire_check()
+
+        owner_states: dict[tuple[int, int], dict] = {}
+        consume_states: dict[tuple[int, int], dict] = {}
+        for group in router._relay_groups:
+            gid = group["id"]
+            active_rounds = [
+                ri for ri, spec in enumerate(group["round_specs"]) if spec.entries
+            ]
+            round_predecessors = _relay_round_predecessors(active_rounds, depth=2)
+            last_round_by_parity = {
+                parity: max(ri for ri in active_rounds if ri % 2 == parity)
+                for parity in {ri % 2 for ri in active_rounds}
+            }
+            if gid in self._relay_owned_gids:
+                chain = group["chain"]
+                position = chain.index(self._rank)
+                pred = chain[position - 1] if position else None
+                succ = chain[position + 1] if position + 1 < len(chain) else None
+                for ri, spec in enumerate(group["round_specs"]):
+                    if not spec.entries:
+                        continue
+                    key = (gid, ri)
+                    operation_pred, parity_pred = round_predecessors[ri]
+                    state = {
+                        "gid": gid,
+                        "ri": ri,
+                        "seq": seq_of(ri),
+                        "pred": pred,
+                        "succ": succ,
+                        "input_peers": (
+                            tuple(sorted(group["trainer_specs"][ri]))
+                            if pred is None
+                            else (pred,)
+                        ),
+                        # Adjacent operations are deliberately ordered even though they use opposite
+                        # parity buffers.  The parity predecessor remains the stronger storage-lifetime
+                        # fence: it cannot be overwritten until its relay and every local read finish.
+                        "operation_pred": (
+                            (gid, operation_pred)
+                            if operation_pred is not None
+                            else None
+                        ),
+                        "prep_pred": (gid, parity_pred)
+                        if parity_pred is not None
+                        else None,
+                        "prior_epoch_prep_seq": (
+                            None
+                            if wt == 0
+                            else (wt - 1) * self.num_rounds
+                            + last_round_by_parity[ri % 2]
+                            + 1
+                        ),
+                        "input_ready": False,
+                        "prepare_launched": False,
+                        "prep_ready": False,
+                        "acks_sent": False,
+                        "relay_submitted": False,
+                        "relay_done": succ is None,
+                        "local_consumed": False,
+                        "prep_free": False,
+                        "upstream_done": False,
+                        "started": time.time(),
+                    }
+                    owner_states[key] = state
+            if (self._rank - sw) in group["members"]:
+                owner = sw + group["owner_of"][self._rank - sw]
+                for ri, spec in enumerate(group["round_specs"]):
+                    if spec.entries:
+                        operation_pred, _parity_pred = round_predecessors[ri]
+                        consume_states[(gid, ri)] = {
+                            "gid": gid,
+                            "ri": ri,
+                            "seq": seq_of(ri),
+                            "owner": owner,
+                            "operation_pred": (
+                                (gid, operation_pred)
+                                if operation_pred is not None
+                                else None
+                            ),
+                            "launched": False,
+                            "done": False,
+                            "started": time.time(),
+                        }
+
+        result_q: queue.Queue = queue.Queue()
+        forward_edges = {
+            (state["succ"], state["gid"])
+            for state in owner_states.values()
+            if state["succ"] is not None
+        }
+        self._ensure_relay_bulk_waiters(forward_edges)
+        if not hasattr(self, "_relay_forward_last"):
+            self._relay_forward_last = {}
+        deadline = time.time() + 600.0
+
+        def _prep_predecessor_free(state: dict) -> bool:
+            predecessor = state["prep_pred"]
+            if predecessor is not None:
+                return owner_states[predecessor]["prep_free"]
+            prior_seq = state["prior_epoch_prep_seq"]
+            return prior_seq is None or self._relay_prep_was_released(
+                state["gid"],
+                state["ri"],
+                prior_seq,
+            )
+
+        def _operation_finished(state: dict, states: dict, field: str) -> bool:
+            predecessor = state["operation_pred"]
+            return predecessor is None or states[predecessor][field]
+
+        def _incoming_ready(state: dict) -> bool:
+            return all(
+                self._relay_flag_reached(
+                    self._RELAY_DATA_KIND,
+                    peer,
+                    state["gid"],
+                    state["seq"],
+                )
+                for peer in state["input_peers"]
+            )
+
+        def _local_ready(state: dict) -> bool:
+            owner = state["owner"]
+            gid, ri, seq = state["gid"], state["ri"], state["seq"]
+            if owner == self._rank:
+                return owner_states[(gid, ri)]["prep_ready"]
+            bank = self._relay_peer_local_flags[owner]
+            channel = self._relay_peer_channel[owner][(gid, ri % 2)]
+            return bank.ready(channel) >= seq
+
+        while True:
+            progress = False
+
+            while True:
+                try:
+                    peer, gid, ri, _seq, error, _landed = result_q.get_nowait()
+                except queue.Empty:
+                    break
+                if error is not None:
+                    raise RuntimeError(
+                        f"relay forward failed peer={peer} group={gid} round={ri} epoch={wt}"
+                    ) from error
+                state = owner_states[(gid, ri)]
+                if state["succ"] != peer or state["relay_done"]:
+                    raise RuntimeError(
+                        f"unexpected relay completion peer={peer} group={gid} round={ri}"
+                    )
+                state["relay_done"] = True
+                progress = True
+
+            # Receive and prepare every independently-ready group slot.
+            for key in sorted(owner_states, key=lambda item: (item[1], item[0])):
+                state = owner_states[key]
+                gid, ri, seq = state["gid"], state["ri"], state["seq"]
+                group = router.relay_group(gid)
+                if not state["input_ready"] and _incoming_ready(state):
+                    state["input_ready"] = True
+                    if state["pred"] is None:
+                        self._tstats["wire_rdma_bytes"] += sum(
+                            spec.nbytes(self.dtype_spec)
+                            for spec in group["trainer_specs"][ri].values()
+                        )
+                    else:
+                        self._tstats["agh_rdma_bytes"] += group["round_specs"][
+                            ri
+                        ].nbytes(
+                            self.dtype_spec,
+                        )
+                    gantt.rec(
+                        "receiver",
+                        self._rank,
+                        wt,
+                        "relay_recv_wait",
+                        ri,
+                        state["started"],
+                        time.time(),
+                    )
+                    progress = True
+                if (
+                    state["input_ready"]
+                    and not state["prepare_launched"]
+                    and _prep_predecessor_free(state)
+                    and _operation_finished(state, owner_states, "prep_ready")
+                ):
+                    stream = self._relay_prepare_stream[(gid, ri % 2)]
+                    with torch.cuda.stream(stream):
+                        self._relay_prepare_plan[(gid, ri)].run()
+                        for reader in self._relay_local_readers.get(gid, ()):
+                            self._relay_ready_event[(gid, ri % 2, reader)].record(
+                                stream
+                            )
+                        self._relay_prepare_event[(gid, ri % 2)].record(stream)
+                    state["prepare_launched"] = True
+                    state["prepare_t0"] = time.time()
+                    progress = True
+                if (
+                    state["prepare_launched"]
+                    and not state["prep_ready"]
+                    and self._relay_prepare_event[(gid, ri % 2)].query()
+                ):
+                    now = time.time()
+                    gantt.rec(
+                        "receiver",
+                        self._rank,
+                        wt,
+                        "relay_assemble",
+                        ri,
+                        state["prepare_t0"],
+                        now,
+                    )
+                    state["prep_ready"] = True
+                    for peer in state["input_peers"]:
+                        self._relay_emit(self._RELAY_ACK_KIND, peer, gid, seq)
+                    state["acks_sent"] = True
+                    readers = self._relay_local_readers.get(gid, ())
+                    if readers:
+                        channel = self._relay_local_channel[(gid, ri % 2)]
+                        self._relay_local_flags.publish_ready(seq, channel)
+                    progress = True
+
+                # Forward after this group's prior write completed, once PREP is ready and this successor's
+                # exact prior use of the destination parity has been ACKed.
+                succ = state["succ"]
+                if (
+                    state["prep_ready"]
+                    and succ is not None
+                    and not state["relay_submitted"]
+                    and _operation_finished(state, owner_states, "relay_done")
+                ):
+                    edge = (succ, gid, ri % 2)
+                    prior_seq = self._relay_forward_last.get(edge)
+                    if prior_seq is None or self._relay_flag_reached(
+                        self._RELAY_ACK_KIND,
+                        succ,
+                        gid,
+                        prior_seq,
+                    ):
+                        size = group["round_specs"][ri].nbytes(self.dtype_spec)
+                        src = self._relay_prep_buf[gid][ri % 2].data_ptr()
+                        dst = self._relay_forward_dst[gid][ri]
+                        if dst is None:
+                            raise RuntimeError(
+                                f"relay successor {succ} omitted group={gid} round={ri} destination"
+                            )
+                        submitted_at = time.time()
+                        handle = self.engine.write_async(
+                            self._relay_peer_session[succ],
+                            [src],
+                            [dst],
+                            [size],
+                        )
+                        self._tstats["agh_rdma_bytes"] += size
+                        self._relay_bulk_wait_queues[(succ, gid)].put(
+                            (
+                                wt,
+                                ri,
+                                seq,
+                                handle,
+                                submitted_at,
+                                "relay_forward",
+                                result_q,
+                            )
+                        )
+                        self._relay_forward_last[edge] = seq
+                        state["relay_submitted"] = True
+                        state["relay_t0"] = submitted_at
+                        progress = True
+
+            # Each model worker consumes one canonical PREP per replication group. Different groups remain
+            # independent; opposite parities within a group are explicitly ordered by operation completion.
+            for key in sorted(consume_states, key=lambda item: (item[1], item[0])):
+                state = consume_states[key]
+                gid, ri, seq, owner = (
+                    state["gid"],
+                    state["ri"],
+                    state["seq"],
+                    state["owner"],
+                )
+                if (
+                    not state["launched"]
+                    and _local_ready(state)
+                    and _operation_finished(state, consume_states, "done")
+                ):
+                    stream = self._relay_consume_stream[(gid, ri % 2)]
+                    ready_event = (
+                        self._relay_prepare_event[(gid, ri % 2)]
+                        if owner == self._rank
+                        else self._relay_peer_ready_event[(gid, ri % 2)]
+                    )
+                    stream.wait_event(ready_event)
+                    with torch.cuda.stream(stream):
+                        self._relay_consume_plan[(gid, ri)].run()
+                        self._relay_consume_event[(gid, ri % 2)].record(stream)
+                    state["launched"] = True
+                    state["launch_t0"] = time.time()
+                    progress = True
+                if (
+                    state["launched"]
+                    and not state["done"]
+                    and self._relay_consume_event[(gid, ri % 2)].query()
+                ):
+                    now = time.time()
+                    gantt.rec(
+                        "receiver",
+                        self._rank,
+                        wt,
+                        "relay_internal_consume",
+                        ri,
+                        state["launch_t0"],
+                        now,
+                    )
+                    state["done"] = True
+                    if owner != self._rank:
+                        bank = self._relay_peer_local_flags[owner]
+                        channel = self._relay_peer_channel[owner][(gid, ri % 2)]
+                        bank.publish_consumed(
+                            self._relay_peer_slot_of_me[owner],
+                            seq,
+                            channel,
+                        )
+                        self._tstats["agh_ipc_bytes"] += router.relay_group(gid)[
+                            "round_specs"
+                        ][ri].nbytes(self.dtype_spec)
+                    progress = True
+
+            # PREP release is local: outbound RDMA finished and every same-node member finished reading.
+            # Full-delivery propagation is recursive and additionally waits for the successor's subtree.
+            for key in sorted(owner_states, key=lambda item: (item[1], item[0])):
+                state = owner_states[key]
+                gid, ri, seq = state["gid"], state["ri"], state["seq"]
+                if not state["local_consumed"] and consume_states[(gid, ri)]["done"]:
+                    if self._relay_local_readers_done(gid, ri, seq):
+                        state["local_consumed"] = True
+                        progress = True
+                if (
+                    not state["prep_free"]
+                    and state["local_consumed"]
+                    and state["relay_done"]
+                ):
+                    state["prep_free"] = True
+                    self._relay_mark_prep_released(gid, ri, seq)
+                    gantt.rec(
+                        "receiver",
+                        self._rank,
+                        wt,
+                        "relay_prep_hold",
+                        ri,
+                        state.get("prepare_t0", state["started"]),
+                        time.time(),
+                    )
+                    progress = True
+                downstream_done = state["succ"] is None or self._relay_flag_reached(
+                    self._RELAY_DATA_KIND,
+                    state["succ"],
+                    gid,
+                    seq,
+                )
+                if (
+                    state["local_consumed"]
+                    and downstream_done
+                    and not state["upstream_done"]
+                ):
+                    if state["pred"] is not None:
+                        self._relay_emit(
+                            self._RELAY_DATA_KIND,
+                            state["pred"],
+                            gid,
+                            seq,
+                        )
+                    else:
+                        # The head reports full chain consumption to exactly the trainers that contributed
+                        # bytes to this canonical group chunk.
+                        for trainer in router.relay_group(gid)["trainer_specs"][ri]:
+                            self._relay_emit(
+                                self._RELAY_DATA_KIND,
+                                trainer,
+                                gid,
+                                seq,
+                            )
+                    state["upstream_done"] = True
+                    progress = True
+
+            if self._relay_local_exit_ready(owner_states, consume_states):
+                retire_tasks = []
+                for state in owner_states.values():
+                    if state["upstream_done"]:
+                        continue
+                    gid, ri = state["gid"], state["ri"]
+                    upstream_peers = (
+                        (state["pred"],)
+                        if state["pred"] is not None
+                        else tuple(sorted(router.relay_group(gid)["trainer_specs"][ri]))
+                    )
+                    retire_tasks.append(
+                        {
+                            "wt": wt,
+                            "gid": gid,
+                            "ri": ri,
+                            "seq": state["seq"],
+                            "succ": state["succ"],
+                            "upstream_peers": upstream_peers,
+                            "prep_released": state["prep_free"],
+                        }
+                    )
+                self._defer_relay_retirement(retire_tasks)
+                break
+            if not progress:
+                if time.time() >= deadline:
+                    owner_pending = {
+                        key: {
+                            field: state[field]
+                            for field in (
+                                "input_ready",
+                                "prepare_launched",
+                                "prep_ready",
+                                "relay_submitted",
+                                "relay_done",
+                                "local_consumed",
+                                "prep_free",
+                                "upstream_done",
+                            )
+                        }
+                        for key, state in owner_states.items()
+                        if not state["relay_done"]
+                    }
+                    consume_pending = [
+                        key
+                        for key, state in consume_states.items()
+                        if not state["done"]
+                    ]
+                    raise TimeoutError(
+                        f"replica relay timeout epoch={wt} owner={owner_pending} "
+                        f"consume={consume_pending}"
+                    )
+                time.sleep(1e-4)
+
+        self._flag_reaper_check()
+        self._epoch += 1
+        self._trace_state("relay_receive_local_done", epoch=wt)
+
+    def _receive_relay_group(self, wt: int, gid: int) -> list[dict]:
+        """Progress one replica group independently on a persistent executor thread.
+
+        Registered PREP is both the ingress destination and relay source. A head snapshots its trainer lanes
+        into epoch scratch before assembling back into PREP; downstream representatives already receive the
+        canonical layout. Every representative then starts its successor write and PREP->DOFF copy
+        independently. ACK is delayed until both readers of PREP (relay and offload) finish, whereas model
+        consumption and recursive full delivery continue from DOFF.
+        """
+        router = self.router
+        assert router is not None
+        group = router.relay_group(gid)
+        sw = router.sender_ws
+        seq_of = lambda ri: wt * self.num_rounds + ri + 1
+        active_rounds = [
+            ri for ri, spec in enumerate(group["round_specs"]) if spec.entries
+        ]
+        if not active_rounds:
+            return []
+        dependencies = _relay_round_predecessors(active_rounds, depth=2)
+        doff_previous: dict[int, int] = {}
+        doff_predecessor: dict[int, int | None] = {}
+        last_doff_by_slot: dict[int, int] = {}
+        for ri in active_rounds:
+            slot = ri % self._relay_doff_depth
+            doff_predecessor[ri] = doff_previous.get(slot)
+            doff_previous[slot] = ri
+            last_doff_by_slot[slot] = ri
+        last_prep_by_parity = {
+            parity: max(ri for ri in active_rounds if ri % 2 == parity)
+            for parity in {ri % 2 for ri in active_rounds}
+        }
+
+        owns = gid in self._relay_owned_gids
+        consumes = (self._rank - sw) in group["members"]
+        owner_states: dict[int, dict] = {}
+        consume_states: dict[int, dict] = {}
+        scratch = None
+        if owns:
+            chain = group["chain"]
+            position = chain.index(self._rank)
+            pred = chain[position - 1] if position else None
+            succ = chain[position + 1] if position + 1 < len(chain) else None
+            if pred is None:
+                scratch = torch.empty(
+                    self._relay_head_scratch_size[gid],
+                    dtype=torch.uint8,
+                    device=self.device,
+                )
+            for ri in active_rounds:
+                operation_pred, prep_pred = dependencies[ri]
+                doff_slot = ri % self._relay_doff_depth
+                owner_states[ri] = {
+                    "gid": gid,
+                    "ri": ri,
+                    "seq": seq_of(ri),
+                    "pred": pred,
+                    "succ": succ,
+                    "input_peers": (
+                        tuple(sorted(group["trainer_specs"][ri]))
+                        if pred is None
+                        else (pred,)
+                    ),
+                    "operation_pred": operation_pred,
+                    "prep_pred": prep_pred,
+                    "doff_pred": doff_predecessor[ri],
+                    "prior_epoch_prep_seq": (
+                        None
+                        if wt == 0
+                        else (wt - 1) * self.num_rounds
+                        + last_prep_by_parity[ri % 2]
+                        + 1
+                    ),
+                    "prior_epoch_doff_seq": (
+                        None
+                        if wt == 0
+                        else (wt - 1) * self.num_rounds
+                        + last_doff_by_slot[doff_slot]
+                        + 1
+                    ),
+                    "input_ready": False,
+                    "prepare_launched": False,
+                    "prep_ready": False,
+                    "offload_launched": False,
+                    "doff_ready": False,
+                    "relay_submitted": False,
+                    "relay_done": succ is None,
+                    "acks_sent": False,
+                    "local_consumed": False,
+                    "prep_free": False,
+                    "upstream_done": False,
+                    "started": time.time(),
+                }
+        if consumes:
+            owner = sw + group["owner_of"][self._rank - sw]
+            for ri in active_rounds:
+                operation_pred, _prep_pred = dependencies[ri]
+                consume_states[ri] = {
+                    "gid": gid,
+                    "ri": ri,
+                    "seq": seq_of(ri),
+                    "owner": owner,
+                    "operation_pred": operation_pred,
+                    "launched": False,
+                    "done": False,
+                    "started": time.time(),
+                }
+
+        result_q: queue.Queue = queue.Queue()
+        if owns and owner_states[active_rounds[0]]["succ"] is not None:
+            self._ensure_relay_bulk_waiters(
+                {(owner_states[active_rounds[0]]["succ"], gid)}
+            )
+        deadline = time.time() + 600.0
+
+        def operation_done(state: dict, states: dict, field: str) -> bool:
+            predecessor = state["operation_pred"]
+            return predecessor is None or states[predecessor][field]
+
+        def prep_slot_free(state: dict) -> bool:
+            predecessor = state["prep_pred"]
+            if predecessor is not None:
+                return owner_states[predecessor]["prep_free"]
+            prior_seq = state["prior_epoch_prep_seq"]
+            return prior_seq is None or self._relay_prep_was_released(
+                gid, state["ri"], prior_seq
+            )
+
+        def doff_slot_free(state: dict) -> bool:
+            predecessor = state["doff_pred"]
+            if predecessor is not None:
+                return owner_states[predecessor]["local_consumed"]
+            prior_seq = state["prior_epoch_doff_seq"]
+            return prior_seq is None or self._relay_doff_was_released(
+                gid, state["ri"], prior_seq
+            )
+
+        def incoming_ready(state: dict) -> bool:
+            return all(
+                self._relay_flag_reached(
+                    self._RELAY_DATA_KIND,
+                    peer,
+                    gid,
+                    state["seq"],
+                )
+                for peer in state["input_peers"]
+            )
+
+        def local_doff_ready(state: dict) -> bool:
+            owner = state["owner"]
+            ri, seq = state["ri"], state["seq"]
+            if owner == self._rank:
+                return owner_states[ri]["doff_ready"]
+            bank = self._relay_peer_local_flags[owner]
+            channel = self._relay_peer_channel[owner][
+                (gid, ri % self._relay_doff_depth)
+            ]
+            return bank.ready(channel) >= seq
+
+        with torch.cuda.device(self.device):
+            while True:
+                progress = False
+
+                while True:
+                    try:
+                        peer, result_gid, ri, _seq, error, _landed = (
+                            result_q.get_nowait()
+                        )
+                    except queue.Empty:
+                        break
+                    if error is not None:
+                        raise RuntimeError(
+                            f"relay forward failed peer={peer} group={gid} round={ri} epoch={wt}"
+                        ) from error
+                    if result_gid != gid or owner_states[ri]["succ"] != peer:
+                        raise RuntimeError(
+                            f"unexpected relay completion peer={peer} group={result_gid} round={ri}"
+                        )
+                    owner_states[ri]["relay_done"] = True
+                    progress = True
+
+                for ri in active_rounds:
+                    if not owns:
+                        break
+                    state = owner_states[ri]
+                    seq = state["seq"]
+                    parity = ri % 2
+                    doff_slot = ri % self._relay_doff_depth
+                    size = group["round_specs"][ri].nbytes(self.dtype_spec)
+
+                    if not state["input_ready"] and incoming_ready(state):
+                        state["input_ready"] = True
+                        if state["pred"] is None:
+                            self._tstats["wire_rdma_bytes"] += sum(
+                                spec.nbytes(self.dtype_spec)
+                                for spec in group["trainer_specs"][ri].values()
+                            )
+                        else:
+                            self._tstats["agh_rdma_bytes"] += size
+                        gantt.rec(
+                            "receiver",
+                            self._rank,
+                            wt,
+                            "relay_recv_wait",
+                            ri,
+                            state["started"],
+                            time.time(),
+                        )
+                        progress = True
+
+                    # Heads snapshot trainer lanes and assemble back into PREP. Downstream input already has
+                    # canonical packed layout, so DATA completion itself makes PREP ready.
+                    if state["pred"] is None:
+                        if (
+                            state["input_ready"]
+                            and not state["prepare_launched"]
+                            and prep_slot_free(state)
+                            and operation_done(state, owner_states, "prep_ready")
+                        ):
+                            assert scratch is not None
+                            stream = self._relay_prepare_stream[(gid, parity)]
+                            with torch.cuda.stream(stream):
+                                snapshot_bytes = self._relay_snapshot_bytes[(gid, ri)]
+                                scratch[:snapshot_bytes].copy_(
+                                    self._relay_prep_buf[gid][parity][:snapshot_bytes]
+                                )
+                                plan = self._relay_prepare_plan[(gid, ri)]
+                                plan.rebase_sources(scratch.data_ptr())
+                                plan.run()
+                                self._relay_prepare_event[(gid, parity)].record(stream)
+                            state["prepare_launched"] = True
+                            state["prepare_t0"] = time.time()
+                            progress = True
+                        if (
+                            state["prepare_launched"]
+                            and not state["prep_ready"]
+                            and self._relay_prepare_event[(gid, parity)].query()
+                        ):
+                            state["prep_ready"] = True
+                            state["prep_ready_at"] = time.time()
+                            gantt.rec(
+                                "receiver",
+                                self._rank,
+                                wt,
+                                "relay_assemble",
+                                ri,
+                                state["prepare_t0"],
+                                state["prep_ready_at"],
+                            )
+                            progress = True
+                    elif (
+                        state["input_ready"]
+                        and not state["prep_ready"]
+                        and prep_slot_free(state)
+                        and operation_done(state, owner_states, "prep_ready")
+                    ):
+                        state["prep_ready"] = True
+                        state["prep_ready_at"] = time.time()
+                        progress = True
+
+                    # PREP->DOFF is ordered per group, and a DOFF generation cannot be overwritten until all
+                    # model readers of its previous generation finish.
+                    if (
+                        state["prep_ready"]
+                        and not state["offload_launched"]
+                        and doff_slot_free(state)
+                        and operation_done(state, owner_states, "doff_ready")
+                    ):
+                        stream = self._relay_offload_stream[(gid, doff_slot)]
+                        with torch.cuda.stream(stream):
+                            self._relay_doff_buf[gid][doff_slot][:size].copy_(
+                                self._relay_prep_buf[gid][parity][:size]
+                            )
+                            for reader in self._relay_local_readers.get(gid, ()):
+                                self._relay_ready_event[
+                                    (gid, doff_slot, reader)
+                                ].record(stream)
+                            self._relay_offload_event[(gid, doff_slot)].record(stream)
+                        state["offload_launched"] = True
+                        state["offload_t0"] = time.time()
+                        progress = True
+                    if (
+                        state["offload_launched"]
+                        and not state["doff_ready"]
+                        and self._relay_offload_event[(gid, doff_slot)].query()
+                    ):
+                        state["doff_ready"] = True
+                        now = time.time()
+                        gantt.rec(
+                            "receiver",
+                            self._rank,
+                            wt,
+                            "relay_doff_copy",
+                            ri,
+                            state["offload_t0"],
+                            now,
+                        )
+                        readers = self._relay_local_readers.get(gid, ())
+                        if readers:
+                            channel = self._relay_local_channel[(gid, doff_slot)]
+                            self._relay_local_flags.publish_ready(seq, channel)
+                        progress = True
+
+                    # Preserve the requested adjacent-round completion fence. Destination parity reuse is the
+                    # independent ACK for this successor's previous use of the same PREP slot.
+                    succ = state["succ"]
+                    if (
+                        state["prep_ready"]
+                        and succ is not None
+                        and not state["relay_submitted"]
+                        and operation_done(state, owner_states, "relay_done")
+                    ):
+                        edge = (succ, gid, parity)
+                        prior_seq = self._relay_forward_last.get(edge)
+                        if prior_seq is None or self._relay_flag_reached(
+                            self._RELAY_ACK_KIND,
+                            succ,
+                            gid,
+                            prior_seq,
+                        ):
+                            submitted_at = time.time()
+                            handle = self.engine.write_async(
+                                self._relay_peer_session[succ],
+                                [self._relay_prep_buf[gid][parity].data_ptr()],
+                                [self._relay_forward_dst[gid][ri]],
+                                [size],
+                            )
+                            self._tstats["agh_rdma_bytes"] += size
+                            self._relay_bulk_wait_queues[(succ, gid)].put(
+                                (
+                                    wt,
+                                    ri,
+                                    seq,
+                                    handle,
+                                    submitted_at,
+                                    "relay_forward",
+                                    result_q,
+                                )
+                            )
+                            self._relay_forward_last[edge] = seq
+                            state["relay_submitted"] = True
+                            progress = True
+
+                    # ACK now describes the merged PREP destination lifetime, not merely assembly. No input
+                    # writer may reuse this parity until both forwarding and offload have stopped reading it.
+                    if (
+                        not state["prep_free"]
+                        and state["doff_ready"]
+                        and state["relay_done"]
+                    ):
+                        state["prep_free"] = True
+                        self._relay_mark_prep_released(gid, ri, seq)
+                        for peer in state["input_peers"]:
+                            self._relay_emit(self._RELAY_ACK_KIND, peer, gid, seq)
+                        state["acks_sent"] = True
+                        gantt.rec(
+                            "receiver",
+                            self._rank,
+                            wt,
+                            "relay_prep_hold",
+                            ri,
+                            state["prep_ready_at"],
+                            time.time(),
+                        )
+                        progress = True
+
+                for ri in active_rounds:
+                    if not consumes:
+                        break
+                    state = consume_states[ri]
+                    owner = state["owner"]
+                    doff_slot = ri % self._relay_doff_depth
+                    if (
+                        not state["launched"]
+                        and local_doff_ready(state)
+                        and operation_done(state, consume_states, "done")
+                    ):
+                        stream = self._relay_consume_stream[(gid, doff_slot)]
+                        ready_event = (
+                            self._relay_offload_event[(gid, doff_slot)]
+                            if owner == self._rank
+                            else self._relay_peer_ready_event[(gid, doff_slot)]
+                        )
+                        stream.wait_event(ready_event)
+                        with torch.cuda.stream(stream):
+                            self._relay_consume_plan[(gid, ri)].run()
+                            self._relay_consume_event[(gid, doff_slot)].record(stream)
+                        state["launched"] = True
+                        state["launch_t0"] = time.time()
+                        progress = True
+                    if (
+                        state["launched"]
+                        and not state["done"]
+                        and self._relay_consume_event[(gid, doff_slot)].query()
+                    ):
+                        state["done"] = True
+                        gantt.rec(
+                            "receiver",
+                            self._rank,
+                            wt,
+                            "relay_internal_consume",
+                            ri,
+                            state["launch_t0"],
+                            time.time(),
+                        )
+                        if owner != self._rank:
+                            bank = self._relay_peer_local_flags[owner]
+                            channel = self._relay_peer_channel[owner][(gid, doff_slot)]
+                            bank.publish_consumed(
+                                self._relay_peer_slot_of_me[owner],
+                                state["seq"],
+                                channel,
+                            )
+                            self._tstats["agh_ipc_bytes"] += group["round_specs"][
+                                ri
+                            ].nbytes(
+                                self.dtype_spec,
+                            )
+                        progress = True
+
+                if owns:
+                    for ri in active_rounds:
+                        state = owner_states[ri]
+                        if (
+                            not state["local_consumed"]
+                            and consume_states[ri]["done"]
+                            and self._relay_local_readers_done(gid, ri, state["seq"])
+                        ):
+                            state["local_consumed"] = True
+                            self._relay_mark_doff_released(gid, ri, state["seq"])
+                            progress = True
+                        downstream_done = state[
+                            "succ"
+                        ] is None or self._relay_flag_reached(
+                            self._RELAY_DATA_KIND,
+                            state["succ"],
+                            gid,
+                            state["seq"],
+                        )
+                        if (
+                            state["local_consumed"]
+                            and downstream_done
+                            and not state["upstream_done"]
+                        ):
+                            for peer in state["input_peers"]:
+                                self._relay_emit(
+                                    self._RELAY_DATA_KIND,
+                                    peer,
+                                    gid,
+                                    state["seq"],
+                                )
+                            state["upstream_done"] = True
+                            progress = True
+
+                if self._relay_local_exit_ready(owner_states, consume_states):
+                    tasks = []
+                    for ri, state in owner_states.items():
+                        if state["upstream_done"]:
+                            continue
+                        tasks.append(
+                            {
+                                "wt": wt,
+                                "gid": gid,
+                                "ri": ri,
+                                "seq": state["seq"],
+                                "succ": state["succ"],
+                                "upstream_peers": state["input_peers"],
+                                "doff_released": state["local_consumed"],
+                            }
+                        )
+                    return tasks
+
+                if not progress:
+                    if time.time() >= deadline:
+                        raise TimeoutError(
+                            f"replica relay timeout epoch={wt} group={gid} "
+                            f"owner={owner_states} consume={consume_states}"
+                        )
+                    time.sleep(1e-4)
+
+    def _receive_weights_relay(self, staged: bool = False) -> None:
+        """Run one independent persistent CPU progress lane per replica group."""
+        if staged:
+            raise RuntimeError("replica-group relay does not support receiver staging")
+        wt = self._epoch
+        self._flag_reaper_ensure()
+        self._relay_retire_check()
+        if not hasattr(self, "_relay_forward_last"):
+            self._relay_forward_last = {}
+
+        gids = sorted(set(self._relay_owned_gids) | set(self._relay_consume_owner))
+        if not gids:
+            raise RuntimeError(
+                f"relay receiver rank {self._rank} has no replica groups"
+            )
+        executor = getattr(self, "_relay_group_executor", None)
+        if executor is None:
+            executor = ThreadPoolExecutor(
+                max_workers=len(gids),
+                thread_name_prefix=f"wbridge-relay-r{self._rank}",
+            )
+            self._relay_group_executor = executor
+        futures = [executor.submit(self._receive_relay_group, wt, gid) for gid in gids]
+        retire_tasks = []
+        for future in futures:
+            retire_tasks.extend(future.result())
+        self._defer_relay_retirement(retire_tasks)
+        self._flag_reaper_check()
+        self._epoch += 1
+        self._trace_state("relay_receive_local_done", epoch=wt)

--- a/examples/weightbridge/wbridge/backend/router.py
+++ b/examples/weightbridge/wbridge/backend/router.py
@@ -1,0 +1,6099 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Multi-round P2P routing plans under per-rank byte caps."""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import json
+import logging
+import mmap
+import os
+import queue
+import struct
+import tempfile
+import threading
+import time
+from typing import Callable, TypeAlias
+
+import torch
+import torch.distributed as dist
+from torch.multiprocessing.reductions import reduce_tensor
+from wbridge.backend.gantt import span as gantt_span
+from wbridge.backend.rdma import DualMooncakeEngine, LocalStagingEngine, RdmaEngine
+from wbridge.backend.tcp_control import TcpControlTransport
+from wbridge.utils.data import (
+    batched_copy,
+    CopyPlan,
+    FuseUnsupported,
+    LoadSpec,
+    Shards,
+    shards_nbytes,
+    shards_numel,
+    ShardSpec,
+    split_shard_evenly,
+    validate_logical_tensor_partitions,
+)
+from wbridge.utils.distributed import get_local_ip, init_custom_process_group
+
+# Per-round cap for total bytes a receiver may take (sum over all senders). Env-overridable so we can
+# trade round count (fewer rounds = fewer, larger RDMA writes = less per-write fixed latency) against the
+# double-buffered wire-buffer memory (which grows with round size).
+RECEIVER_ROUND_CAP_BYTES = int(
+    os.environ.get("WBRIDGE_ROUND_CAP_BYTES") or str(2 * 1024**3)
+)
+
+# Same-node bulk data plane: bypass the network RDMA engine and move the bytes with a direct CUDA-IPC copy
+# over NVLink. This is the SAME mechanism the receiver<->receiver dedup exchange already uses for co-located
+# class peers; setting it here unifies both bulk legs. Same-node replica ready/consumed sequences use shared
+# memory, while other tiny flags still use the selected backend. Set WBRIDGE_SAME_NODE_IPC=0 to force bulk
+# back through that backend (A/B measurement, or if a peer's allocator cannot export IPC handles).
+SAME_NODE_IPC = os.environ.get("WBRIDGE_SAME_NODE_IPC", "1") == "1"
+
+# Bulk (weight) bytes by transport since connect, split by leg — see :meth:`WBEndpoint.transport_stats`.
+# ``ipc`` = direct CUDA-IPC copy over NVLink; ``rdma`` = the selected :class:`RdmaEngine` data path.
+# Cross-node flags ride that backend; CUDA-IPC replica peers use a
+# node-local shared sequence bank so their control path does not dominate small payloads.
+_EMPTY_TSTATS: dict = {
+    "wire_ipc_bytes": 0,  # trainer->rollout leg (sender: written; receiver: landed)
+    "wire_rdma_bytes": 0,
+    "agh_ipc_bytes": 0,  # rollout<->rollout dedup exchange leg (receivers only)
+    "agh_rdma_bytes": 0,
+}
+
+logger = logging.getLogger(__name__)
+
+
+def _hbm_debug(stage: str, **fields) -> None:
+    """Emit an opt-in allocator/device snapshot without perturbing normal runs."""
+    mode = os.environ.get("WBRIDGE_HBM_DEBUG", "").strip().lower()
+    if mode not in {"1", "true", "sync"} or not torch.cuda.is_available():
+        return
+    if mode == "sync":
+        torch.cuda.synchronize()
+    free_bytes, total_bytes = torch.cuda.mem_get_info()
+    record = {
+        "stage": stage,
+        "pid": os.getpid(),
+        "device": torch.cuda.current_device(),
+        "free_bytes": free_bytes,
+        "total_bytes": total_bytes,
+        "allocated_bytes": torch.cuda.memory_allocated(),
+        "reserved_bytes": torch.cuda.memory_reserved(),
+        **fields,
+    }
+    print(
+        "WBHBM " + json.dumps(record, sort_keys=True, separators=(",", ":")), flush=True
+    )
+
+
+def _ipc_event_readers(
+    peers: list[int],
+    peer_ip: dict[int, str],
+    local_ip: str,
+    *,
+    enabled: bool,
+) -> list[int]:
+    """Return only peers able to import this process's CUDA-IPC events."""
+    if not enabled:
+        return []
+    return [peer for peer in peers if peer_ip.get(peer) == local_ip]
+
+
+def _relay_round_predecessors(
+    active_rounds: list[int] | tuple[int, ...],
+    depth: int = 2,
+) -> dict[int, tuple[int | None, int | None]]:
+    """Return ``round -> (previous operation, previous parity use)``.
+
+    Relay buffers are depth two, but adjacent rounds use different parities and can otherwise run far ahead
+    of one another.  The first predecessor keeps one operation stream ordered for a replica group/edge; the
+    second is the exact lifetime fence for the physical parity slot.  Missing rounds are skipped, so a sparse
+    group depends on its previous *actual* operation and its previous actual use of that parity.
+    """
+    if depth < 1:
+        raise ValueError(f"relay buffer depth must be positive, got {depth}")
+    previous_operation: int | None = None
+    previous_parity: dict[int, int] = {}
+    dependencies: dict[int, tuple[int | None, int | None]] = {}
+    for ri in active_rounds:
+        if ri in dependencies:
+            raise ValueError(f"duplicate relay round {ri}")
+        parity = ri % depth
+        dependencies[ri] = (previous_operation, previous_parity.get(parity))
+        previous_operation = ri
+        previous_parity[parity] = ri
+    return dependencies
+
+
+def _enable_cuda_peer_access(dst_device: int, src_device: int) -> None:
+    """Enable SM-issued loads from ``src_device`` while executing on ``dst_device``."""
+    if dst_device == src_device:
+        return
+    if not torch.cuda.can_device_access_peer(dst_device, src_device):
+        raise RuntimeError(
+            f"CUDA device {dst_device} cannot access peer device {src_device}"
+        )
+    try:
+        from cuda.bindings import runtime as cudart
+    except (
+        ImportError
+    ) as exc:  # pragma: no cover - cuda-python is a required runtime dependency
+        raise RuntimeError(
+            "fused internal consume requires cuda-python for CUDA peer mapping"
+        ) from exc
+    with torch.cuda.device(dst_device):
+        error = cudart.cudaDeviceEnablePeerAccess(src_device, 0)[0]
+    allowed = {
+        cudart.cudaError_t.cudaSuccess,
+        cudart.cudaError_t.cudaErrorPeerAccessAlreadyEnabled,
+    }
+    if error not in allowed:
+        raise RuntimeError(
+            f"cudaDeviceEnablePeerAccess({src_device}) on device {dst_device} failed: {error}"
+        )
+
+
+def _open_cuda_ipc_mapping(dst_device: int, metadata: dict) -> tuple[int, int]:
+    """Open an exported allocation in ``dst_device``'s address space.
+
+    Returns ``(tensor_base, allocation_base)``. The first is the pointer corresponding to the exporter's
+    tensor ``data_ptr`` and is used to translate source views; the second must be passed to
+    :func:`_close_cuda_ipc_mapping`. PyTorch's normal tensor rebuild opens on the exporter's device, which is
+    suitable for ``cudaMemcpyPeerAsync`` but is not a dereferenceable address for a destination-device
+    kernel.
+    """
+    try:
+        from cuda.bindings import runtime as cudart
+    except (
+        ImportError
+    ) as exc:  # pragma: no cover - cuda-python is a required runtime dependency
+        raise RuntimeError(
+            "fused internal consume requires cuda-python for destination-side IPC mapping"
+        ) from exc
+
+    raw = bytes(metadata["handle"])
+    if len(raw) != 64:
+        raise RuntimeError(f"invalid CUDA IPC memory handle size {len(raw)}")
+    handle = cudart.cudaIpcMemHandle_t()
+    handle.reserved = raw
+    with torch.cuda.device(dst_device):
+        error, device_ptr = cudart.cudaIpcOpenMemHandle(
+            handle,
+            cudart.cudaIpcMemLazyEnablePeerAccess,
+        )
+    if error != cudart.cudaError_t.cudaSuccess:
+        raise RuntimeError(
+            f"cudaIpcOpenMemHandle on device {dst_device} failed: {error}"
+        )
+    allocation_base = int(device_ptr)
+    return allocation_base + int(metadata["tensor_offset_bytes"]), allocation_base
+
+
+def _close_cuda_ipc_mapping(dst_device: int, allocation_base: int) -> None:
+    from cuda.bindings import runtime as cudart
+
+    with torch.cuda.device(dst_device):
+        error = cudart.cudaIpcCloseMemHandle(allocation_base)[0]
+    if error != cudart.cudaError_t.cudaSuccess:
+        raise RuntimeError(
+            f"cudaIpcCloseMemHandle on device {dst_device} failed: {error}"
+        )
+
+
+def _cuda_ipc_kernel_metadata(reduced: tuple) -> dict:
+    """Return the raw CUDA-IPC allocation metadata needed by a peer-load kernel.
+
+    ``torch.multiprocessing.reductions.reduce_tensor`` is still published alongside this metadata so the
+    remote process owns a normal tensor object that keeps the exported allocation alive.  The raw mapping is
+    opened separately on the *consumer* GPU: a kernel launched there can then dereference the producer's
+    bytes directly instead of first copying them into a local staging tensor.
+    """
+    _rebuild, reduce_args = reduced
+    storage_handle = bytes(reduce_args[7])
+    if len(storage_handle) < 64:
+        raise RuntimeError(
+            f"wbridge: invalid exported CUDA IPC handle size {len(storage_handle)}"
+        )
+    tensor_itemsize = torch.empty((), dtype=reduce_args[5]).element_size()
+    return {
+        # PyTorch prefixes its allocator handle with bookkeeping bytes on current releases;
+        # cudaIpcOpenMemHandle consumes the trailing cudaIpcMemHandle_t payload itself.
+        "handle": storage_handle[-64:],
+        "tensor_offset_bytes": int(reduce_args[9])
+        + int(reduce_args[3]) * tensor_itemsize,
+    }
+
+
+class _LocalReplFlagBank:
+    """Node-local ready/consumed sequences for CUDA-IPC replica peers.
+
+    Bulk same-node exchange already bypasses the network RDMA backend and uses CUDA IPC. Sending its tiny
+    host-side rendezvous flags through one RDMA operation per peer is both unnecessary and, for an
+    eight-GPU node, much more expensive than the payload. One receiver owns a small mmap-backed bank:
+
+    Each channel contains one producer-ready sequence followed by one consumed sequence per reader. Channel
+    zero retains the original whole-column/PREP lifetime. Topology adds one channel per external
+    ``grecv[k, parity]`` slot, allowing adjacent rounds to become ready and be released independently.
+
+    The ready sequence does not replace the CUDA IPC event.  The producer records every per-reader event
+    before publishing the CPU sequence; the reader first observes that sequence and then enqueues its event
+    wait, preserving the existing GPU visibility fence. Cross-node peers continue to use RDMA flags.
+    """
+
+    _I64 = struct.Struct("=q")
+
+    def __init__(
+        self,
+        fd: int,
+        path: str,
+        view: mmap.mmap,
+        *,
+        owner: bool,
+        slots: int,
+        channels: int,
+    ) -> None:
+        self._fd = fd
+        self.path = path
+        self._view = view
+        self._owner = owner
+        self.slots = slots
+        self.channels = channels
+
+    @classmethod
+    def create(cls, slots: int, *, channels: int = 1) -> "_LocalReplFlagBank":
+        assert slots >= 0 and channels >= 1
+        shared_dir = os.environ.get("WBRIDGE_LOCAL_SHM_DIR")
+        if not shared_dir:
+            shared_dir = (
+                "/dev/shm" if os.path.isdir("/dev/shm") else tempfile.gettempdir()
+            )
+        shared_dir = os.path.abspath(os.path.expanduser(shared_dir))
+        fd, path = tempfile.mkstemp(prefix="wbridge-repl-", dir=shared_dir)
+        size = cls._I64.size * channels * (1 + slots)
+        os.ftruncate(fd, size)
+        return cls(
+            fd,
+            path,
+            mmap.mmap(fd, size, access=mmap.ACCESS_WRITE),
+            owner=True,
+            slots=slots,
+            channels=channels,
+        )
+
+    @classmethod
+    def open(
+        cls,
+        path: str,
+        *,
+        slots: int | None = None,
+        channels: int = 1,
+    ) -> "_LocalReplFlagBank":
+        fd = os.open(path, os.O_RDWR)
+        size = os.fstat(fd).st_size
+        if size < cls._I64.size:
+            os.close(fd)
+            raise RuntimeError(
+                f"invalid local replica flag bank {path!r}: {size} bytes"
+            )
+        words = size // cls._I64.size
+        if slots is None:
+            if channels != 1:
+                os.close(fd)
+                raise ValueError(
+                    "slots must be provided when opening a multi-channel replica flag bank"
+                )
+            slots = words - 1
+        if words != channels * (1 + slots):
+            os.close(fd)
+            raise RuntimeError(
+                f"replica flag bank shape mismatch {path!r}: words={words}, "
+                f"slots={slots}, channels={channels}"
+            )
+        return cls(
+            fd,
+            path,
+            mmap.mmap(fd, size, access=mmap.ACCESS_WRITE),
+            owner=False,
+            slots=slots,
+            channels=channels,
+        )
+
+    def _base(self, channel: int) -> int:
+        if not 0 <= channel < self.channels:
+            raise IndexError(f"flag channel {channel} outside [0,{self.channels})")
+        return self._I64.size * channel * (1 + self.slots)
+
+    def publish_ready(self, seq: int, channel: int = 0) -> None:
+        self._I64.pack_into(self._view, self._base(channel), seq)
+
+    def ready(self, channel: int = 0) -> int:
+        return self._I64.unpack_from(self._view, self._base(channel))[0]
+
+    def publish_consumed(self, slot: int, seq: int, channel: int = 0) -> None:
+        if not 0 <= slot < self.slots:
+            raise IndexError(f"reader slot {slot} outside [0,{self.slots})")
+        self._I64.pack_into(
+            self._view, self._base(channel) + self._I64.size * (1 + slot), seq
+        )
+
+    def consumed(self, slot: int, channel: int = 0) -> int:
+        if not 0 <= slot < self.slots:
+            raise IndexError(f"reader slot {slot} outside [0,{self.slots})")
+        return self._I64.unpack_from(
+            self._view,
+            self._base(channel) + self._I64.size * (1 + slot),
+        )[0]
+
+    def close(self) -> None:
+        try:
+            self._view.close()
+        finally:
+            try:
+                os.close(self._fd)
+            finally:
+                if self._owner:
+                    try:
+                        os.unlink(self.path)
+                    except FileNotFoundError:
+                        pass
+
+
+CommRoundPlan: TypeAlias = tuple[ShardSpec, dict[int, ShardSpec]]
+
+
+_EVEN_ROUND_SOFT_HEADROOM_PCT = 5
+
+
+def _even_round_soft_target(total: int, rounds: int, hard_cap: int) -> int:
+    """Per-rank balancing threshold with a little room for indivisible tensor names.
+
+    The target is deliberately softer than ``ceil(total / rounds)``: without headroom, one rank crossing
+    that exact average can reject a tiny tensor that still fits every hard cap and create a runt round.
+    """
+    assert total >= 0 and rounds >= 1 and hard_cap >= 0
+    target = -(-total // rounds)
+    target = -(-(target * (100 + _EVEN_ROUND_SOFT_HEADROOM_PCT)) // 100)
+    return min(target, hard_cap)
+
+
+def _canonical_dtype_spec(
+    dtype_specs: list[dict[str, torch.dtype]],
+) -> dict[str, torch.dtype]:
+    """Merge per-rank dtype maps into one name-sorted map shared identically by every rank."""
+    merged: dict[str, torch.dtype] = {}
+    for dtype_spec in dtype_specs:
+        for name, dtype in dtype_spec.items():
+            if name in merged:
+                assert merged[name] == dtype, f"Dtype mismatch for {name}"
+            else:
+                merged[name] = dtype
+    return {name: merged[name] for name in sorted(merged)}
+
+
+def _arena_slot_offset(off: int, ri: int, depth: int, stride: int) -> int:
+    """Absolute byte offset of a per-round region inside a depth-buffered arena slot.
+
+    ``arena_layout``'s RECV and fused-prepare (own/send) offsets are relative to one ``stride``-byte slot.
+    The shared ``grecv`` bank is already absolute and must not pass through this helper. Keeping the slot
+    arithmetic here prevents a slotted path from silently falling back to parity zero.
+    """
+    assert depth >= 1 and stride >= 0 and ri >= 0 and off >= 0
+    return (ri % depth) * stride + off
+
+
+def _arena_slot_predecessors(rounds: list[int], depth: int) -> dict[int, int | None]:
+    """Map each active round to the previous active round that used the same arena slot.
+
+    Slot ownership follows the *global round number* (``ri % depth``), not position in the filtered list of
+    rounds active on one endpoint.  Those differ whenever an endpoint has an empty round; using
+    ``rounds[idx - depth]`` then waits for the wrong consumer and can either hang or overwrite live bytes.
+    """
+    assert depth >= 1
+    last: dict[int, int] = {}
+    out: dict[int, int | None] = {}
+    for ri in rounds:
+        assert ri >= 0
+        slot = ri % depth
+        out[ri] = last.get(slot)
+        last[slot] = ri
+    return out
+
+
+def _arena_peer_predecessors(
+    rounds: list[dict],
+    field: str = "send",
+    *,
+    depth: int = 1,
+) -> list[dict[int, tuple[int, int]]]:
+    """For every round/peer write, return the prior generation of its peer/parity GRECV slot.
+
+    The shared ``grecv`` bank has ``depth`` stable destination slots per peer, selected by global round
+    parity. Before writing peer ``p`` in round ``ri``, the writer observes the consumed flag for the prior
+    use of ``(p, ri % depth)``. A predecessor is ``(epoch_delta, round)``: ``(0, r)`` is an earlier round in
+    this epoch, while ``(-1, r)`` wraps the first use of one parity to that parity's final use in the prior
+    epoch. The caller skips a negative epoch on epoch zero, when every slot is initially free.
+
+    Peer sets may vary between rounds, so the predecessor is tracked independently for every
+    ``(peer, parity)`` rather than inferred as simply ``ri - depth``.
+    """
+    assert depth >= 1
+    active: list[list[int]] = []
+    final: dict[tuple[int, int], int] = {}
+    for ri, rd in enumerate(rounds):
+        peers = [
+            peer for peer, (_off, nb) in sorted(rd.get(field, {}).items()) if nb > 0
+        ]
+        active.append(peers)
+        for peer in peers:
+            final[(peer, ri % depth)] = ri
+
+    last: dict[tuple[int, int], int] = {}
+    out: list[dict[int, tuple[int, int]]] = []
+    for ri, peers in enumerate(active):
+        pred: dict[int, tuple[int, int]] = {}
+        for peer in peers:
+            key = (peer, ri % depth)
+            pred[peer] = (0, last[key]) if key in last else (-1, final[key])
+            last[key] = ri
+        out.append(pred)
+    return out
+
+
+def _arena_total_bytes(rounds: list[dict], depth: int, stride: int) -> int:
+    """Physical bytes for ``depth`` rollout PREP slots plus depth-buffered ``grecv`` slots."""
+    assert depth >= 1 and stride >= 0
+    total = depth * stride
+    for rd in rounds:
+        for off, nb in rd.get("grecv", {}).values():
+            assert off >= depth * stride and nb >= 0
+            total = max(total, off + nb)
+    return total
+
+
+def _doff_arena_layout(
+    rounds: list[dict],
+    prep_stride: int,
+    depth: int,
+) -> tuple[list[dict], int, int]:
+    """Build the compact, non-RDMA internal-offload (DOFF) arena.
+
+    A DOFF generation is a shadow of one rollout SEND/PREP slot plus one exclusive region for every direct
+    external source.  External payload sizes are intentionally *not* pooled: each source receives its own
+    maximum-sized region, so a small source can never be blocked behind or fragmented by a large one.  The
+    returned per-round offsets select ``round % depth`` while retaining each round's exact payload length.
+
+    Returns ``(round_layout, total_bytes, generation_stride)``.  ``round_layout[ri]["own"]`` covers the
+    complete SEND/PREP slot and ``round_layout[ri]["grecv"][source]`` covers the offloaded copy of that
+    source's GRECV payload.
+    """
+    assert depth >= 1 and prep_stride >= 0
+    source_max: dict[int, int] = {}
+    for rd in rounds:
+        for source, (_off, nb) in rd.get("grecv", {}).items():
+            assert nb >= 0
+            source_max[source] = max(source_max.get(source, 0), nb)
+
+    source_rel: dict[int, int] = {}
+    generation_stride = prep_stride
+    for source in sorted(source_max):
+        source_rel[source] = generation_stride
+        generation_stride += source_max[source]
+
+    out: list[dict] = []
+    for ri, rd in enumerate(rounds):
+        base = (ri % depth) * generation_stride
+        out.append(
+            {
+                "slot": ri % depth,
+                "own": (base, prep_stride),
+                "grecv": {
+                    source: (base + source_rel[source], nb)
+                    for source, (_off, nb) in rd.get("grecv", {}).items()
+                },
+            }
+        )
+    return out, depth * generation_stride, generation_stride
+
+
+def _arena_recv_total_bytes(rounds: list[dict], depth: int) -> int:
+    """Physical bytes for the isolated trainer-ingress allocation.
+
+    :meth:`WeightRouter.arena_layout` gives every trainer sender a stable, non-overlapping lane within each
+    parity slot and records the common slot stride as ``recv_stride``.  Keeping this allocation separate from
+    the rollout PREP/GRECV arena means neither an RDMA-capable trainer nor a same-node trainer pull can touch a
+    buffer that rollout peers are concurrently reading.
+    """
+    assert depth >= 1
+    strides = {rd.get("recv_stride", 0) for rd in rounds}
+    assert len(strides) <= 1, f"inconsistent RECV strides: {strides}"
+    stride = next(iter(strides), 0)
+    assert stride >= 0
+    for ri, rd in enumerate(rounds):
+        for off, nb in rd.get("recv", {}).values():
+            assert off >= 0 and nb >= 0 and off + nb <= stride, (ri, off, nb, stride)
+    return depth * stride
+
+
+def _merge_recv_prep_layout(rounds: list[dict], depth: int, prep_stride: int) -> int:
+    """Overlay each RECV parity slot with its PREP parity slot and relocate GRECV after them.
+
+    ``arena_layout`` initially addresses PREP at ``depth * prep_stride`` and GRECV immediately after it.
+    The merged experimental layout uses a physical slot large enough for either the stable trainer-ingress
+    lanes or PREP.  RECV is snapshotted to an epoch-scoped non-RDMA buffer before A+R overwrites the slot.
+    Only absolute GRECV offsets need relocation; RECV/PREP offsets stay relative to their physical slot.
+    """
+    assert depth >= 1 and prep_stride >= 0
+    recv_strides = {rd.get("recv_stride", 0) for rd in rounds}
+    assert len(recv_strides) <= 1, f"inconsistent RECV strides: {recv_strides}"
+    recv_stride = next(iter(recv_strides), 0)
+    slot_stride = max(recv_stride, prep_stride)
+    shift = depth * (slot_stride - prep_stride)
+    if shift:
+        for rd in rounds:
+            rd["grecv"] = {
+                peer: (off + shift, nb)
+                for peer, (off, nb) in rd.get("grecv", {}).items()
+            }
+    return slot_stride
+
+
+def _numa_cpus(node: int) -> list[int] | None:
+    """CPU ids belonging to NUMA `node`, parsed from /sys; None if unavailable."""
+    try:
+        spec = open(f"/sys/devices/system/node/node{node}/cpulist").read().strip()
+    except OSError:
+        return None
+    cpus: list[int] = []
+    for part in spec.split(","):
+        if not part:
+            continue
+        if "-" in part:
+            a, b = part.split("-")
+            cpus += list(range(int(a), int(b) + 1))
+        else:
+            cpus.append(int(part))
+    return cpus or None
+
+
+@contextlib.contextmanager
+def _numa_local_alloc(node: int):
+    """Temporarily bind this thread to `node`'s CPUs so pinned-host allocations first-touch NUMA-local.
+
+    Host RDMA to/from DRAM that is cross-NUMA from the NIC materially reduces bandwidth; allocating the
+    staging buffers on the NIC's NUMA node closed most of the gap in isolated testing. We restore the
+    prior affinity on exit so we don't confine the SGLang/Megatron worker threads to one socket. No-op when
+    the node is unknown (-1) or its cpulist can't be read (falls back to default placement).
+    """
+    cpus = _numa_cpus(node) if node is not None and node >= 0 else None
+    if not cpus:
+        yield
+        return
+    try:
+        prev = os.sched_getaffinity(0)
+    except OSError:
+        prev = None
+    try:
+        try:
+            os.sched_setaffinity(0, set(cpus))
+        except OSError:
+            pass
+        yield
+    finally:
+        if prev:
+            with contextlib.suppress(OSError):
+                os.sched_setaffinity(0, set(prev))
+
+
+def _shards_canonical_key(shards: Shards):
+    """Order-independent hashable identity of a worker's shard set for one tensor."""
+    return tuple(sorted(tuple(tuple(dim) for dim in shard) for shard in shards))
+
+
+def _carve_named(spec: ShardSpec, buf_u8: "torch.Tensor", dtype_spec: dict) -> dict:
+    """Present a contiguous uint8 buffer as a per-name logical dict matching ``ShardSpec.make_named_buffer``
+    (flat ``shards_numel``-element tensor per name, in spec order). Lets the persistent, RDMA-registered
+    all-gather buffers be driven by the existing 2-stage machinery (``setitem_pairs``/``copy_fromto_pairs``)
+    with no transient allocation."""
+    out: dict = {}
+    off = 0
+    for name, shards in spec:
+        it = dtype_spec[name].itemsize
+        nbytes = shards_numel(shards) * it
+        out[name] = buf_u8[off : off + nbytes].view(dtype_spec[name])
+        off += nbytes
+    return out
+
+
+def _packed_name_regions(
+    spec: ShardSpec, dtype_spec: dict[str, torch.dtype]
+) -> dict[str, tuple[int, int]]:
+    """Byte region of each tensor name inside a buffer packed in ``ShardSpec`` iteration order."""
+    out: dict[str, tuple[int, int]] = {}
+    off = 0
+    for name, shards in spec:
+        nb = shards_nbytes(shards, dtype_spec[name])
+        out[name] = (off, nb)
+        off += nb
+    return out
+
+
+def _packed_copy_spans(
+    src_spec: ShardSpec,
+    dst_spec: ShardSpec,
+    names: tuple[str, ...] | list[str] | set[str],
+    dtype_spec: dict[str, torch.dtype],
+    *,
+    src_base: int = 0,
+    dst_base: int = 0,
+) -> list[tuple[int, int, int]]:
+    """Direct byte-copy spans for whole tensor names between two packed layouts.
+
+    Multi-group topology packs the exact external payload once during assemble+repack, but its destination
+    is the stable ``grecv[source]`` layout, which can contain other groups' names between the selected ones.
+    Likewise, an internal peer's ``own`` / ``grecv`` layouts can feed several disjoint destinations without
+    a repack between the external and internal phases. Adjacent source+destination spans are coalesced.
+    """
+    src_regions = _packed_name_regions(src_spec, dtype_spec)
+    dst_regions = _packed_name_regions(dst_spec, dtype_spec)
+    spans: list[tuple[int, int, int]] = []
+    for name in sorted(set(names)):
+        assert name in src_regions and name in dst_regions, (
+            f"missing packed topology name {name}"
+        )
+        assert src_spec[name] == dst_spec[name], f"topology shard mismatch for {name}"
+        so, sn = src_regions[name]
+        do, dn = dst_regions[name]
+        assert sn == dn
+        cur = (src_base + so, dst_base + do, sn)
+        if (
+            spans
+            and spans[-1][0] + spans[-1][2] == cur[0]
+            and spans[-1][1] + spans[-1][2] == cur[1]
+        ):
+            ps, pd, pn = spans[-1]
+            spans[-1] = (ps, pd, pn + cur[2])
+        else:
+            spans.append(cur)
+    return spans
+
+
+def _dedup_specs(specs: list[ShardSpec]) -> list[ShardSpec]:
+    """De-replicate a role's specs (per tensor name): workers holding an *identical* shard set form a
+    replication class; each shared shard is split evenly along its longest axis so member ``j`` of a
+    size-``k`` class is viewed as owning only sub-shard ``j``. The sub-shards partition the class's
+    shards. Deterministic (sorted names / classes / members / shard keys) so every rank derives the
+    identical reduction — required for the per-pair flag ping-pong to stay in lockstep.
+    """
+    ns = len(specs)
+    reduced: list[dict[str, Shards]] = [{} for _ in range(ns)]
+    names: set[str] = set()
+    for spec in specs:
+        names |= set(spec.entries.keys())
+    for name in sorted(names):
+        classes: dict = {}  # canonical shard key -> [member ranks], insertion-ordered by rank
+        for i in range(ns):
+            if name in specs[i].entries:
+                classes.setdefault(_shards_canonical_key(specs[i][name]), []).append(i)
+        for members in classes.values():
+            members.sort()
+            k = len(members)
+            # Canonical (sorted) shard list so every rank agrees which sub-shard is the j-th.
+            canon = sorted(
+                (list(shard) for shard in specs[members[0]][name]),
+                key=lambda sh: tuple(tuple(dim) for dim in sh),
+            )
+            for j, i in enumerate(members):
+                subs = [
+                    ss
+                    for shard in canon
+                    if (ss := split_shard_evenly(shard, k, j)) is not None
+                ]
+                if subs:
+                    reduced[i][name] = subs
+    return [ShardSpec(entries) for entries in reduced]
+
+
+def dedup_send_specs(send_specs: list[ShardSpec]) -> list[ShardSpec]:
+    """Sender-side de-replication: replicated trainers each send only a disjoint sub-slice, so
+    ``compute_overlap`` yields no duplicate sends and the receiver reconstructs the shard as the union
+    over its sender peers. (Physical model params unchanged — ``_fuse_copy_pairs`` intersects the reduced
+    overlap with the full LoadSpec, so each sender packs just its sub-slice.) See :func:`_dedup_specs`."""
+    return _dedup_specs(send_specs)
+
+
+def consolidate_groups(
+    nat_classes: dict[str, list[list[int]]],
+    class_bytes: dict[tuple[str, tuple[int, ...]], int],
+    threshold: float,
+) -> dict[str, list[list[int]]]:
+    """Consolidate small, widely-replicated exchange groups (opt-in dedup refinement).
+
+    A tensor replicated across ``k`` rollout workers is split k-way + reconstructed by a k-way all-gather;
+    for a *small* tensor with *large* ``k`` that all-gather costs many per-pair flag handshakes while
+    saving almost no RDMA. This pass repeatedly dissolves a multi-worker group that carries a low-traffic
+    receiver<->receiver pair (edge traffic < ``threshold`` bytes) into a PARTITION of smaller pieces —
+    each either an EXISTING group (piggyback its already-paid sync edges) or a singleton (direct full send
+    from the trainer, no exchange) — trading a little sender RDMA for much less exchange sync.
+
+    Inputs: ``nat_classes`` = natural per-tensor replication classes ``{name: [sorted class, ...]}``;
+    ``class_bytes[(name, tuple(class))]`` = that shard's bytes. ``threshold`` may be ``float('inf')`` for
+    the most aggressive decomposition (used to activate the topology-aware exchange, where we want every
+    dissolvable group folded onto the standalone same-rank classes). Returns the refined grouping (same
+    shape) — a partition of each natural class. Pure + deterministic (sorted iteration everywhere), so every
+    rank derives the identical grouping (required for the flag ping-pong lockstep). Terminates: each round
+    removes exactly one distinct multi-worker group and adds none (cover pieces are existing groups or
+    singletons), and — via the overlap guard below — a group with no other multi-worker group overlapping
+    it is never targeted, so ``threshold=inf`` still terminates (and standalone classes stay intact)."""
+    # Per tensor: list of (sub-group, shard bytes), starting at the natural classes.
+    tsg: dict[str, list[tuple[frozenset, int]]] = {
+        name: [(frozenset(c), class_bytes[(name, tuple(c))]) for c in nat_classes[name]]
+        for name in sorted(nat_classes)
+    }
+
+    def group_bytes() -> dict[frozenset, int]:
+        gb: dict[frozenset, int] = {}
+        for name in sorted(tsg):
+            for sg, b in tsg[name]:
+                gb[sg] = gb.get(sg, 0) + b
+        return gb
+
+    while True:
+        gb = group_bytes()
+        # (1) per-pair edge traffic: a size-k group of B bytes puts 2B/k on each of its worker pairs.
+        pair_t: dict[tuple[int, int], float] = {}
+        for rs, b in gb.items():
+            k = len(rs)
+            if k < 2:
+                continue
+            contrib = 2.0 * b / k
+            ms = sorted(rs)
+            for a in range(k):
+                for c in range(a + 1, k):
+                    key = (ms[a], ms[c])
+                    pair_t[key] = pair_t.get(key, 0.0) + contrib
+        low = {p for p, t in pair_t.items() if t < threshold}
+        if not low:
+            break
+        # Pick a dissolvable group: a multi-worker replica-set carrying some low pair (deterministic:
+        # largest first, then lexicographic — every rank dissolves the same one).
+        target = None
+        for rs in sorted(gb, key=lambda s: (-len(s), sorted(s))):
+            if len(rs) < 2:
+                continue
+            ms = sorted(rs)
+            if not any(
+                (ms[a], ms[c]) in low
+                for a in range(len(ms))
+                for c in range(a + 1, len(ms))
+            ):
+                continue
+            # Overlap guard: only dissolve a group that another multi-worker group can help cover (shares
+            # a worker with it). A standalone group can only be covered by singletons, which would destroy
+            # its dedup entirely — leave it intact. This preserves the same-rank classes the topo-aware
+            # exchange rides on, and guarantees termination at threshold=inf (a group with no overlapping
+            # peer group is never targeted, so the multi-worker group count still strictly decreases).
+            if any(rs & other for other in gb if other != rs and len(other) >= 2):
+                target = rs
+                break
+        if target is None:
+            break
+        # Greedy set-cover of `target` by existing strictly-smaller subsets (worker-count desc); remainder
+        # -> singletons. Each piece is a valid sub-group (subset of the class -> holds the shard).
+        remaining = set(target)
+        cover: list[frozenset] = []
+        for g in sorted(
+            (s for s in gb if s != target and len(s) < len(target)),
+            key=lambda s: (-len(s), sorted(s)),
+        ):
+            if g <= remaining:
+                cover.append(g)
+                remaining -= g
+        cover += [frozenset((w,)) for w in sorted(remaining)]
+        # Reassign every tensor that used `target` to the cover pieces; each piece re-fetches the full
+        # shard (keeps that tensor's bytes) -> its bytes fold onto the existing piggyback groups.
+        for name in sorted(tsg):
+            new: list[tuple[frozenset, int]] = []
+            for sg, b in tsg[name]:
+                if sg == target:
+                    new.extend((piece, b) for piece in cover)
+                else:
+                    new.append((sg, b))
+            tsg[name] = new
+
+    return {name: sorted([sorted(sg) for sg, _ in tsg[name]]) for name in sorted(tsg)}
+
+
+def _dedup_specs_by_subgroups(
+    specs: list[ShardSpec], subgroups: dict[str, list[list[int]]]
+) -> list[ShardSpec]:
+    """Like :func:`_dedup_specs` but split each tensor within the PROVIDED sub-group (a refinement of its
+    natural class from :func:`consolidate_groups`) instead of the internally-derived class. Member ``j`` of
+    a size-``m`` sub-group owns sub-shard ``j``; a size-1 sub-group keeps the full shard (0-peer receive)."""
+    reduced: list[dict[str, Shards]] = [{} for _ in specs]
+    for name in sorted(subgroups):
+        for sg in subgroups[name]:
+            members = sorted(sg)
+            m = len(members)
+            canon = sorted(
+                (list(shard) for shard in specs[members[0]][name]),
+                key=lambda sh: tuple(tuple(dim) for dim in sh),
+            )
+            for j, i in enumerate(members):
+                subs = [
+                    ss
+                    for shard in canon
+                    if (ss := split_shard_evenly(shard, m, j)) is not None
+                ]
+                if subs:
+                    reduced[i][name] = subs
+    return [ShardSpec(entries) for entries in reduced]
+
+
+class WeightRouter:
+    """Computes Data Plane P2P routing between Trainer Workers and Rollout Workers."""
+
+    def __init__(
+        self,
+        rank: int,
+        sender_ws: int,
+        all_specs: list[ShardSpec],
+        dtype_spec: dict[str, torch.dtype],
+        *,
+        global_rounds: list[set[str]] | None = None,
+        peer_ip: dict[int, str] | None = None,
+        direct_same_node: bool = False,
+    ) -> None:
+        self.rank = rank
+        self.sender_ws = sender_ws
+        self.world_size = len(all_specs)
+        self.receiver_ws = self.world_size - sender_ws
+        assert all(isinstance(spec, ShardSpec) for spec in all_specs), (
+            "all_specs must be a list of ShardSpec"
+        )
+        validate_logical_tensor_partitions(all_specs)
+        self.send_specs = all_specs[:sender_ws]
+        self.recv_specs = all_specs[sender_ws:]
+        self.direct_same_node = bool(direct_same_node)
+        # Sender-side de-replication: workers holding identical shards each send only a disjoint sub-slice.
+        # Always on — a no-op when nothing is replicated (a class of size 1 splits to itself).
+        self.send_specs = dedup_send_specs(self.send_specs)
+        self.dtype_spec = dtype_spec
+        # Receiver-side de-replication (per-tensor): every tensor is split by its OWN replication-class
+        # size, so replicated rollouts each receive only a disjoint sub-slice from the senders, then
+        # reconstruct the full shard by a per-tensor all-to-all over the split ingress/exchange buffers (see
+        # `_setup_rdma_buffers`). Keep the ORIGINAL recv specs — class discovery and the full-shard consume
+        # need them. Always on (no-op when unreplicated: a size-1 class splits to itself; a rank with no
+        # class peer just receives + consumes its own slice — the 0-peer arena case).
+        self.recv_specs_full = list(self.recv_specs)
+        # Group consolidation, threshold-controlled via WBRIDGE_DEDUP_PAIR_BYTES (per-pair edge bytes):
+        #   0            -> OFF: natural class dedup, byte-identical to the original class-based dedup.
+        #   large / inf (default) -> most aggressive: fold every dissolvable group onto the standalone
+        #                   same-rank classes, reducing exchange fan-out and duplicate traffic.  The
+        #                   topology-aware exchange can also consume the unconsolidated overlapping groups
+        #                   as long as each individual group is balanced across its participating nodes.
+        # When on, the deduped recv specs + recv_tensor_classes both use the sub-groups.
+        self._recv_subgroups: dict[str, list[list[int]]] | None = None
+        # These structures depend only on the canonical sender/receiver specs, not on how names are split
+        # into communication rounds.  The RDMA-cap planner evaluates several candidate round counts; without
+        # caching, each probe rebuilt the full Cartesian shard-overlap matrix and all natural receiver classes.
+        self._recv_tensor_classes_cache: dict[str, list[list[int]]] | None = None
+        self._arena_class_index_source: dict[str, list[list[int]]] | None = None
+        self._arena_class_index: dict[str, dict[int, list[int]]] = {}
+        self._pair_name_bytes_by_recv: list[dict[int, dict[str, int]]] | None = None
+        self._trainer_peer_counts_cache: list[int] | None = None
+        self._recv_name_bytes_cache: list[dict[str, int]] | None = None
+        self.planner_invariant_seconds = 0.0
+        self.planner_probe_timings: list[dict[str, float | int]] = []
+        self._last_rollout_rdma_timing: dict[str, float] = {}
+        # The library default consolidates aggressively to reduce exchange fan-out. Keep an explicit
+        # 0 escape hatch for tensors that are too large to duplicate while dissolving a replication group.
+        thr = float(os.environ.get("WBRIDGE_DEDUP_PAIR_BYTES", "inf") or "0")
+        if self.direct_same_node:
+            # A local receiver consumes trainer pack buffers directly, so it needs its complete runtime
+            # shard from the trainers and has no receiver-receiver reconstruction class.  Keep sender-side
+            # de-duplication above (e.g. CP replicas still split their source ownership), but route that
+            # complete union independently to every rollout replica.  Singleton classes make every existing
+            # arena/topology query agree that no rollout exchange is required.
+            self._recv_subgroups = {
+                name: [
+                    [ri]
+                    for ri, spec in enumerate(self.recv_specs_full)
+                    if name in spec.entries
+                ]
+                for name in sorted(
+                    {name for spec in self.recv_specs_full for name in spec.entries}
+                )
+            }
+            if self.rank in (0, self.sender_ws):
+                role = "sender" if self.rank < self.sender_ws else "receiver"
+                logger.info(
+                    "wbridge direct-same-node [rank %d %s]: full receiver routes; rollout exchange off",
+                    self.rank,
+                    role,
+                )
+        elif thr > 0:
+            nat = self._natural_recv_classes()
+            class_bytes = {
+                (name, tuple(c)): shards_nbytes(
+                    self.recv_specs_full[c[0]][name], self.dtype_spec[name]
+                )
+                for name in nat
+                for c in nat[name]
+            }
+            self._recv_subgroups = consolidate_groups(nat, class_bytes, thr)
+            self.recv_specs = _dedup_specs_by_subgroups(
+                self.recv_specs, self._recv_subgroups
+            )
+            if self.rank in (
+                0,
+                self.sender_ws,
+            ):  # one sender + one receiver report the effect
+                n_nat = sum(len(v) for v in nat.values())
+                n_sub = sum(len(v) for v in self._recv_subgroups.values())
+                n_single = sum(
+                    1 for v in self._recv_subgroups.values() for sg in v if len(sg) == 1
+                )
+                thr_str = (
+                    "inf" if thr == float("inf") else "%.0fMB" % (thr / (1024 * 1024))
+                )
+                role = "sender" if self.rank < self.sender_ws else "receiver"
+                msg = (
+                    "wbridge dedup-consolidate [rank %d %s]: %d tensors, %d natural groups -> %d "
+                    "sub-groups (%d singletons), thr=%s"
+                    % (self.rank, role, len(nat), n_nat, n_sub, n_single, thr_str)
+                )
+                logger.info(msg)
+                if (
+                    os.environ.get("WBRIDGE_DEDUP_DIAG") == "1"
+                ):  # frameworkless replay has no log handler
+                    print("[" + msg + "]", flush=True)
+        else:
+            self.recv_specs = _dedup_specs(self.recv_specs)
+            if (
+                self.rank in (0, self.sender_ws)
+                and os.environ.get("WBRIDGE_DEDUP_DIAG") == "1"
+            ):
+                role = "sender" if self.rank < self.sender_ws else "receiver"
+                print(
+                    "[wbridge dedup-consolidate [rank %d %s]: OFF (natural class dedup)]"
+                    % (self.rank, role),
+                    flush=True,
+                )
+        # Filled once physical receiver placement is known (after the session/IP gather, before arena
+        # allocation).  Keeping this on WeightRouter lets every receiver independently derive exactly the
+        # same multi-group routes without another control-plane exchange.
+        self._topology_ok = False
+        self._topology_groups: list[dict] = []
+        self._topology_plans: list[list[dict]] = []
+        self._topology_group_cache_key: tuple[str | None, ...] | None = None
+        self._topology_group_cache: list[dict] | None = None
+        self._topology_name_groups_cache: dict[str, tuple[dict, ...]] = {}
+        self._topology_group_cache_valid = False
+        # Replica-group relay is configured only after physical receiver placement is known.  It is a
+        # separate data plane from the column all-gather above: trainers address one head per replication
+        # group, and one representative per participating node forwards the already-assembled payload down
+        # a chain.  Local group members consume the representative's PREP buffer over CUDA IPC.
+        self._relay_ok = False
+        self._relay_groups: list[dict] = []
+        self.planner_mode = (
+            "broadcast" if global_rounds is not None else "legacy_round_cap"
+        )
+        self.planned_rollout_rdma_peak_bytes: int | None = None
+        if global_rounds is None:
+            self.global_rounds = self.compute_global_rounds(peer_ip=peer_ip)
+        else:
+            self.global_rounds = [set(names) for names in global_rounds]
+            self._validate_global_rounds(self.global_rounds)
+        self.local_rounds = self.compute_local_rounds()
+        if self.rank == 0 and os.environ.get("WBRIDGE_DEDUP_DIAG") == "1":
+            try:
+                self._dedup_diag()
+            except Exception as e:  # noqa: BLE001 — diagnostics must never break a run
+                logger.warning("wbridge dedup-diag failed: %s", e)
+
+    def _pack_rounds(
+        self, name_send, name_recv, hard_send, hard_recv, soft_send, soft_recv
+    ):
+        """Greedy name-priority packing into BALANCED rounds under per-rank byte caps.
+
+        Per round, walk ``sorted(remaining names)`` and add a name only if it (a) touches no rank already
+        in *critical state* — a sender/receiver that has reached its individual even target ``C'`` — and
+        (b) keeps every rank it touches within the hard cap ``C``. Adding a name may push ranks to/over
+        ``C'``; those go critical and no later name this round may touch them. The round closes when every
+        rank is critical (all reached ``C'``) or the names run out. Tracking criticality PER RANK (not an
+        aggregate total) keeps each round balanced even when the name order front-loads a subset of ranks:
+        once the early ranks are satisfied we keep scanning for names that fill only the lagging ranks.
+        ``soft=inf`` on every rank => no rank ever goes critical => plain fill-to-hard-cap (legacy).
+        """
+        S, Rw = self.sender_ws, self.receiver_ws
+        tsend = {
+            n: tuple(si for si in range(S) if name_send[n][si]) for n in self.dtype_spec
+        }
+        trecv = {
+            n: tuple(ri for ri in range(Rw) if name_recv[n][ri])
+            for n in self.dtype_spec
+        }
+        remaining = set(self.dtype_spec)
+        rounds: list[set[str]] = []
+        while remaining:
+            send_used = [0] * S
+            recv_used = [0] * Rw
+            crit_send = [
+                soft_send[si] <= 0 for si in range(S)
+            ]  # zero-target ranks start satisfied
+            crit_recv = [soft_recv[ri] <= 0 for ri in range(Rw)]
+            round_plan: set[str] = set()
+            for name in sorted(remaining):
+                if any(crit_send[si] for si in tsend[name]) or any(
+                    crit_recv[ri] for ri in trecv[name]
+                ):
+                    continue  # touches a rank that already hit its even target C' -> don't over-fill it
+                ns, nr = name_send[name], name_recv[name]
+                if any(send_used[si] + ns[si] > hard_send for si in tsend[name]) or any(
+                    recv_used[ri] + nr[ri] > hard_recv for ri in trecv[name]
+                ):
+                    continue  # would exceed the hard cap C on some rank -> defer to a later round
+                for si in tsend[name]:
+                    send_used[si] += ns[si]
+                    if send_used[si] >= soft_send[si]:
+                        crit_send[si] = True
+                for ri in trecv[name]:
+                    recv_used[ri] += nr[ri]
+                    if recv_used[ri] >= soft_recv[ri]:
+                        crit_recv[ri] = True
+                round_plan.add(name)
+                if all(crit_send) and all(crit_recv):
+                    break  # every rank reached its even target -> round is balanced and full
+            if not round_plan:
+                raise RuntimeError(
+                    "routing deadlock: no tensor fits per-round caps (try smaller per-tensor overlap or raise caps)"
+                )
+            remaining -= round_plan
+            rounds.append(round_plan)
+        return rounds
+
+    def _ensure_round_invariants(self) -> list[dict[int, dict[str, int]]]:
+        """Cache sender/receiver overlap bytes and other data independent of the round partition."""
+        if self._pair_name_bytes_by_recv is not None:
+            return self._pair_name_bytes_by_recv
+
+        started = time.perf_counter()
+        # A Kimi-scale plan has O(70k) logical tensor names but each rank-pair overlaps only O(10-100)
+        # of them.  Scanning every name for every (sender, receiver) pair made this phase perform billions
+        # of negative dict lookups.  Give each name a stable bit position and intersect rank presence maps
+        # in C with one Python-int AND; only set bits reach the shard-geometry overlap calculation.
+        names = tuple(self.dtype_spec)
+        name_order = {name: index for index, name in enumerate(names)}
+
+        def presence_bitmap(spec: ShardSpec) -> int:
+            bitmap = 0
+            for name in spec.entries:
+                index = name_order.get(name)
+                if index is not None:
+                    bitmap |= 1 << index
+            return bitmap
+
+        def bitmap_names(bitmap: int):
+            while bitmap:
+                least_bit = bitmap & -bitmap
+                yield names[least_bit.bit_length() - 1]
+                bitmap ^= least_bit
+
+        send_presence = [presence_bitmap(spec) for spec in self.send_specs]
+        recv_presence = [presence_bitmap(spec) for spec in self.recv_specs]
+        pair_name_bytes_by_recv: list[dict[int, dict[str, int]]] = [
+            {} for _ in range(self.receiver_ws)
+        ]
+        for si, send_spec in enumerate(self.send_specs):
+            for ri, recv_spec in enumerate(self.recv_specs):
+                common = send_presence[si] & recv_presence[ri]
+                if not common:
+                    continue
+                overlap = ShardSpec.compute_overlap(
+                    send_spec, recv_spec, bitmap_names(common)
+                )
+                if overlap:
+                    pair_name_bytes_by_recv[ri][si] = {
+                        name: shards_nbytes(shards, self.dtype_spec[name])
+                        for name, shards in overlap.entries.items()
+                    }
+
+        self._pair_name_bytes_by_recv = pair_name_bytes_by_recv
+        self._trainer_peer_counts_cache = [
+            len(sender_bytes) for sender_bytes in pair_name_bytes_by_recv
+        ]
+        self._recv_name_bytes_cache = [
+            {
+                name: shards_nbytes(shards, self.dtype_spec[name])
+                for name, shards in spec.entries.items()
+            }
+            for spec in self.recv_specs
+        ]
+        # Every byte in the de-replicated receiver spec must have a trainer source.  A framework mapping
+        # omission otherwise survives LoadSpec verification (the missing worker parameter is simply absent
+        # from the sender spec) and fails much later as an opaque arena-layout assertion.  Validate the
+        # actual shard-overlap bytes here and report exact tensor names/ranks.
+        for ri, expected_by_name in enumerate(self._recv_name_bytes_cache):
+            covered_by_name: dict[str, int] = {}
+            for name_bytes in pair_name_bytes_by_recv[ri].values():
+                for name, nbytes in name_bytes.items():
+                    covered_by_name[name] = covered_by_name.get(name, 0) + nbytes
+            mismatch = {
+                name: (expected, covered_by_name.get(name, 0))
+                for name, expected in expected_by_name.items()
+                if covered_by_name.get(name, 0) != expected
+            }
+            if mismatch:
+                sample = list(sorted(mismatch.items()))[:20]
+                raise ValueError(
+                    "incomplete trainer coverage for receiver "
+                    f"{ri}: {len(mismatch)} tensor(s) differ; "
+                    f"sample(name: (expected_bytes, covered_bytes))={sample}"
+                )
+        self.planner_invariant_seconds += time.perf_counter() - started
+        return pair_name_bytes_by_recv
+
+    def _name_rank_bytes(self) -> tuple[dict[str, list[int]], dict[str, list[int]]]:
+        """Per-tensor wire bytes charged to every trainer and rollout rank."""
+        names = tuple(self.dtype_spec)
+        pair_name_bytes_by_recv = self._ensure_round_invariants()
+        name_send = {name: [0] * self.sender_ws for name in names}
+        name_recv = {name: [0] * self.receiver_ws for name in names}
+        for ri, sender_bytes in enumerate(pair_name_bytes_by_recv):
+            for si, name_bytes in sender_bytes.items():
+                for name, nb in name_bytes.items():
+                    name_send[name][si] += nb
+                    name_recv[name][ri] += nb
+        return name_send, name_recv
+
+    def _validate_global_rounds(self, rounds: list[set[str]]) -> None:
+        if not rounds or any(not names for names in rounds):
+            raise ValueError("the round plan must contain one or more non-empty rounds")
+        seen: set[str] = set()
+        duplicate: set[str] = set()
+        for names in rounds:
+            duplicate |= seen & names
+            seen |= names
+        expected = set(self.dtype_spec)
+        if seen != expected or duplicate:
+            raise ValueError(
+                f"invalid round plan: missing={sorted(expected - seen)}, "
+                f"extra={sorted(seen - expected)}, duplicate={sorted(duplicate)}"
+            )
+
+    def _pack_exact_rounds(
+        self,
+        name_send: dict[str, list[int]],
+        name_recv: dict[str, list[int]],
+        num_rounds: int,
+    ) -> list[set[str]]:
+        """Use the existing per-rank critical-target greedy to make exactly ``num_rounds`` rounds.
+
+        Targets are recomputed from the bytes still unassigned at the start of every round. This retains the
+        name-priority and per-rank balancing behavior of :meth:`_pack_rounds`, while reserving at least one
+        tensor for every future round and assigning all remainder to the final round.
+        """
+        names = sorted(self.dtype_spec)
+        if not 1 <= num_rounds <= len(names):
+            raise ValueError(
+                f"requested {num_rounds} rounds, but the plan has {len(names)} tensor names; "
+                "the valid range is [1, number of tensors]"
+            )
+        remaining = set(names)
+        send_remaining = [
+            sum(name_send[n][si] for n in names) for si in range(self.sender_ws)
+        ]
+        recv_remaining = [
+            sum(name_recv[n][ri] for n in names) for ri in range(self.receiver_ws)
+        ]
+        send_touched = {
+            n: tuple(i for i, nb in enumerate(name_send[n]) if nb) for n in names
+        }
+        recv_touched = {
+            n: tuple(i for i, nb in enumerate(name_recv[n]) if nb) for n in names
+        }
+        rounds: list[set[str]] = []
+        for round_index in range(num_rounds):
+            rounds_left = num_rounds - round_index
+            if rounds_left == 1:
+                round_plan = set(remaining)
+            else:
+                # Unlike the legacy hard-cap repack, exact-R planning does not need 5% headroom to avoid
+                # stranding a cap-fitting tensor: there is no hard cap. Aim at the exact remaining average;
+                # an indivisible tensor may cross it, then that rank becomes critical for this round.
+                soft_send = [-(-total // rounds_left) for total in send_remaining]
+                soft_recv = [-(-total // rounds_left) for total in recv_remaining]
+                send_used = [0] * self.sender_ws
+                recv_used = [0] * self.receiver_ws
+                crit_send = [target <= 0 for target in soft_send]
+                crit_recv = [target <= 0 for target in soft_recv]
+                # Leave at least one name for every future round.
+                max_names = len(remaining) - (rounds_left - 1)
+                round_plan = set()
+                for name in sorted(remaining):
+                    if len(round_plan) >= max_names:
+                        break
+                    if any(crit_send[si] for si in send_touched[name]) or any(
+                        crit_recv[ri] for ri in recv_touched[name]
+                    ):
+                        continue
+                    for si in send_touched[name]:
+                        send_used[si] += name_send[name][si]
+                        if send_used[si] >= soft_send[si]:
+                            crit_send[si] = True
+                    for ri in recv_touched[name]:
+                        recv_used[ri] += name_recv[name][ri]
+                        if recv_used[ri] >= soft_recv[ri]:
+                            crit_recv[ri] = True
+                    round_plan.add(name)
+                    if all(crit_send) and all(crit_recv):
+                        break
+                if not round_plan:
+                    # A sparse overlap pattern can make every remaining name touch one already-critical
+                    # rank. Advancing the first deterministic name preserves exact progress; the next round
+                    # recomputes its targets from the resulting remainder.
+                    round_plan = {min(remaining)}
+
+            for name in round_plan:
+                for si, nb in enumerate(name_send[name]):
+                    send_remaining[si] -= nb
+                for ri, nb in enumerate(name_recv[name]):
+                    recv_remaining[ri] -= nb
+            remaining -= round_plan
+            rounds.append(round_plan)
+
+        assert not remaining and all(
+            total == 0 for total in send_remaining + recv_remaining
+        )
+        self._validate_global_rounds(rounds)
+        return rounds
+
+    def _legacy_cap_rounds(
+        self,
+        name_send: dict[str, list[int]],
+        name_recv: dict[str, list[int]],
+    ) -> list[set[str]]:
+        """The original per-round wire-cap planner, retained as a compatibility fallback."""
+
+        hard_recv = RECEIVER_ROUND_CAP_BYTES
+        hard_send = RECEIVER_ROUND_CAP_BYTES * self.receiver_ws // self.sender_ws
+
+        inf = float("inf")
+        inf_send = [inf] * self.sender_ws
+        inf_recv = [inf] * self.receiver_ws
+
+        # Pass 1: minimum round count R at the hard cap C.
+        R = len(
+            self._pack_rounds(
+                name_send, name_recv, hard_send, hard_recv, inf_send, inf_recv
+            )
+        )
+        if R <= 1:
+            return self._pack_rounds(
+                name_send, name_recv, hard_send, hard_recv, inf_send, inf_recv
+            )
+
+        # Pass 2: per-rank even target C' = ceil(rank total / R). A round fills each rank to its own C'
+        # (critical) and won't over-fill an already-critical rank, so traffic is balanced across ranks
+        # regardless of tensor-name order.
+        send_tot = [
+            sum(name_send[n][si] for n in self.dtype_spec)
+            for si in range(self.sender_ws)
+        ]
+        recv_tot = [
+            sum(name_recv[n][ri] for n in self.dtype_spec)
+            for ri in range(self.receiver_ws)
+        ]
+        soft_send = [
+            _even_round_soft_target(send_tot[si], R, hard_send)
+            for si in range(self.sender_ws)
+        ]
+        soft_recv = [
+            _even_round_soft_target(recv_tot[ri], R, hard_recv)
+            for ri in range(self.receiver_ws)
+        ]
+        rounds = self._pack_rounds(
+            name_send, name_recv, hard_send, hard_recv, soft_send, soft_recv
+        )
+        logger.info(
+            "wbridge router: %d rounds, even-split per-rank C'(+5%%)~%.2f GiB/recv "
+            "(R=%d, hard cap %.2f GiB/recv)",
+            len(rounds),
+            max(soft_recv) / 1024**3,
+            R,
+            hard_recv / 1024**3,
+        )
+        return rounds
+
+    def compute_global_rounds(
+        self, *, peer_ip: dict[int, str] | None = None
+    ) -> list[set[str]]:
+        """Build a balanced plan from one of the two production planner modes.
+
+        ``WBRIDGE_NUM_ROUNDS`` requests an exact number of balanced rounds.
+        ``WBRIDGE_ROLLOUT_RDMA_CAP_BYTES`` selects the smallest exact round count whose largest rollout
+        worker's registered permanent buffers fit the specified cap. The latter requires physical placement
+        in ``peer_ip`` because topology-aware GRECV storage is placement-dependent.
+
+        If neither is set, the former per-round wire cap remains available for compatibility with old runs.
+        """
+        requested = os.environ.get("WBRIDGE_NUM_ROUNDS", "").strip()
+        rdma_cap = os.environ.get("WBRIDGE_ROLLOUT_RDMA_CAP_BYTES", "").strip()
+        if requested and rdma_cap:
+            raise ValueError(
+                "WBRIDGE_NUM_ROUNDS and WBRIDGE_ROLLOUT_RDMA_CAP_BYTES are mutually exclusive"
+            )
+        name_send, name_recv = self._name_rank_bytes()
+        if requested:
+            rounds = self._pack_exact_rounds(name_send, name_recv, int(requested))
+            self.planner_mode = "explicit_rounds"
+            logger.info(
+                "wbridge router: explicit balanced round plan R=%d", len(rounds)
+            )
+            return rounds
+        if rdma_cap:
+            cap = int(rdma_cap)
+            if cap <= 0:
+                raise ValueError(
+                    f"WBRIDGE_ROLLOUT_RDMA_CAP_BYTES must be positive, got {cap}"
+                )
+            if peer_ip is None:
+                raise ValueError(
+                    "rollout RDMA-cap planning requires physical peer_ip placement"
+                )
+            rounds, peak = self._rounds_for_rollout_rdma_cap(
+                name_send, name_recv, peer_ip, cap
+            )
+            self.planner_mode = "rollout_rdma_cap"
+            self.planned_rollout_rdma_peak_bytes = peak
+            logger.info(
+                "wbridge router: rollout RDMA cap %.3f GiB selected R=%d, peak %.3f GiB",
+                cap / 1024**3,
+                len(rounds),
+                peak / 1024**3,
+            )
+            return rounds
+        return self._legacy_cap_rounds(name_send, name_recv)
+
+    def compute_local_rounds(self) -> list[CommRoundPlan]:
+        """
+        Plan for *rank*: round *i* is :class:`CommRoundPlan` — ``peer_specs[peer]`` is the wire overlap
+        with global rank *peer*; on receivers ``recv_subspec`` is this round's buffer layout (merged overlaps).
+        """
+        out: list[tuple[ShardSpec, dict[int, ShardSpec]]] = []
+        is_sender = self.rank < self.sender_ws
+        if is_sender:
+            full_spec = self.send_specs[self.rank]
+            overlaps = {
+                ri + self.sender_ws: ShardSpec.compute_overlap(
+                    full_spec, self.recv_specs[ri]
+                )
+                for ri in range(self.receiver_ws)
+            }
+        else:
+            full_spec = self.recv_specs[self.rank - self.sender_ws]
+            overlaps = {
+                si: ShardSpec.compute_overlap(self.send_specs[si], full_spec)
+                for si in range(self.sender_ws)
+            }
+        for round_plan in self.global_rounds:
+            round_overlaps = {
+                rank: sub_overlap
+                for rank, overlap in overlaps.items()
+                if (sub_overlap := overlap.subset(round_plan))
+            }
+            out.append((full_spec.subset(round_plan), round_overlaps))
+        return out
+
+    def _natural_recv_classes(self) -> dict[str, list[list[int]]]:
+        """Per-tensor replication classes over rollout workers (for tensor-level dedup). Returns
+        ``{name: [class, ...]}`` where each class is the sorted local indices of receivers holding an
+        IDENTICAL shard set for that tensor; a member's slice index is its position in its class. Matches
+        how :func:`_dedup_specs` splits (per name, per canonical shard key). Deterministic across ranks
+        (uses the shared originals ``recv_specs_full``)."""
+        names: set[str] = set()
+        for s in self.recv_specs_full:
+            names |= set(s.entries.keys())
+        out: dict[str, list[list[int]]] = {}
+        for name in sorted(names):
+            groups: dict = {}
+            for rl in range(self.receiver_ws):
+                s = self.recv_specs_full[rl]
+                if name in s.entries:
+                    groups.setdefault(_shards_canonical_key(s[name]), []).append(rl)
+            out[name] = [sorted(m) for m in groups.values()]
+        return out
+
+    def recv_tensor_classes(self) -> dict[str, list[list[int]]]:
+        """Per-tensor exchange groups: the natural replication classes, OR the consolidated sub-groups when
+        WBRIDGE_DEDUP_PAIR_BYTES>0 (a partition-refinement — same shape, consumed identically downstream)."""
+        if self._recv_subgroups is not None:
+            return self._recv_subgroups
+        if self._recv_tensor_classes_cache is None:
+            self._recv_tensor_classes_cache = self._natural_recv_classes()
+        return self._recv_tensor_classes_cache
+
+    @staticmethod
+    def topo_subgroups(
+        members_global: list[int], ip_of: dict[int, str]
+    ) -> tuple[list[list[int]], bool]:
+        """Partition an exchange group into ``n`` subgroups of exactly ONE worker per node, for the
+        topology-aware 2-phase all-gather. ``members_global`` = the group's global ranks; ``ip_of`` =
+        ``{global_rank: host_ip}`` (== ``WBEndpoint._peer_ip``). Returns ``(subgroups, ok)`` where
+        ``subgroups[j]`` = sorted global ranks = the j-th worker (by rank) on each node.
+
+        ``ok=False`` when the nodes hold UNEQUAL member counts (the same-``n`` property fails) or a member's
+        IP is unknown — the caller then falls back to the single-phase all-gather. Pure + deterministic
+        (sorted throughout), so every member derives the identical partition with no extra handshake (the
+        same determinism guarantee ``consolidate_groups`` relies on, since ``ip_of`` is globally gathered)."""
+        by_node: dict[str, list[int]] = {}
+        for r in sorted(members_global):
+            ip = ip_of.get(r)
+            if ip is None:
+                return [], False
+            by_node.setdefault(ip, []).append(r)
+        counts = [len(rs) for rs in by_node.values()]
+        n = counts[0] if counts else 0
+        if n == 0 or any(c != n for c in counts):
+            return [], False  # unequal workers per node -> not 1-per-node partitionable
+        nodes = [by_node[ip] for ip in sorted(by_node)]  # each list already rank-sorted
+        subgroups = [sorted(node[j] for node in nodes) for j in range(n)]
+        return subgroups, True
+
+    def configure_topology(self, ip_of: dict[int, str]) -> bool:
+        """Build the topology-aware exchange plan for every receiver and round.
+
+        A receiver may belong to any number of replication groups.  Each multi-worker group is independently
+        eligible when every participating node contributes the same number of workers.  For one such group,
+        :meth:`topo_subgroups` makes one-worker-per-node *columns*: workers first exchange only their exact
+        group payload inside their column, then each worker pulls the other columns from its local peers.
+
+        The returned per-round plan uses receiver-local indices and contains:
+
+        ``external``
+            ``peer -> names`` packed into one cross-node write during fused assemble+repack.
+        ``pull``
+            ``local_peer -> (source-kind, source-worker, names)`` routes.  Multiple routes between the same
+            local pair are intentional because there is no repack between external and internal exchange.
+        Singleton classes need no exchange and are ignored.  A group wholly inside one node is valid (its
+        columns are singletons and only the internal phase runs), as is one worker per node (only external).
+        If *any* multi-worker group is unbalanced, the entire topology path is disabled so all ranks take the
+        existing single-phase protocol consistently.
+        """
+        sw = self.sender_ws
+        classes = self.recv_tensor_classes()
+        placement_key = tuple(
+            ip_of.get(sw + member) for member in range(self.receiver_ws)
+        )
+        if self._topology_group_cache_key == placement_key:
+            groups = self._topology_group_cache or []
+            groups_valid = self._topology_group_cache_valid
+        else:
+            group_names: dict[tuple[int, ...], set[str]] = {}
+            for name in sorted(classes):
+                for members in classes[name]:
+                    key = tuple(sorted(members))
+                    if len(key) >= 2:
+                        group_names.setdefault(key, set()).add(name)
+
+            groups = []
+            groups_valid = True
+            for members in sorted(group_names):
+                columns_g, ok = self.topo_subgroups([sw + m for m in members], ip_of)
+                if not ok:
+                    groups_valid = False
+                    groups = []
+                    break
+                columns = tuple(tuple(g - sw for g in col) for col in columns_g)
+                column_of = {m: col for col in columns for m in col}
+                same_node_of = {
+                    m: tuple(
+                        p
+                        for p in members
+                        if p != m and ip_of.get(sw + p) == ip_of.get(sw + m)
+                    )
+                    for m in members
+                }
+                groups.append(
+                    {
+                        "members": members,
+                        "names": tuple(sorted(group_names[members])),
+                        "columns": columns,
+                        "column_of": column_of,
+                        "same_node_of": same_node_of,
+                    }
+                )
+            self._topology_group_cache_key = placement_key
+            self._topology_group_cache = groups
+            name_groups: dict[str, list[dict]] = {}
+            for group in groups:
+                for name in group["names"]:
+                    name_groups.setdefault(name, []).append(group)
+            self._topology_name_groups_cache = {
+                name: tuple(tensor_groups)
+                for name, tensor_groups in name_groups.items()
+            }
+            self._topology_group_cache_valid = groups_valid
+
+        # No replicated tensors means there is no topology exchange to enable.  This is not a structural
+        # failure for any group; it merely leaves the normal zero-peer consume path in charge.
+        if not groups_valid or not groups:
+            self._topology_ok = False
+            self._topology_groups = []
+            self._topology_plans = []
+            return False
+
+        plans: list[list[dict]] = [[] for _ in range(self.receiver_ws)]
+        for rl in range(self.receiver_ws):
+            for round_set in self.global_rounds:
+                round_names = sorted(n for n in round_set if n in self.recv_specs[rl])
+                external: dict[int, set[str]] = {}
+                routes: dict[int, dict[tuple[str, int], set[str]]] = {}
+                peers: set[int] = set()
+                for name in round_names:
+                    for grp in self._topology_name_groups_cache.get(name, ()):
+                        if rl not in grp["members"]:
+                            continue
+                        peers.update(p for p in grp["members"] if p != rl)
+                        for p in grp["column_of"][rl]:
+                            if p != rl:
+                                external.setdefault(p, set()).add(name)
+                        for p in grp["same_node_of"][rl]:
+                            proutes = routes.setdefault(p, {})
+                            proutes.setdefault(("own", p), set()).add(name)
+                            for q in grp["column_of"][p]:
+                                if q != p:
+                                    proutes.setdefault(("grecv", q), set()).add(name)
+
+                external_out = {
+                    p: tuple(sorted(names))
+                    for p, names in sorted(external.items())
+                    if names
+                }
+                pull_out = {
+                    p: tuple(
+                        (kind, source, tuple(sorted(names)))
+                        for (kind, source), names in sorted(proutes.items())
+                        if names
+                    )
+                    for p, proutes in sorted(routes.items())
+                }
+                # Prove the two phases cover the generic all-gather exactly once, name by name.  A source
+                # may be split across phases (direct in one group, routed through a local column in another),
+                # which is precisely why a peer-level whole-buffer assumption is insufficient.
+                delivered: dict[int, set[str]] = {}
+                for source, selected in external_out.items():
+                    delivered.setdefault(source, set()).update(selected)
+                for peer_routes in pull_out.values():
+                    for _kind, source, selected in peer_routes:
+                        prior = delivered.setdefault(source, set())
+                        assert not prior.intersection(selected), (
+                            f"duplicate topology delivery rl={rl} source={source} "
+                            f"names={sorted(prior.intersection(selected))}"
+                        )
+                        prior.update(selected)
+                payloads = self._arena_payloads(rl, round_names, classes)
+                expected = {p: set(payloads.get(p, ())) for p in peers}
+                assert delivered == expected, (
+                    f"incomplete topology delivery rl={rl}: delivered={delivered} expected={expected}"
+                )
+                internal = tuple(sorted(pull_out))
+                plans[rl].append(
+                    {
+                        "external": external_out,
+                        "pull": pull_out,
+                        "peers": tuple(sorted(peers)),
+                        "internal": internal,
+                    }
+                )
+
+        self._topology_ok = True
+        self._topology_groups = groups
+        self._topology_plans = plans
+        return True
+
+    def topology_plan(self, rl: int, ri: int) -> dict:
+        """Return the configured receiver-local topology plan for one global round."""
+        assert self._topology_ok, (
+            "topology was not configured or is structurally ineligible"
+        )
+        return self._topology_plans[rl][ri]
+
+    def configure_relay(self, ip_of: dict[int, str]) -> bool:
+        """Build deterministic replica-group head/relay chains for the current round plan.
+
+        Tensor replication classes are first coalesced by identical member set.  For each resulting group,
+        one representative (the lowest global rank) is selected on every participating node.  Representatives
+        form a global-rank-ordered chain; the first is the trainer-facing head.  Every member consumes from
+        its node's representative, so cross-node traffic carries one full canonical group payload per link,
+        while same-node replication is serviced by direct CUDA-IPC reads.
+
+        The old global name-to-round assignment is retained verbatim.  ``round_specs[ri]`` is the canonical
+        full receiver shard for the group's names in that round, and ``trainer_specs[ri]`` partitions it by
+        the already de-replicated trainer sources.  No receiver-side repack is required: every chain hop uses
+        the same packed ``round_specs[ri]`` byte layout.
+        """
+        sw = self.sender_ws
+        # Relay uses the same threshold-controlled refinement as exchange.  In particular CONS=INF
+        # dissolves the small, wide natural classes onto the already-required TP/EP replica groups.  A
+        # dissolved tensor is deliberately duplicated once per covering subgroup; that small byte cost lets
+        # it piggyback on an existing relay chain instead of creating another independently synchronized
+        # group.  CONS=0 still returns the unmodified natural classes.
+        classes = self.recv_tensor_classes()
+        grouped_names: dict[tuple[int, ...], set[str]] = {}
+        for name in sorted(classes):
+            for members in classes[name]:
+                key = tuple(sorted(members))
+                if not key:
+                    continue
+                grouped_names.setdefault(key, set()).add(name)
+
+        groups: list[dict] = []
+        for gid, members in enumerate(sorted(grouped_names)):
+            names = tuple(sorted(grouped_names[members]))
+            by_node: dict[str, list[int]] = {}
+            for member in members:
+                global_rank = sw + member
+                node = ip_of.get(global_rank)
+                if node is None:
+                    self._relay_ok = False
+                    self._relay_groups = []
+                    return False
+                by_node.setdefault(node, []).append(member)
+
+            # Lowest rank per node owns the group's depth-2 RECV/PREP buffers.  Sorting the owners by global
+            # rank makes the lowest owner the head and is stable across every process without coordination.
+            owners = tuple(
+                sorted(min(node_members) for node_members in by_node.values())
+            )
+            chain = tuple(sw + owner for owner in owners)
+            owner_of = {member: min(by_node[ip_of[sw + member]]) for member in members}
+            local_readers = {
+                owner: tuple(
+                    sorted(member for member in members if owner_of[member] == owner)
+                )
+                for owner in owners
+            }
+
+            canonical = self.recv_specs_full[members[0]].subset(set(names))
+            for member in members[1:]:
+                candidate = self.recv_specs_full[member].subset(set(names))
+                if candidate.entries != canonical.entries:
+                    raise RuntimeError(
+                        f"relay group {members} is not byte-canonical between members "
+                        f"{members[0]} and {member}"
+                    )
+
+            round_specs: list[ShardSpec] = []
+            trainer_specs: list[dict[int, ShardSpec]] = []
+            for round_names in self.global_rounds:
+                group_spec = canonical.subset(set(round_names))
+                round_specs.append(group_spec)
+                trainer_specs.append(
+                    {
+                        si: overlap
+                        for si, sender_spec in enumerate(self.send_specs)
+                        if (
+                            overlap := ShardSpec.compute_overlap(
+                                sender_spec, group_spec
+                            )
+                        ).entries
+                    }
+                )
+                if group_spec.entries:
+                    expected_bytes = group_spec.nbytes(self.dtype_spec)
+                    covered_bytes = sum(
+                        spec.nbytes(self.dtype_spec)
+                        for spec in trainer_specs[-1].values()
+                    )
+                    if covered_bytes != expected_bytes:
+                        raise RuntimeError(
+                            f"relay group {gid} round {len(round_specs) - 1} trainer coverage is "
+                            f"{covered_bytes} bytes, expected {expected_bytes}"
+                        )
+
+            groups.append(
+                {
+                    "id": gid,
+                    "members": members,
+                    "names": names,
+                    "owners": owners,
+                    "chain": chain,
+                    "head": chain[0],
+                    "owner_of": owner_of,
+                    "local_readers": local_readers,
+                    "round_specs": tuple(round_specs),
+                    "trainer_specs": tuple(trainer_specs),
+                }
+            )
+
+        self._relay_ok = bool(groups)
+        self._relay_groups = groups
+        return self._relay_ok
+
+    def relay_group(self, gid: int) -> dict:
+        if not self._relay_ok:
+            raise RuntimeError("replica-group relay was not configured")
+        return self._relay_groups[gid]
+
+    def _arena_class_of(self, classes: dict, name: str, member: int) -> list[int]:
+        if classes is not self._arena_class_index_source:
+            self._arena_class_index = {
+                tensor_name: {
+                    member_rank: members
+                    for members in tensor_classes
+                    for member_rank in members
+                }
+                for tensor_name, tensor_classes in classes.items()
+            }
+            self._arena_class_index_source = classes
+        return self._arena_class_index.get(name, {}).get(member, [])
+
+    def _arena_payloads(
+        self,
+        rl: int,
+        round_names: list[str],
+        classes: dict,
+    ) -> dict[int, tuple[str, ...]]:
+        """Build every peer payload in one name-major pass over a receiver's sorted round names."""
+        payloads: dict[int, list[str]] = {}
+        for name in round_names:
+            for peer in self._arena_class_of(classes, name, rl):
+                if peer != rl:
+                    payloads.setdefault(peer, []).append(name)
+        return {peer: tuple(names) for peer, names in payloads.items()}
+
+    def _arena_shared(
+        self, rl: int, p: int, round_names: list[str], classes: dict
+    ) -> list[str]:
+        """Tensors that receivers *rl* and *p* both hold in the SAME per-tensor class this round — the
+        slices they exchange in the all-gather. Sorted (deterministic)."""
+        return list(self._arena_payloads(rl, sorted(round_names), classes).get(p, ()))
+
+    def arena_layout(self, rl: int, classes: dict | None = None, *, depth: int = 1):
+        """Split ingress/exchange layout for receiver local index *rl* (pure; no CUDA).
+
+        Two physically independent allocations have deliberately different reachability and lifetimes:
+
+        * **RECV ingress** — trainer-reachable only. There are ``depth`` parity slots with common stride
+          ``recv_stride``. Within each parity, every trainer sender ``si`` owns a stable lane sized to its
+          maximum contribution among rounds of that parity. ``recv[si] = (off, current_nb)`` selects the
+          current prefix of that lane. Consequently one trainer can never overwrite another trainer's
+          unassembled input; a sender only needs the ACK for its own previous use of ``(receiver, parity)``.
+        * **PREP** ``[0, depth*S)`` — rollout-readable fused-prepare output: ``own`` plus one staging range per
+          unique partial ``send`` or topology-packed ``topo_send`` payload. Identical payloads alias, and a
+          full payload aliases ``own``. Each round's offsets are relative to its ``S``-byte parity slot.
+        * **GRECV** ``[depth*S, total)`` — one rollout-writable shared bank. In the topology path it contains
+          only exact cross-node ingress payloads; same-node columns are consumed directly from their owner's
+          CUDA-IPC arena and need no local staging. The generic fallback retains one full slot per peer.
+          Every allocated source gets one stable subrange for each parity it uses, sized to that source's
+          maximum payload on that parity. Thus depth 2 lets round ``r+1`` land without waiting for round ``r``
+          consumption; reuse of a physical slot is gated by round ``r-2``.
+
+        Returns ``(rounds, S, peer_set)`` where ``S = max_r prep(r)`` is the rollout PREP stride. RECV offsets
+        use the separate ``recv_stride`` recorded in every round; own/send use ``S``; GRECV offsets are already
+        absolute in the rollout allocation::
+
+            {"s2r", "recv_stride", "prep", "prep_base", "agh",
+             "recv":      {si: (off, nb)}, # isolated ingress, stable per (parity, sender)
+             "own":       (off, nb),       # rollout PREP slot
+             "send":      {p: (off, nb)},  # generic fallback; identical payloads alias / own
+             "topo_send": {p: (off, nb)},  # exact per-column payload, packed across groups
+             "grecv":       {p: (off, nb)}, # absolute offsets, stable per (external source, round parity)
+             "grecv_names": {p: names}}     # exact packed layout of each current grecv payload
+
+        ``agh`` remains logical accounting (``prep + Σ current grecv bytes``), not a contiguous region.
+        :func:`_arena_recv_total_bytes` and :func:`_arena_total_bytes` size the two allocations.
+
+        ``peer_set`` is the sorted union of class peers across rounds. Deterministic (senders, peers, and
+        names are all iterated in sorted order). Every :meth:`ShardSpec.subset` call is passed a FRESH
+        ``set(...)`` — ``subset`` does ``names &= entries.keys()`` (a list raises ``TypeError``)."""
+        assert depth >= 1
+        if self.direct_same_node:
+            # Direct local consume never lands trainer bytes in a receiver allocation: the model-copy kernel
+            # reads the sender's exported pack buffer itself.  Return a structurally complete zero-payload
+            # layout so setup, RDMA-cap planning, and metadata publication can retain their normal control
+            # flow without allocating RECV/PREP/GRECV/DOFF storage.
+            return (
+                [
+                    {
+                        "s2r": 0,
+                        "recv_stride": 0,
+                        "prep": 0,
+                        "prep_base": 0,
+                        "agh": 0,
+                        "agh_base": 0,
+                        "recv": {},
+                        "own": (0, 0),
+                        "send": {},
+                        "topo_send": {},
+                        "grecv": {},
+                        "grecv_names": {},
+                    }
+                    for _ in self.global_rounds
+                ],
+                0,
+                [],
+            )
+        my = self.recv_specs[rl]
+        classes = classes if classes is not None else self.recv_tensor_classes()
+        pair_name_bytes = self._ensure_round_invariants()[rl]
+        assert self._recv_name_bytes_cache is not None
+        recv_name_bytes = self._recv_name_bytes_cache
+        my_name_bytes = recv_name_bytes[rl]
+        rounds: list[dict] = []
+        peer_set: set[int] = set()
+        # ---- Pass A: logical per-round RECV sizes + compact PREP payloads ----
+        for ri, names in enumerate(self.global_rounds):
+            round_names = sorted(
+                n for n in names if n in my.entries
+            )  # tensors I hold this round
+            round_name_set = set(round_names)
+            recv: dict[int, tuple[int, int]] = {}
+            cursor = 0
+            for si in range(self.sender_ws):
+                name_bytes = pair_name_bytes.get(si)
+                nb = (
+                    sum(
+                        value
+                        for name, value in name_bytes.items()
+                        if name in round_name_set
+                    )
+                    if name_bytes
+                    else 0
+                )
+                if nb:
+                    recv[si] = (cursor, nb)
+                    cursor += nb
+            s2r = cursor
+            payload_of = self._arena_payloads(rl, round_names, classes)
+            peers_this = set(payload_of)
+            cur = 0
+            own_rel = (cur, s2r)
+            cur += s2r
+            # Step 1: deduplicate logical send payloads before making any physical-buffer decision. An
+            # all-gather normally sends the same local slice to every member of a replication class.
+            payload_nb = {
+                payload: sum(my_name_bytes[name] for name in payload)
+                for payload in dict.fromkeys(payload_of.values())
+            }
+            # Step 2: assign one physical source per unique payload. If it is the entire canonical `own`
+            # slice, use `own` directly; assembly will populate the send source in the same copy kernel.
+            # Otherwise reserve one compact staging region for that unique subset. All send sources are
+            # read-only once prepared, so concurrent RDMA reads / CUDA-IPC pulls may safely alias.
+            full_payload = tuple(round_names)
+            send_payloads: dict[tuple[str, ...], tuple[int, int]] = {}
+            send_rel: dict[int, tuple[int, int]] = {}
+            for p in sorted(peers_this):
+                shared = payload_of[p]
+                nb = payload_nb[shared]
+                slot = send_payloads.get(shared)
+                if slot is None:
+                    if shared == full_payload:
+                        assert nb == s2r
+                        slot = own_rel
+                    else:
+                        slot = (cur, nb)
+                        cur += nb
+                    send_payloads[shared] = slot
+                send_rel[p] = slot
+            # Topology-aware multi-group exchange may send only a SUBSET of the names shared with a peer:
+            # precisely those groups for which the two workers occupy the same cross-node column.  Pack all
+            # such names for one peer contiguously during the same assemble+repack kernel.  Reuse a generic
+            # send/own slot whenever the payload happens to be identical, so the common one-group case costs
+            # no additional arena memory or copy.
+            topo_send_rel: dict[int, tuple[int, int]] = {}
+            if self._topology_ok:
+                external = self.topology_plan(rl, ri)["external"]
+                for p, topo_names in sorted(external.items()):
+                    assert p in payload_of
+                    assert set(topo_names) <= set(payload_of[p])
+                    payload = tuple(topo_names)
+                    nb = sum(my_name_bytes[name] for name in payload)
+                    slot = send_payloads.get(payload)
+                    if slot is None:
+                        if payload == full_payload:
+                            assert nb == s2r
+                            slot = own_rel
+                        else:
+                            slot = (cur, nb)
+                            cur += nb
+                        send_payloads[payload] = slot
+                    topo_send_rel[p] = slot
+            prep = cur
+            grecv_names: dict[int, tuple[str, ...]] = {}
+            if self._topology_ok:
+                # Only cross-node columns land in this worker. Internal columns are read directly from the
+                # owning worker by the fused internal-consume kernel, so allocating their former staging
+                # slots would retain the extra model-sized GRECV copy this path is intended to remove.
+                for source in range(self.receiver_ws):
+                    incoming = self.topology_plan(source, ri)["external"].get(rl, ())
+                    if incoming:
+                        assert source in peers_this
+                        grecv_names[source] = tuple(incoming)
+            else:
+                grecv_names = dict(payload_of)
+            grecv_nb = {
+                p: sum(recv_name_bytes[p][name] for name in names)
+                for p, names in grecv_names.items()
+            }
+            agh = prep + sum(grecv_nb.values())
+            rounds.append(
+                {
+                    "s2r": s2r,
+                    "prep": prep,
+                    "agh": agh,
+                    "recv": recv,
+                    "_own": own_rel,
+                    "_send": send_rel,
+                    "_topo_send": topo_send_rel,
+                    "_grecv_nb": grecv_nb,
+                    "grecv_names": grecv_names,
+                }
+            )
+            peer_set |= peers_this
+        # ---- Pass B: stable trainer lanes in the separate RECV allocation ----
+        # A compact per-round layout is unsafe: e.g. sender A in round 0 and sender B in round 2 can both get
+        # offset zero, while B only waits for B's round-0 destinations and may overwrite A's still-unassembled
+        # bytes. Stable lanes turn slot ownership into (receiver, parity, sender), matching the ACK endpoints.
+        lane_nb = [[0] * self.sender_ws for _ in range(depth)]
+        for ri, rd in enumerate(rounds):
+            par = ri % depth
+            for si, (_off, nb) in rd["recv"].items():
+                lane_nb[par][si] = max(lane_nb[par][si], nb)
+        lane_off: list[list[int]] = []
+        parity_bytes: list[int] = []
+        for par in range(depth):
+            offsets = []
+            cursor = 0
+            for si in range(self.sender_ws):
+                offsets.append(cursor)
+                cursor += lane_nb[par][si]
+            lane_off.append(offsets)
+            parity_bytes.append(cursor)
+        recv_stride = max(parity_bytes, default=0)
+        for ri, rd in enumerate(rounds):
+            par = ri % depth
+            rd["recv"] = {
+                si: (lane_off[par][si], nb) for si, (_old_off, nb) in rd["recv"].items()
+            }
+            rd["recv_stride"] = recv_stride
+
+        # ---- Pass C: top-anchor PREP in each rollout parity slot ----
+        S = max((rd["prep"] for rd in rounds), default=0)
+        for rd in rounds:
+            base = S - rd["prep"]
+            rd["prep_base"] = base
+            rd["agh_base"] = (
+                base  # compatibility alias; AGH itself is no longer contiguous
+            )
+            o, n = rd.pop("_own")
+            rd["own"] = (o + base, n)
+            rd["send"] = {
+                p: (off + base, nb) for p, (off, nb) in rd.pop("_send").items()
+            }
+            rd["topo_send"] = {
+                p: (off + base, nb) for p, (off, nb) in rd.pop("_topo_send").items()
+            }
+        # ---- Pass D: one absolute, stable slot per (peer, round parity) in the shared GRECV bank ----
+        grecv_max = {
+            (p, slot): max(
+                (
+                    rd["_grecv_nb"].get(p, 0)
+                    for ri, rd in enumerate(rounds)
+                    if ri % depth == slot
+                ),
+                default=0,
+            )
+            for p in sorted(peer_set)
+            for slot in range(depth)
+        }
+        bank = depth * S
+        grecv_slot: dict[tuple[int, int], tuple[int, int]] = {}
+        for p in sorted(peer_set):
+            for slot in range(depth):
+                slot_nb = grecv_max[(p, slot)]
+                if slot_nb:
+                    grecv_slot[(p, slot)] = (bank, slot_nb)
+                    bank += slot_nb
+        for ri, rd in enumerate(rounds):
+            sizes = rd.pop("_grecv_nb")
+            rd["grecv"] = {
+                p: (grecv_slot[(p, ri % depth)][0], nb) for p, nb in sizes.items()
+            }
+        return rounds, S, sorted(peer_set)
+
+    def rollout_rdma_bytes(self, peer_ip: dict[int, str]) -> list[int]:
+        """Registered permanent bytes for every rollout worker under the current round plan.
+
+        This mirrors :meth:`WBEndpoint._setup_rdma_buffers`: isolated RECV plus PREP/GRECV (or their merged
+        allocation) and all registered control-flag banks. DOFF is intentionally excluded because it is a
+        CUDA-IPC-only, non-RDMA allocation. The result is topology- and placement-aware.
+        """
+        total_started = time.perf_counter()
+        if os.environ.get("WBRIDGE_REPLICA_RELAY", "0") == "1":
+            return self.relay_rollout_rdma_bytes(peer_ip)
+
+        depth = 2 if os.environ.get("WBRIDGE_RECV_PIPELINE", "1") == "1" else 1
+        merged = os.environ.get("WBRIDGE_MERGED_RECV_PREP", "0") == "1"
+        topo_enabled = os.environ.get("WBRIDGE_TOPO_EXCHANGE", "1") == "1"
+        topology_started = time.perf_counter()
+        configured = bool(topo_enabled and self.configure_topology(peer_ip))
+        if (
+            configured
+            and not SAME_NODE_IPC
+            and any(
+                self.topology_plan(member, ri)["internal"]
+                for member in range(self.receiver_ws)
+                for ri in range(len(self.global_rounds))
+            )
+        ):
+            self._topology_ok = False
+            configured = False
+        if merged and (depth != 2 or not configured):
+            raise ValueError(
+                "rollout RDMA-cap planning with WBRIDGE_MERGED_RECV_PREP=1 requires "
+                "depth-2 topology exchange"
+            )
+
+        topology_seconds = time.perf_counter() - topology_started
+        invariant_started = time.perf_counter()
+        self._ensure_round_invariants()
+        assert self._trainer_peer_counts_cache is not None
+        trainer_peer_counts = self._trainer_peer_counts_cache
+        invariant_seconds = time.perf_counter() - invariant_started
+
+        out = []
+        rounds = len(self.global_rounds)
+        arena_started = time.perf_counter()
+        for receiver_local_rank in range(self.receiver_ws):
+            layout, prep_stride, class_peers = self.arena_layout(
+                receiver_local_rank,
+                depth=depth,
+            )
+            recv_bytes = _arena_recv_total_bytes(layout, depth)
+            if merged:
+                slot_stride = _merge_recv_prep_layout(layout, depth, prep_stride)
+                arena_bytes = _arena_total_bytes(layout, depth, slot_stride)
+                data_bytes = arena_bytes
+            else:
+                arena_bytes = _arena_total_bytes(layout, depth, prep_stride)
+                data_bytes = recv_bytes + arena_bytes
+            # Base peer flags: incoming + source. Replica exchange: READY and consumed, each with incoming
+            # + source. Every bank owns one int64 word per (peer, round).
+            flag_bytes = (
+                max(trainer_peer_counts[receiver_local_rank], 1) * rounds * 2 * 8
+                + len(class_peers) * rounds * 4 * 8
+            )
+            out.append(data_bytes + flag_bytes)
+        arena_seconds = time.perf_counter() - arena_started
+        self._last_rollout_rdma_timing = {
+            "topology_seconds": topology_seconds,
+            "invariant_cache_seconds": invariant_seconds,
+            "arena_seconds": arena_seconds,
+            "total_seconds": time.perf_counter() - total_started,
+        }
+        return out
+
+    def relay_rollout_rdma_bytes(self, peer_ip: dict[int, str]) -> list[int]:
+        """Registered permanent bytes for each rollout worker in replica-relay mode.
+
+        This mirrors :meth:`WBEndpoint._setup_relay_buffers`. Every node representative owns two registered
+        PREP buffers per represented group. Downstream writes land directly in PREP. At a head the same PREP
+        parity is temporarily interpreted as stable per-trainer ingress lanes, then snapshotted and assembled
+        in place; its allocation is therefore the maximum of the canonical payload and the lane bank. DOFF
+        consumption shadows and head assembly scratch are epoch/local CUDA allocations and intentionally do
+        not count toward permanent registered memory. All workers also register the four DATA/ACK flag banks.
+        """
+        if not self.configure_relay(peer_ip):
+            raise ValueError("rollout RDMA-cap planning found no replica-relay groups")
+
+        rounds = len(self.global_rounds)
+        world_size = self.sender_ws + self.receiver_ws
+        flag_bytes = 4 * world_size * len(self._relay_groups) * rounds * 8
+        out = [flag_bytes for _ in range(self.receiver_ws)]
+
+        for group in self._relay_groups:
+            parity_payload_max = [0, 0]
+            for ri, spec in enumerate(group["round_specs"]):
+                parity_payload_max[ri % 2] = max(
+                    parity_payload_max[ri % 2],
+                    spec.nbytes(self.dtype_spec),
+                )
+
+            for owner in group["owners"]:
+                if self.sender_ws + owner == group["head"]:
+                    lane_max = [
+                        {sender: 0 for sender in range(self.sender_ws)}
+                        for _ in range(2)
+                    ]
+                    for ri, trainer_specs in enumerate(group["trainer_specs"]):
+                        for sender, spec in trainer_specs.items():
+                            lane_max[ri % 2][sender] = max(
+                                lane_max[ri % 2][sender],
+                                spec.nbytes(self.dtype_spec),
+                            )
+                    head_lane_bytes = [sum(lanes.values()) for lanes in lane_max]
+                else:
+                    head_lane_bytes = [0, 0]
+                prep_bytes = sum(
+                    max(payload, lanes, 1)
+                    for payload, lanes in zip(parity_payload_max, head_lane_bytes)
+                )
+                out[owner] += prep_bytes
+        return out
+
+    def _rounds_for_rollout_rdma_cap(
+        self,
+        name_send: dict[str, list[int]],
+        name_recv: dict[str, list[int]],
+        peer_ip: dict[int, str],
+        cap: int,
+    ) -> tuple[list[set[str]], int]:
+        """Binary-search the smallest balanced round count whose rollout peak fits ``cap``."""
+        max_rounds = len(self.dtype_spec)
+        if max_rounds < 1:
+            raise ValueError("cannot plan an empty dtype specification")
+        cache: dict[int, tuple[list[set[str]], int]] = {}
+
+        def evaluate(num_rounds: int) -> tuple[list[set[str]], int]:
+            cached = cache.get(num_rounds)
+            if cached is not None:
+                return cached
+            probe_started = time.perf_counter()
+            pack_started = probe_started
+            planned = self._pack_exact_rounds(name_send, name_recv, num_rounds)
+            pack_seconds = time.perf_counter() - pack_started
+            self.global_rounds = planned
+            rdma_started = time.perf_counter()
+            peak = max(self.rollout_rdma_bytes(peer_ip), default=0)
+            rdma_seconds = time.perf_counter() - rdma_started
+            probe_seconds = time.perf_counter() - probe_started
+            timing: dict[str, float | int] = {
+                "rounds": num_rounds,
+                "pack_seconds": pack_seconds,
+                "rdma_seconds": rdma_seconds,
+                "probe_seconds": probe_seconds,
+                **self._last_rollout_rdma_timing,
+            }
+            self.planner_probe_timings.append(timing)
+            cache[num_rounds] = (planned, peak)
+            logger.info(
+                "wbridge router RDMA-cap probe: R=%d peak=%.3f GiB cap=%.3f GiB fit=%s "
+                "time=%.3fs (pack=%.3fs topology=%.3fs arena=%.3fs)",
+                num_rounds,
+                peak / 1024**3,
+                cap / 1024**3,
+                peak <= cap,
+                probe_seconds,
+                pack_seconds,
+                self._last_rollout_rdma_timing.get("topology_seconds", 0.0),
+                self._last_rollout_rdma_timing.get("arena_seconds", 0.0),
+            )
+            return planned, peak
+
+        planned, peak = evaluate(1)
+        if peak <= cap:
+            self.global_rounds = planned
+            return planned, peak
+
+        # Exponentially bracket the transition before binary search. Starting by materializing the maximum
+        # one-tensor-per-round topology is needlessly expensive for large models when a small R already fits.
+        low, high = 1, min(2, max_rounds)
+        while True:
+            _planned, high_peak = evaluate(high)
+            if high_peak <= cap:
+                break
+            if high == max_rounds:
+                raise ValueError(
+                    "rollout RDMA cap is infeasible: even one tensor per round needs "
+                    f"{high_peak / 1024**3:.3f} GiB, cap is {cap / 1024**3:.3f} GiB"
+                )
+            low = high
+            high = min(2 * high, max_rounds)
+
+        low += 1
+        while low < high:
+            middle = (low + high) // 2
+            _planned, peak = evaluate(middle)
+            if peak <= cap:
+                high = middle
+            else:
+                low = middle + 1
+
+        selected = low
+        planned, peak = evaluate(selected)
+        # Registered-buffer size is expected to decrease with finer balanced rounds. Guard the boundary
+        # explicitly: if parity packing produced a local non-monotonicity, walk down to the true adjacent
+        # transition rather than silently wasting rounds.
+        while selected > 1:
+            prior_plan, prior_peak = evaluate(selected - 1)
+            if prior_peak > cap:
+                break
+            selected -= 1
+            planned, peak = prior_plan, prior_peak
+
+        self.global_rounds = planned
+        peak = max(self.rollout_rdma_bytes(peer_ip), default=0)
+        assert peak <= cap
+        return planned, peak
+
+    def cpu_recv_layout(self, rl: int):
+        """Full-depth CPU RECV layout for receiver local index *rl* (RS-on; pure, no CUDA).
+
+        RS-off's GPU RECV lanes live in the isolated parity slot (``[slot*R, (slot+1)*R)``). Under
+        receiver-staging the standalone receiving thread lands EVERY round's data in CPU before the main
+        thread's GPU consume, so the CPU landing arena must be **full-depth**: a distinct slot per
+        ``(round, sender)``, laid contiguously across all rounds. The senders' per-round RECV byte layout
+        WITHIN a round has the same per-sender overlap sizes as :meth:`arena_layout`'s ``recv``; the CPU arena
+        remains compact and advances round-to-round instead of using stable GPU sender lanes. Returns
+        ``(rounds_recv, total)`` where ``rounds_recv[ri] = {si: (abs_off, nb)}`` are absolute offsets into a
+        ``total``-byte CPU buffer. Deterministic (sorted names/senders)."""
+        my = self.recv_specs[rl]
+        ov_full = {
+            si: ShardSpec.compute_overlap(self.send_specs[si], my)
+            for si in range(self.sender_ws)
+        }
+        rounds_recv: list[dict[int, tuple[int, int]]] = []
+        off = 0
+        for names in self.global_rounds:
+            round_names = sorted(n for n in names if n in my.entries)
+            recv: dict[int, tuple[int, int]] = {}
+            for si in range(self.sender_ws):
+                nb = ov_full[si].subset(set(round_names)).nbytes(self.dtype_spec)
+                if nb:
+                    recv[si] = (off, nb)
+                    off += nb
+            rounds_recv.append(recv)
+        return rounds_recv, off
+
+    def _dedup_diag(self) -> None:
+        """Quantify how much the per-tensor receiver dedup (the implemented arena path) saves vs a
+        hypothetical whole-spec (worker-level) dedup. For each tensor, the trainer->rollout receive traffic
+        is ``sum_w bytes_w / class_size_w``: whole-spec uses the worker's full-spec class size, per-tensor
+        uses that tensor's own replication-class size. Logs total savings + the top contributing tensors.
+        Gated by WBRIDGE_DEDUP_DIAG=1, run once on rank 0. Pure read-only accounting (no transfer change)."""
+        specs = self.recv_specs_full
+        n = len(specs)
+
+        def whole_key(s):
+            return tuple(
+                sorted((nm, _shards_canonical_key(sh)) for nm, sh in s.entries.items())
+            )
+
+        ws_classes: dict = {}
+        for w in range(n):
+            ws_classes.setdefault(whole_key(specs[w]), []).append(w)
+        m_ws = {
+            w: len(g) for g in ws_classes.values() for w in g
+        }  # whole-spec class size per worker
+
+        names = sorted({nm for s in specs for nm in s.entries})
+        tot_ws = tot_pt = 0.0
+        rows = []
+        for name in names:
+            holders = [w for w in range(n) if name in specs[w].entries]
+            pt: dict = {}
+            for w in holders:
+                pt.setdefault(_shards_canonical_key(specs[w][name]), []).append(w)
+            c_t = {
+                w: len(g) for g in pt.values() for w in g
+            }  # per-tensor class size per worker
+            ws_b = pt_b = 0.0
+            for w in holders:
+                b = specs[w].subset([name]).nbytes(self.dtype_spec)
+                ws_b += b / m_ws[w]
+                pt_b += b / c_t[w]
+            tot_ws += ws_b
+            tot_pt += pt_b
+            rows.append(
+                (
+                    ws_b - pt_b,
+                    name,
+                    sorted({m_ws[w] for w in holders}),
+                    sorted(set(c_t.values())),
+                    ws_b,
+                )
+            )
+
+        save = tot_ws - tot_pt
+        logger.info(
+            "wbridge dedup-diag: recv traffic whole-spec=%.2f GiB, per-tensor=%.2f GiB, "
+            "savings=%.2f GiB (%.1f%%) over %d tensors, %d receivers",
+            tot_ws / 1024**3,
+            tot_pt / 1024**3,
+            save / 1024**3,
+            100 * save / tot_ws if tot_ws else 0.0,
+            len(names),
+            n,
+        )
+        rows.sort(reverse=True)
+        for sv, name, mws, cc, _wsb in rows[:12]:
+            if sv <= 1024**2:  # skip < 1 MiB
+                break
+            logger.info(
+                "  dedup-diag save=%.3f GiB  whole-spec m=%s -> per-tensor c=%s  %s",
+                sv / 1024**3,
+                mws,
+                cc,
+                name,
+            )
+
+        # Consolidation effectiveness: one group per worker remains a useful low-fanout target, but is no
+        # longer a topology precondition. Overlapping groups are eligible when each group is node-balanced.
+        classes = self.recv_tensor_classes()
+        worker_groups: dict[int, set] = {}
+        for cls in classes.values():
+            for c in cls:
+                if len(c) >= 2:
+                    for rl in c:
+                        worker_groups.setdefault(rl, set()).add(tuple(c))
+        n_one = sum(1 for gs in worker_groups.values() if len(gs) == 1)
+        n_multi = sum(1 for gs in worker_groups.values() if len(gs) > 1)
+        logger.info(
+            "wbridge dedup-diag: one-group-per-worker: %d receiver(s) in exactly one multi-worker "
+            "group, %d in >1 (multi-group topology), %d in none (0-peer)",
+            n_one,
+            n_multi,
+            n - n_one - n_multi,
+        )
+
+
+class WBEndpoint:
+    """Shared RDMA endpoint base for Trainer Worker senders and Rollout Worker receivers.
+
+    Weight data moves by **one-sided RDMA writes** (:class:`~wbridge.backend.rdma.base.RdmaEngine`), never
+    a process-group collective. At connect, a one-time CPU **Gloo** group is used only to
+    ``all_gather_object`` the routing specs, engine session ids, and registered buffer addresses; it
+    carries no weight data. Each (sender, receiver) pair then ping-pongs per round over dedicated,
+    pre-registered buffers: the sender writes the packed chunk then a monotonic "done" flag; the receiver
+    polls that flag, consumes, then writes a "consumed" flag the sender polls before reusing the buffer.
+    """
+
+    cuda_device: str
+    shard_spec: ShardSpec
+    dtype_spec: dict[str, torch.dtype]
+    load_spec: (
+        LoadSpec  # HF<->worker mapping (set by subclass); drives the fused copy plan
+    )
+    wksd: dict[
+        str, torch.Tensor
+    ]  # live parameter tensors (set by subclass); stable addresses across WTs
+    router: WeightRouter | None = None
+    group: dist.ProcessGroup | None = (
+        None  # one-time Gloo metadata group; unused during transfer
+    )
+    engine: RdmaEngine | None = None
+    # In-process GPU<->CPU staging "engine" (built only when a staging switch is on). SS uses it to offload
+    # the packed wire buffer to CPU before the RDMA write; RS uses it to load the CPU-landed bytes into the
+    # GPU arena before assemble. None when both staging switches are off (the default path).
+    local_engine: LocalStagingEngine | None = None
+    device: str | None = None
+    session: str = ""
+
+    # Staging switches (set by the subclass before set_up_connection). Independent: SS offloads the sender's
+    # packed bytes to CPU before RDMA; RS lands the receiver's incoming bytes in CPU before the GPU load.
+    sender_staging: bool = False
+    receiver_staging: bool = False
+
+    # Flag slots hold monotonic int64 sequence numbers.
+    _FLAG_DTYPE = torch.int64
+    _FLAG_ITEMSIZE = 8
+    _RELAY_DATA_KIND = 3
+    _RELAY_ACK_KIND = 4
+    _RELAY_SEQ_BITS = 48
+
+    # The sender's per-peer pack buffers (`_data_buf`) are double-buffered by round parity (ri % _NUM_BUF)
+    # to pipeline rounds: with 2 buffers the sender keeps one round's RDMA writes in flight while packing the
+    # next, which is what fills the fabric. Depth 2 is the validated sweet spot — higher plateaus/regresses
+    # and costs ~N/2× the pack memory on the trainer. The receiver independently selects an arena depth;
+    # both sides address it by global-round parity.
+    _NUM_BUF = 2
+
+    def _init_profile_output(self) -> None:
+        """Initialize the per-epoch gate that keeps profiling output after report ``block_end``.
+
+        Sender completion is asynchronous: the application may record ``block_end`` before the Stage-2
+        thread has produced the final spans.  Receivers have the inverse ordering.  The pending/released
+        handshake handles both without making either side wait, and every epoch contributes exactly one
+        immutable output callback.
+        """
+        if hasattr(self, "_profile_output_lock"):
+            return
+        self._profile_output_lock = threading.Lock()
+        self._profile_output_pending: dict[tuple[int, int], Callable[[], None]] = {}
+        self._profile_output_released: set[tuple[int, int]] = set()
+        self._profile_output_generation = -1
+
+    def _profile_output_key(self, epoch: int) -> tuple[int, int]:
+        return self._profile_output_generation, epoch
+
+    @staticmethod
+    def _emit_profile_output(output: Callable[[], None]) -> None:
+        """Best-effort profiling output must never turn a successful transfer into a failure."""
+        try:
+            output()
+        except Exception:  # noqa: BLE001 - diagnostics are intentionally non-fatal
+            logger.exception("wbridge: failed to emit deferred profiling output")
+
+    def _defer_profile_output(self, epoch: int, output: Callable[[], None]) -> None:
+        """Publish a complete epoch snapshot, emitting now only if ``block_end`` was already released."""
+        key = self._profile_output_key(epoch)
+        with self._profile_output_lock:
+            if key in self._profile_output_released:
+                self._profile_output_released.remove(key)
+                emit = True
+            else:
+                if key in self._profile_output_pending:
+                    raise RuntimeError(
+                        f"duplicate profiling snapshot for epoch {epoch}"
+                    )
+                self._profile_output_pending[key] = output
+                emit = False
+        if emit:
+            self._emit_profile_output(output)
+
+    def flush_profile_outputs(self, epoch: int | None = None) -> None:
+        """Release one epoch's captured output after the caller records its report ``block_end``.
+
+        This method intentionally does not wait for an asynchronous sender epoch to finish.  If its final
+        snapshot is not ready yet, the Stage-2 thread emits it after publishing transfer completion.
+        """
+        if epoch is None:
+            epoch = getattr(self, "_epoch", 0) - 1
+        if epoch < 0:
+            return
+        key = self._profile_output_key(epoch)
+        with self._profile_output_lock:
+            output = self._profile_output_pending.pop(key, None)
+            if output is None:
+                self._profile_output_released.add(key)
+        if output is not None:
+            self._emit_profile_output(output)
+
+    def _take_profile_output(
+        self,
+        epoch: int,
+        nrounds: int,
+        extra_outputs: tuple[Callable[[], None], ...] = (),
+    ) -> Callable[[], None]:
+        """Snapshot Gantt/control profiling in memory and return its deferred output callback."""
+        # Every producer that records profile events is quiescent at the two call sites. Async flag-handle
+        # reaping may continue, but deliberately records no spans and cannot contaminate the next snapshot.
+        # No file or logger output occurs while taking either snapshot.
+        from wbridge.backend import gantt
+
+        events = gantt.take()
+        ctl_lines = self._ctl_take_report(epoch, nrounds)
+
+        def output() -> None:
+            gantt.dump(events)
+            for line in ctl_lines:
+                logger.warning("%s", line)
+            for emit in extra_outputs:
+                emit()
+
+        return output
+
+    def _capture_profile_outputs(
+        self,
+        epoch: int,
+        nrounds: int,
+        extra_outputs: tuple[Callable[[], None], ...] = (),
+    ) -> None:
+        self._defer_profile_output(
+            epoch, self._take_profile_output(epoch, nrounds, extra_outputs)
+        )
+
+    def _trace_state(self, stage: str, **fields) -> None:
+        """Emit one machine-readable protocol state transition for deadlock reconstruction.
+
+        This is deliberately gated by ``WBRIDGE_TOPO_DEBUG`` and has no synchronization side effects.  The
+        thread name distinguishes the receiver main/EC lanes and the sender main/background lanes.  A hang
+        can therefore be reconstructed by taking the last ``WBSTATE`` record for every ``(rank, thread)``.
+        """
+        if os.environ.get("WBRIDGE_TOPO_DEBUG") != "1":
+            return
+        record = {
+            "rank": getattr(self, "_rank", getattr(self, "rank", -1)),
+            "role": "sender" if getattr(self, "_is_sender", False) else "receiver",
+            "thread": threading.current_thread().name,
+            "stage": stage,
+            **fields,
+        }
+        print(
+            "WBSTATE " + json.dumps(record, sort_keys=True, separators=(",", ":")),
+            flush=True,
+        )
+
+    # ---------------------------------------------------------------- connect
+    def set_up_connection(self, **pg_args) -> None:
+        """Bring up the Gloo metadata group + RDMA engine, then exchange routing + buffer metadata."""
+        protocol = pg_args.pop("protocol", "efa")
+        sender_ws = pg_args.pop("sender_world_size")
+        rank = pg_args["rank"]
+        ws = pg_args["world_size"]
+        init_method = pg_args["init_method"]
+        group_name = pg_args.get("group_name", "wbridge")
+
+        self._init_profile_output()
+        self._profile_output_generation += 1
+        self._teardown()
+        self.device = self.cuda_device
+        self.group = init_custom_process_group(
+            backend="gloo",
+            init_method=init_method,
+            world_size=ws,
+            rank=rank,
+            group_name=f"{group_name}-meta",
+        )
+        self._init_engine(protocol)
+        self._finish_setup(rank, ws, sender_ws)
+
+    def _init_engine(self, protocol: str) -> None:
+        # The selected network implementation stays behind the RdmaEngine interface. Mooncake uses a
+        # composite engine for its network and optional same-node NVLink transports; Monarch supplies its
+        # libibverbs implementation directly.
+        if protocol == "monarch":
+            # Lazy import: pulling in monarch loads a large native extension, and it is only importable
+            # inside a Monarch actor process. See rdma/monarch.py for why this backend exists.
+            from wbridge.backend.rdma.monarch import MonarchEngine
+
+            engine: RdmaEngine = MonarchEngine()
+            engine.init(get_local_ip(), protocol)
+            self.engine = engine
+            self.session = engine.session_id()
+            self.local_engine = None
+            if self.sender_staging or self.receiver_staging:
+                raise RuntimeError(
+                    "protocol='monarch' does not support sender/receiver staging yet"
+                )
+            return
+        engine: RdmaEngine = DualMooncakeEngine()
+        # Supplying a transport-capable Mooncake build is the deployment environment's responsibility.
+        # Under staging, host DRAM is on the network RDMA path. For Mooncake/EFA, pin each rank to a NIC
+        # local to its GPU so concurrent ranks do not funnel through the same device. The both-OFF
+        # GPU-direct path carries its own GPU-to-NIC affinity and does not request this host-memory pin.
+        engine.init(
+            get_local_ip(),
+            protocol,
+            "",
+            pin_local_nic=(self.sender_staging or self.receiver_staging),
+        )
+        self.engine = engine
+        self.session = engine.session_id()
+        # A staging endpoint additionally runs an in-process GPU<->CPU engine (D2H for SS, H2D for RS). A
+        # process is exclusively a sender or a receiver, so at most one switch is ever set here.
+        self.local_engine = None
+        if self.sender_staging or self.receiver_staging:
+            le = LocalStagingEngine()
+            le.init(get_local_ip(), protocol, "")
+            self.local_engine = le
+
+    def transport_stats(self) -> dict:
+        """Bulk weight bytes moved since connect, split by transport and by leg.
+
+        ``wire_*`` is the trainer->rollout leg (bytes this rank sent, or landed, depending on role) and
+        ``agh_*`` the rollout<->rollout dedup exchange. ``ipc`` counts direct CUDA-IPC copies over NVLink,
+        ``rdma`` counts the selected :class:`RdmaEngine`. Flag traffic is excluded: cross-node flags use it
+        or the optional host TCP control plane, while same-node replica sequences use a shared CPU bank. A
+        co-located deployment should report ``*_rdma_bytes == 0``; that assertion is what
+        :mod:`examples.train` ``--colocate`` checks.
+        """
+        st = dict(getattr(self, "_tstats", _EMPTY_TSTATS))
+        st["role"] = "sender" if getattr(self, "_is_sender", False) else "receiver"
+        st["rank"] = getattr(self, "_rank", -1)
+        st["same_node_peers"] = sorted(getattr(self, "_same_node_peers", []))
+        st["ipc_peers"] = sorted(
+            getattr(self, "_sn_peers" if st["role"] == "sender" else "_sn_senders", ())
+        )
+        st["rdma_peers"] = sorted(
+            set(getattr(self, "peers", [])) - set(st["ipc_peers"])
+        )
+        return st
+
+    def _ensure_relay_bulk_waiters(self, edges: set[tuple[int, int]]) -> None:
+        """Create one persistent completion/DATA publisher per ``(destination, group)`` edge."""
+        if not hasattr(self, "_relay_bulk_wait_lock"):
+            self._relay_bulk_wait_lock = threading.Lock()
+            self._relay_bulk_wait_queues = {}
+            self._relay_bulk_wait_threads = {}
+        with self._relay_bulk_wait_lock:
+            for edge in sorted(edges):
+                if edge in self._relay_bulk_wait_threads:
+                    continue
+                peer, gid = edge
+                work_q: queue.Queue = queue.Queue()
+                thread = threading.Thread(
+                    target=self._relay_bulk_waiter,
+                    args=(peer, gid, work_q),
+                    name=f"wbridge-relay-wire-{peer}-g{gid}",
+                    daemon=True,
+                )
+                self._relay_bulk_wait_queues[edge] = work_q
+                self._relay_bulk_wait_threads[edge] = thread
+                thread.start()
+
+    def _relay_bulk_waiter(self, peer: int, gid: int, work_q: queue.Queue) -> None:
+        while True:
+            task = work_q.get()
+            if task is None:
+                return
+            wt, ri, seq, handle, submitted_at, leg, result_q = task
+            error: BaseException | None = None
+            landed_at = submitted_at
+            try:
+                if handle is not None:
+                    self.engine.wait([handle])
+                    landed_at = time.time()
+                # DATA publication is the data-before-flag fence for this exact group/round edge.
+                self._relay_emit(self._RELAY_DATA_KIND, peer, gid, seq)
+                from wbridge.backend import gantt
+
+                gantt.rec(
+                    "relay-wire",
+                    self._rank,
+                    wt,
+                    f"{leg}_peer_{peer}_group_{gid}",
+                    ri,
+                    submitted_at,
+                    landed_at,
+                )
+            except BaseException as exc:  # noqa: BLE001 - surfaced by the owning progress loop
+                error = exc
+            result_q.put((peer, gid, ri, seq, error, landed_at))
+
+    def _stop_relay_bulk_waiters(self) -> None:
+        if not hasattr(self, "_relay_bulk_wait_lock"):
+            return
+        with self._relay_bulk_wait_lock:
+            queues = list(self._relay_bulk_wait_queues.values())
+            threads = list(self._relay_bulk_wait_threads.values())
+            self._relay_bulk_wait_queues = {}
+            self._relay_bulk_wait_threads = {}
+        for work_q in queues:
+            work_q.put(None)
+        for thread in threads:
+            if thread.is_alive():
+                thread.join(timeout=5.0)
+
+    def _teardown(self) -> None:
+        """Close the engine (unregisters buffers) and destroy the metadata group, for reconnects."""
+        self._stop_relay_bulk_waiters()
+        tcp_control = getattr(self, "_tcp_control", None)
+        if tcp_control is not None:
+            tcp_control.close()
+        self._tcp_control = None
+        # Async flag handles reference both the engine and registered source words. Retire them before either
+        # is torn down. This is lifecycle cleanup only; normal epoch completion never waits here.
+        self._flag_reaper_stop()
+        for mappings in (
+            getattr(self, "_repl_peer_ipc_mapping", {}),
+            getattr(self, "_repl_peer_doff_ipc_mapping", {}),
+            getattr(self, "_relay_peer_ipc_mapping", {}),
+        ):
+            for device, allocation_base in mappings.values():
+                with contextlib.suppress(Exception):
+                    _close_cuda_ipc_mapping(device, allocation_base)
+        for mapping_list in getattr(self, "_peer_pack_ipc_mapping", {}).values():
+            for device, allocation_base in mapping_list:
+                with contextlib.suppress(Exception):
+                    _close_cuda_ipc_mapping(device, allocation_base)
+        for bank in getattr(self, "_repl_peer_local_flags", {}).values():
+            bank.close()
+        for bank in getattr(self, "_relay_peer_local_flags", {}).values():
+            bank.close()
+        own_bank = getattr(self, "_repl_local_flags", None)
+        if own_bank is not None:
+            own_bank.close()
+        relay_bank = getattr(self, "_relay_local_flags", None)
+        if relay_bank is not None:
+            relay_bank.close()
+        self._repl_peer_local_flags = {}
+        self._repl_local_flags = None
+        self._relay_peer_local_flags = {}
+        self._relay_local_flags = None
+        if self.engine is not None:
+            self.engine.close()
+            self.engine = None
+        if self.local_engine is not None:
+            self.local_engine.close()
+            self.local_engine = None
+        if self.group is not None:
+            try:
+                dist.destroy_process_group(self.group)
+            except Exception:
+                pass
+            self.group = None
+        self._data_buf: dict[int, torch.Tensor] = {}
+        self._relay_send_buf = {}
+        self._relay_prep_buf = {}
+        self._relay_doff_buf = {}
+        self._relay_peer_doff = {}
+        self._relay_peer_kernel_base = {}
+        self._relay_peer_ipc_mapping = {}
+        self._relay_peer_ready_event = {}
+        self._relay_prepare_plan = {}
+        self._relay_offload_stream = {}
+        self._relay_offload_event = {}
+        self._relay_consume_plan = {}
+        self._cpu_grid: dict[
+            int, list[torch.Tensor | None]
+        ] = {}  # SS: per-(peer, round) CPU offload
+        self._cpu_recv = None  # RS: full-depth CPU receive arena
+        self._flag_buf = None
+        self._flag_src = None
+        # Drop same-node CUDA-IPC state so a reconnect re-imports against the freshly reallocated arena (torch
+        # GC closes the imported mem/event handles). Guarded — these exist only for receivers with class peers.
+        self._repl_peer_arena = {}
+        self._repl_peer_kernel_base = {}
+        self._repl_peer_ipc_mapping = {}
+        self._repl_peer_doff_arena = {}
+        self._repl_peer_doff_kernel_base = {}
+        self._repl_peer_doff_ipc_mapping = {}
+        self._repl_peer_ready_event = {}
+        self._repl_peer_doff_ready_event = {}
+        self._repl_ready_event = {}
+        self._topo_slot_ready_event = {}
+        self._repl_peer_topo_slot_ready_event = {}
+        self._topo_local_slot_channel = {}
+        self._topo_peer_slot_channel = {}
+        self._repl_same_node = set()
+        self._repl_peer_grecv_off = {}
+        self._repl_peer_send_off = {}  # PULL: per-round offset of peer's send[me] within peer's arena
+        self._repl_peer_slot_of_me = {}
+        # Topology-aware exchange state (rebuilt per connect against fresh arenas). See the per-peer
+        # resolve block + WeightRouter.configure_topology.
+        self._topo_ok = False
+        self._topo_structure_ok = False
+        self._topo_ext_peers = []  # subgroup cross-node PUSH peers (phase 1)
+        self._topo_int_peers = []  # same-node source columns consumed directly over CUDA IPC
+        # peer -> per-round (external slot source or None, src_off, packed spec, selected names)
+        self._topo_internal_consume_src = {}
+        self._topo_internal_consume_bytes = {}
+        self._topo_internal_consume_bytes_by_lane = []
+        self._topo_ext_send_peers_by_round = []
+        self._topo_ext_recv_peers_by_round = []
+        self._topo_int_peers_by_round = []
+        self._topo_int_readers_by_round = []
+        self._topo_ext_release_readers_by_round = []
+        self._topo_ext_xfer = {}
+        self._topo_peer_predecessors = []
+        self._topo_internal_consume_plan = []
+        self._topo_internal_consume_own_lane = []
+        self._topo_internal_consume_stream = {}
+        self._topo_internal_consume_event = {}
+        self._topo_internal_consume_lane_sources = []
+        self._topo_internal_consume_source_lane = []
+        self._direct_consume_plan = []
+        self._doff_copy_stream = {}
+        self._doff_copy_event = {}
+        self._doff_slot_released = {}
+        # Same-node trainer->rollout CUDA-IPC bypass (see the export/import blocks in _setup_rdma_buffers).
+        # Dropped here so a reconnect re-exports/re-imports against freshly allocated buffers.
+        self._same_node_peers: list[
+            int
+        ] = []  # peers on this host, by the session-gather's IPs
+        self._sn_peers: set[int] = (
+            set()
+        )  # sender: receivers that PULL our pack buffers (no RDMA)
+        self._sn_senders: set[int] = (
+            set()
+        )  # receiver: senders whose pack buffers we PULL
+        self._pack_ready_event = {}  # sender: per-receiver exported "pack landed" event
+        self._peer_pack_buf = {}  # receiver: {sender: [imported pack buffer per parity]}
+        self._peer_pack_kernel_base = {}  # receiver: raw peer mappings for direct consume kernels
+        self._peer_pack_ipc_mapping = {}  # receiver: mappings closed explicitly on reconnect
+        self._peer_pack_event = {}  # receiver: {sender: imported pack-landed event}
+        self._peer_pack_num_buf = {}  # receiver: {sender: its pack-buffer parity depth}
+        self._direct_same_node = False
+        self._tstats = dict(_EMPTY_TSTATS)
+
+    def _finish_setup(self, rank: int, ws: int, sender_ws: int) -> None:
+        """Exchange specs (build router), then allocate/register buffers and exchange their addresses."""
+        grp = self.group
+        all_shard_specs: list = [None] * ws
+        dist.all_gather_object(all_shard_specs, self.shard_spec, group=grp)
+
+        all_dtype_specs: list = [None] * ws
+        dist.all_gather_object(all_dtype_specs, self.dtype_spec, group=grp)
+        # All workers plan independently below.  Start them from the same stable name order even though
+        # each worker's local dtype map contains a different subset/insertion order.
+        self.dtype_spec = _canonical_dtype_spec(all_dtype_specs)
+
+        # Who is physically co-located with whom. Gathered BEFORE the big metadata exchange because the
+        # same-node CUDA-IPC exports below (pack buffers + events) are built into that exchange, and we only
+        # want to pay for them — and only risk reduce_tensor's allocator constraint — for peers on this host.
+        all_sessions: list = [None] * ws
+        dist.all_gather_object(all_sessions, self.session, group=grp)
+        self._local_ip = get_local_ip()
+        self._peer_ip = {
+            r: DualMooncakeEngine._ip_of(DualMooncakeEngine._split(s)[0])
+            for r, s in enumerate(all_sessions)
+        }
+
+        # Every worker has the same globally ordered specs, canonical dtype map, placement map, and planner
+        # configuration.  Compute the deterministic global rounds independently so setup has no rank-0
+        # planner/broadcast dependency; `rank` affects only the local-round projection after global planning.
+        direct_requested = os.environ.get("WBRIDGE_DIRECT_SAME_NODE", "0") == "1"
+        one_physical_node = len(set(self._peer_ip.values())) == 1
+        direct_same_node = bool(
+            direct_requested
+            and SAME_NODE_IPC
+            and one_physical_node
+            and not self.sender_staging
+            and not self.receiver_staging
+            and os.environ.get("WBRIDGE_REPLICA_RELAY", "0") != "1"
+        )
+        if direct_requested and not direct_same_node and rank == 0:
+            logger.warning(
+                "WBRIDGE_DIRECT_SAME_NODE=1 requested but unavailable "
+                "(one_node=%s same_node_ipc=%s sender_staging=%s receiver_staging=%s relay=%s); "
+                "using the normal exchange path",
+                one_physical_node,
+                SAME_NODE_IPC,
+                self.sender_staging,
+                self.receiver_staging,
+                os.environ.get("WBRIDGE_REPLICA_RELAY", "0"),
+            )
+        self.router = WeightRouter(
+            rank,
+            sender_ws,
+            all_shard_specs,
+            self.dtype_spec,
+            peer_ip=self._peer_ip,
+            direct_same_node=direct_same_node,
+        )
+        self._direct_same_node = direct_same_node
+        self.num_rounds = len(self.router.local_rounds)
+        self._is_sender = rank < sender_ws
+        self._rank = rank
+        self._epoch = 0
+        self._relay_enabled = os.environ.get("WBRIDGE_REPLICA_RELAY", "0") == "1"
+        if self._relay_enabled:
+            if self.sender_staging or self.receiver_staging:
+                raise RuntimeError(
+                    "WBRIDGE_REPLICA_RELAY=1 does not support host staging"
+                )
+            if not SAME_NODE_IPC:
+                raise RuntimeError(
+                    "WBRIDGE_REPLICA_RELAY=1 requires WBRIDGE_SAME_NODE_IPC=1"
+                )
+            if not self.router.configure_relay(self._peer_ip):
+                raise RuntimeError(
+                    "replica-group relay found no routable replication groups"
+                )
+            self._setup_relay_buffers(rank, ws)
+            self._build_relay_plans()
+        else:
+            self._setup_rdma_buffers(rank, ws)
+            self._build_fuse_plans()
+        self._trace_state("connected", rounds=self.num_rounds)
+        logger.info(
+            "wbridge rank %d connected: %d peers, %d rounds, session=%s",
+            rank,
+            len(self.peers),
+            self.num_rounds,
+            self.session,
+        )
+
+    def _setup_relay_buffers(self, rank: int, ws: int) -> None:
+        """Allocate and resolve the replica-group relay protocol's depth-2 buffers.
+
+        Senders own one SEND parity pair per group they contribute to. A node representative owns only one
+        registered PREP parity pair per represented group: trainer lanes and downstream relay writes land
+        directly there. Heads snapshot the lane image into epoch scratch before assembling back in place.
+        Every representative additionally owns non-RDMA DOFF generations used by local/model consumers, so
+        PREP lifetime ends after forwarding plus offload rather than after model consumption.
+        """
+        assert (
+            self.engine is not None
+            and self.router is not None
+            and self.device is not None
+        )
+        self.world_size = ws
+        self._relay_num_groups = len(self.router._relay_groups)
+        if self._relay_num_groups == 0:
+            raise RuntimeError("relay setup requires at least one group")
+        self._recv_depth = 2
+        self._NUM_BUF = 2
+        if os.environ.get("WBRIDGE_RECV_PIPELINE", "1") != "1":
+            raise RuntimeError(
+                "WBRIDGE_REPLICA_RELAY requires depth-2 receiver buffers"
+            )
+        if int(os.environ.get("WBRIDGE_SENDER_NUM_BUF", "2")) != 2:
+            raise RuntimeError(
+                "WBRIDGE_REPLICA_RELAY requires WBRIDGE_SENDER_NUM_BUF=2"
+            )
+
+        self._ctlp = os.environ.get("WBRIDGE_CTL_PROFILE") == "1"
+        self._ctl = {}
+        self._flag_reaper_q = None
+        self._flag_reaper_thread = None
+        self._flag_reaper_lock = threading.Lock()
+        self._flag_reaper_errors = []
+        self._flag_submit_lock = threading.Lock()
+        self._tstats = dict(_EMPTY_TSTATS)
+        self._same_node_peers = []
+        self._sn_peers = set()
+        self._sn_senders = set()
+
+        # Every control word is exclusive to (writer peer, group, global round).  DATA and ACK have separate
+        # banks, and each bank has a matching immutable async-write source allocation.
+        flag_words = ws * self._relay_num_groups * self.num_rounds
+        self._relay_data_buf = torch.zeros(
+            flag_words, dtype=self._FLAG_DTYPE
+        ).pin_memory()
+        self._relay_data_src = torch.zeros(
+            flag_words, dtype=self._FLAG_DTYPE
+        ).pin_memory()
+        self._relay_ack_buf = torch.zeros(
+            flag_words, dtype=self._FLAG_DTYPE
+        ).pin_memory()
+        self._relay_ack_src = torch.zeros(
+            flag_words, dtype=self._FLAG_DTYPE
+        ).pin_memory()
+        for tensor in (
+            self._relay_data_buf,
+            self._relay_data_src,
+            self._relay_ack_buf,
+            self._relay_ack_src,
+        ):
+            self.engine.register(
+                tensor.data_ptr(),
+                tensor.numel() * self._FLAG_ITEMSIZE,
+                is_flag=True,
+                tensor=tensor,
+            )
+
+        sw = self.router.sender_ws
+        rl = rank - sw
+        self._relay_send_specs: list[dict[int, ShardSpec]] = [
+            {} for _ in range(self.num_rounds)
+        ]
+        self._relay_send_buf: dict[int, list[torch.Tensor]] = {}
+        self._relay_owned_gids: list[int] = []
+        self._relay_consume_owner: dict[int, int] = {}
+        self._relay_local_readers: dict[int, tuple[int, ...]] = {}
+        self._relay_prep_buf: dict[int, list[torch.Tensor]] = {}
+        self._relay_prep_offsets: dict[int, list[dict[int, int]]] = {}
+        self._relay_prep_sizes: dict[int, list[int]] = {}
+        self._relay_head_scratch_size: dict[int, int] = {}
+        self._relay_doff_depth = int(os.environ.get("WBRIDGE_DOFF", "1"))
+        if self._relay_doff_depth < 1:
+            raise ValueError(f"WBRIDGE_DOFF must be >= 1, got {self._relay_doff_depth}")
+        self._relay_doff_buf: dict[int, list[torch.Tensor]] = {}
+
+        registered_destinations: list[torch.Tensor] = []
+        total_send = total_prep = total_doff = 0
+        if self._is_sender:
+            for group in self.router._relay_groups:
+                gid = group["id"]
+                for ri in range(self.num_rounds):
+                    spec = group["trainer_specs"][ri].get(rank)
+                    if spec is not None:
+                        self._relay_send_specs[ri][gid] = spec
+                if not any(gid in by_group for by_group in self._relay_send_specs):
+                    continue
+                parity_max = [0, 0]
+                for ri, by_group in enumerate(self._relay_send_specs):
+                    if gid in by_group:
+                        parity_max[ri % 2] = max(
+                            parity_max[ri % 2],
+                            by_group[gid].nbytes(self.dtype_spec),
+                        )
+                bufs = []
+                for parity in range(2):
+                    size = max(parity_max[parity], 1)
+                    tensor = torch.zeros(size, dtype=torch.uint8, device=self.device)
+                    self.engine.register(
+                        tensor.data_ptr(), tensor.numel(), tensor=tensor
+                    )
+                    bufs.append(tensor)
+                    total_send += tensor.numel()
+                self._relay_send_buf[gid] = bufs
+        else:
+            for group in self.router._relay_groups:
+                gid = group["id"]
+                if rl in group["members"]:
+                    self._relay_consume_owner[gid] = sw + group["owner_of"][rl]
+                if rank not in group["chain"]:
+                    continue
+                self._relay_owned_gids.append(gid)
+                local_members = group["local_readers"][rl]
+                self._relay_local_readers[gid] = tuple(
+                    sw + member for member in local_members if sw + member != rank
+                )
+                parity_payload_max = [0, 0]
+                round_sizes = []
+                for ri, spec in enumerate(group["round_specs"]):
+                    size = spec.nbytes(self.dtype_spec)
+                    round_sizes.append(size)
+                    parity_payload_max[ri % 2] = max(parity_payload_max[ri % 2], size)
+                self._relay_prep_sizes[gid] = round_sizes
+
+                is_head = rank == group["head"]
+                offsets_by_round: list[dict[int, int]] = [
+                    {} for _ in range(self.num_rounds)
+                ]
+                ingress_parity_size = [0, 0]
+                if is_head:
+                    # Trainers land directly in PREP. Stable lanes within each parity prevent one trainer's
+                    # contribution from aliasing another's. Once every lane lands, the whole ingress image
+                    # is snapshotted to epoch scratch and assembled back into this same PREP allocation.
+                    lane_max = [{si: 0 for si in range(sw)} for _ in range(2)]
+                    for ri, trainer_specs in enumerate(group["trainer_specs"]):
+                        for si, spec in trainer_specs.items():
+                            lane_max[ri % 2][si] = max(
+                                lane_max[ri % 2][si],
+                                spec.nbytes(self.dtype_spec),
+                            )
+                    lane_off: list[dict[int, int]] = []
+                    for parity in range(2):
+                        cursor = 0
+                        current = {}
+                        for si in range(sw):
+                            current[si] = cursor
+                            cursor += lane_max[parity][si]
+                        lane_off.append(current)
+                        ingress_parity_size[parity] = cursor
+                    for ri, trainer_specs in enumerate(group["trainer_specs"]):
+                        offsets_by_round[ri] = {
+                            si: lane_off[ri % 2][si] for si in trainer_specs
+                        }
+                else:
+                    pred = group["chain"][group["chain"].index(rank) - 1]
+                    for ri, size in enumerate(round_sizes):
+                        if size:
+                            offsets_by_round[ri] = {pred: 0}
+                self._relay_prep_offsets[gid] = offsets_by_round
+
+                prep_bufs: list[torch.Tensor] = []
+                for parity in range(2):
+                    prep_tensor = torch.zeros(
+                        max(parity_payload_max[parity], ingress_parity_size[parity], 1),
+                        dtype=torch.uint8,
+                        device=self.device,
+                    )
+                    self.engine.register(
+                        prep_tensor.data_ptr(),
+                        prep_tensor.numel(),
+                        tensor=prep_tensor,
+                    )
+                    registered_destinations.append(prep_tensor)
+                    prep_bufs.append(prep_tensor)
+                    total_prep += prep_tensor.numel()
+                self._relay_prep_buf[gid] = prep_bufs
+                if is_head:
+                    self._relay_head_scratch_size[gid] = max(
+                        (tensor.numel() for tensor in prep_bufs),
+                        default=1,
+                    )
+
+                # Internal/model consumption reads a non-RDMA DOFF generation, never PREP. PREP therefore
+                # becomes reusable as soon as its successor write and PREP->DOFF copy finish, independently
+                # of local model-copy latency. DOFF defaults to depth one and is source-exclusive per group.
+                doff_slot_max = [0] * self._relay_doff_depth
+                for ri, size in enumerate(round_sizes):
+                    doff_slot_max[ri % self._relay_doff_depth] = max(
+                        doff_slot_max[ri % self._relay_doff_depth],
+                        size,
+                    )
+                doff_bufs = [
+                    torch.empty(max(size, 1), dtype=torch.uint8, device=self.device)
+                    for size in doff_slot_max
+                ]
+                self._relay_doff_buf[gid] = doff_bufs
+                total_doff += sum(tensor.numel() for tensor in doff_bufs)
+
+        # Same-node DOFF READY/DONE bank. One channel per represented (group, DOFF slot), one consumed slot
+        # per local reader. The paired CUDA IPC event is the visibility fence; PREP itself is never exposed to
+        # readers and can be forwarded/reused without waiting for their model-copy kernels.
+        self._relay_local_flags = None
+        self._relay_local_channel: dict[tuple[int, int], int] = {}
+        self._relay_local_slot_of: dict[int, int] = {}
+        self._relay_ready_event: dict[tuple[int, int, int], torch.cuda.Event] = {}
+        if not self._is_sender:
+            local_reader_union = sorted(
+                {
+                    reader
+                    for readers in self._relay_local_readers.values()
+                    for reader in readers
+                }
+            )
+            self._relay_local_slot_of = {
+                reader: slot for slot, reader in enumerate(local_reader_union)
+            }
+            active_channels = [
+                (gid, slot)
+                for gid in self._relay_owned_gids
+                if self._relay_local_readers.get(gid)
+                for slot in range(self._relay_doff_depth)
+            ]
+            self._relay_local_channel = {
+                key: channel for channel, key in enumerate(active_channels)
+            }
+            if local_reader_union:
+                self._relay_local_flags = _LocalReplFlagBank.create(
+                    len(local_reader_union),
+                    channels=max(1, len(active_channels)),
+                )
+                for gid, slot in active_channels:
+                    for reader in self._relay_local_readers[gid]:
+                        self._relay_ready_event[(gid, slot, reader)] = torch.cuda.Event(
+                            interprocess=True,
+                        )
+
+        doff_reduce: dict[int, list[tuple | None]] = {}
+        doff_kernel_ipc: dict[int, list[dict | None]] = {}
+        relay_event_ipc: dict[tuple[int, int], dict[int, bytes]] = {}
+        ipc_device = -1
+
+        def _kernel_ipc(reduced: tuple) -> dict:
+            _rebuild, reduce_args = reduced
+            storage_handle = bytes(reduce_args[7])
+            if len(storage_handle) < 64:
+                raise RuntimeError(
+                    f"invalid relay CUDA IPC handle size {len(storage_handle)}"
+                )
+            itemsize = torch.empty((), dtype=reduce_args[5]).element_size()
+            return {
+                "handle": storage_handle[-64:],
+                "tensor_offset_bytes": int(reduce_args[9])
+                + int(reduce_args[3]) * itemsize,
+            }
+
+        if not self._is_sender and self._relay_local_flags is not None:
+            with torch.cuda.device(self.device):
+                for event in self._relay_ready_event.values():
+                    event.record()
+            ipc_device = torch.device(self.device).index
+            for gid in self._relay_owned_gids:
+                if not self._relay_local_readers.get(gid):
+                    continue
+                reductions = [
+                    reduce_tensor(tensor) for tensor in self._relay_doff_buf[gid]
+                ]
+                doff_reduce[gid] = reductions
+                doff_kernel_ipc[gid] = [_kernel_ipc(reduced) for reduced in reductions]
+                for slot in range(self._relay_doff_depth):
+                    relay_event_ipc[(gid, slot)] = {
+                        reader: self._relay_ready_event[
+                            (gid, slot, reader)
+                        ].ipc_handle()
+                        for reader in self._relay_local_readers[gid]
+                    }
+
+        self._tcp_control = None
+        if os.environ.get("WBRIDGE_TCP_CONTROL", "0") == "1":
+            self._tcp_control = TcpControlTransport(
+                rank, self._local_ip, self._tcp_flag_landed
+            )
+
+        fi = self._FLAG_ITEMSIZE
+        regions = [
+            (tensor.data_ptr() + index * fi, fi)
+            for tensor in (self._relay_data_buf, self._relay_ack_buf)
+            for index in range(tensor.numel())
+        ]
+        regions.extend(
+            (tensor.data_ptr(), tensor.numel()) for tensor in registered_destinations
+        )
+        self.engine.publish_regions(regions)
+
+        head_prep: dict[int, list[dict[int, int]]] = {}
+        chain_prep: dict[int, list[int | None]] = {}
+        if not self._is_sender:
+            for gid in self._relay_owned_gids:
+                group = self.router.relay_group(gid)
+                if rank == group["head"]:
+                    head_prep[gid] = [
+                        {
+                            si: self._relay_prep_buf[gid][ri % 2].data_ptr() + off
+                            for si, off in self._relay_prep_offsets[gid][ri].items()
+                        }
+                        for ri in range(self.num_rounds)
+                    ]
+                else:
+                    chain_prep[gid] = [
+                        self._relay_prep_buf[gid][ri % 2].data_ptr()
+                        if self._relay_prep_sizes[gid][ri]
+                        else None
+                        for ri in range(self.num_rounds)
+                    ]
+
+        info = {
+            "session": self.session,
+            "engine_payload": self.engine.publish_payload(),
+            "tcp_control_endpoint": (
+                self._tcp_control.endpoint if self._tcp_control is not None else None
+            ),
+            "relay_groups": self._relay_num_groups,
+            "relay_data_addr": self._relay_data_buf.data_ptr(),
+            "relay_ack_addr": self._relay_ack_buf.data_ptr(),
+            "relay_head_prep": head_prep,
+            "relay_chain_prep": chain_prep,
+            "relay_local_flags": (
+                self._relay_local_flags.path
+                if self._relay_local_flags is not None
+                else ""
+            ),
+            "relay_local_slots": self._relay_local_slot_of,
+            "relay_local_channels": self._relay_local_channel,
+            "relay_doff_depth": self._relay_doff_depth,
+            "relay_doff_reduce": doff_reduce,
+            "relay_doff_kernel_ipc": doff_kernel_ipc,
+            "relay_ready_event_ipc": relay_event_ipc,
+            "device": ipc_device,
+        }
+        all_info: list[dict | None] = [None] * ws
+        dist.all_gather_object(all_info, info, group=self.group)
+        if any(
+            item is None or item.get("relay_groups") != self._relay_num_groups
+            for item in all_info
+        ):
+            raise RuntimeError(
+                "replica-group relay configuration mismatch across ranks"
+            )
+
+        # Direct writer/reader graph for this rank.
+        data_peers: set[int] = set()
+        control_peers: set[int] = set()
+        if self._is_sender:
+            for ri, specs in enumerate(self._relay_send_specs):
+                for gid in specs:
+                    data_peers.add(self.router.relay_group(gid)["head"])
+        else:
+            for gid in self._relay_owned_gids:
+                group = self.router.relay_group(gid)
+                pos = group["chain"].index(rank)
+                if pos == 0:
+                    control_peers.update(
+                        si for specs in group["trainer_specs"] for si in specs
+                    )
+                else:
+                    control_peers.add(group["chain"][pos - 1])
+                if pos + 1 < len(group["chain"]):
+                    succ = group["chain"][pos + 1]
+                    data_peers.add(succ)
+                    control_peers.add(succ)
+        control_peers |= data_peers
+        self.peers = sorted(control_peers)
+        self.flag_slot_of = {}
+        self._relay_peer_session: dict[int, str] = {}
+        self._relay_data_dst: dict[int, int] = {}
+        self._relay_ack_dst: dict[int, int] = {}
+        for peer in sorted(control_peers):
+            pinfo = all_info[peer]
+            assert pinfo is not None
+            self._relay_peer_session[peer] = pinfo["session"]
+            self._relay_data_dst[peer] = pinfo["relay_data_addr"]
+            self._relay_ack_dst[peer] = pinfo["relay_ack_addr"]
+            self.engine.attach_peer(pinfo["session"], pinfo.get("engine_payload"))
+
+        self._relay_send_dst: dict[int, list[int | None]] = {}
+        if self._is_sender:
+            for gid in self._relay_send_buf:
+                head = self.router.relay_group(gid)["head"]
+                pinfo = all_info[head]
+                assert pinfo is not None
+                table = pinfo["relay_head_prep"].get(gid)
+                if table is None:
+                    raise RuntimeError(
+                        f"relay head {head} omitted group {gid} PREP metadata"
+                    )
+                self._relay_send_dst[gid] = [row.get(rank) for row in table]
+
+        self._relay_forward_dst: dict[int, list[int | None]] = {}
+        if not self._is_sender:
+            for gid in self._relay_owned_gids:
+                chain = self.router.relay_group(gid)["chain"]
+                pos = chain.index(rank)
+                if pos + 1 >= len(chain):
+                    continue
+                succ = chain[pos + 1]
+                pinfo = all_info[succ]
+                assert pinfo is not None
+                table = pinfo["relay_chain_prep"].get(gid)
+                if table is None:
+                    raise RuntimeError(
+                        f"relay successor {succ} omitted group {gid} PREP metadata"
+                    )
+                self._relay_forward_dst[gid] = table
+
+        if self._tcp_control is not None:
+            tcp_peers = {
+                peer
+                for peer in control_peers
+                if self._peer_ip.get(peer) != self._local_ip
+            }
+            endpoints = {
+                peer: all_info[peer]["tcp_control_endpoint"] for peer in tcp_peers
+            }
+            missing = sorted(
+                peer for peer, endpoint in endpoints.items() if endpoint is None
+            )
+            if missing:
+                raise RuntimeError(
+                    f"relay TCP control peers {missing} did not publish endpoints"
+                )
+            self._tcp_control.configure(tcp_peers, endpoints)
+
+        # Import the local representative's DOFF buffers/events for every remotely-owned group consumed here.
+        self._relay_peer_local_flags: dict[int, _LocalReplFlagBank] = {}
+        self._relay_peer_channel: dict[int, dict[tuple[int, int], int]] = {}
+        self._relay_peer_slot_of_me: dict[int, int] = {}
+        self._relay_peer_doff: dict[tuple[int, int], torch.Tensor] = {}
+        self._relay_peer_kernel_base: dict[tuple[int, int], int] = {}
+        self._relay_peer_ipc_mapping: dict[tuple[int, int], tuple[int, int]] = {}
+        self._relay_peer_ready_event: dict[tuple[int, int], torch.cuda.Event] = {}
+        if not self._is_sender:
+            for gid, owner in self._relay_consume_owner.items():
+                if owner == rank:
+                    continue
+                if self._peer_ip.get(owner) != self._local_ip:
+                    raise RuntimeError(
+                        f"relay group {gid} local owner {owner} is not co-located with reader {rank}"
+                    )
+                pinfo = all_info[owner]
+                assert pinfo is not None
+                path = pinfo["relay_local_flags"]
+                if not path:
+                    raise RuntimeError(f"relay owner {owner} omitted local flag bank")
+                if owner not in self._relay_peer_local_flags:
+                    slots = pinfo["relay_local_slots"]
+                    channels = pinfo["relay_local_channels"]
+                    self._relay_peer_local_flags[owner] = _LocalReplFlagBank.open(
+                        path,
+                        slots=len(slots),
+                        channels=max(1, len(channels)),
+                    )
+                    self._relay_peer_channel[owner] = dict(channels)
+                    self._relay_peer_slot_of_me[owner] = slots[rank]
+                if int(pinfo.get("relay_doff_depth", 0)) != self._relay_doff_depth:
+                    raise RuntimeError(
+                        f"relay DOFF mismatch with owner {owner}: local={self._relay_doff_depth} "
+                        f"remote={pinfo.get('relay_doff_depth')}"
+                    )
+                reductions = pinfo["relay_doff_reduce"].get(gid)
+                kernel_metadata = pinfo["relay_doff_kernel_ipc"].get(gid)
+                if reductions is None or kernel_metadata is None:
+                    raise RuntimeError(
+                        f"relay owner {owner} omitted group {gid} DOFF IPC metadata"
+                    )
+                for slot in range(self._relay_doff_depth):
+                    rebuild, args = reductions[slot]
+                    tensor = rebuild(*args)
+                    self._relay_peer_doff[(gid, slot)] = tensor
+                    local_device = torch.device(self.device).index
+                    _enable_cuda_peer_access(local_device, int(pinfo["device"]))
+                    kernel_base, allocation_base = _open_cuda_ipc_mapping(
+                        local_device,
+                        kernel_metadata[slot],
+                    )
+                    self._relay_peer_kernel_base[(gid, slot)] = kernel_base
+                    self._relay_peer_ipc_mapping[(gid, slot)] = (
+                        local_device,
+                        allocation_base,
+                    )
+                    handle = pinfo["relay_ready_event_ipc"][(gid, slot)][rank]
+                    self._relay_peer_ready_event[(gid, slot)] = (
+                        torch.cuda.Event.from_ipc_handle(
+                            local_device,
+                            handle,
+                        )
+                    )
+
+        logger.info(
+            "wbridge rank %d: replica relay groups=%d owned=%d consumed=%d buffers SEND %.2f GiB "
+            "PREP %.2f GiB DOFF(non-RDMA) %.2f GiB peers=%s",
+            rank,
+            self._relay_num_groups,
+            len(self._relay_owned_gids),
+            len(self._relay_consume_owner),
+            total_send / 1024**3,
+            total_prep / 1024**3,
+            total_doff / 1024**3,
+            self.peers,
+        )
+
+    def _setup_rdma_buffers(self, rank: int, ws: int) -> None:
+        """Allocate + register the data buffers (sender pack buffers / receiver arena) + flag channels,
+        then all-gather their addresses over Gloo."""
+        assert (
+            self.engine is not None
+            and self.router is not None
+            and self.device is not None
+        )
+
+        # Largest byte chunk this rank exchanges with each peer across all rounds (buffer is reused).
+        max_bytes: dict[int, int] = {}
+        for _full_spec, overlap_specs in self.router.local_rounds:
+            for peer, ospec in overlap_specs.items():
+                nb = ospec.nbytes(self.dtype_spec)
+                if nb > max_bytes.get(peer, 0):
+                    max_bytes[peer] = nb
+        self.peers = sorted(max_bytes)
+        self.flag_slot_of = {peer: i for i, peer in enumerate(self.peers)}
+        n = max(len(self.peers), 1)
+
+        # Peers on THIS host (from the session pre-gather). Their bulk bytes can skip network RDMA entirely:
+        # the receiver reads them straight out of the sender's pack buffer over CUDA-IPC (see the export
+        # block below and WeightReceiver's ipc_pull). Staging puts the bytes in host DRAM, which CUDA IPC cannot
+        # map, so a staging endpoint never takes part (both switches are off by default).
+        self._same_node_peers = [
+            p for p in self.peers if self._peer_ip.get(p) == self._local_ip
+        ]
+        staged = self.sender_staging if self._is_sender else self.receiver_staging
+        self._sn_ipc_ok = SAME_NODE_IPC and not staged
+        sn_candidates = self._same_node_peers if self._sn_ipc_ok else []
+
+        # Incoming flags (peers write here) + outgoing flag sources.  Give every (peer, round) message an
+        # exclusive word: write_async() may return before the NIC has fetched its source, so a single reused
+        # scratch word would require a completion wait.  Round slots are safe to reuse in a later epoch by
+        # protocol causality: the peer must observe this generation before it can produce the response that
+        # permits the same round slot to recur.  The CPU footprint is only peers*rounds*8 bytes.
+        flag_words = n * self.num_rounds
+        self._flag_buf = torch.zeros(flag_words, dtype=self._FLAG_DTYPE).pin_memory()
+        self._flag_src = torch.zeros(flag_words, dtype=self._FLAG_DTYPE).pin_memory()
+        self.engine.register(
+            self._flag_buf.data_ptr(),
+            self._flag_buf.numel() * self._FLAG_ITEMSIZE,
+            is_flag=True,
+            tensor=self._flag_buf,
+        )
+        self.engine.register(
+            self._flag_src.data_ptr(),
+            self._flag_src.numel() * self._FLAG_ITEMSIZE,
+            is_flag=True,
+            tensor=self._flag_src,
+        )
+
+        # NUMA node of the pinned bulk NIC (-1 if unpinned): the big host staging buffers below are allocated
+        # first-touch-local to it so the NIC's DMA isn't cross-socket (a major host-RDMA throughput lever).
+        self._numa_node = getattr(self.engine, "bulk_numa_node", lambda: -1)()
+
+        # Per-(sender,round) RECV destination this rank publishes so its senders write to the right place
+        # regardless of THIS receiver's staging mode. Senders leave these empty (set in the receiver branch).
+        self._recv_base = 0
+        self._recv_off_of: dict[int, list[int | None]] = {}
+
+        # Only SENDERS allocate per-peer pack buffers (GPU uint8) as the RDMA write SOURCE; a receiver instead
+        # allocates isolated ingress + rollout exchange buffers below. DOUBLE-BUFFERED by round parity to
+        # pipeline the sender's pack/write rounds. Registered once, reused across all WTs.
+        self._data_buf: dict[int, list[torch.Tensor]] = {}
+        self._cpu_grid = {}
+        # Sender pack-buffer depth (double-buffering). Default 2 (pipeline pack(ri+1) with RDMA(ri)); set
+        # WBRIDGE_SENDER_NUM_BUF=1 to single-buffer (no pack/RDMA overlap). Sweepable for perf studies.
+        self._NUM_BUF = int(
+            os.environ.get("WBRIDGE_SENDER_NUM_BUF", str(type(self)._NUM_BUF))
+        )
+        if self._is_sender:
+            total = 0
+            for peer in self.peers:
+                bufs = []
+                for _ in range(self._NUM_BUF):
+                    buf = torch.zeros(
+                        max_bytes[peer], dtype=torch.uint8, device=self.device
+                    )
+                    self.engine.register(buf.data_ptr(), max_bytes[peer], tensor=buf)
+                    if self.local_engine is not None:
+                        self.local_engine.register_buffer(
+                            buf
+                        )  # SS: GPU wire is the D2H source
+                    bufs.append(buf)
+                    total += max_bytes[peer]
+                self._data_buf[peer] = bufs
+            free_b = torch.cuda.mem_get_info()[0]
+            logger.info(
+                "wbridge rank %d: %d pack buffers (%d peers x%d parity) = %.2f GiB; %.2f GiB free",
+                rank,
+                len(self.peers) * self._NUM_BUF,
+                len(self.peers),
+                self._NUM_BUF,
+                total / 1024**3,
+                free_b / 1024**3,
+            )
+            # SS: a FULL CPU-pinned grid indexed by (peer, round) — the D2H offload target and the
+            # CPU->remote RDMA source (host-pinned => the network path in the dual engine). Sized from each
+            # round's per-peer overlap; ~one model's wire bytes total (covered by the >=-CPU-RAM assumption).
+            if self.sender_staging:
+                assert self.local_engine is not None
+                cpu_total = 0
+                with _numa_local_alloc(
+                    self._numa_node
+                ):  # first-touch NUMA-local to the bulk NIC
+                    for peer in self.peers:
+                        slots: list[torch.Tensor | None] = []
+                        for _ri, (_fs, ov) in enumerate(self.router.local_rounds):
+                            nb = ov[peer].nbytes(self.dtype_spec) if peer in ov else 0
+                            if nb:
+                                t = torch.zeros(nb, dtype=torch.uint8).pin_memory()
+                                self.engine.register(t.data_ptr(), nb, tensor=t)
+                                self.local_engine.register_buffer(t)
+                                slots.append(t)
+                                cpu_total += nb
+                            else:
+                                slots.append(None)
+                        self._cpu_grid[peer] = slots
+                logger.info(
+                    "wbridge rank %d: SS CPU grid = %.2f GiB (pinned, %d peers x %d rounds, numa=%d)",
+                    rank,
+                    cpu_total / 1024**3,
+                    len(self.peers),
+                    self.num_rounds,
+                    self._numa_node,
+                )
+
+        # ---- Receiver-side de-replication: isolated ingress + rollout exchange arena ----
+        # A receiver receives only its per-tensor 1/m slice from trainers, then reconstructs the full shard by
+        # a per-tensor all-to-all. `_recv_arena` is trainer-reachable and parity-buffered with a stable lane per
+        # trainer. `_arena` is rollout-peer-reachable and holds parity-buffered fused own/send PREP followed by
+        # exact cross-node ingress parity slots (the generic fallback uses one GRECV slot per peer/parity). Same-node
+        # columns are consumed directly from peer IPC mappings. Keeping the allocations physically separate
+        # makes the 3-stage lifetime explicit: receive(r+1), prepare(r), external+internal-consume(r-1).
+        self._repl_peers: list[int] = []
+        # Depth-2 RECV pipelining (WBRIDGE_RECV_PIPELINE=1): the arena is double-buffered by round parity so
+        # the sender can keep 2 rounds in flight (stream) while the receiver processes serially underneath.
+        # Round ri lives in arena[(ri % _recv_depth)*S : ...]. depth=1 is the original single-buffer path.
+        self._recv_depth = (
+            2 if os.environ.get("WBRIDGE_RECV_PIPELINE", "1") == "1" else 1
+        )
+        # Experimental memory profile: overlay each trainer RECV parity with rollout PREP and snapshot RECV
+        # into one epoch-scoped, non-RDMA scratch buffer before A+R overwrites the slot. This trades one extra
+        # D2D copy and stricter whole-slot backpressure for substantially lower persistent receiver HBM.
+        self._merged_recv_prep = (
+            not self._is_sender
+            and os.environ.get("WBRIDGE_MERGED_RECV_PREP", "0") == "1"
+        )
+        # Topology-aware internal consume (WBRIDGE_TOPO_EXCHANGE=1): do cross-node exchange only within
+        # one-worker-per-node columns, then let each local GPU consume every required column directly over
+        # NVLink. With one worker per node only the self internal-consume kernel remains.
+        # Resolved per peer at connect (needs _peer_ip); falls back when the structure doesn't hold.
+        self._topo_exchange = os.environ.get("WBRIDGE_TOPO_EXCHANGE", "1") == "1"
+        # Control-plane profiler (WBRIDGE_CTL_PROFILE=1): per-primitive time/count/immediate-hit for the
+        # three direct-async flag submissions plus three pinned-CPU flag polls.
+        self._ctlp = os.environ.get("WBRIDGE_CTL_PROFILE") == "1"
+        self._ctl: dict = {}
+        # Flag publication is direct write_async() from its causal producer. A completion reaper exists only
+        # to retire backend handles and surface errors; it never publishes a flag and never gates progress.
+        self._flag_reaper_q: queue.Queue | None = None
+        self._flag_reaper_thread: threading.Thread | None = None
+        self._flag_reaper_lock = threading.Lock()
+        self._flag_reaper_errors: list[BaseException] = []
+        # The RdmaEngine contract does not require concurrent submissions on one engine object to be safe.
+        # Serialize only the tens-of-microseconds write_async() call; transfers still run in parallel and no
+        # completion can hold this lock.
+        self._flag_submit_lock = threading.Lock()
+        if not self._is_sender:
+            sw = self.router.sender_ws
+            rl = rank - sw
+            # Placement is known before arena allocation, so the topology planner can reserve exact packed
+            # cross-node payloads in PREP.  A global structural decision keeps all receiver ranks on the same
+            # protocol if even one replica group has unequal workers per participating node.
+            configured_topology = bool(
+                self._topo_exchange and self.router.configure_topology(self._peer_ip)
+            )
+            needs_internal_ipc = bool(
+                configured_topology
+                and any(
+                    self.router.topology_plan(member, ri)["internal"]
+                    for member in range(self.router.receiver_ws)
+                    for ri in range(self.num_rounds)
+                )
+            )
+            if needs_internal_ipc and not SAME_NODE_IPC:
+                # Keep the full generic GRECV layout so the explicit transport A/B remains a valid fallback.
+                self.router._topology_ok = False
+                configured_topology = False
+            self._topo_structure_ok = configured_topology
+            layout, S, peer_set = self.router.arena_layout(rl, depth=self._recv_depth)
+            self._arena_layout = (
+                layout  # per-round offset tables, consumed by _build_arena_plans
+            )
+            recv_stride = layout[0]["recv_stride"] if layout else 0
+            if self._merged_recv_prep:
+                if self.receiver_staging:
+                    raise RuntimeError(
+                        "WBRIDGE_MERGED_RECV_PREP=1 does not support receiver staging"
+                    )
+                if self._recv_depth != 2:
+                    raise RuntimeError(
+                        "WBRIDGE_MERGED_RECV_PREP=1 requires depth-2 RECV pipelining"
+                    )
+                if not self._topo_structure_ok:
+                    raise RuntimeError(
+                        "WBRIDGE_MERGED_RECV_PREP=1 requires topology-aware exchange"
+                    )
+                slot_stride = _merge_recv_prep_layout(layout, self._recv_depth, S)
+                self._arena_S = slot_stride
+                self._recv_S = slot_stride
+            else:
+                self._arena_S = S  # PREP parity p -> arena[p*S:(p+1)*S]
+                self._recv_S = recv_stride
+            self._prep_payload_S = S
+            self._recv_payload_S = recv_stride
+            self._doff_depth = int(os.environ.get("WBRIDGE_DOFF", "1"))
+            if self._doff_depth < 1:
+                raise ValueError(f"WBRIDGE_DOFF must be >= 1, got {self._doff_depth}")
+            self._doff_layout, doff_bytes, self._doff_S = _doff_arena_layout(
+                layout,
+                S,
+                self._doff_depth,
+            )
+            arena_bytes = _arena_total_bytes(layout, self._recv_depth, self._arena_S)
+            recv_bytes = _arena_recv_total_bytes(layout, self._recv_depth)
+            _hbm_debug(
+                "receiver_buffers_prealloc",
+                rank=rank,
+                arena_bytes=arena_bytes,
+                recv_bytes=recv_bytes,
+                doff_bytes=doff_bytes,
+            )
+            shared_grecv_bytes = arena_bytes - self._recv_depth * self._arena_S
+            self._repl_peers = [
+                sw + p for p in peer_set
+            ]  # arena union of the per-tensor class peers
+            direct_grecv_peers = sorted({p for rd in layout for p in rd["grecv"]})
+            direct_grecv_slots = sorted(
+                {
+                    (sw + source, ri % self._recv_depth)
+                    for ri, rd in enumerate(layout)
+                    for source in rd["grecv"]
+                }
+            )
+            direct_doff_slots = sorted(
+                {
+                    (rank, ri % self._doff_depth)
+                    for ri, (_full, overlaps) in enumerate(self.router.local_rounds)
+                    if overlaps
+                }
+                | {
+                    (sw + source, ri % self._doff_depth)
+                    for ri, rd in enumerate(layout)
+                    for source, (_off, nb) in rd["grecv"].items()
+                    if nb
+                }
+            )
+            # One node-local READY/DONE channel per fixed (source, DOFF slot). Unlike the old GRECV channel,
+            # this lifetime is independent of the registered ingress parity: GRECV is released immediately
+            # after its D2D offload, while this channel remains live until all local readers finish DOFF.
+            self._topo_local_slot_channel = (
+                {slot: channel for channel, slot in enumerate(direct_doff_slots)}
+                if self._topo_structure_ok
+                else {}
+            )
+            self._arena = torch.zeros(
+                max(arena_bytes, 1), dtype=torch.uint8, device=self.device
+            )
+            _hbm_debug("receiver_arena_allocated", rank=rank, arena_bytes=arena_bytes)
+            # DOFF is deliberately not registered with the RDMA engine. It is a fixed, per-source shadow of
+            # SEND+GRECV, shared only with same-node readers over CUDA IPC. Depth defaults to one.
+            self._doff_arena = torch.empty(
+                max(doff_bytes, 1), dtype=torch.uint8, device=self.device
+            )
+            _hbm_debug("receiver_doff_allocated", rank=rank, doff_bytes=doff_bytes)
+            if self._merged_recv_prep:
+                # A view of the merged parity bank. Register the owning arena only once; trainer RECV and
+                # rollout PREP/GRECV addresses all live in this one CUDA allocation.
+                self._recv_arena = self._arena[: self._recv_depth * self._arena_S]
+            else:
+                self._recv_arena = torch.zeros(
+                    max(recv_bytes, 1), dtype=torch.uint8, device=self.device
+                )
+                _hbm_debug("receiver_recv_allocated", rank=rank, recv_bytes=recv_bytes)
+                self.engine.register(
+                    self._recv_arena.data_ptr(),
+                    self._recv_arena.numel(),
+                    tensor=self._recv_arena,
+                )
+            self.engine.register(
+                self._arena.data_ptr(), self._arena.numel(), tensor=self._arena
+            )
+            free_b = torch.cuda.mem_get_info()[0]
+            persistent_bytes = (
+                arena_bytes if self._merged_recv_prep else recv_bytes + arena_bytes
+            )
+            if self._merged_recv_prep:
+                logger.info(
+                    "wbridge rank %d: tensor-dedup buffers %.2f GiB persistent = merged RECV/PREP "
+                    "%.2f GiB (M %.2f GiB x%d; R %.2f, S %.2f) + %.2f GiB external grecv; "
+                    "epoch scratch %.2f GiB; %.2f GiB free",
+                    rank,
+                    persistent_bytes / 1024**3,
+                    (self._recv_depth * self._arena_S) / 1024**3,
+                    self._arena_S / 1024**3,
+                    self._recv_depth,
+                    recv_stride / 1024**3,
+                    S / 1024**3,
+                    shared_grecv_bytes / 1024**3,
+                    recv_stride / 1024**3,
+                    free_b / 1024**3,
+                )
+            else:
+                logger.info(
+                    "wbridge rank %d: tensor-dedup buffers %.2f GiB = isolated RECV %.2f GiB "
+                    "(R %.2f GiB x%d) + rollout PREP %.2f GiB (S %.2f GiB x%d) + "
+                    "%.2f GiB external grecv (%d parity slots across %d sources; %d class peers); "
+                    "%.2f GiB free",
+                    rank,
+                    persistent_bytes / 1024**3,
+                    recv_bytes / 1024**3,
+                    self._recv_S / 1024**3,
+                    self._recv_depth,
+                    (self._recv_depth * S) / 1024**3,
+                    S / 1024**3,
+                    self._recv_depth,
+                    shared_grecv_bytes / 1024**3,
+                    len(direct_grecv_slots),
+                    len(direct_grecv_peers),
+                    len(self._repl_peers),
+                    free_b / 1024**3,
+                )
+            logger.info(
+                "wbridge rank %d: DOFF=%d non-RDMA internal shadow %.2f GiB "
+                "(one generation %.2f GiB, %d exclusive source slots)",
+                rank,
+                self._doff_depth,
+                doff_bytes / 1024**3,
+                self._doff_S / 1024**3,
+                len({source for source, _slot in direct_doff_slots}),
+            )
+            if persistent_bytes >= free_b * 0.8:
+                # This is deliberately advisory. ``free_b`` is sampled AFTER the allocation, so the former
+                # assertion compared the arena against the memory left over and rejected allocations that had
+                # already succeeded despite substantial free memory remaining. SGLang has already
+                # sized its model/KV pools by this point; let the deployment choose its desired headroom.
+                logger.warning(
+                    "wbridge rank %d: persistent tensor-dedup buffers %.2f GiB leave %.2f GiB free; "
+                    "continuing without the former post-allocation headroom assertion",
+                    rank,
+                    persistent_bytes / 1024**3,
+                    free_b / 1024**3,
+                )
+            if self.local_engine is not None:
+                self.local_engine.register_buffer(
+                    self._recv_arena
+                )  # RS: isolated GPU RECV is the H2D destination
+            # Publish per-(sender, round) RECV destination. RS-off: senders write directly into their stable
+            # lane in the parity-selected GPU ingress slot. RS-on: senders write into a FULL-depth CPU-pinned
+            # arena (a slot per round), which the main thread then H2D-loads into that GPU ingress lane before
+            # assemble. Publishing (rather than recomputing on the sender) is what makes RS
+            # transparent to the sender: it just writes to recv_base + recv_off_of[my_rank][ri].
+            nr = self.num_rounds
+            if self.receiver_staging:
+                cpu_rounds, cpu_total = self.router.cpu_recv_layout(rl)
+                self._cpu_recv_layout = cpu_rounds
+                with _numa_local_alloc(
+                    self._numa_node
+                ):  # first-touch NUMA-local to the bulk NIC
+                    self._cpu_recv = torch.zeros(
+                        max(cpu_total, 1), dtype=torch.uint8
+                    ).pin_memory()
+                self.engine.register(
+                    self._cpu_recv.data_ptr(),
+                    self._cpu_recv.numel(),
+                    tensor=self._cpu_recv,
+                )  # senders' RDMA dst
+                self.local_engine.register_buffer(self._cpu_recv)  # H2D source
+                self._recv_base = self._cpu_recv.data_ptr()
+                self._recv_off_of = {
+                    si: [
+                        (cpu_rounds[ri][si][0] if si in cpu_rounds[ri] else None)
+                        for ri in range(nr)
+                    ]
+                    for si in range(sw)
+                }
+                logger.info(
+                    "wbridge rank %d: RS CPU recv = %.2f GiB (pinned, full-depth over %d rounds, numa=%d)",
+                    rank,
+                    cpu_total / 1024**3,
+                    nr,
+                    self._numa_node,
+                )
+            else:
+                self._recv_base = self._recv_arena.data_ptr()
+                # Bake the round-parity base into the published RECV offset so senders write round ri into
+                # recv_arena[(ri%depth)*R]. Stable per-sender offsets inside R prevent cross-sender overwrite.
+                self._recv_off_of = {
+                    si: [
+                        (
+                            (
+                                _arena_slot_offset(
+                                    layout[ri]["recv"][si][0],
+                                    ri,
+                                    self._recv_depth,
+                                    self._recv_S,
+                                )
+                            )
+                            if si in layout[ri]["recv"]
+                            else None
+                        )
+                        for ri in range(nr)
+                    ]
+                    for si in range(sw)
+                }
+            # Ready + consumed flag channels, sized to _repl_peers.
+            if self._repl_peers:
+                nr = len(self._repl_peers)
+                repl_words = nr * self.num_rounds
+                self._repl_flag_buf = torch.zeros(
+                    repl_words, dtype=self._FLAG_DTYPE
+                ).pin_memory()
+                self._repl_flag_src = torch.zeros(
+                    repl_words, dtype=self._FLAG_DTYPE
+                ).pin_memory()
+                self.engine.register(
+                    self._repl_flag_buf.data_ptr(),
+                    repl_words * self._FLAG_ITEMSIZE,
+                    is_flag=True,
+                    tensor=self._repl_flag_buf,
+                )
+                self.engine.register(
+                    self._repl_flag_src.data_ptr(),
+                    repl_words * self._FLAG_ITEMSIZE,
+                    is_flag=True,
+                    tensor=self._repl_flag_src,
+                )
+                # Second flag channel: "I have consumed round r". Before a peer overwrites one parity slot
+                # in OUR shared GRECV bank, it waits for our CONS from its previous write to that same parity.
+                self._repl_cons_buf = torch.zeros(
+                    repl_words, dtype=self._FLAG_DTYPE
+                ).pin_memory()
+                self._repl_cons_src = torch.zeros(
+                    repl_words, dtype=self._FLAG_DTYPE
+                ).pin_memory()
+                self.engine.register(
+                    self._repl_cons_buf.data_ptr(),
+                    repl_words * self._FLAG_ITEMSIZE,
+                    is_flag=True,
+                    tensor=self._repl_cons_buf,
+                )
+                self.engine.register(
+                    self._repl_cons_src.data_ptr(),
+                    repl_words * self._FLAG_ITEMSIZE,
+                    is_flag=True,
+                    tensor=self._repl_cons_src,
+                )
+                self._repl_flag_slot_of = {
+                    peer: i for i, peer in enumerate(self._repl_peers)
+                }
+                # Same-node CUDA-IPC peers rendezvous through this shared CPU bank.  It is published in the
+                # metadata gather below and opened only by peers on this host; remote peers retain the
+                # registered RDMA flag buffers above.
+                self._repl_local_flags = _LocalReplFlagBank.create(
+                    nr,
+                    channels=max(1, len(self._topo_local_slot_channel)),
+                )
+                self._repl_peer_local_flags: dict[int, _LocalReplFlagBank] = {}
+                # Same-node class peers exchange their slice over a DIRECT CUDA-IPC P2P copy (NVLink) gated by
+                # a CUDA-IPC EVENT, instead of a network RDMA flag. Cross-node peers must not own
+                # CUDA-IPC events: at 256 rollout ranks, allocating every event for all 255 class peers would
+                # materialize thousands of CUDA event resources per GPU even though only the other workers on
+                # this host can import them. The remote side's published agh_ipc_ok is checked during resolve;
+                # allocating for the local same-node candidates is a safe superset of the final IPC set.
+                ipc_event_readers = _ipc_event_readers(
+                    self._repl_peers,
+                    self._peer_ip,
+                    self._local_ip,
+                    enabled=SAME_NODE_IPC,
+                )
+                self._repl_ready_event = {
+                    peer: torch.cuda.Event(interprocess=True)
+                    for peer in ipc_event_readers
+                }
+                self._topo_slot_ready_event = {
+                    slot: {
+                        reader: torch.cuda.Event(interprocess=True)
+                        for reader in ipc_event_readers
+                    }
+                    for slot in self._topo_local_slot_channel
+                }
+                self._repl_same_node: set[int] = set()
+                self._repl_peer_arena: dict[
+                    int, torch.Tensor
+                ] = {}  # imported peer arena (aliased)
+                self._repl_peer_kernel_base: dict[
+                    int, int
+                ] = {}  # peer tensor base in OUR GPU VA
+                self._repl_peer_ipc_mapping: dict[
+                    int, tuple[int, int]
+                ] = {}  # peer -> (device, alloc base)
+                self._repl_peer_doff_arena: dict[int, torch.Tensor] = {}
+                self._repl_peer_doff_kernel_base: dict[int, int] = {}
+                self._repl_peer_doff_ipc_mapping: dict[int, tuple[int, int]] = {}
+                self._repl_peer_ready_event: dict[
+                    int, torch.cuda.Event
+                ] = {}  # peer's event we wait on
+                self._repl_peer_topo_slot_ready_event: dict[
+                    int, dict[tuple[int, int], torch.cuda.Event]
+                ] = {}
+                self._topo_peer_slot_channel: dict[int, dict[tuple[int, int], int]] = {}
+                self._repl_peer_grecv_off: dict[
+                    int, list[int | None]
+                ] = {}  # per-round grecv byte offset in peer arena
+                self._repl_peer_send_off: dict[
+                    int, list[int | None]
+                ] = {}  # per-round send[me] offset in peer arena (PULL)
+
+        # CUDA-IPC handles for the same-node direct-P2P path (receivers with class peers only). The arena is a
+        # persistent cudaMalloc block so ONE storage handle covers all rounds; each per-reader ready event is
+        # recorded once here to materialize the underlying cudaEvent before exporting its handle. ``device`` is
+        # OUR device index — readers must open our event against the exporter's device in from_ipc_handle.
+        arena_reduce = None
+        arena_kernel_ipc = None
+        doff_reduce = None
+        doff_kernel_ipc = None
+        ready_event_ipc = None
+        topo_slot_ready_event_ipc = None
+        ipc_device = -1
+        if not self._is_sender and self._repl_ready_event:
+            _hbm_debug(
+                "receiver_ipc_export_start",
+                rank=rank,
+                repl_peers=len(self._repl_peers),
+                topo_slots=len(self._topo_slot_ready_event),
+                ipc_event_readers=len(self._repl_ready_event),
+                ipc_event_count=(
+                    len(self._repl_ready_event)
+                    + sum(
+                        len(events) for events in self._topo_slot_ready_event.values()
+                    )
+                ),
+            )
+            try:
+                arena_reduce = reduce_tensor(self._arena)
+                doff_reduce = reduce_tensor(self._doff_arena)
+            except Exception as e:  # noqa: BLE001
+                raise RuntimeError(
+                    "wbridge: failed to export the arena/DOFF CUDA-IPC handle (reduce_tensor) for the same-node "
+                    "NVLink P2P path — the rollout allocator must NOT use expandable_segments"
+                ) from e
+
+            arena_kernel_ipc = _cuda_ipc_kernel_metadata(arena_reduce)
+            doff_kernel_ipc = _cuda_ipc_kernel_metadata(doff_reduce)
+            with torch.cuda.device(self._arena.device):
+                for event in self._repl_ready_event.values():
+                    event.record()
+                for events in self._topo_slot_ready_event.values():
+                    for event in events.values():
+                        event.record()
+            _hbm_debug("receiver_events_recorded", rank=rank)
+            ready_event_ipc = {
+                reader: event.ipc_handle()
+                for reader, event in self._repl_ready_event.items()
+            }
+            topo_slot_ready_event_ipc = {
+                slot: {reader: event.ipc_handle() for reader, event in events.items()}
+                for slot, events in self._topo_slot_ready_event.items()
+            }
+            ipc_device = self._arena.device.index
+
+        # Same-node trainer->rollout bypass, SENDER side. Export this rank's per-peer pack buffers (all
+        # parities — the receiver picks ri % pack_num_buf, exactly as pack does) plus one production event per
+        # co-located receiver. That receiver then PULLs round ri's bytes straight out of our pack buffer over
+        # NVLink and we skip the network RDMA write altogether. PULL, not push, for the same reason the dedup
+        # exchange pulls: writing peer CUDA-IPC memory measured much slower than reading it.
+        #
+        # Export is best-effort: reduce_tensor needs a plain cudaMalloc block, so a trainer whose allocator
+        # uses expandable_segments cannot export. That is not fatal — we simply publish no handles, no
+        # receiver confirms, and every peer stays on the RDMA path.
+        pack_ipc = None
+        pack_kernel_ipc = None
+        pack_event_ipc = None
+        if self._is_sender and sn_candidates:
+            try:
+                pack_ipc = {
+                    p: [reduce_tensor(b) for b in self._data_buf[p]]
+                    for p in sn_candidates
+                }
+                pack_kernel_ipc = {
+                    p: [_cuda_ipc_kernel_metadata(reduced) for reduced in reductions]
+                    for p, reductions in pack_ipc.items()
+                }
+                dev = self._data_buf[sn_candidates[0]][0].device
+                self._pack_ready_event = {
+                    p: torch.cuda.Event(interprocess=True) for p in sn_candidates
+                }
+                with torch.cuda.device(dev):
+                    for p in sn_candidates:
+                        self._pack_ready_event[
+                            p
+                        ].record()  # materialize the cudaEvent before exporting
+                pack_event_ipc = {
+                    p: self._pack_ready_event[p].ipc_handle() for p in sn_candidates
+                }
+                ipc_device = dev.index
+            except Exception as e:  # noqa: BLE001 — degrade to RDMA rather than fail the connect
+                logger.warning(
+                    "wbridge rank %d: cannot export pack buffers over CUDA-IPC (%s); same-node "
+                    "peers %s stay on the RDMA path (is expandable_segments on?)",
+                    rank,
+                    e,
+                    sn_candidates,
+                )
+                pack_ipc = pack_kernel_ipc = pack_event_ipc = None
+                self._pack_ready_event = {}
+
+        # Optional host-network control plane. Every rank binds before the metadata gather, so the gathered
+        # endpoint is immediately connectable. Only inter-node peer pairs are connected below; same-node
+        # replica flags retain their mmap path and same-node trainer flags retain the existing engine path.
+        self._tcp_control = None
+        if os.environ.get("WBRIDGE_TCP_CONTROL", "0") == "1":
+            self._tcp_control = TcpControlTransport(
+                rank, self._local_ip, self._tcp_flag_landed
+            )
+
+        # ---- Declare every region a peer may write into, for backends whose remote addressing is a
+        # handle rather than an address (MonarchEngine). No-op for Mooncake. Must precede the metadata
+        # exchange below, since the handles travel in it.
+        regions: list[tuple[int, int]] = []
+        fi = self._FLAG_ITEMSIZE
+        regions += [
+            (self._flag_buf.data_ptr() + i * fi, fi)
+            for i in range(self._flag_buf.numel())
+        ]
+        if not self._is_sender:
+            if self._repl_peers:
+                regions += [
+                    (self._repl_flag_buf.data_ptr() + i * fi, fi)
+                    for i in range(self._repl_flag_buf.numel())
+                ]
+                regions += [
+                    (self._repl_cons_buf.data_ptr() + i * fi, fi)
+                    for i in range(self._repl_cons_buf.numel())
+                ]
+            # Sender->receiver landing slots: address from the published recv_off_of (RS-aware), size
+            # from this round's arena layout.
+            for ri, rd in enumerate(self._arena_layout):
+                for si, (off, nb) in rd["recv"].items():
+                    pub = self._recv_off_of.get(si, [])
+                    if ri < len(pub) and pub[ri] is not None and nb:
+                        regions.append((self._recv_base + pub[ri], nb))
+                # Class peers push their slice into our grecv[peer] (cross-node path).
+                for p_rl, (goff, gnb) in rd["grecv"].items():
+                    if gnb:
+                        regions.append((self._arena.data_ptr() + goff, gnb))
+        self.engine.publish_regions(regions)
+
+        merged_slot_pred: dict[int, int | None] = {}
+        merged_slot_last: dict[int, int] = {}
+        if not self._is_sender and self._merged_recv_prep:
+            active_rounds = [
+                ri
+                for ri, (_full, overlaps) in enumerate(self.router.local_rounds)
+                if overlaps
+            ]
+            merged_slot_pred = _arena_slot_predecessors(active_rounds, self._recv_depth)
+            for ri in active_rounds:
+                merged_slot_last[ri % self._recv_depth] = ri
+
+        info = {
+            "session": self.session,
+            "tcp_control_endpoint": (
+                self._tcp_control.endpoint if self._tcp_control is not None else None
+            ),
+            "flag_addr": self._flag_buf.data_ptr(),
+            "flag_slot_of": self.flag_slot_of,
+            "flag_rounds": self.num_rounds,
+            # Arena base (0 on senders). Class peers add the absolute shared-bank grecv offset computed by
+            # arena_layout; own/send offsets still receive their local round-parity base at the source.
+            "arena_addr": self._arena.data_ptr() if not self._is_sender else 0,
+            # Sender->receiver RECV destination, published so senders are agnostic to this receiver's RS mode
+            # (parity-selected GPU arena for RS-off; full-depth CPU arena for RS-on). Empty on senders.
+            "recv_base": self._recv_base,
+            "recv_off_of": self._recv_off_of,
+            "merged_recv_prep": bool(getattr(self, "_merged_recv_prep", False)),
+            "merged_slot_pred": merged_slot_pred,
+            "merged_slot_last": merged_slot_last,
+            # Receiver<->receiver all-to-all flags (empty unless this receiver has class peers):
+            "repl_flag_addr": self._repl_flag_buf.data_ptr() if self._repl_peers else 0,
+            "repl_cons_addr": self._repl_cons_buf.data_ptr() if self._repl_peers else 0,
+            "repl_flag_slot_of": getattr(self, "_repl_flag_slot_of", {}),
+            "repl_local_flags": (
+                self._repl_local_flags.path
+                if getattr(self, "_repl_local_flags", None) is not None
+                else ""
+            ),
+            "topo_slot_channels": getattr(self, "_topo_local_slot_channel", {}),
+            # Same-node direct-P2P handshake (None on senders / receivers without class peers):
+            "arena_reduce": arena_reduce,  # torch CUDA-IPC handle for the peer's arena
+            "arena_kernel_ipc": arena_kernel_ipc,  # destination-device mapping for SM peer loads
+            "doff_reduce": doff_reduce,  # non-RDMA fixed internal-offload arena
+            "doff_kernel_ipc": doff_kernel_ipc,  # destination-device mapping for DOFF SM loads
+            "doff_depth": getattr(self, "_doff_depth", 0),
+            "ready_event_ipc": ready_event_ipc,  # {reader_rank: event ipc_handle} for our copies to them
+            # {(external_source, parity): {reader_rank: event}}; one timeline per physical GRECV slot.
+            "topo_slot_ready_event_ipc": topo_slot_ready_event_ipc,
+            "device": ipc_device,  # exporter device index for from_ipc_handle
+            # Same-node trainer->rollout bypass (None unless this is a sender with co-located receivers):
+            "pack_ipc": pack_ipc,  # {receiver_rank: [CUDA-IPC handle per pack parity]}
+            "pack_kernel_ipc": pack_kernel_ipc,  # raw mappings for direct sender-pack consume kernels
+            "pack_event_ipc": pack_event_ipc,  # {receiver_rank: pack-landed event ipc_handle}
+            "pack_num_buf": self._NUM_BUF
+            if self._is_sender
+            else 0,  # parity depth (env-overridable)
+            # WBRIDGE_SAME_NODE_IPC as THIS rank sees it. Published (not read locally) so the class-peer
+            # gate below is the same conjunction on both sides: a mixed setting must disable the direct
+            # path for the pair, never leave one peer pulling while the other pushes. Deliberately not
+            # folded into the staging-aware _sn_ipc_ok — the AGH exchange is GPU-arena even under RS.
+            "agh_ipc_ok": SAME_NODE_IPC,
+            # Backend-specific blob (MonarchEngine: its region -> RDMABuffer handle map). None for Mooncake.
+            "engine_payload": self.engine.publish_payload(),
+        }
+        all_info: list = [None] * ws
+        dist.all_gather_object(all_info, info, group=self.group)
+
+        if self._tcp_control is not None:
+            control_peers = {
+                peer
+                for peer in set(self.peers) | set(self._repl_peers)
+                if self._peer_ip.get(peer) != self._local_ip
+            }
+            endpoints = {
+                peer: all_info[peer].get("tcp_control_endpoint")
+                for peer in control_peers
+            }
+            missing = sorted(
+                peer for peer, endpoint in endpoints.items() if endpoint is None
+            )
+            if missing:
+                raise RuntimeError(
+                    f"WBRIDGE_TCP_CONTROL mismatch: peer rank(s) {missing} did not enable it"
+                )
+            self._tcp_control.configure(control_peers, endpoints)
+            logger.info(
+                "wbridge rank %d: host-network TCP control connected to %d inter-node peer(s) %s",
+                rank,
+                len(control_peers),
+                sorted(control_peers),
+            )
+
+        # Resolve, for each peer we write to, its (session, remote arena addr, remote flag addr). The data
+        # destination is the peer's ARENA (base + per-round RECV offset from arena_layout), so no per-round
+        # table crosses the wire — only the arena base does.
+        sw = self.router.sender_ws
+        rl = rank - sw
+        nr_rounds = self.num_rounds
+        self.peer_session: dict[int, str] = {}
+        self._arena_send_dst: dict[
+            int, list[int | None]
+        ] = {}  # per-round RECV addr in receiver's arena
+        self._merged_recv_peers: set[int] = set()
+        self._merged_recv_pred: dict[int, dict[int, int | None]] = {}
+        self._merged_recv_last: dict[int, dict[int, int]] = {}
+        self._flag_dst: dict[int, int] = {}
+        for peer in self.peers:
+            pinfo = all_info[peer]
+            self.peer_session[peer] = pinfo["session"]
+            self.engine.attach_peer(pinfo["session"], pinfo.get("engine_payload"))
+            if pinfo.get("flag_rounds") != self.num_rounds:
+                raise RuntimeError(
+                    f"flag round-slot mismatch with peer {peer}: "
+                    f"local={self.num_rounds} remote={pinfo.get('flag_rounds')}"
+                )
+            slot = pinfo["flag_slot_of"][
+                rank
+            ]  # our slot in the peer's incoming flag buffer
+            self._flag_dst[peer] = (
+                pinfo["flag_addr"] + slot * self.num_rounds * self._FLAG_ITEMSIZE
+            )
+            if self._is_sender:
+                # Use the receiver's PUBLISHED per-round RECV offsets (RS-aware) rather than recomputing the
+                # layout locally — so the same sender code targets a GPU arena (RS-off) or a full-depth CPU
+                # arena (RS-on) transparently.
+                base = pinfo["recv_base"]
+                offs = pinfo["recv_off_of"].get(rank, [])
+                self._arena_send_dst[peer] = [
+                    (base + offs[ri])
+                    if (ri < len(offs) and offs[ri] is not None)
+                    else None
+                    for ri in range(nr_rounds)
+                ]
+                if pinfo.get("merged_recv_prep", False):
+                    self._merged_recv_peers.add(peer)
+                    self._merged_recv_pred[peer] = {
+                        int(ri): (None if pred is None else int(pred))
+                        for ri, pred in pinfo.get("merged_slot_pred", {}).items()
+                    }
+                    self._merged_recv_last[peer] = {
+                        int(parity): int(ri)
+                        for parity, ri in pinfo.get("merged_slot_last", {}).items()
+                    }
+            elif self._sn_ipc_ok and pinfo["pack_ipc"] and rank in pinfo["pack_ipc"]:
+                # Same-node trainer->rollout bypass, RECEIVER side. The sender published a handle for OUR
+                # rank, which is its statement that it is co-located with us and able to export; import its
+                # pack buffers (one per parity) + its pack-landed event and we will PULL each round's bytes
+                # instead of waiting for an RDMA write. The event is reconstructed on OUR device (the one
+                # the pull's stream runs on) — opening it on the exporter's device segfaults on the wait.
+                self._peer_pack_buf[peer] = [
+                    rebuild(*args) for rebuild, args in pinfo["pack_ipc"][rank]
+                ]
+                kernel_metadata = (pinfo.get("pack_kernel_ipc") or {}).get(rank)
+                if kernel_metadata is None or len(kernel_metadata) != len(
+                    self._peer_pack_buf[peer]
+                ):
+                    raise RuntimeError(
+                        f"wbridge rank {rank}: sender {peer} omitted direct pack-buffer CUDA-IPC metadata"
+                    )
+                local_device = self._arena.device.index
+                _enable_cuda_peer_access(local_device, int(pinfo["device"]))
+                self._peer_pack_kernel_base[peer] = []
+                self._peer_pack_ipc_mapping[peer] = []
+                for metadata in kernel_metadata:
+                    kernel_base, allocation_base = _open_cuda_ipc_mapping(
+                        local_device, metadata
+                    )
+                    self._peer_pack_kernel_base[peer].append(kernel_base)
+                    self._peer_pack_ipc_mapping[peer].append(
+                        (local_device, allocation_base)
+                    )
+                self._peer_pack_event[peer] = torch.cuda.Event.from_ipc_handle(
+                    self._arena.device.index, pinfo["pack_event_ipc"][rank]
+                )
+                self._peer_pack_num_buf[peer] = pinfo["pack_num_buf"]
+                self._sn_senders.add(peer)
+
+        # Agree on the bypass set. A sender may drop its RDMA write ONLY for a receiver that really
+        # imported its handles: if the two sides disagree the sender never writes and the receiver polls a
+        # flag forever, so the sender's set is derived from the receivers' CONFIRMATION, never from its own
+        # view of co-location. One tiny extra gather at connect buys immunity to that deadlock.
+        sn_confirm = sorted(self._sn_senders) if not self._is_sender else []
+        all_confirm: list = [None] * ws
+        dist.all_gather_object(all_confirm, sn_confirm, group=self.group)
+        if self._is_sender:
+            self._sn_peers = {p for p in self.peers if rank in (all_confirm[p] or [])}
+        active = self._sn_peers if self._is_sender else self._sn_senders
+        if active:
+            logger.info(
+                "wbridge rank %d: same-node CUDA-IPC bypass ON for %d/%d peer(s) %s — their bulk "
+                "weight bytes skip RDMA (NVLink copy)",
+                rank,
+                len(active),
+                len(self.peers),
+                sorted(active),
+            )
+        elif self._same_node_peers:
+            logger.info(
+                "wbridge rank %d: %d co-located peer(s) %s stay on RDMA (same_node_ipc=%s, "
+                "staging=%s)",
+                rank,
+                len(self._same_node_peers),
+                self._same_node_peers,
+                SAME_NODE_IPC,
+                self.sender_staging or self.receiver_staging,
+            )
+
+        # Resolve the class peers we write our slice to: the peer's arena grecv[us] offset + their repl flag
+        # slot (no per-round table crosses the wire — only the arena base does).
+        self._repl_peer_session: dict[int, str] = {}
+        self._arena_peer_dst: dict[
+            int, list[int | None]
+        ] = {}  # per-round grecv addr in peer's arena
+        self._repl_flag_dst: dict[int, int] = {}
+        self._repl_cons_dst: dict[int, int] = {}
+        self._repl_peer_slot_of_me: dict[int, int] = {}
+        local_ip = get_local_ip()
+        for peer in self._repl_peers:
+            pinfo = all_info[peer]
+            peer_merged = bool(pinfo.get("merged_recv_prep", False))
+            if peer_merged != self._merged_recv_prep:
+                raise RuntimeError(
+                    f"merged RECV/PREP mismatch with receiver peer {peer}: "
+                    f"local={self._merged_recv_prep} remote={peer_merged}"
+                )
+            self._repl_peer_session[peer] = pinfo["session"]
+            self.engine.attach_peer(pinfo["session"], pinfo.get("engine_payload"))
+            lp, lp_S, _ = self.router.arena_layout(
+                peer - sw, depth=self._recv_depth
+            )  # class peer's per-round layout + its arena stride
+            if peer_merged:
+                lp_S = _merge_recv_prep_layout(lp, self._recv_depth, lp_S)
+            base = pinfo["arena_addr"]
+            self._arena_peer_dst[peer] = [
+                (base + lp[ri]["grecv"][rl][0]) if rl in lp[ri]["grecv"] else None
+                for ri in range(nr_rounds)
+            ]
+            slot = pinfo["repl_flag_slot_of"][rank]
+            self._repl_peer_slot_of_me[peer] = slot
+            row_off = slot * self.num_rounds * self._FLAG_ITEMSIZE
+            self._repl_flag_dst[peer] = pinfo["repl_flag_addr"] + row_off
+            self._repl_cons_dst[peer] = pinfo["repl_cons_addr"] + row_off
+            # Same-node class peer -> direct CUDA-IPC P2P + event; cross-node stays on RDMA + flags.
+            # WBRIDGE_SAME_NODE_IPC gates this leg too, so the switch covers BOTH same-node data paths and
+            # a run with it off is a clean all-RDMA A/B. Read from both sides' published flag (see
+            # "agh_ipc_ok" above) so the decision can never come out asymmetric.
+            peer_ip = DualMooncakeEngine._ip_of(
+                DualMooncakeEngine._split(pinfo["session"])[0]
+            )
+            if (
+                peer_ip == local_ip
+                and pinfo["arena_reduce"] is not None
+                and pinfo.get("doff_reduce") is not None
+                and SAME_NODE_IPC
+                and pinfo["agh_ipc_ok"]
+            ):
+                self._repl_same_node.add(peer)
+                local_flag_path = pinfo.get("repl_local_flags", "")
+                if not local_flag_path:
+                    raise RuntimeError(
+                        f"wbridge rank {rank}: same-node replica peer {peer} did not publish local flags"
+                    )
+                peer_slot_channels = dict(pinfo.get("topo_slot_channels") or {})
+                self._repl_peer_local_flags[peer] = _LocalReplFlagBank.open(
+                    local_flag_path,
+                    slots=len(pinfo["repl_flag_slot_of"]),
+                    channels=max(1, len(peer_slot_channels)),
+                )
+                self._topo_peer_slot_channel[peer] = peer_slot_channels
+                if int(pinfo.get("doff_depth", 0)) != self._doff_depth:
+                    raise RuntimeError(
+                        f"DOFF mismatch with receiver peer {peer}: "
+                        f"local={self._doff_depth} remote={pinfo.get('doff_depth')}"
+                    )
+                local_device = self._arena.device.index
+                _enable_cuda_peer_access(local_device, int(pinfo["device"]))
+                kernel_ipc = pinfo.get("arena_kernel_ipc")
+                if kernel_ipc is None:
+                    raise RuntimeError(
+                        f"wbridge rank {rank}: same-node peer {peer} omitted kernel CUDA-IPC metadata"
+                    )
+                kernel_base, allocation_base = _open_cuda_ipc_mapping(
+                    local_device, kernel_ipc
+                )
+                self._repl_peer_kernel_base[peer] = kernel_base
+                self._repl_peer_ipc_mapping[peer] = (local_device, allocation_base)
+                rebuild, args = pinfo["arena_reduce"]
+                self._repl_peer_arena[peer] = rebuild(
+                    *args
+                )  # uint8 tensor aliasing peer's arena
+                doff_kernel_ipc = pinfo.get("doff_kernel_ipc")
+                if doff_kernel_ipc is None:
+                    raise RuntimeError(
+                        f"wbridge rank {rank}: same-node peer {peer} omitted DOFF CUDA-IPC metadata"
+                    )
+                doff_kernel_base, doff_allocation_base = _open_cuda_ipc_mapping(
+                    local_device,
+                    doff_kernel_ipc,
+                )
+                self._repl_peer_doff_kernel_base[peer] = doff_kernel_base
+                self._repl_peer_doff_ipc_mapping[peer] = (
+                    local_device,
+                    doff_allocation_base,
+                )
+                doff_rebuild, doff_args = pinfo["doff_reduce"]
+                self._repl_peer_doff_arena[peer] = doff_rebuild(*doff_args)
+                # Reconstruct the peer's ready-event on OUR (reader's) device — the same device _con_stream
+                # runs on, so wait_event is a same-device op. Reconstructing on the exporter's device segfaults
+                # on the cross-device wait. The IPC event still tracks the exporter's record. Key by OUR rank
+                # (the peer created one event per reader it writes to).
+                self._repl_peer_ready_event[peer] = torch.cuda.Event.from_ipc_handle(
+                    self._arena.device.index, pinfo["ready_event_ipc"][rank]
+                )
+                slot_event_ipc = pinfo.get("topo_slot_ready_event_ipc") or {}
+                self._repl_peer_topo_slot_ready_event[peer] = {
+                    slot: torch.cuda.Event.from_ipc_handle(
+                        self._arena.device.index,
+                        handles[rank],
+                    )
+                    for slot, handles in slot_event_ipc.items()
+                    if rank in handles
+                }
+                # Per-round grecv byte offset in the peer's arena = absolute dst - peer arena base.
+                self._repl_peer_grecv_off[peer] = [
+                    (self._arena_peer_dst[peer][ri] - base)
+                    if self._arena_peer_dst[peer][ri] is not None
+                    else None
+                    for ri in range(nr_rounds)
+                ]
+                # PULL: per-round offset of the peer's send[me] slice WITHIN the peer's arena tensor (which
+                # aliases from the peer's base). This is what we READ over NVLink into our grecv[peer]. By the
+                # layout's symmetry peer.send[rl] and our grecv[peer] are the same bytes and size, so the read
+                # replaces the (slow) push-write of our send[peer] into the peer's grecv[me].
+                self._repl_peer_send_off[peer] = [
+                    _arena_slot_offset(
+                        lp[ri]["send"][rl][0], ri, self._recv_depth, lp_S
+                    )
+                    if rl in lp[ri]["send"]
+                    else None
+                    for ri in range(nr_rounds)
+                ]
+        if self._repl_peers:
+            logger.info(
+                "wbridge rank %d: %d repl peers (same-node NVLink-IPC %d, cross-node RDMA %d)",
+                rank,
+                len(self._repl_peers),
+                len(self._repl_same_node),
+                len(self._repl_peers) - len(self._repl_same_node),
+            )
+        # Topology-aware resolution. A structurally enabled receiver already allocated compact external-only
+        # GRECV, so a later CUDA-IPC/runtime failure cannot use the generic staged fallback. Gather both facts
+        # and fail the entire connection consistently if any compact receiver cannot resolve.
+        local_topo_ok = bool(
+            self._topo_exchange
+            and not self._is_sender
+            and self._resolve_topo_exchange(rank, sw, rl, nr_rounds)
+        )
+        topo_votes: list[tuple[bool, bool] | None] = [None] * ws
+        dist.all_gather_object(
+            topo_votes,
+            (
+                (bool(self._topo_structure_ok), local_topo_ok)
+                if not self._is_sender
+                else None
+            ),
+            group=self.group,
+        )
+        receiver_votes = [topo_votes[r] for r in range(sw, ws)]
+        compact_layout = any(v is not None and v[0] for v in receiver_votes)
+        global_topo_ok = all(v is not None and v[0] and v[1] for v in receiver_votes)
+        if compact_layout and not global_topo_ok:
+            failed = [
+                sw + i
+                for i, v in enumerate(receiver_votes)
+                if v is None or not (v[0] and v[1])
+            ]
+            raise RuntimeError(
+                "wbridge fused internal-consume topology allocated compact GRECV but runtime resolution "
+                f"failed on receiver rank(s) {failed}; refusing an unsafe staged fallback"
+            )
+        self._topo_ok = bool(local_topo_ok and global_topo_ok)
+        if self._topo_ok:
+            logger.info(
+                "wbridge rank %d: fused internal consume ON (ext=%d cross-node, int=%d same-node)",
+                rank,
+                len(self._topo_ext_peers),
+                len(self._topo_int_peers),
+            )
+        elif self._topo_exchange and self._repl_peers and not self._is_sender:
+            logger.info(
+                "wbridge rank %d: topo-aware requested but structure unsuitable -> single-phase",
+                rank,
+            )
+
+    def _resolve_topo_exchange(
+        self, rank: int, sw: int, rl: int, nr_rounds: int
+    ) -> bool:
+        """Bind the configured multi-group topology plan to this receiver's concrete arena addresses.
+
+        ``WeightRouter.configure_topology`` has already decided eligibility and reserved exact packed
+        ``topo_send`` payloads.  This method validates the runtime peer/IPC imports and turns its symbolic
+        name routes into batched external RDMA spans and per-peer direct internal-consume source
+        descriptors. The latter retain source layout metadata rather than a local destination: the consume
+        plan built after resolution maps the imported peer bytes straight into model tensors.
+
+        A structurally enabled topology uses a compact external-only GRECV layout. Consequently a runtime
+        resolution failure is made fatal by the global vote in :meth:`_setup_rdma_buffers`; it cannot fall
+        back to the generic staged all-gather without reallocating the arena.
+        """
+        _td = os.environ.get("WBRIDGE_TOPO_DEBUG") == "1"
+
+        def _no(reason):
+            if _td:
+                print(f"TDBG-RESOLVE rank {rank}: fallback ({reason})", flush=True)
+            return False
+
+        if not self._topo_structure_ok or not self.router._topology_ok:
+            return _no("global topology structure is ineligible")
+
+        plans = [self.router.topology_plan(rl, ri) for ri in range(nr_rounds)]
+        expected = {sw + p for plan in plans for p in plan["peers"]}
+        if set(self._repl_peers) != expected:
+            return _no(
+                f"repl_peers {sorted(self._repl_peers)} != planned {sorted(expected)}"
+            )
+
+        ext_send_by_round = [tuple(sw + p for p in plan["external"]) for plan in plans]
+        ext_recv_by_round = [
+            tuple(
+                sw + source
+                for source in range(self.router.receiver_ws)
+                if rl in self.router.topology_plan(source, ri)["external"]
+            )
+            for ri in range(nr_rounds)
+        ]
+        int_by_round = [tuple(sw + p for p in plan["internal"]) for plan in plans]
+        int_readers_by_round = [
+            tuple(
+                sw + reader
+                for reader in range(self.router.receiver_ws)
+                if rl in self.router.topology_plan(reader, ri)["internal"]
+            )
+            for ri in range(nr_rounds)
+        ]
+        ext_release_readers_by_round: list[dict[int, tuple[int, ...]]] = []
+        for ri, ext_sources in enumerate(ext_recv_by_round):
+            deps: dict[int, tuple[int, ...]] = {}
+            for peer in ext_sources:
+                source_rl = peer - sw
+                readers = []
+                for reader in range(self.router.receiver_ws):
+                    routes = self.router.topology_plan(reader, ri)["pull"].get(rl, ())
+                    if any(
+                        kind == "grecv" and source == source_rl
+                        for kind, source, _names in routes
+                    ):
+                        readers.append(sw + reader)
+                deps[peer] = tuple(readers)
+            ext_release_readers_by_round.append(deps)
+        ext_send_union = sorted({p for peers in ext_send_by_round for p in peers})
+        ext_recv_union = sorted({p for peers in ext_recv_by_round for p in peers})
+        ext_union = sorted(set(ext_send_union) | set(ext_recv_union))
+        int_union = sorted({p for peers in int_by_round for p in peers})
+        if any(self._peer_ip.get(p) == self._local_ip for p in ext_union):
+            return _no(f"external peer is same-node: {ext_union}")
+        if not set(int_union) <= self._repl_same_node:
+            return _no(
+                f"internal peers not all IPC-imported: int={int_union} "
+                f"same_node={sorted(self._repl_same_node)}"
+            )
+
+        recv_specs = self.router.recv_specs
+        depth = self._recv_depth
+        layout_cache: dict[int, tuple[list[dict], int]] = {
+            rl: (self._arena_layout, self._arena_S),
+        }
+        doff_layout_cache: dict[int, list[dict]] = {rl: self._doff_layout}
+
+        def _layout(member: int) -> tuple[list[dict], int]:
+            cached = layout_cache.get(member)
+            if cached is None:
+                rounds, stride, _ = self.router.arena_layout(member, depth=depth)
+                if getattr(self, "_merged_recv_prep", False):
+                    stride = _merge_recv_prep_layout(rounds, depth, stride)
+                cached = (rounds, stride)
+                layout_cache[member] = cached
+            return cached
+
+        def _round_names(member: int, ri: int) -> tuple[str, ...]:
+            return tuple(
+                sorted(
+                    n for n in self.router.global_rounds[ri] if n in recv_specs[member]
+                )
+            )
+
+        def _doff_layout(member: int) -> list[dict]:
+            cached = doff_layout_cache.get(member)
+            if cached is None:
+                member_rounds, prep_stride, _ = self.router.arena_layout(
+                    member, depth=depth
+                )
+                cached, _total, _stride = _doff_arena_layout(
+                    member_rounds,
+                    prep_stride,
+                    self._doff_depth,
+                )
+                doff_layout_cache[member] = cached
+            return cached
+
+        def _own_spec(member: int, ri: int) -> ShardSpec:
+            return recv_specs[member].subset(set(_round_names(member, ri)))
+
+        def _grecv_spec(
+            dst_member: int, source_member: int, ri: int
+        ) -> ShardSpec | None:
+            dst_layout, _ = _layout(dst_member)
+            names = dst_layout[ri]["grecv_names"].get(source_member)
+            return recv_specs[source_member].subset(set(names)) if names else None
+
+        # External source and destination are both exact packed column payloads. The RDMA backend receives a
+        # span list because non-adjacent names can exist in a reused PREP source, but compact GRECV itself has
+        # no holes for internally delivered names.
+        ext_xfer: dict[int, list[list[tuple[int, int, int]]]] = {
+            p: [[] for _ in range(nr_rounds)] for p in ext_send_union
+        }
+        arena_base = self._arena.data_ptr()
+        for ri, plan in enumerate(plans):
+            rd = self._arena_layout[ri]
+            for p_rl, names in plan["external"].items():
+                peer = sw + p_rl
+                if p_rl not in rd["topo_send"]:
+                    return _no(f"missing topo_send peer={peer} ri={ri}")
+                remote_base = self._arena_peer_dst[peer][ri]
+                if remote_base is None:
+                    return _no(f"missing remote grecv peer={peer} ri={ri}")
+                src_spec = recv_specs[rl].subset(set(names))
+                dst_spec = _grecv_spec(p_rl, rl, ri)
+                if dst_spec is None:
+                    return _no(f"missing compact remote grecv spec peer={peer} ri={ri}")
+                s_off, s_nb = rd["topo_send"][p_rl]
+                if src_spec.nbytes(self.dtype_spec) != s_nb:
+                    return _no(f"topo_send size peer={peer} ri={ri}")
+                spans = _packed_copy_spans(
+                    src_spec,
+                    dst_spec,
+                    names,
+                    self.dtype_spec,
+                    src_base=arena_base
+                    + _arena_slot_offset(s_off, ri, depth, self._arena_S),
+                    dst_base=remote_base,
+                )
+                if not spans:
+                    return _no(f"empty external payload peer={peer} ri={ri}")
+                ext_xfer[peer][ri] = spans
+
+        # Internal consume reads either a peer's parity-slotted own payload or one of that peer's compact
+        # external GRECV slots. Preserve the packed source spec and selected names so _build_arena_plans can
+        # compose wire->model mappings directly, with no local staging destination.
+        internal_src: dict[
+            int, list[list[tuple[int | None, int, ShardSpec, tuple[str, ...]]]]
+        ] = {p: [[] for _ in range(nr_rounds)] for p in int_union}
+        internal_bytes: dict[int, list[int]] = {
+            p: [0 for _ in range(nr_rounds)] for p in int_union
+        }
+        for ri, plan in enumerate(plans):
+            for p_rl, routes in plan["pull"].items():
+                peer = sw + p_rl
+                peer_layout, peer_S = _layout(p_rl)
+                peer_rd = peer_layout[ri]
+                peer_doff_rd = _doff_layout(p_rl)[ri]
+                sources: list[tuple[int | None, int, ShardSpec, tuple[str, ...]]] = []
+                selected: set[tuple[int, str]] = set()
+                for kind, source, names in routes:
+                    for name in names:
+                        key = (source, name)
+                        if key in selected:
+                            return _no(
+                                f"duplicate internal route peer={peer} source={source} name={name}"
+                            )
+                        selected.add(key)
+                    if kind == "own":
+                        if source != p_rl:
+                            return _no(f"invalid own route peer={peer} source={source}")
+                        src_spec = _own_spec(p_rl, ri)
+                        src_region = peer_rd["own"]
+                        src_base = peer_doff_rd["own"][0] + src_region[0]
+                        slot_source = None
+                    elif kind == "grecv":
+                        src_spec = _grecv_spec(p_rl, source, ri)
+                        if src_spec is None:
+                            return _no(
+                                f"missing peer grecv spec peer={peer} source={source} ri={ri}"
+                            )
+                        src_region = peer_rd["grecv"].get(source)
+                        if src_region is None:
+                            return _no(
+                                f"missing peer grecv peer={peer} source={source} ri={ri}"
+                            )
+                        src_base = peer_doff_rd["grecv"][source][0]
+                        slot_source = sw + source
+                    else:
+                        return _no(f"unknown internal route kind={kind}")
+                    if src_spec.nbytes(self.dtype_spec) != src_region[1]:
+                        return _no(
+                            f"internal source size peer={peer} source={source} ri={ri}"
+                        )
+                    regions = _packed_name_regions(src_spec, self.dtype_spec)
+                    if not set(names) <= regions.keys():
+                        return _no(
+                            f"internal source names peer={peer} source={source} ri={ri}"
+                        )
+                    selected_names = tuple(sorted(names))
+                    sources.append((slot_source, src_base, src_spec, selected_names))
+                    internal_bytes[peer][ri] += sum(
+                        regions[name][1] for name in selected_names
+                    )
+                if not sources:
+                    return _no(f"empty internal payload peer={peer} ri={ri}")
+                internal_src[peer][ri] = sources
+
+        # Compact GRECV has one slot per (direct external source, round parity). Gate each write on the
+        # target's previous direct generation of this same physical slot; target CONS is emitted only after
+        # its own local internal-consume kernel and every downstream local reader kernel have finished.
+        incoming_external = {
+            peer: tuple(
+                ri
+                for ri in range(nr_rounds)
+                if rl in self.router.topology_plan(peer - sw, ri)["external"]
+            )
+            for peer in ext_send_union
+        }
+        missing_external = sorted(
+            p for p, rounds in incoming_external.items() if not rounds
+        )
+        if missing_external:
+            return _no(
+                f"external peer(s) have no reciprocal generation: {missing_external}"
+            )
+        peer_pred: list[dict[int, tuple[int, int]]] = []
+        for ri, ext_peers in enumerate(ext_send_by_round):
+            pred: dict[int, tuple[int, int]] = {}
+            for peer in ext_peers:
+                same_slot = [
+                    r for r in incoming_external[peer] if r % depth == ri % depth
+                ]
+                if not same_slot:
+                    return _no(
+                        f"external peer={peer} has no reciprocal parity for ri={ri}"
+                    )
+                earlier = [r for r in same_slot if r < ri]
+                pred[peer] = (0, earlier[-1]) if earlier else (-1, same_slot[-1])
+            peer_pred.append(pred)
+
+        self._topo_ext_peers = ext_union
+        self._topo_int_peers = int_union
+        self._topo_ext_send_peers_by_round = ext_send_by_round
+        self._topo_ext_recv_peers_by_round = ext_recv_by_round
+        self._topo_int_peers_by_round = int_by_round
+        self._topo_int_readers_by_round = int_readers_by_round
+        self._topo_ext_release_readers_by_round = ext_release_readers_by_round
+        self._topo_ext_xfer = ext_xfer
+        self._topo_internal_consume_src = internal_src
+        self._topo_internal_consume_bytes = internal_bytes
+        self._topo_peer_predecessors = peer_pred
+        if _td:
+            print(
+                f"TDBG-RESOLVE rank {rank}: TOPO OK groups={len(self.router._topology_groups)} "
+                f"ext={ext_union} int={int_union}",
+                flush=True,
+            )
+        return True
+
+    def _build_relay_plans(self) -> None:
+        """Bind static model↔group-buffer copy plans for replica relay."""
+        assert self.router is not None
+        sw = self.router.sender_ws
+        if self._is_sender:
+            self._relay_pack_plans: list[CopyPlan | None] = []
+            self._relay_sizes: list[dict[int, int]] = []
+            for ri, specs in enumerate(self._relay_send_specs):
+                pairs: list[tuple[torch.Tensor, torch.Tensor]] = []
+                sizes: dict[int, int] = {}
+                for gid, spec in sorted(specs.items()):
+                    size = spec.nbytes(self.dtype_spec)
+                    sizes[gid] = size
+                    pairs.extend(
+                        self.load_spec.fuse_copy_pairs(
+                            spec,
+                            self._relay_send_buf[gid][ri % 2],
+                            self.wksd,
+                            self.dtype_spec,
+                            src_to_dst=False,
+                        )
+                    )
+                self._relay_pack_plans.append(CopyPlan(pairs) if pairs else None)
+                self._relay_sizes.append(sizes)
+            logger.info(
+                "wbridge rank %d: built %d replica-group sender pack plans",
+                self._rank,
+                sum(plan is not None for plan in self._relay_pack_plans),
+            )
+            return
+
+        # Only heads prepare: trainer lanes already live in PREP, so the head snapshots them into an
+        # epoch-scoped scratch allocation and assembles scratch -> canonical PREP in place. Rebindable source
+        # descriptors let these static plans follow a fresh scratch address each epoch.
+        self._relay_prepare_plan: dict[tuple[int, int], CopyPlan] = {}
+        self._relay_snapshot_bytes: dict[tuple[int, int], int] = {}
+        self._relay_consume_plan: dict[tuple[int, int], CopyPlan] = {}
+        self._relay_prepare_stream: dict[tuple[int, int], torch.cuda.Stream] = {}
+        self._relay_prepare_event: dict[tuple[int, int], torch.cuda.Event] = {}
+        self._relay_offload_stream: dict[tuple[int, int], torch.cuda.Stream] = {}
+        self._relay_offload_event: dict[tuple[int, int], torch.cuda.Event] = {}
+        self._relay_consume_stream: dict[tuple[int, int], torch.cuda.Stream] = {}
+        self._relay_consume_event: dict[tuple[int, int], torch.cuda.Event] = {}
+        rl = self._rank - sw
+        scratch_templates: dict[int, torch.Tensor] = {}
+
+        for group in self.router._relay_groups:
+            gid = group["id"]
+            owner = sw + group["owner_of"].get(rl, -1)
+            for ri, group_spec in enumerate(group["round_specs"]):
+                if not group_spec.entries:
+                    continue
+                parity = ri % 2
+                doff_slot = ri % self._relay_doff_depth
+                size = group_spec.nbytes(self.dtype_spec)
+                if gid in self._relay_owned_gids:
+                    if self._rank == group["head"]:
+                        scratch = scratch_templates.get(gid)
+                        if scratch is None:
+                            scratch = torch.empty(
+                                self._relay_head_scratch_size[gid],
+                                dtype=torch.uint8,
+                                device=self.device,
+                            )
+                            scratch_templates[gid] = scratch
+                        prep = self._relay_prep_buf[gid][parity][:size]
+                        prep_named = _carve_named(group_spec, prep, self.dtype_spec)
+                        trainer_specs = group["trainer_specs"][ri]
+                        scratch_named = {
+                            si: _carve_named(
+                                spec,
+                                scratch[
+                                    self._relay_prep_offsets[gid][ri][
+                                        si
+                                    ] : self._relay_prep_offsets[gid][ri][si]
+                                    + spec.nbytes(self.dtype_spec)
+                                ],
+                                self.dtype_spec,
+                            )
+                            for si, spec in trainer_specs.items()
+                        }
+                        pairs = group_spec(prep_named).setitem_named_pairs(
+                            trainer_specs,
+                            scratch_named,
+                        )
+                        self._relay_prepare_plan[(gid, ri)] = CopyPlan(
+                            pairs,
+                            source_region=(scratch.data_ptr(), scratch.numel()),
+                        )
+                        self._relay_snapshot_bytes[(gid, ri)] = max(
+                            self._relay_prep_offsets[gid][ri][si]
+                            + spec.nbytes(self.dtype_spec)
+                            for si, spec in trainer_specs.items()
+                        )
+                        self._relay_prepare_stream.setdefault(
+                            (gid, parity),
+                            torch.cuda.Stream(device=self.device),
+                        )
+                        self._relay_prepare_event.setdefault(
+                            (gid, parity), torch.cuda.Event()
+                        )
+                    self._relay_offload_stream.setdefault(
+                        (gid, doff_slot),
+                        torch.cuda.Stream(device=self.device),
+                    )
+                    self._relay_offload_event.setdefault(
+                        (gid, doff_slot),
+                        torch.cuda.Event(),
+                    )
+
+                if rl not in group["members"]:
+                    continue
+                if owner == self._rank:
+                    source_tensor = self._relay_doff_buf[gid][doff_slot][:size]
+                    pairs = self.load_spec.fuse_copy_pairs(
+                        group_spec,
+                        source_tensor,
+                        self.wksd,
+                        self.dtype_spec,
+                        src_to_dst=True,
+                    )
+                    plan = CopyPlan(pairs)
+                else:
+                    source_tensor = self._relay_peer_doff[(gid, doff_slot)][:size]
+                    pairs = self.load_spec.fuse_copy_pairs(
+                        group_spec,
+                        source_tensor,
+                        self.wksd,
+                        self.dtype_spec,
+                        src_to_dst=True,
+                    )
+                    tensor_base = self._relay_peer_doff[(gid, doff_slot)].data_ptr()
+                    kernel_base = self._relay_peer_kernel_base[(gid, doff_slot)]
+                    source_ptrs = [
+                        kernel_base + (source.data_ptr() - tensor_base)
+                        for _destination, source in pairs
+                    ]
+                    plan = CopyPlan(pairs, source_ptrs=source_ptrs)
+                self._relay_consume_plan[(gid, ri)] = plan
+                self._relay_consume_stream.setdefault(
+                    (gid, doff_slot),
+                    torch.cuda.Stream(device=self.device),
+                )
+                self._relay_consume_event.setdefault(
+                    (gid, doff_slot), torch.cuda.Event()
+                )
+
+        logger.info(
+            "wbridge rank %d: built replica relay prepare=%d consume=%d plans",
+            self._rank,
+            len(self._relay_prepare_plan),
+            len(self._relay_consume_plan),
+        )
+
+    # ------------------------------------------------- fused model<->wire plan
+    def _build_fuse_plans(self) -> None:
+        """Precompute the per-round :class:`CopyPlan`\\ s replayed each WT.
+
+        Receivers build tensor-dedup arena plans (fused prepare + consume over the single arena, via
+        :meth:`_build_arena_plans`). Senders build one fused model->wire pack plan per round: the fused copy
+        (``LoadSpec.fuse_copy_pairs``) collapses the two packing stages (model<->logical, logical<->wire)
+        into a single copy bound to the persistent model params and the persistent RDMA pack buffers — no
+        transient logical buffer. Rounds whose shard shapes the fast path can't map
+        (:class:`FuseUnsupported`) fall back to the transient 2-stage path. When
+        ``WBRIDGE_FUSE_SELFCHECK=1`` each round is validated byte-for-byte against the 2-stage path at
+        connect (opt-in: it allocates transient scratch and can be memory-heavy).
+        """
+        if not self._is_sender:
+            if self._direct_same_node:
+                self._build_direct_consume_plans()
+            else:
+                self._build_arena_plans()  # tensor-dedup receiver: fused prepare + consume over the arena
+            return
+
+        # Sender: one fused model->wire pack plan per round.
+        selfcheck = os.environ.get("WBRIDGE_FUSE_SELFCHECK", "0") == "1"
+        self._fuse_plans: list[CopyPlan | None] = []
+        self._fuse_sizes: list[dict[int, int]] = []
+        self._fuse_fallback: list[bool] = []
+        n_fused = n_fallback = 0
+        for ri, (full_spec, overlap_specs) in enumerate(self.router.local_rounds):
+            self._fuse_sizes.append(
+                {p: o.nbytes(self.dtype_spec) for p, o in overlap_specs.items()}
+            )
+            if not overlap_specs:
+                self._fuse_plans.append(None)
+                self._fuse_fallback.append(False)
+                continue
+            try:
+                pairs = []
+                for peer, ospec in overlap_specs.items():
+                    pairs += self.load_spec.fuse_copy_pairs(
+                        ospec,
+                        self._data_buf[peer][ri % self._NUM_BUF],
+                        self.wksd,
+                        self.dtype_spec,
+                        src_to_dst=False,
+                    )
+                plan = CopyPlan(pairs)
+                if selfcheck:
+                    self._selfcheck_round(ri, full_spec, overlap_specs)
+                self._fuse_plans.append(plan)
+                self._fuse_fallback.append(False)
+                n_fused += 1
+            except (FuseUnsupported, AssertionError) as e:
+                logger.warning(
+                    "wbridge rank %d: round %d fuse->2-stage fallback (%s)",
+                    self._rank,
+                    ri,
+                    e,
+                )
+                self._fuse_plans.append(None)
+                self._fuse_fallback.append(True)
+                n_fallback += 1
+        logger.info(
+            "wbridge rank %d: fused %d rounds, %d fallback",
+            self._rank,
+            n_fused,
+            n_fallback,
+        )
+        if os.environ.get("WBRIDGE_TIMING") == "1":
+            # Snapshot per-(this rank, peer) wire bytes per round, for collective-vs-RDMA comparisons.
+            for ri, sz in enumerate(self._fuse_sizes):
+                if sz:
+                    logger.info(
+                        "wbridge-snap rank %d round %d bytes %s",
+                        self._rank,
+                        ri,
+                        dict(sorted(sz.items())),
+                    )
+
+    def _build_direct_consume_plans(self) -> None:
+        """Bind same-node trainer pack buffers directly to this receiver's live model parameters.
+
+        In this mode receiver de-duplication/exchange is disabled: every rollout replica has a complete
+        trainer route, while sender-side replicated shards remain de-duplicated.  A round therefore consists
+        only of sender pack followed by this plan.  ``source_ptrs`` point at CUDA-IPC mappings opened on the
+        receiver GPU, so the copy/transpose/reshard kernel reads remote pack bytes over NVLink and writes the
+        final runtime tensors without RECV, PREP, GRECV, DOFF, or a second consume pass.
+        """
+        self._direct_consume_plan: list[CopyPlan | None] = []
+        total_launches = 0
+        for ri, (full_spec, overlap_specs) in enumerate(self.router.local_rounds):
+            if not overlap_specs:
+                self._direct_consume_plan.append(None)
+                continue
+            missing = sorted(set(overlap_specs) - self._sn_senders)
+            if missing:
+                raise RuntimeError(
+                    f"direct same-node consume round {ri} has non-IPC sender(s) {missing}"
+                )
+            covered = sum(
+                spec.nbytes(self.dtype_spec) for spec in overlap_specs.values()
+            )
+            expected = full_spec.nbytes(self.dtype_spec)
+            if covered != expected:
+                raise RuntimeError(
+                    f"direct same-node consume round {ri} coverage mismatch: "
+                    f"covered={covered} expected={expected}"
+                )
+            pairs: list[tuple[torch.Tensor, torch.Tensor]] = []
+            source_ptrs: list[int] = []
+            for peer, source_spec in sorted(overlap_specs.items()):
+                parity = ri % self._peer_pack_num_buf[peer]
+                source_buf = self._peer_pack_buf[peer][parity]
+                source_bytes = source_spec.nbytes(self.dtype_spec)
+                peer_pairs = self.load_spec.fuse_copy_pairs(
+                    source_spec,
+                    source_buf[:source_bytes],
+                    self.wksd,
+                    self.dtype_spec,
+                    src_to_dst=True,
+                )
+                kernel_base = self._peer_pack_kernel_base[peer][parity]
+                source_ptrs.extend(
+                    kernel_base + (source.data_ptr() - source_buf.data_ptr())
+                    for _destination, source in peer_pairs
+                )
+                pairs.extend(peer_pairs)
+            plan = CopyPlan(pairs, unified_dtype_kernels=True, source_ptrs=source_ptrs)
+            self._direct_consume_plan.append(plan)
+            total_launches += plan.launch_count
+        logger.info(
+            "wbridge rank %d: direct same-node consume ON (%d rounds, %d total kernel launches)",
+            self._rank,
+            sum(plan is not None for plan in self._direct_consume_plan),
+            total_launches,
+        )
+
+    def _build_arena_plans(self) -> None:
+        """Tensor-dedup receiver: per-round CopyPlans across isolated RECV and rollout arenas.
+
+        RECV offsets normally use ``_recv_arena`` and its parity stride. With merged RECV/PREP they name
+        offsets in a template slot and are rebound each epoch to the temporary snapshot buffer. Own/send use
+        the rollout ``_arena`` PREP stride; shared-bank grecv offsets are absolute in ``_arena``. Two plans:
+
+        * ``_arena_prepare[ri]``: one direct RECV -> destinations plan containing ``own`` plus each unique
+          non-aliased generic ``send`` or exact topology ``topo_send`` payload. Deduplication happens in
+          :meth:`arena_layout` first; a full-slice send aliases ``own`` and therefore adds no destination.
+          Partial payloads are copied directly from their original RECV name views in the same kernel—never
+          from ``own``—so there is no inter-program dependency and no second repack launch.
+        * Generic fallback ``_arena_consume[ri]``: my ``own`` slice + each peer's ``grecv`` slice -> model.
+        * Topology ``_topo_internal_consume_plan[ri][source_lane]``: one direct wire->model kernel per active
+          ``(same-node owner, external source slot)`` lane. The owner's own/PREP descriptor joins its first
+          slot, or a source-less lane when it has no external input. Peer plans read imported CUDA-IPC
+          addresses over NVLink; there is no local internal GRECV copy or final fan-in consume kernel.
+
+        ``full_spec`` (``local_rounds[ri][0]`` = my deduped recv spec for the round) has
+        ``nbytes == own.nb == s2r``. The prepare remains one fused kernel even though its sources and
+        destinations now live in different allocations.
+        """
+        sw = self.router.sender_ws
+        rl = self._rank - sw
+        classes = self.router.recv_tensor_classes()
+        layout = self._arena_layout
+        arena = self._arena
+        doff_arena = getattr(
+            self, "_doff_arena", arena
+        )  # generic/offline fallback does not allocate DOFF
+        recv_arena = self._recv_arena
+        my_spec = self.router.recv_specs[rl]
+        self._arena_prepare: list = []
+        self._arena_consume: list = []
+        Lane = tuple[
+            int, int | None
+        ]  # (same-node source-column owner, external grecv source or None)
+        self._topo_internal_consume_plan: list[dict[Lane, CopyPlan]] = []
+        self._topo_internal_consume_own_lane: list[dict[int, Lane]] = []
+        self._topo_internal_consume_bytes_by_lane: list[dict[Lane, int]] = []
+        self._topo_internal_consume_lane_sources: list[dict[Lane, tuple[int, ...]]] = []
+        self._topo_internal_consume_source_lane: list[dict[tuple[int, int], Lane]] = []
+        # Streams/events are persistent per independently-ready slot lane and populated lazily below. A
+        # column's own PREP payload is attached to its first external slot (or a None lane if it has none),
+        # preserving one kernel/column in 1T2R while allowing multiple external slots to commit separately.
+        self._topo_internal_consume_stream: dict[Lane, torch.cuda.Stream] = {}
+        self._topo_internal_consume_event: dict[Lane, torch.cuda.Event] = {}
+
+        def _selected_consume_pairs(
+            source_spec: ShardSpec,
+            source_buf: torch.Tensor,
+            selected_names: tuple[str, ...] | list[str],
+        ) -> list[tuple[torch.Tensor, torch.Tensor]]:
+            """Compose selected packed names directly into this worker's model destinations."""
+            regions = _packed_name_regions(source_spec, self.dtype_spec)
+            pairs: list[tuple[torch.Tensor, torch.Tensor]] = []
+            for name in sorted(set(selected_names)):
+                assert name in regions, f"internal consume source missing {name}"
+                off, nb = regions[name]
+                name_spec = source_spec.subset({name})
+                pairs.extend(
+                    self.load_spec.fuse_copy_pairs(
+                        name_spec,
+                        source_buf[off : off + nb],
+                        self.wksd,
+                        self.dtype_spec,
+                        src_to_dst=True,
+                    )
+                )
+            return pairs
+
+        for ri, (full_spec, overlap_specs) in enumerate(self.router.local_rounds):
+            rd = layout[ri]
+            ab = _arena_slot_offset(0, ri, self._recv_depth, self._arena_S)
+            # Merged mode snapshots the live parity into one scratch buffer at offset zero before A+R. Build
+            # descriptors against slot zero as a pointer template; poll_requests rebases them to the actual
+            # epoch allocation. Non-merged mode binds its persistent RECV parity directly.
+            rb = (
+                0
+                if getattr(self, "_merged_recv_prep", False)
+                else _arena_slot_offset(0, ri, self._recv_depth, self._recv_S)
+            )
+            round_names = sorted(
+                n for n in self.router.global_rounds[ri] if n in my_spec.entries
+            )
+            own_off, own_nb = rd["own"]
+            prepare_pairs = []
+            if overlap_specs:
+                own_view = _carve_named(
+                    full_spec,
+                    arena[ab + own_off : ab + own_off + own_nb],
+                    self.dtype_spec,
+                )
+                # Carve each sender's ORIGINAL packed layout once. A partial send payload can then select
+                # whole names from these views without incorrectly rebasing its first selected name to byte 0.
+                recv_named = {
+                    si: _carve_named(
+                        ospec,
+                        recv_arena[
+                            rb + rd["recv"][si][0] : rb
+                            + rd["recv"][si][0]
+                            + rd["recv"][si][1]
+                        ],
+                        self.dtype_spec,
+                    )
+                    for si, ospec in overlap_specs.items()
+                }
+                prepare_pairs += full_spec(own_view).setitem_named_pairs(
+                    overlap_specs, recv_named
+                )
+
+                prepared: dict[tuple[int, int], tuple[str, ...]] = {
+                    (own_off, own_nb): tuple(name for name, _ in full_spec),
+                }
+
+                def _prepare_payload(
+                    shared: tuple[str, ...], slot: tuple[int, int]
+                ) -> None:
+                    """Add one unique packed payload destination to the fused prepare CopyPlan."""
+                    if not shared:
+                        return
+                    if slot in prepared:
+                        # Exact alias: another peer uses this deduplicated payload, or the complete payload
+                        # is `own` itself. It has already been added to the fused destination plan.
+                        assert prepared[slot] == shared
+                        return
+                    prepared[slot] = shared
+                    s_off, s_nb = slot
+                    send_spec = my_spec.subset(set(shared))
+                    assert send_spec.nbytes(self.dtype_spec) == s_nb
+                    send_view = _carve_named(
+                        send_spec,
+                        arena[ab + s_off : ab + s_off + s_nb],
+                        self.dtype_spec,
+                    )
+                    send_src_specs = {
+                        si: sub
+                        for si, ospec in overlap_specs.items()
+                        if (sub := ospec.subset(set(shared))).entries
+                    }
+                    prepare_pairs.extend(
+                        send_spec(send_view).setitem_named_pairs(
+                            send_src_specs, recv_named
+                        )
+                    )
+
+                if self._topo_ok:
+                    for p_rl, shared in self.router.topology_plan(rl, ri)[
+                        "external"
+                    ].items():
+                        assert p_rl in rd["topo_send"]
+                        _prepare_payload(tuple(shared), rd["topo_send"][p_rl])
+                else:
+                    # Runtime topology resolution can still reject a structurally valid plan (for example,
+                    # CUDA-IPC import was disabled). In that case populate the generic single-phase sends.
+                    # Once topology resolves successfully these potentially much larger payloads are unused,
+                    # so omit them from the assemble kernel even though their fallback arena slots remain.
+                    for peer in self._repl_peers:
+                        p_rl = peer - sw
+                        if p_rl not in rd["send"]:
+                            continue
+                        shared = tuple(
+                            self.router._arena_shared(rl, p_rl, round_names, classes)
+                        )
+                        _prepare_payload(shared, rd["send"][p_rl])
+            self._arena_prepare.append(
+                CopyPlan(
+                    prepare_pairs,
+                    source_region=(recv_arena.data_ptr(), self._recv_payload_S)
+                    if getattr(self, "_merged_recv_prep", False)
+                    else None,
+                )
+            )
+            if self._topo_ok:
+                plans: dict[Lane, CopyPlan] = {}
+                own_lane: dict[int, Lane] = {}
+                lane_pairs: dict[Lane, list[tuple[torch.Tensor, torch.Tensor]]] = {}
+                lane_ptrs: dict[Lane, list[int]] = {}
+                lane_sources: dict[Lane, set[int]] = {}
+
+                def _extend_lane(
+                    lane: Lane,
+                    pairs: list[tuple[torch.Tensor, torch.Tensor]],
+                    source_ptrs: list[int] | None = None,
+                    source_key: int | None = None,
+                ) -> None:
+                    if not pairs:
+                        return
+                    lane_pairs.setdefault(lane, []).extend(pairs)
+                    if source_ptrs is not None:
+                        lane_ptrs.setdefault(lane, []).extend(source_ptrs)
+                    if source_key is not None:
+                        lane_sources.setdefault(lane, set()).add(source_key)
+
+                # Self column: attach own PREP to the first external slot. Every exact grecv source remains
+                # an independent lane, so its external writer can be released as soon as that lane commits.
+                self_slots = [sw + source for source in sorted(rd["grecv_names"])]
+                self_primary = self_slots[0] if self_slots else None
+                self_own_lane: Lane = (self._rank, self_primary)
+                own_lane[self._rank] = self_own_lane
+                doff_rd = self._doff_layout[ri]
+                doff_own_off = doff_rd["own"][0]
+                self_pairs = list(
+                    self.load_spec.fuse_copy_pairs(
+                        full_spec,
+                        doff_arena[
+                            doff_own_off + own_off : doff_own_off + own_off + own_nb
+                        ],
+                        self.wksd,
+                        self.dtype_spec,
+                        src_to_dst=True,
+                    )
+                )
+                _extend_lane(self_own_lane, self_pairs, source_key=self._rank)
+                for source_rl, names in rd["grecv_names"].items():
+                    _g_off, g_nb = rd["grecv"][source_rl]
+                    doff_g_off, doff_g_nb = doff_rd["grecv"][source_rl]
+                    assert doff_g_nb == g_nb
+                    source_spec = self.router.recv_specs[source_rl].subset(set(names))
+                    assert source_spec.nbytes(self.dtype_spec) == g_nb
+                    _extend_lane(
+                        (self._rank, sw + source_rl),
+                        _selected_consume_pairs(
+                            source_spec,
+                            doff_arena[doff_g_off : doff_g_off + g_nb],
+                            names,
+                        ),
+                        source_key=sw + source_rl,
+                    )
+
+                # Remote columns: split descriptors by exact external source slot. The own descriptor joins
+                # the first slot, keeping the common 1T2R case at one kernel per source column.
+                for peer in self._topo_int_peers_by_round[ri]:
+                    peer_arena = self._repl_peer_doff_arena[peer]
+                    peer_tensor_base = peer_arena.data_ptr()
+                    peer_kernel_base = self._repl_peer_doff_kernel_base[peer]
+                    descriptors = self._topo_internal_consume_src[peer][ri]
+                    peer_slots = sorted(
+                        {slot for slot, *_rest in descriptors if slot is not None}
+                    )
+                    peer_primary = peer_slots[0] if peer_slots else None
+                    peer_own_lane: Lane = (peer, peer_primary)
+                    if any(slot is None for slot, *_rest in descriptors):
+                        own_lane[peer] = peer_own_lane
+                    for slot_source, src_off, source_spec, names in descriptors:
+                        src_nb = source_spec.nbytes(self.dtype_spec)
+                        new_pairs = _selected_consume_pairs(
+                            source_spec,
+                            peer_arena[src_off : src_off + src_nb],
+                            names,
+                        )
+                        new_ptrs = [
+                            peer_kernel_base + (source.data_ptr() - peer_tensor_base)
+                            for _destination, source in new_pairs
+                        ]
+                        lane = (
+                            peer,
+                            peer_primary if slot_source is None else slot_source,
+                        )
+                        _extend_lane(
+                            lane,
+                            new_pairs,
+                            new_ptrs,
+                            source_key=(peer if slot_source is None else slot_source),
+                        )
+
+                lane_bytes: dict[Lane, int] = {}
+                for lane in sorted(
+                    lane_pairs,
+                    key=lambda item: (item[0], -1 if item[1] is None else item[1]),
+                ):
+                    pairs = lane_pairs[lane]
+                    source_ptrs = lane_ptrs.get(lane)
+                    if lane[0] != self._rank:
+                        assert source_ptrs is not None and len(source_ptrs) == len(
+                            pairs
+                        )
+                    else:
+                        assert source_ptrs is None
+                    # A lane can contain both BF16 model weights and FP32 norms. Keep flat and transformed
+                    # mappings unified within each dtype, while issuing the unavoidable one kernel per dtype.
+                    plan = CopyPlan(
+                        pairs,
+                        unified_dtype_kernels=True,
+                        source_ptrs=source_ptrs,
+                    )
+                    assert plan.launch_count == len({dst.dtype for dst, _src in pairs})
+                    plans[lane] = plan
+                    lane_bytes[lane] = sum(
+                        src.numel() * src.element_size() for _dst, src in pairs
+                    )
+                    self._topo_internal_consume_stream.setdefault(
+                        lane,
+                        torch.cuda.Stream(device=arena.device),
+                    )
+                    self._topo_internal_consume_event.setdefault(
+                        lane, torch.cuda.Event()
+                    )
+
+                expected_owners = {self._rank, *self._topo_int_peers_by_round[ri]}
+                if full_spec.entries:
+                    assert {owner for owner, _source in plans} == expected_owners, (
+                        f"internal consume owners ri={ri}: "
+                        f"built={sorted({owner for owner, _source in plans})} "
+                        f"expected={sorted(expected_owners)}"
+                    )
+                self._topo_internal_consume_plan.append(plans)
+                self._topo_internal_consume_own_lane.append(own_lane)
+                self._topo_internal_consume_bytes_by_lane.append(lane_bytes)
+                frozen_lane_sources = {
+                    lane: tuple(sorted(sources))
+                    for lane, sources in lane_sources.items()
+                }
+                self._topo_internal_consume_lane_sources.append(frozen_lane_sources)
+                self._topo_internal_consume_source_lane.append(
+                    {
+                        (lane[0], source): lane
+                        for lane, sources in frozen_lane_sources.items()
+                        for source in sources
+                    }
+                )
+                self._arena_consume.append(None)
+            else:
+                # Generic staged fallback: consume own + every filled peer GRECV slot in one local plan.
+                cpairs = list(
+                    self.load_spec.fuse_copy_pairs(
+                        full_spec,
+                        arena[ab + own_off : ab + own_off + own_nb],
+                        self.wksd,
+                        self.dtype_spec,
+                        src_to_dst=True,
+                    )
+                )
+                for peer in self._repl_peers:
+                    p_rl = peer - sw
+                    if p_rl not in rd["grecv"]:
+                        continue
+                    shared = self.router._arena_shared(rl, p_rl, round_names, classes)
+                    qspec = self.router.recv_specs[p_rl].subset(set(shared))
+                    if qspec.entries:
+                        g_off, g_nb = rd["grecv"][p_rl]
+                        cpairs += self.load_spec.fuse_copy_pairs(
+                            qspec,
+                            arena[g_off : g_off + g_nb],
+                            self.wksd,
+                            self.dtype_spec,
+                            src_to_dst=True,
+                        )
+                self._arena_consume.append(CopyPlan(cpairs))
+                self._topo_internal_consume_plan.append({})
+                self._topo_internal_consume_own_lane.append({})
+                self._topo_internal_consume_bytes_by_lane.append({})
+                self._topo_internal_consume_lane_sources.append({})
+                self._topo_internal_consume_source_lane.append({})
+        # RS-on: per-round CPU->GPU staging hops driving the LocalStagingEngine. Senders land ALL rounds in
+        # the full-depth CPU arena; before assemble(ri) the main thread H2D-copies round ri's per-sender
+        # slices into the parity-selected GPU arena RECV zone (same offsets assemble reads). (src,dst,size) lists
+        # are stable across WTs. Empty list => no-op (RS-off, or a round with no incoming data).
+        self._rs_h2d: list[tuple[list[int], list[int], list[int]]] = []
+        if self.receiver_staging:
+            cpu_base = self._cpu_recv.data_ptr()
+            gpu_base = recv_arena.data_ptr()
+            for ri in range(len(self.router.local_rounds)):
+                cpu_r = self._cpu_recv_layout[ri]
+                src, dst, sz = [], [], []
+                for si, (goff, nb) in layout[ri]["recv"].items():
+                    src.append(cpu_base + cpu_r[si][0])
+                    dst.append(
+                        gpu_base
+                        + _arena_slot_offset(goff, ri, self._recv_depth, self._recv_S)
+                    )
+                    sz.append(nb)
+                self._rs_h2d.append((src, dst, sz))
+        else:
+            self._rs_h2d = [([], [], []) for _ in self.router.local_rounds]
+        logger.info(
+            "wbridge rank %d: built %d fused-prepare tensor-dedup rounds "
+            "(recv %.2f GiB, rollout %.2f GiB, %d peers)",
+            self._rank,
+            len(self._arena_prepare),
+            recv_arena.numel() / 1024**3,
+            arena.numel() / 1024**3,
+            len(self._repl_peers),
+        )
+
+    def _two_stage_save(self, full_spec, overlap_specs, wire_bufs) -> None:
+        """model -> wire via the transient logical buffer (fallback path / self-check reference)."""
+        buf = full_spec.make_named_buffer(self.dtype_spec, self.device)
+        batched_copy(
+            self.load_spec.copy_fromto_pairs(
+                full_spec, buf, self.wksd, src_to_dst=False
+            )
+        )
+        bound = full_spec(buf)
+        pairs = []
+        for peer, ospec in overlap_specs.items():
+            _nb, pp = bound.pack_into_pairs(ospec, wire_bufs[peer])
+            pairs += pp
+        batched_copy(pairs)
+
+    def _selfcheck_round(self, ri, full_spec, overlap_specs) -> None:
+        """Assert the fused SAVE matches the 2-stage path byte-for-byte (opt-in; transient scratch).
+
+        Sender-only: compares the packed wire bytes (non-destructive; reads the real model) and raises
+        :class:`FuseUnsupported` on mismatch so the round falls back to the 2-stage path.
+        """
+        a = {p: torch.zeros_like(self._data_buf[p][0]) for p in overlap_specs}
+        b = {p: torch.zeros_like(self._data_buf[p][0]) for p in overlap_specs}
+        self._two_stage_save(full_spec, overlap_specs, a)
+        pairs = []
+        for peer, ospec in overlap_specs.items():
+            pairs += self.load_spec.fuse_copy_pairs(
+                ospec, b[peer], self.wksd, self.dtype_spec, src_to_dst=False
+            )
+        batched_copy(pairs)
+        torch.cuda.synchronize()
+        for peer, ospec in overlap_specs.items():
+            nb = ospec.nbytes(self.dtype_spec)
+            if not torch.equal(a[peer][:nb], b[peer][:nb]):
+                # Localize the first differing tensor (per-ospec byte walk) — pinpoints which consolidated
+                # slice shape the fuse mis-maps. Diagnostic only; still raises to fall back to 2-stage.
+                if os.environ.get("WBRIDGE_DEDUP_DIAG") == "1":
+                    off = 0
+                    for name, shards in ospec:
+                        ln = shards_nbytes(shards, self.dtype_spec[name])
+                        if ln and not torch.equal(
+                            a[peer][off : off + ln], b[peer][off : off + ln]
+                        ):
+                            print(
+                                f"[FUSE-DIAG] SAVE mismatch round {ri} peer {peer} tensor={name} "
+                                f"nbytes={ln} shards={[list(s) for s in shards]}",
+                                flush=True,
+                            )
+                        off += ln
+                raise FuseUnsupported(f"selfcheck SAVE mismatch round {ri} peer {peer}")
+
+    # -------------------------------------------------------------- transfer
+    def _seq(self, ri: int) -> int:
+        """Globally-monotonic flag value for round *ri* of the current update epoch (1-indexed)."""
+        return self._seq_at(self._epoch, ri)
+
+    def _seq_at(self, epoch: int, ri: int) -> int:
+        """Sequence value for an explicit epoch/round generation."""
+        assert epoch >= 0 and 0 <= ri < self.num_rounds
+        return epoch * self.num_rounds + ri + 1
+
+    def _ctl_acc(self, key: str, dt: float, imm: int) -> None:
+        d = self._ctl.setdefault(
+            key, [0.0, 0, 0]
+        )  # [total_s, count, immediate-hit count]
+        d[0] += dt
+        d[1] += 1
+        d[2] += imm
+
+    def _ctl_take_report(self, wt: int, nrounds: int) -> list[str]:
+        """Snapshot and reset one epoch's control profile without performing logger output."""
+        if not self._ctlp or not self._ctl:
+            return []
+        lines = []
+        for k in sorted(self._ctl):
+            t, n, imm = self._ctl[k]
+            lines.append(
+                "[ctl-prof] wt=%d %-8s total=%6.1fms n=%3d per=%.2fms imm=%d/%d /round=%.1fms"
+                % (
+                    wt,
+                    k,
+                    t * 1e3,
+                    n,
+                    (t / n * 1e3 if n else 0.0),
+                    imm,
+                    n,
+                    t * 1e3 / max(nrounds, 1),
+                )
+            )
+        nb = getattr(self, "_ctl_bytes", 0)
+        if nb:
+            # Absolute achieved bulk bandwidth for THIS rank this epoch — the number that is directly
+            # comparable to the standalone ladder benchmark's GB/s/rank.
+            bw = self._ctl.get("b_wait", (0.0, 0, 0))[0]
+            lines.append(
+                "[ctl-prof] wt=%d b_bytes  total=%.3f GiB over b_wait=%.1fms -> %.2f GB/s"
+                % (wt, nb / 1024**3, bw * 1e3, (nb / bw / 1e9) if bw else 0.0)
+            )
+            self._ctl_bytes = 0
+        self._ctl = {}
+        return lines
+
+    def _flag_reaper_ensure(self) -> None:
+        """Start the off-path async-handle reaper.
+
+        This is deliberately not a control-plane publisher: producers submit their own writes immediately.
+        The daemon only calls ``wait`` later so backend batch handles are retired and failures are reported.
+        A stalled handle can therefore delay cleanup, but can never delay a different flag submission.
+        """
+        if not hasattr(self, "_flag_reaper_lock"):
+            self._flag_reaper_lock = threading.Lock()
+            self._flag_reaper_q = None
+            self._flag_reaper_thread = None
+            self._flag_reaper_errors = []
+            self._flag_submit_lock = threading.Lock()
+        with self._flag_reaper_lock:
+            if self._flag_reaper_thread is not None:
+                return
+            self._flag_reaper_q = queue.Queue()
+            self._flag_reaper_thread = threading.Thread(
+                target=self._flag_reaper_worker,
+                name="wbridge-flag-reaper",
+                daemon=True,
+            )
+            self._flag_reaper_thread.start()
+
+    def _flag_reaper_worker(self) -> None:
+        """Retire already-submitted flag handles without participating in protocol progress."""
+        assert self._flag_reaper_q is not None
+        while True:
+            item = self._flag_reaper_q.get()
+            if item is None:
+                return
+            handle, kind, peer, seq = item
+            try:
+                self.engine.wait([handle])
+                self._trace_state("flag_reaped", kind=kind, peer=peer, seq=seq)
+            except BaseException as exc:  # noqa: BLE001 - surfaced by the producer-side health check
+                with self._flag_reaper_lock:
+                    self._flag_reaper_errors.append(exc)
+                logger.exception(
+                    "wbridge rank %d: asynchronous flag failed kind=%d peer=%d seq=%d",
+                    self._rank,
+                    kind,
+                    peer,
+                    seq,
+                )
+
+    def _flag_reaper_check(self) -> None:
+        """Raise an already-observed asynchronous flag error without waiting for outstanding handles."""
+        if not hasattr(self, "_flag_reaper_lock"):
+            return
+        with self._flag_reaper_lock:
+            error = self._flag_reaper_errors[0] if self._flag_reaper_errors else None
+        if error is not None:
+            raise RuntimeError(
+                f"wbridge rank {self._rank}: asynchronous flag write failed"
+            ) from error
+
+    def _flag_reaper_stop(self) -> None:
+        """Drain and stop the handle reaper during endpoint teardown only."""
+        if not hasattr(self, "_flag_reaper_lock"):
+            return
+        with self._flag_reaper_lock:
+            work_q = self._flag_reaper_q
+            thread = self._flag_reaper_thread
+        if work_q is None or thread is None:
+            return
+        work_q.put(None)
+        thread.join()
+        with self._flag_reaper_lock:
+            self._flag_reaper_q = None
+            self._flag_reaper_thread = None
+
+    def _flag_message_slot(self, peer_slot: int, seq: int) -> tuple[int, int]:
+        """Return ``(flat slot, round)`` for one peer's exclusive message word."""
+        ri = (seq - 1) % self.num_rounds
+        return peer_slot * self.num_rounds + ri, ri
+
+    def _control_flag_landed(
+        self, transport: str, kind: int, peer: int, seq: int
+    ) -> None:
+        """Publish a control record into the aligned int64 word polled by the protocol.
+
+        Required host contract: naturally aligned 64-bit loads and stores to cache-coherent pinned
+        host memory must be single-copy atomic across threads. The Torch allocation is aligned, and
+        the int64 slot stride preserves that alignment. The receive thread writes it directly to avoid
+        constructing a Torch operation for every 16-byte socket record. A host that does not provide
+        this atomicity is unsupported: a torn read could fabricate a future sequence and let the
+        protocol consume or reuse a buffer prematurely. TCP preserves order per peer, and the max
+        guard makes a stale duplicate harmless; neither property protects against a torn load/store.
+        """
+        if kind in (self._RELAY_DATA_KIND, self._RELAY_ACK_KIND):
+            gid, actual_seq = self._decode_relay_token(seq)
+            wt, ri = divmod(actual_seq - 1, self.num_rounds)
+            slot = self._relay_flag_slot(peer, gid, actual_seq)
+            buf = (
+                self._relay_data_buf
+                if kind == self._RELAY_DATA_KIND
+                else self._relay_ack_buf
+            )
+            stored_seq = actual_seq
+            op = "relay_data" if kind == self._RELAY_DATA_KIND else "relay_ack"
+        else:
+            wt, ri = divmod(seq - 1, self.num_rounds)
+            stored_seq = seq
+            op = ("ack", "ready", "cons")[kind] if 0 <= kind <= 2 else "invalid"
+        if kind == 0:
+            slot, _ = self._flag_message_slot(self.flag_slot_of[peer], seq)
+            buf = self._flag_buf
+        elif kind == 1:
+            slot, _ = self._flag_message_slot(self._repl_flag_slot_of[peer], seq)
+            buf = self._repl_flag_buf
+        elif kind == 2:
+            slot, _ = self._flag_message_slot(self._repl_flag_slot_of[peer], seq)
+            buf = self._repl_cons_buf
+        elif kind not in (self._RELAY_DATA_KIND, self._RELAY_ACK_KIND):
+            raise ValueError(
+                f"invalid {transport} control kind {kind} from peer {peer}"
+            )
+        word = ctypes.c_int64.from_address(buf.data_ptr() + slot * self._FLAG_ITEMSIZE)
+        if stored_seq > word.value:
+            word.value = stored_seq
+        from wbridge.backend import gantt
+
+        now = time.time()
+        gantt.rec(
+            f"ctl-{transport}",
+            self._rank,
+            wt,
+            f"{transport}_{op}_recv_peer_{peer}",
+            ri,
+            now,
+            now,
+        )
+
+    def _encode_relay_token(self, gid: int, seq: int) -> int:
+        if not 0 <= gid < getattr(self, "_relay_num_groups", 0):
+            raise ValueError(f"invalid relay group id {gid}")
+        if not 0 < seq < (1 << self._RELAY_SEQ_BITS):
+            raise ValueError(
+                f"relay sequence {seq} exceeds {self._RELAY_SEQ_BITS}-bit token field"
+            )
+        return (gid << self._RELAY_SEQ_BITS) | seq
+
+    def _decode_relay_token(self, token: int) -> tuple[int, int]:
+        mask = (1 << self._RELAY_SEQ_BITS) - 1
+        gid, seq = token >> self._RELAY_SEQ_BITS, token & mask
+        if not 0 <= gid < getattr(self, "_relay_num_groups", 0) or seq <= 0:
+            raise ValueError(f"invalid relay control token {token}")
+        return gid, seq
+
+    def _relay_flag_slot(self, peer: int, gid: int, seq: int) -> int:
+        if not 0 <= peer < self.world_size:
+            raise ValueError(f"invalid relay peer rank {peer}")
+        ri = (seq - 1) % self.num_rounds
+        return (peer * self._relay_num_groups + gid) * self.num_rounds + ri
+
+    def _relay_flag_reached(self, kind: int, peer: int, gid: int, seq: int) -> bool:
+        self._control_check()
+        slot = self._relay_flag_slot(peer, gid, seq)
+        buf = (
+            self._relay_data_buf
+            if kind == self._RELAY_DATA_KIND
+            else self._relay_ack_buf
+        )
+        return int(buf[slot].item()) >= seq
+
+    def _poll_relay_flag(
+        self,
+        kind: int,
+        peer: int,
+        gid: int,
+        seq: int,
+        *,
+        timeout_s: float = 600.0,
+    ) -> None:
+        t0 = time.time()
+        while not self._relay_flag_reached(kind, peer, gid, seq):
+            if time.time() - t0 > timeout_s:
+                label = "DATA" if kind == self._RELAY_DATA_KIND else "ACK"
+                raise TimeoutError(
+                    f"wbridge rank {self._rank}: relay {label} timeout peer={peer} "
+                    f"group={gid} seq={seq}"
+                )
+            time.sleep(1e-4)
+
+    def _relay_emit(self, kind: int, peer: int, gid: int, seq: int) -> None:
+        """Publish one group-specific DATA or RECV-drained ACK sequence."""
+        if kind not in (self._RELAY_DATA_KIND, self._RELAY_ACK_KIND):
+            raise ValueError(f"invalid relay flag kind {kind}")
+        self._flag_reaper_check()
+        token = self._encode_relay_token(gid, seq)
+        tcp_control = getattr(self, "_tcp_control", None)
+        if tcp_control is not None and tcp_control.has_peer(peer):
+            tcp_control.send(kind, peer, token)
+            return
+
+        slot = self._relay_flag_slot(peer, gid, seq)
+        src = (
+            self._relay_data_src
+            if kind == self._RELAY_DATA_KIND
+            else self._relay_ack_src
+        )
+        dst_base = (
+            self._relay_data_dst[peer]
+            if kind == self._RELAY_DATA_KIND
+            else self._relay_ack_dst[peer]
+        )
+        src[slot] = seq
+        remote_slot = self._relay_flag_slot(self._rank, gid, seq)
+        src_addr = src.data_ptr() + slot * self._FLAG_ITEMSIZE
+        dst_addr = dst_base + remote_slot * self._FLAG_ITEMSIZE
+        with self._flag_submit_lock:
+            handle = self.engine.write_async(
+                self._relay_peer_session[peer],
+                [src_addr],
+                [dst_addr],
+                [self._FLAG_ITEMSIZE],
+            )
+        if handle is not None:
+            self._flag_reaper_ensure()
+            assert self._flag_reaper_q is not None
+            self._flag_reaper_q.put((handle, kind, peer, token))
+
+    def _tcp_flag_landed(self, kind: int, peer: int, seq: int) -> None:
+        self._control_flag_landed("tcp", kind, peer, seq)
+
+    def _control_check(self) -> None:
+        tcp_control = getattr(self, "_tcp_control", None)
+        if tcp_control is not None:
+            tcp_control.check()
+
+    def _post_flag_async(self, kind: int, peer: int, seq: int) -> None:
+        """Submit one control word directly and return without waiting for remote completion."""
+        self._flag_reaper_check()
+        wt, ri = divmod(seq - 1, self.num_rounds)
+        op = ("ctl_ack", "ctl_ready", "ctl_cons")[kind]
+        tcp_control = getattr(self, "_tcp_control", None)
+        if tcp_control is not None and tcp_control.has_peer(peer):
+            started = time.perf_counter() if self._ctlp else None
+            self._trace_state(
+                "tcp_ctl_flag_submit",
+                kind=kind,
+                peer=peer,
+                seq=seq,
+                round=ri,
+            )
+            with gantt_span("ctl", self._rank, wt, op, ri):
+                with gantt_span("ctl", self._rank, wt, f"{op}_submit", ri):
+                    tcp_control.send(kind, peer, seq)
+            self._trace_state(
+                "tcp_ctl_flag_submitted",
+                kind=kind,
+                peer=peer,
+                seq=seq,
+                round=ri,
+            )
+            if started is not None:
+                self._ctl_acc(
+                    ("w_ack", "w_ready", "w_cons")[kind],
+                    time.perf_counter() - started,
+                    0,
+                )
+            return
+        if not hasattr(self, "_flag_submit_lock"):
+            self._flag_submit_lock = threading.Lock()
+        if kind == 0:  # trainer DATA-ready or receiver ACK
+            slot, slot_ri = self._flag_message_slot(self.flag_slot_of[peer], seq)
+            src, sess, dst_base = (
+                self._flag_src,
+                self.peer_session[peer],
+                self._flag_dst[peer],
+            )
+        elif kind == 1:  # rollout external READY
+            slot, slot_ri = self._flag_message_slot(self._repl_flag_slot_of[peer], seq)
+            src = self._repl_flag_src
+            sess, dst_base = self._repl_peer_session[peer], self._repl_flag_dst[peer]
+        else:  # rollout external CONS
+            slot, slot_ri = self._flag_message_slot(self._repl_flag_slot_of[peer], seq)
+            src = self._repl_cons_src
+            sess, dst_base = self._repl_peer_session[peer], self._repl_cons_dst[peer]
+        assert slot_ri == ri
+        started = time.perf_counter() if self._ctlp else None
+        self._trace_state("ctl_flag_submit", kind=kind, peer=peer, seq=seq, slot=slot)
+        with gantt_span("ctl", self._rank, wt, op, ri):
+            with gantt_span("ctl", self._rank, wt, f"{op}_submit", ri):
+                with self._flag_submit_lock:
+                    src[slot] = seq
+                    src_ptr = src.data_ptr() + slot * self._FLAG_ITEMSIZE
+                    dst_ptr = dst_base + ri * self._FLAG_ITEMSIZE
+                    handle = self.engine.write_async(
+                        sess,
+                        [src_ptr],
+                        [dst_ptr],
+                        [self._FLAG_ITEMSIZE],
+                    )
+        self._trace_state(
+            "ctl_flag_submitted", kind=kind, peer=peer, seq=seq, slot=slot
+        )
+        if started is not None:
+            self._ctl_acc(
+                ("w_ack", "w_ready", "w_cons")[kind], time.perf_counter() - started, 0
+            )
+        if handle is not None:
+            self._flag_reaper_ensure()
+            assert self._flag_reaper_q is not None
+            self._flag_reaper_q.put((handle, kind, peer, seq))
+
+    def _flag_emit(self, kind: int, peer: int, seq: int) -> None:
+        """Publish ACK/DATA-ready, READY, or CONS with no shared writer queue or completion wait."""
+        if kind == 0:
+            self._write_flag(peer, seq)
+        elif kind == 1:
+            self._write_repl_flag(peer, seq)
+        else:
+            self._write_repl_cons_flag(peer, seq)
+
+    def _write_flag(self, peer: int, seq: int) -> None:
+        """Asynchronously write *seq* into its exclusive peer/round DATA-ready or ACK word."""
+        self._post_flag_async(0, peer, seq)
+
+    def _poll_flag(self, peer: int, seq: int, *, timeout_s: float = 600.0) -> None:
+        """Spin until *peer* has written a flag >= *seq* into our incoming slot for it."""
+        slot, _ = self._flag_message_slot(self.flag_slot_of[peer], seq)
+        buf = self._flag_buf
+        have = int(buf[slot].item())
+        self._trace_state("wait_wire_flag", peer=peer, want=seq, have=have)
+        if self._ctlp:
+            _t = time.perf_counter()
+            _imm = 1 if int(buf[slot].item()) >= seq else 0
+        t0 = time.time()
+        warned = 0.0
+        while int(buf[slot].item()) < seq:
+            self._control_check()
+            time.sleep(1e-4)
+            el = time.time() - t0
+            if el > timeout_s:
+                raise TimeoutError(
+                    f"wbridge rank {self._rank}: waited {el:.0f}s for peer {peer} "
+                    f"flag (want>={seq}, have {int(buf[slot].item())})"
+                )
+            if el - warned >= 30.0:
+                warned = el
+                logger.warning(
+                    "wbridge rank %d: waiting %.0fs for peer %d flag (want>=%d, have %d)",
+                    self._rank,
+                    el,
+                    peer,
+                    seq,
+                    int(buf[slot].item()),
+                )
+        self._trace_state(
+            "wait_wire_flag_done", peer=peer, want=seq, have=int(buf[slot].item())
+        )
+        if self._ctlp:
+            self._ctl_acc("p_recv", time.perf_counter() - _t, _imm)
+
+    def _flag_reached(self, peer: int, seq: int) -> bool:
+        """Non-blocking counterpart of :meth:`_poll_flag` for scheduler-side readiness checks.
+
+        Incoming sequence flags live in pinned CPU memory, so peeking one does not synchronize or otherwise
+        touch CUDA.  The sender writes the flag only after its bulk transfer completes; consequently a true
+        result carries the same data-before-flag guarantee as the blocking poll.
+        """
+        self._control_check()
+        slot, _ = self._flag_message_slot(self.flag_slot_of[peer], seq)
+        return int(self._flag_buf[slot].item()) >= seq
+
+    def _write_repl_flag(self, peer: int, seq: int) -> None:
+        """One-sided write of *seq* into class-peer *peer*'s incoming repl-flag slot for this rank."""
+        if peer in getattr(self, "_repl_peer_local_flags", {}):
+            self._trace_state("write_ready_flag_local", peer=peer, seq=seq)
+            self._repl_local_flags.publish_ready(seq)
+            return
+        self._post_flag_async(1, peer, seq)
+
+    def _repl_flag_reached(self, peer: int, seq: int) -> bool:
+        """Non-blockingly test one replica peer's READY sequence.
+
+        Internal peers use a node-local mmap word; external peers use the existing pinned CPU flag slot.
+        This lets one E+C dispatcher scan every internal dependency and service peers in actual readiness
+        order instead of blocking on an arbitrary fixed peer order.
+        """
+        local = getattr(self, "_repl_peer_local_flags", {}).get(peer)
+        if local is not None:
+            return local.ready() >= seq
+        self._control_check()
+        slot, _ = self._flag_message_slot(self._repl_flag_slot_of[peer], seq)
+        return int(self._repl_flag_buf[slot].item()) >= seq
+
+    def _topo_slot_ready_reached(
+        self, owner: int, source: int, slot: int, seq: int
+    ) -> bool:
+        """Test READY for ``source -> owner.grecv[source, slot]``."""
+        local = self._repl_peer_local_flags.get(owner)
+        channel = self._topo_peer_slot_channel.get(owner, {}).get((source, slot))
+        if local is None or channel is None:
+            raise RuntimeError(
+                f"missing topology slot READY mapping owner={owner} source={source} slot={slot}"
+            )
+        return local.ready(channel) >= seq
+
+    def _publish_topo_slot_ready(
+        self,
+        source: int,
+        slot: int,
+        readers: tuple[int, ...],
+        seq: int,
+        stream: torch.cuda.Stream | None = None,
+    ) -> None:
+        """Publish one DOFF source slot to all same-node readers.
+
+        The CUDA event is per reader (IPC import requirement); the CPU sequence is one shared channel, so
+        reader fan-out costs one coherent store rather than one control-plane message per consumer. ``stream``
+        is the source's offload stream; publishing the CPU word after enqueueing these records lets readers
+        wait for the exact D2D-copy generation without a host synchronization.
+        """
+        key = (source, slot)
+        channel = self._topo_local_slot_channel.get(key)
+        if channel is None:
+            raise RuntimeError(
+                f"missing local topology slot channel for external source {source} slot={slot}"
+            )
+        events = self._topo_slot_ready_event.get(key, {})
+        for reader in readers:
+            event = events.get(reader)
+            if event is None:
+                raise RuntimeError(
+                    f"missing topology slot event source={source} slot={slot} reader={reader}"
+                )
+            if stream is None:
+                event.record()
+            else:
+                event.record(stream)
+        self._repl_local_flags.publish_ready(seq, channel)
+
+    def _write_topo_slot_cons_flag(
+        self, owner: int, source: int, slot: int, seq: int
+    ) -> None:
+        """Commit this reader's completed consume of one owner/external-source slot."""
+        local = self._repl_peer_local_flags.get(owner)
+        channel = self._topo_peer_slot_channel.get(owner, {}).get((source, slot))
+        if local is None or channel is None:
+            raise RuntimeError(
+                f"missing topology slot commit mapping owner={owner} source={source} slot={slot}"
+            )
+        local.publish_consumed(self._repl_peer_slot_of_me[owner], seq, channel)
+
+    def _topo_slot_cons_flag_reached(
+        self, reader: int, source: int, slot: int, seq: int
+    ) -> bool:
+        """Test whether one local reader committed this worker's external slot."""
+        channel = self._topo_local_slot_channel.get((source, slot))
+        if channel is None:
+            raise RuntimeError(
+                f"missing local topology slot channel for external source {source} slot={slot}"
+            )
+        return (
+            self._repl_local_flags.consumed(
+                self._repl_flag_slot_of[reader],
+                channel,
+            )
+            >= seq
+        )
+
+    def _poll_repl_flag(self, peer: int, seq: int, *, timeout_s: float = 600.0) -> None:
+        """Spin until class-peer *peer* has written a repl-flag >= *seq* into our slot for it."""
+        local = getattr(self, "_repl_peer_local_flags", {}).get(peer)
+        buf = self._repl_flag_buf
+        if local is not None:
+            read = local.ready
+        else:
+            slot, _ = self._flag_message_slot(self._repl_flag_slot_of[peer], seq)
+            read = lambda: int(buf[slot].item())
+        have = read()
+        self._trace_state("wait_ready_flag", peer=peer, want=seq, have=have)
+        if self._ctlp:
+            _t = time.perf_counter()
+            _imm = 1 if read() >= seq else 0
+        t0 = time.time()
+        warned = 0.0
+        while read() < seq:
+            if not local:
+                self._control_check()
+            time.sleep(1e-4)
+            el = time.time() - t0
+            if el > timeout_s:
+                raise TimeoutError(
+                    f"wbridge rank {self._rank}: waited {el:.0f}s for repl peer {peer} "
+                    f"flag (want>={seq}, have {read()})"
+                )
+            if el - warned >= 30.0:
+                warned = el
+                logger.warning(
+                    "wbridge rank %d: waiting %.0fs for repl peer %d flag (want>=%d, have %d)",
+                    self._rank,
+                    el,
+                    peer,
+                    seq,
+                    read(),
+                )
+        self._trace_state("wait_ready_flag_done", peer=peer, want=seq, have=read())
+        if self._ctlp:
+            self._ctl_acc("p_ready", time.perf_counter() - _t, _imm)
+
+    def _write_repl_cons_flag(self, peer: int, seq: int) -> None:
+        """One-sided write of *seq* into class-peer *peer*'s incoming repl-CONSUMED-flag slot for this rank.
+        Signals that this rank's internal-consume kernel finished reading the peer's generation, or that its
+        own external ingress generation is fully consumed, so the protected source/destination may be reused."""
+        local = getattr(self, "_repl_peer_local_flags", {}).get(peer)
+        if local is not None:
+            self._trace_state("write_consumed_flag_local", peer=peer, seq=seq)
+            # This rank occupies this slot in the peer's incoming replica-peer ordering.
+            local.publish_consumed(self._repl_peer_slot_of_me[peer], seq)
+            return
+        self._post_flag_async(2, peer, seq)
+
+    def _repl_cons_flag_reached(self, peer: int, seq: int) -> bool:
+        """Non-blockingly test one peer's consumed/release sequence."""
+        if peer in getattr(self, "_repl_peer_local_flags", {}):
+            return self._repl_local_flags.consumed(self._repl_flag_slot_of[peer]) >= seq
+        self._control_check()
+        slot, _ = self._flag_message_slot(self._repl_flag_slot_of[peer], seq)
+        return int(self._repl_cons_buf[slot].item()) >= seq
+
+    def _poll_repl_cons_flag(
+        self, peer: int, seq: int, *, timeout_s: float = 600.0
+    ) -> None:
+        """Spin until class-peer *peer* has consumed round >= *seq* (its repl-consumed-flag for us)."""
+        buf = self._repl_cons_buf
+        local = peer in getattr(self, "_repl_peer_local_flags", {})
+        if local:
+            peer_slot = self._repl_flag_slot_of[peer]
+            read = lambda: self._repl_local_flags.consumed(peer_slot)
+        else:
+            slot, _ = self._flag_message_slot(self._repl_flag_slot_of[peer], seq)
+            read = lambda: int(buf[slot].item())
+        have = read()
+        self._trace_state("wait_consumed_flag", peer=peer, want=seq, have=have)
+        if self._ctlp:
+            _t = time.perf_counter()
+            _imm = 1 if read() >= seq else 0
+        t0 = time.time()
+        warned = 0.0
+        while read() < seq:
+            if not local:
+                self._control_check()
+            time.sleep(1e-4)
+            el = time.time() - t0
+            if el > timeout_s:
+                raise TimeoutError(
+                    f"wbridge rank {self._rank}: waited {el:.0f}s for repl peer {peer} "
+                    f"consumed-flag (want>={seq}, have {read()})"
+                )
+            if el - warned >= 30.0:
+                warned = el
+                logger.warning(
+                    "wbridge rank %d: waiting %.0fs for repl peer %d consumed-flag (want>=%d, have %d)",
+                    self._rank,
+                    el,
+                    peer,
+                    seq,
+                    read(),
+                )
+        self._trace_state("wait_consumed_flag_done", peer=peer, want=seq, have=read())
+        if self._ctlp:
+            self._ctl_acc("p_cons", time.perf_counter() - _t, _imm)

--- a/examples/weightbridge/wbridge/backend/sender.py
+++ b/examples/weightbridge/wbridge/backend/sender.py
@@ -1,0 +1,1377 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Trainer Worker side of WeightBridge: :class:`WeightSender` drives the WeightBridge data plane.
+
+A Trainer Worker rank joins a merged metadata group with Rollout Workers, using the per-engine ZMQ
+coordinators for discovery and ``connect``.  Per-update readiness is data-driven: the first completed bulk
+round's CPU-pinned sequence flag wakes receiver rank 0.  Weight chunks move by one-sided RDMA writes in P2P
+rounds defined by a shared :class:`~wbridge.backend.router.WeightRouter`.  A legacy ``receive`` doorbell is
+retained only for the unusual layout in which an engine's rank 0 has no trainer input and therefore cannot
+observe a data flag.  See :class:`SenderArgs` for transport options.
+"""
+
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+import zmq
+from wbridge.backend.control_channel import CONNECT, RECEIVE, WORLD_QUERY
+from wbridge.backend.router import WBEndpoint
+from wbridge.utils.data import LoadSpec, ShardSpec
+
+logger = logging.getLogger(__name__)
+from wbridge.backend import gantt
+
+
+def _recv_lane_predecessors(
+    round_peers: list[list[int] | tuple[int, ...]],
+    depth: int,
+) -> tuple[list[dict[int, int | None]], dict[tuple[int, int], int]]:
+    """Return the previous and final writer generations for isolated remote RECV lanes.
+
+    A physical ingress lane is identified by ``(destination receiver, round % depth)`` from one trainer's
+    perspective (the trainer rank itself selects the receiver-side sender lane). Peer sets may change every
+    round, so predecessors must be tracked per destination rather than by a single round per parity.
+    """
+    assert depth >= 1
+    last: dict[tuple[int, int], int] = {}
+    pred: list[dict[int, int | None]] = []
+    for ri, peers in enumerate(round_peers):
+        par = ri % depth
+        current: dict[int, int | None] = {}
+        for peer in sorted(peers):
+            key = (peer, par)
+            current[peer] = last.get(key)
+            last[key] = ri
+        pred.append(current)
+    return pred, last
+
+
+def _receiver_rank_has_input(router, receiver_local_rank: int) -> bool:
+    """Whether a deduplicated receiver shard overlaps at least one trainer shard.
+
+    Engine rank 0 normally observes an input-ready flag and needs no external update doorbell.  A receiver
+    with no overlap has no peer flag slot at all, so sender rank 0 keeps the old coordinator notification as
+    a narrow fallback for just that engine.
+    """
+    dst = router.recv_specs[receiver_local_rank]
+    return any(ShardSpec.compute_overlap(src, dst).entries for src in router.send_specs)
+
+
+@dataclass
+class SenderArgs:
+    """Transport args forwarded to :class:`WeightSender`.
+
+    Attributes:
+        world_size: Number of Trainer Worker ranks participating in the connect group.
+        protocol: Data-plane backend. ``"efa"`` selects Mooncake on AWS EFA, ``"monarch"`` selects
+            Monarch's libibverbs backend, and ``"tcp"`` selects Mooncake for local/toy runs.
+        receiver_urls: ZMQ ``tcp://host:port`` endpoints of the per-engine coordinators, one per rollout engine.
+        master_addr: Host/IP of the Trainer Worker rank-0 process used for the Gloo metadata rendezvous.
+        master_port: TCP port for the Gloo metadata group.
+    """
+
+    world_size: int
+    receiver_urls: list[str]
+    master_addr: str
+    master_port: int
+    protocol: str = "efa"
+    # Sender-staging (SS): pack -> offload to a CPU grid -> RDMA from CPU (instead of RDMA straight from the
+    # GPU wire buffer). Lets send() return a CUDA event after pack+offload while the CPU->remote RDMA
+    # overlaps the trainer's next step. Off by default (the validated straight-from-GPU path).
+    sender_staging: bool = False
+
+
+class WeightSender(WBEndpoint):
+    """Packs and P2P-sends sharded weights from Trainer Workers to :class:`WeightReceiver` peers.
+
+    Rank 0 must call :meth:`connect` before :meth:`send`; that establishes the process group
+    (and rank-0 only drives the Rollout Engine HTTP endpoints). Each round, :attr:`save_weights` fills
+    the logical chunk buffers that :attr:`load_weights` on the receiver will consume (same
+    :class:`~wbridge.utils.data.ShardSpec` layout).
+    """
+
+    def __init__(
+        self,
+        args: SenderArgs,
+        rank: int,
+        shard_spec: ShardSpec,
+        load_spec: LoadSpec,
+        wksd: dict[str, torch.Tensor],
+    ) -> None:
+        self.cuda_device = f"cuda:{torch.cuda.current_device()}"
+
+        self.protocol = args.protocol
+        self.receiver_urls = args.receiver_urls
+        self.world_size = args.world_size
+        self.init_method = f"tcp://{args.master_addr}:{args.master_port}"
+        self.sender_staging = (
+            args.sender_staging
+        )  # WBEndpoint switch (read by router._init_engine/_setup)
+
+        self.rank = rank
+        self.shard_spec = shard_spec
+        self.dtype_spec = {}
+        # HF<->worker mapping + live params; the fused model->wire CopyPlan is built once at connect.
+        self.load_spec = load_spec
+        self.wksd = wksd
+
+        self.connected = False
+        # Persistent Stage-2 (RDMA) thread + its coordination, created at connect().
+        self._send_thread = None
+        self._sq = None
+        self._cv = None
+        self._completed: set = set()
+        self._werr: list = []
+        self._drained_count = 0
+        self._offload_ev: dict[
+            int, object
+        ] = {}  # SS: per-round D2H completion events (wire-reuse gate)
+        self._fallback_receive_engines: list[int] = []
+        # Bulk completion is independent per receiver. RdmaEngine exposes blocking wait(handles), but no
+        # wait-any primitive, so one endpoint-lifetime waiter per destination turns each completion directly
+        # into that receiver's DATA-ready flag without blocking the Stage-2 thread's ACK scan for others.
+        self._wire_wait_queues: dict[int, queue.Queue] = {}
+        self._wire_wait_threads: dict[int, threading.Thread] = {}
+        self._wire_wait_lock = threading.Lock()
+
+    def connect(self) -> None:
+        """Query each engine coordinator's receiver count over ZMQ, then form the merged connection.
+
+        Every Trainer rank opens a ZMQ ``DEALER`` to each per-engine coordinator (``receiver_urls``,
+        ``tcp://``) and queries the receiver world size — the coordinator's ``ROUTER`` multiplexes all
+        trainer clients. rank 0 then fires the ``connect`` message to each coordinator and joins the Gloo
+        rendezvous BEFORE gathering the acks: the receiver joins Gloo while handling ``connect``, which
+        needs rank 0 present, so awaiting the ack first would deadlock. :meth:`set_up_connection` runs on
+        every Trainer rank with the same ``init_method`` + total ``world_size`` (trainers + all Rollout
+        Workers).
+        """
+        import time as _time
+
+        _t_start = _time.time()
+        print(f"[wbridge-sender] rank {self.rank} entering connect()", flush=True)
+
+        if self.group is not None:
+            dist.destroy_process_group(self.group)
+
+        # One DEALER per engine coordinator; the coordinator ROUTER serves every trainer rank.
+        self._ctx = zmq.Context.instance()
+        self._coord = [self._ctx.socket(zmq.DEALER) for _ in self.receiver_urls]
+        for d, url in zip(self._coord, self.receiver_urls):
+            d.connect(url)
+
+        # Query receiver world sizes (retry the whole round-trip — the coordinator may not be bound yet).
+        rollout_num_workers = [
+            self._coord_request(i, {"type": WORLD_QUERY}, timeout_s=5.0, retries=60)[
+                "world_size"
+            ]
+            for i in range(len(self._coord))
+        ]
+        total_world_size = self.world_size + sum(rollout_num_workers)
+
+        pg_init_args = {
+            "protocol": self.protocol,
+            "init_method": self.init_method,
+            "world_size": total_world_size,
+            "rank": self.rank,
+            "group_name": "wbridge",
+            "sender_world_size": self.world_size,
+        }
+
+        if self.rank == 0:
+            # Fire connect (non-blocking send) to each coordinator, contiguous rank base per engine — do
+            # NOT await the ack before joining Gloo below (see the deadlock note in the docstring).
+            base_rank = self.world_size
+            for d, num_workers in zip(self._coord, rollout_num_workers):
+                d.send(
+                    json.dumps(
+                        {**pg_init_args, "type": CONNECT, "rank": base_rank}
+                    ).encode("utf-8")
+                )
+                base_rank += num_workers
+
+        print(
+            f"[wbridge-sender] rank {self.rank} total_ws={total_world_size}, entering set_up_connection "
+            f"(elapsed={_time.time() - _t_start:.1f}s)",
+            flush=True,
+        )
+        self.set_up_connection(**pg_init_args)
+
+        if self.rank == 0:
+            # Receiver ranks are contiguous by engine in the merged metadata group.  Most engine rank-0s
+            # have trainer input and use its first data flag as the update doorbell.  Preserve a coordinator
+            # notification only where no such flag can ever exist.
+            receiver_local_base = 0
+            self._fallback_receive_engines = []
+            for engine_idx, num_workers in enumerate(rollout_num_workers):
+                if not _receiver_rank_has_input(self.router, receiver_local_base):
+                    self._fallback_receive_engines.append(engine_idx)
+                receiver_local_base += num_workers
+            if self._fallback_receive_engines:
+                logger.warning(
+                    "wbridge sender rank 0: engine(s) %s have a zero-input rank 0; retaining the legacy "
+                    "per-update coordinator doorbell for those engine(s)",
+                    self._fallback_receive_engines,
+                )
+
+        # Now gather the connect acks (they complete during set_up_connection's Gloo rendezvous).
+        if self.rank == 0:
+            for i, d in enumerate(self._coord):
+                reply = self._coord_recv(d, timeout_s=600.0)
+                if reply.get("status") != "success":
+                    raise RuntimeError(
+                        f"wbridge connect: coordinator {self.receiver_urls[i]} -> {reply}"
+                    )
+
+        # Only rank 0 drives connect and the zero-input fallback; other ranks needed world-query only.
+        if self.rank != 0:
+            for d in self._coord:
+                d.close(linger=0)
+            self._coord = []
+
+        # Persistent Stage-2 (RDMA) thread: lets send() return a CUDA event after pack+offload while the
+        # transfer overlaps the trainer's next step. Started once; daemon (dies with the process).
+        self._sq = queue.Queue()
+        self._cv = threading.Condition()
+        self._completed = set()
+        self._werr = []
+        self._drained_count = 0
+        # Flag writes publish directly from Stage-2 into exclusive per-round words. The reaper only retires
+        # async handles; it does not serialize publication or participate in protocol progress.
+        self._flag_reaper_ensure()
+        self._send_thread = threading.Thread(
+            target=self._send_worker, name="wbridge-send-adapter", daemon=True
+        )
+        self._send_thread.start()
+
+        self.connected = True
+
+    # ---- ZMQ coordinator helpers (rank 0 keeps DEALERs only for zero-input-rank fallback) ----
+    def _coord_recv(self, dealer, *, timeout_s: float) -> dict:
+        """Block up to *timeout_s* for a coordinator reply on *dealer*; raise on timeout."""
+        if not dealer.poll(int(timeout_s * 1000)):
+            raise TimeoutError(
+                f"wbridge sender rank {self.rank}: no coordinator reply within {timeout_s:.0f}s"
+            )
+        return json.loads(dealer.recv().decode("utf-8"))
+
+    def _coord_request(
+        self, idx: int, msg: dict, *, timeout_s: float, retries: int
+    ) -> dict:
+        """Send *msg* to coordinator *idx* and return its reply, retrying the whole round-trip.
+
+        On timeout the DEALER is discarded and recreated (dropping the queued send) so a late-starting
+        coordinator doesn't accumulate duplicate requests. The surviving socket stays in ``self._coord``.
+        """
+        for _ in range(retries):
+            d = self._coord[idx]
+            d.send(json.dumps(msg).encode("utf-8"))
+            if d.poll(int(timeout_s * 1000)):
+                return json.loads(d.recv().decode("utf-8"))
+            d.close(linger=0)
+            nd = self._ctx.socket(zmq.DEALER)
+            nd.connect(self.receiver_urls[idx])
+            self._coord[idx] = nd
+        raise RuntimeError(
+            f"wbridge sender rank {self.rank}: coordinator {self.receiver_urls[idx]} request "
+            f"{msg.get('type')!r} failed after {retries} attempts"
+        )
+
+    def _await_peer_consumed(self, peer: int, prev_ri: int, wt: int) -> None:
+        """Wait until *peer* drained our previous use of its isolated trainer-ingress lane."""
+        seq = wt * self.num_rounds + prev_ri + 1
+        self._poll_flag(peer, seq)
+
+    def _ensure_wire_waiters(self, peers: set[int]) -> None:
+        """Create one persistent bulk-completion/DATA-ready waiter per destination."""
+        # Direct integration tests construct WeightSender with __new__(), so keep this helper self-initializing.
+        if not hasattr(self, "_wire_wait_lock"):
+            self._wire_wait_queues = {}
+            self._wire_wait_threads = {}
+            self._wire_wait_lock = threading.Lock()
+        with self._wire_wait_lock:
+            for peer in sorted(peers):
+                if peer in self._wire_wait_threads:
+                    continue
+                work_q: queue.Queue = queue.Queue()
+                thread = threading.Thread(
+                    target=self._wire_waiter,
+                    args=(peer, work_q),
+                    name=f"wbridge-wire-ready-{peer}",
+                    daemon=True,
+                )
+                self._wire_wait_queues[peer] = work_q
+                self._wire_wait_threads[peer] = thread
+                thread.start()
+
+    def _stop_wire_waiters(self) -> None:
+        """Stop persistent destination waiters after Stage-2 has drained all submitted work."""
+        if not hasattr(self, "_wire_wait_lock"):
+            return
+        with self._wire_wait_lock:
+            queues = list(self._wire_wait_queues.values())
+            threads = list(self._wire_wait_threads.values())
+            self._wire_wait_queues = {}
+            self._wire_wait_threads = {}
+        for work_q in queues:
+            work_q.put(None)
+        for thread in threads:
+            if thread.is_alive():
+                thread.join(timeout=5.0)
+
+    def _wire_waiter(self, peer: int, work_q: queue.Queue) -> None:
+        """Turn one peer's ordered bulk completions directly into DATA-ready publications.
+
+        A destination queue preserves that peer's generation order. Different queues wait concurrently, so
+        a slow peer cannot delay completion detection or DATA-ready publication for any other receiver.
+        """
+        while True:
+            task = work_q.get()
+            if task is None:
+                return
+            wt, ri, seq, bid, submitted_at, submit_done_at, is_ipc, result_q = task
+            error: BaseException | None = None
+            wait_s = 0.0
+            landed_at = submit_done_at
+            wait_started_at = submitted_at
+            try:
+                if not is_ipc:
+                    if bid is not None:
+                        wait_t0 = time.perf_counter()
+                        wait_started_at = time.time()
+                        self.engine.wait([bid])
+                        wait_s = time.perf_counter() - wait_t0
+                        landed_at = time.time()
+                # Nothing—not even Gantt bookkeeping—belongs between observed bulk completion and this
+                # data-before-flag submission. The spans are recorded retrospectively below.
+                flag_started_at = time.time()
+                self._flag_emit(0, peer, seq)
+                flag_submitted_at = time.time()
+                if not is_ipc:
+                    gantt.rec(
+                        "send-adapter",
+                        self._rank,
+                        wt,
+                        f"rdma_peer_wait_{peer}",
+                        ri,
+                        wait_started_at,
+                        landed_at,
+                    )
+                    # This is the authoritative trainer->receiver wire interval used by receiver Gantts.
+                    # Its t0 is sampled immediately before this peer's write_async submission, rather than
+                    # inferred from when the receiver happened to enter its polling loop.
+                    gantt.rec(
+                        "send-wire",
+                        self._rank,
+                        wt,
+                        f"rdma_peer_{peer}",
+                        ri,
+                        submitted_at,
+                        landed_at,
+                    )
+                gantt.rec(
+                    "send-adapter",
+                    self._rank,
+                    wt,
+                    f"data_ready_peer_{peer}",
+                    ri,
+                    flag_started_at,
+                    flag_submitted_at,
+                )
+                self._trace_state(
+                    "sender_peer_data_ready",
+                    epoch=wt,
+                    round=ri,
+                    peer=peer,
+                    seq=seq,
+                )
+                if is_ipc:
+                    # The receiver pulls from our pack buffer only after DATA-ready. Its ACK is therefore the
+                    # source-lifetime fence; keeping this wait on the peer worker avoids blocking other peers.
+                    with gantt.span(
+                        "send-adapter",
+                        self._rank,
+                        wt,
+                        f"ipc_pull_wait_peer_{peer}",
+                        ri,
+                    ):
+                        self._poll_flag(peer, seq)
+            except BaseException as exc:  # noqa: BLE001 - surfaced by the owning Stage-2 round
+                error = exc
+            result_q.put((peer, error, wait_s, landed_at))
+
+    def _send_worker(self) -> None:
+        """Persistent Stage-2: pull per-round items, RDMA-write, wait, write done-flags; drain per epoch.
+
+        Uses the epoch *wt* carried in each item (NOT :attr:`_epoch`, which advances the instant send() has
+        enqueued the epoch) for flag sequence numbers. Runs the same write+flag+ping-pong body as the old
+        per-send completion thread; the source pointer per round is the GPU wire buffer (SS-off) or the CPU
+        grid slot (SS-on), decided by send().
+        """
+        if getattr(self, "_relay_enabled", False):
+            self._relay_send_worker()
+            return
+        # Remote RECV ownership is (receiver, parity, trainer-sender). Peer sets vary by round, so one scalar
+        # predecessor per parity can wait for an unrelated receiver and miss the receiver actually being reused.
+        recv_pred, last_recv_use = _recv_lane_predecessors(
+            [list(overlaps) for _full, overlaps in self.router.local_rounds],
+            self._recv_depth,
+        )
+        # A merged receiver overlays every trainer lane with one shared PREP parity. Its FREE/ACK therefore
+        # describes the receiver's whole slot, not this sender's last contribution. Override both in-epoch
+        # predecessors and epoch-drain generations with the receiver-published global slot schedule.
+        for peer in getattr(self, "_merged_recv_peers", set()):
+            for parity, ri in self._merged_recv_last[peer].items():
+                last_recv_use[(peer, parity)] = ri
+        while True:
+            self._trace_state("sender_worker_idle")
+            item = self._sq.get()
+            if item is None:
+                self._stop_wire_waiters()
+                return
+            if item[0] == "round":
+                _, wt, ri, ready_ev, peers, srcs = item
+                try:
+                    self._trace_state(
+                        "sender_round_enter", epoch=wt, round=ri, peers=peers
+                    )
+                    topo_debug = os.environ.get("WBRIDGE_TOPO_DEBUG") == "1"
+                    if topo_debug:
+                        print(
+                            f"TDBG-SEND r{self._rank} wt{wt} ri{ri} ENTER peers={peers}",
+                            flush=True,
+                        )
+                    # Stage-2 waits only for this round's source pack/offload. Destination ACK gates are
+                    # scanned non-blockingly below; bulk completions block only their persistent peer waiter.
+                    if ready_ev is not None:
+                        with gantt.span(
+                            "send-adapter", self._rank, wt, "offload_wait", ri
+                        ):
+                            self._trace_state(
+                                "sender_pack_event_wait", epoch=wt, round=ri
+                            )
+                            ready_ev.synchronize()  # pack (SS-off) / D2H offload (SS) of ri complete
+                            self._trace_state(
+                                "sender_pack_event_done", epoch=wt, round=ri
+                            )
+                    dst = self._arena_send_dst
+                    sz = self._fuse_sizes[ri]
+                    # Co-located receivers PULL round ri out of our pack buffer over NVLink (CUDA-IPC) once
+                    # they see the done-flag, so there is nothing for us to push: they are excluded from the
+                    # RDMA batch entirely. Everyone else takes the unchanged RDMA path.
+                    sn = [p for p in peers if p in self._sn_peers]
+                    xn = [p for p in peers if p not in self._sn_peers]
+                    seq = wt * self.num_rounds + ri + 1
+                    gate_prev = {
+                        p: (
+                            self._merged_recv_pred[p].get(ri)
+                            if p in self._merged_recv_peers
+                            else recv_pred[ri].get(p)
+                        )
+                        for p in peers
+                        # Non-merged same-node destinations are receiver-pulled and retain their existing
+                        # inline ACK. Merged same-node destinations still need the whole-slot FREE gate.
+                        if p in xn or p in self._merged_recv_peers
+                    }
+                    gate_seq = {
+                        p: wt * self.num_rounds + prev_ri + 1
+                        for p, prev_ri in gate_prev.items()
+                        if prev_ri is not None
+                    }
+                    gate_started = time.time()
+                    last_gate_at = gate_started
+                    pending_submit = set(peers)
+                    pending_complete = set(peers)
+                    result_q: queue.Queue = queue.Queue()
+                    self._ensure_wire_waiters(set(peers))
+                    submit_first: float | None = None
+                    submit_last: float | None = None
+                    bulk_last: float | None = None
+                    self._trace_state(
+                        "sender_peer_progress_enter",
+                        epoch=wt,
+                        round=ri,
+                        peers=peers,
+                        gates=sorted((p, gate_prev[p]) for p in gate_seq),
+                    )
+                    if topo_debug and gate_seq:
+                        print(
+                            f"TDBG-SEND r{self._rank} wt{wt} ri{ri} AWAIT_ACK "
+                            f"gates={sorted((p, gate_prev[p]) for p in gate_seq)}",
+                            flush=True,
+                        )
+                    deadline = time.time() + 600.0
+                    while pending_complete:
+                        progress = False
+                        # A peer becomes independently submit-eligible as soon as its own destination slot is
+                        # free. Never block here: the scanner continues checking every other destination.
+                        ready_peers = [
+                            p
+                            for p in sorted(pending_submit)
+                            if p not in gate_seq or self._flag_reached(p, gate_seq[p])
+                        ]
+                        for p in ready_peers:
+                            now = time.time()
+                            if p in gate_seq:
+                                gantt.rec(
+                                    "send-adapter",
+                                    self._rank,
+                                    wt,
+                                    f"await_peer_{p}",
+                                    ri,
+                                    gate_started,
+                                    now,
+                                )
+                                last_gate_at = max(last_gate_at, now)
+                            is_ipc = p in sn
+                            submitted_at = now
+                            submit_done_at = now
+                            bid = None
+                            if not is_ipc and dst[p][ri] is not None:
+                                self._trace_state(
+                                    "sender_peer_bulk_submit",
+                                    epoch=wt,
+                                    round=ri,
+                                    peer=p,
+                                )
+                                submit_perf = time.perf_counter()
+                                submitted_at = time.time()
+                                with gantt.span(
+                                    "send-adapter",
+                                    self._rank,
+                                    wt,
+                                    f"rdma_peer_submit_{p}",
+                                    ri,
+                                ):
+                                    bid = self.engine.write_async(
+                                        self.peer_session[p],
+                                        [srcs[p]],
+                                        [dst[p][ri]],
+                                        [sz[p]],
+                                    )
+                                submit_done_at = time.time()
+                                if self._ctlp:
+                                    self._ctl_acc(
+                                        "b_submit", time.perf_counter() - submit_perf, 0
+                                    )
+                                    self._ctl_acc("b_peers", 1.0, 0)
+                                    self._ctl_acc(
+                                        "b_handles", float(bid is not None), 0
+                                    )
+                                self._tstats["wire_rdma_bytes"] += sz[p]
+                                if self._ctlp:
+                                    self._ctl_bytes = (
+                                        getattr(self, "_ctl_bytes", 0) + sz[p]
+                                    )
+                                submit_first = (
+                                    submitted_at
+                                    if submit_first is None
+                                    else min(
+                                        submit_first,
+                                        submitted_at,
+                                    )
+                                )
+                                submit_last = (
+                                    submit_done_at
+                                    if submit_last is None
+                                    else max(
+                                        submit_last,
+                                        submit_done_at,
+                                    )
+                                )
+                            elif is_ipc:
+                                self._tstats["wire_ipc_bytes"] += sz[p]
+                            self._wire_wait_queues[p].put(
+                                (
+                                    wt,
+                                    ri,
+                                    seq,
+                                    bid,
+                                    submitted_at,
+                                    submit_done_at,
+                                    is_ipc,
+                                    result_q,
+                                )
+                            )
+                            pending_submit.remove(p)
+                            progress = True
+
+                        # Peer waiters publish DATA-ready before reporting completion. Drain every result that
+                        # is already available, then return to ACK scanning without waiting on a slow handle.
+                        while True:
+                            try:
+                                peer, error, wait_s, landed_at = result_q.get_nowait()
+                            except queue.Empty:
+                                break
+                            if error is not None:
+                                raise RuntimeError(
+                                    f"wbridge sender rank {self._rank}: peer {peer} completion/DATA-ready "
+                                    f"failed at epoch={wt} round={ri}"
+                                ) from error
+                            if peer not in pending_complete:
+                                raise RuntimeError(
+                                    f"wbridge sender rank {self._rank}: duplicate completion for peer "
+                                    f"{peer} epoch={wt} round={ri}"
+                                )
+                            pending_complete.remove(peer)
+                            if peer in xn and dst[peer][ri] is not None:
+                                bulk_last = (
+                                    landed_at
+                                    if bulk_last is None
+                                    else max(bulk_last, landed_at)
+                                )
+                                if self._ctlp:
+                                    self._ctl_acc("b_wait", wait_s, 0)
+                            progress = True
+
+                        if pending_complete and not progress:
+                            now = time.time()
+                            if now >= deadline:
+                                raise TimeoutError(
+                                    f"wbridge sender rank {self._rank}: waited 600s for peer progress "
+                                    f"epoch={wt} round={ri} submit={sorted(pending_submit)} "
+                                    f"complete={sorted(pending_complete)}"
+                                )
+                            time.sleep(1e-4)
+
+                    if gate_seq:
+                        gantt.rec(
+                            "send-adapter",
+                            self._rank,
+                            wt,
+                            "await",
+                            ri,
+                            gate_started,
+                            last_gate_at,
+                        )
+                    if submit_first is not None and submit_last is not None:
+                        gantt.rec(
+                            "send-adapter",
+                            self._rank,
+                            wt,
+                            "rdma_submit",
+                            ri,
+                            submit_first,
+                            submit_last,
+                        )
+                    if submit_first is not None and bulk_last is not None:
+                        # Backward-compatible aggregate envelope. Exact destination intervals are the
+                        # rdma_peer_<receiver-rank> records emitted by the persistent waiters.
+                        gantt.rec(
+                            "send-adapter",
+                            self._rank,
+                            wt,
+                            "rdma_wait",
+                            ri,
+                            submit_first,
+                            bulk_last,
+                        )
+                        gantt.rec(
+                            "send-adapter",
+                            self._rank,
+                            wt,
+                            "rdma_write",
+                            ri,
+                            submit_first,
+                            bulk_last,
+                        )
+                    self._trace_state(
+                        "sender_input_flags_done",
+                        epoch=wt,
+                        round=ri,
+                        seq=seq,
+                        peers=peers,
+                    )
+                    if topo_debug:
+                        print(
+                            f"TDBG-SEND r{self._rank} wt{wt} ri{ri} RECV_FLAGS_DONE seq={seq}",
+                            flush=True,
+                        )
+                    with self._cv:
+                        self._completed.add(ri)
+                        self._cv.notify_all()
+                    self._trace_state("sender_round_done", epoch=wt, round=ri, seq=seq)
+                except BaseException as e:  # noqa: BLE001
+                    with self._cv:
+                        self._werr.append(e)
+                        self._cv.notify_all()
+                    self._stop_wire_waiters()
+                    return
+            else:  # ("epoch_end", wt, last_users)
+                _, wt, last_users = item
+                try:
+                    self._trace_state(
+                        "sender_epoch_drain",
+                        epoch=wt,
+                        rounds=last_users,
+                        recv_lanes=[
+                            (p, par, ri)
+                            for (p, par), ri in sorted(last_recv_use.items())
+                        ],
+                    )
+                    with gantt.span("send-adapter", self._rank, wt, "drain", -1):
+                        # Every remote ingress lane must be drained before epoch N+1 can reuse it. Same-node
+                        # pack readers were already waited inline above, immediately after their round.
+                        for (p, _par), prev_ri in sorted(last_recv_use.items()):
+                            self._await_peer_consumed(p, prev_ri, wt)
+                    # Every last-round ACK above causally requires its sender completion flag to have landed.
+                    # Surface a failure already observed by the off-path handle reaper, but do not wait for
+                    # outstanding flag writes: exclusive slots and causal reuse make that unnecessary.
+                    self._flag_reaper_check()
+                except BaseException as e:  # noqa: BLE001
+                    with self._cv:
+                        self._werr.append(e)
+                        self._cv.notify_all()
+                    self._stop_wire_waiters()
+                    return
+                # Detach every event/control sample while the epoch is quiescent, but do not write anything
+                # yet. Publish transfer completion first so post-block profiling I/O can never become the
+                # next send()'s previous-epoch wait.
+                profile_output = self._take_profile_output(wt, self.num_rounds)
+                with self._cv:
+                    self._drained_count += 1
+                    self._cv.notify_all()
+                self._trace_state("sender_epoch_drained", epoch=wt)
+                # The trainer may already have recorded block_end, or may still be inside an equality/debug
+                # completion wait. The per-epoch gate emits in the former case and parks the snapshot in the
+                # latter; both orderings keep file/logger output outside the reported interval.
+                self._defer_profile_output(wt, profile_output)
+
+    def _relay_send_worker_legacy(self) -> None:
+        """Stage-2 progress for ordered, independent trainer→group-head edges.
+
+        A round-wide completion barrier turns one slow group into a burst/gap pattern on every other edge.
+        Instead, each ``(head, group)`` edge advances independently.  Write ``r`` is submitted only after
+        that edge's write ``r-1`` completed and the head ACKed the previous use of its destination parity
+        (normally ``r-2``).  Different edges remain concurrent.
+        """
+        while True:
+            item = self._sq.get()
+            if item is None:
+                self._stop_relay_bulk_waiters()
+                return
+            try:
+                if item[0] != "relay_round":
+                    raise RuntimeError(
+                        f"relay epoch must start with a round, got {item[0]!r}"
+                    )
+                wt = item[1]
+                result_q: queue.Queue = queue.Queue()
+                states: dict[tuple[int, int], dict] = {}
+                previous_operation: dict[tuple[int, int], tuple[int, int]] = {}
+                previous_parity: dict[tuple[int, int, int], tuple[int, int]] = {}
+                epoch_active: list[tuple[int, int]] | None = None
+                deadline = time.time() + 600.0
+
+                def ingest(current: tuple) -> None:
+                    nonlocal epoch_active
+                    kind = current[0]
+                    if kind == "relay_round":
+                        _, current_wt, ri, ready_event, gids = current
+                        if current_wt != wt:
+                            raise RuntimeError(
+                                f"interleaved relay epochs {wt} and {current_wt}"
+                            )
+                        edges = set()
+                        for gid in gids:
+                            key = (ri, gid)
+                            if key in states:
+                                raise RuntimeError(f"duplicate relay send state {key}")
+                            head = self.router.relay_group(gid)["head"]
+                            edge = (head, gid)
+                            parity_edge = (head, gid, ri % 2)
+                            states[key] = {
+                                "ri": ri,
+                                "gid": gid,
+                                "seq": wt * self.num_rounds + ri + 1,
+                                "head": head,
+                                "ready_event": ready_event,
+                                "pack_ready": ready_event is None,
+                                "pack_ready_at": time.time()
+                                if ready_event is None
+                                else None,
+                                "write_pred": previous_operation.get(edge),
+                                "parity_pred": previous_parity.get(parity_edge),
+                                "submitted": False,
+                                "write_done": False,
+                            }
+                            previous_operation[edge] = key
+                            previous_parity[parity_edge] = key
+                            edges.add(edge)
+                        self._ensure_relay_bulk_waiters(edges)
+                    elif kind == "relay_epoch_end":
+                        _, current_wt, active = current
+                        if current_wt != wt:
+                            raise RuntimeError(
+                                f"interleaved relay epoch end {current_wt}, expected {wt}"
+                            )
+                        if epoch_active is not None:
+                            raise RuntimeError(f"duplicate relay epoch end for {wt}")
+                        epoch_active = list(active)
+                    else:
+                        raise RuntimeError(f"unexpected relay sender item {kind!r}")
+
+                ingest(item)
+                while True:
+                    progress = False
+
+                    # Keep accepting newly packed rounds while older edges make progress.  In particular,
+                    # never wait for every group in round r before admitting round r+1.
+                    while True:
+                        try:
+                            queued = self._sq.get_nowait()
+                        except queue.Empty:
+                            break
+                        if queued is None:
+                            raise RuntimeError(
+                                f"relay sender stopped during epoch {wt}"
+                            )
+                        ingest(queued)
+                        progress = True
+
+                    while True:
+                        try:
+                            peer, gid, ri, seq, error, _landed_at = (
+                                result_q.get_nowait()
+                            )
+                        except queue.Empty:
+                            break
+                        key = (ri, gid)
+                        state = states.get(key)
+                        if (
+                            state is None
+                            or state["head"] != peer
+                            or state["seq"] != seq
+                        ):
+                            raise RuntimeError(
+                                f"unexpected trainer relay completion peer={peer} group={gid} "
+                                f"round={ri} seq={seq}"
+                            )
+                        if error is not None:
+                            raise RuntimeError(
+                                f"trainer relay edge failed peer={peer} group={gid} "
+                                f"epoch={wt} round={ri}"
+                            ) from error
+                        if state["write_done"]:
+                            raise RuntimeError(
+                                f"duplicate trainer relay completion {key}"
+                            )
+                        state["write_done"] = True
+                        with self._cv:
+                            self._relay_completed.add(key)
+                            self._cv.notify_all()
+                        progress = True
+
+                    for key in sorted(states):
+                        state = states[key]
+                        ready_event = state["ready_event"]
+                        if (
+                            not state["pack_ready"]
+                            and ready_event is not None
+                            and ready_event.query()
+                        ):
+                            state["pack_ready"] = True
+                            state["pack_ready_at"] = time.time()
+                            progress = True
+                        if not state["pack_ready"] or state["submitted"]:
+                            continue
+
+                        write_pred = state["write_pred"]
+                        if (
+                            write_pred is not None
+                            and not states[write_pred]["write_done"]
+                        ):
+                            continue
+                        parity_pred = state["parity_pred"]
+                        if parity_pred is not None:
+                            prior = states[parity_pred]
+                            if not self._relay_flag_reached(
+                                self._RELAY_ACK_KIND,
+                                state["head"],
+                                state["gid"],
+                                prior["seq"],
+                            ):
+                                continue
+
+                        ri, gid, head = state["ri"], state["gid"], state["head"]
+                        size = self._relay_sizes[ri][gid]
+                        src = self._relay_send_buf[gid][ri % 2].data_ptr()
+                        dst = self._relay_send_dst[gid][ri]
+                        if dst is None:
+                            raise RuntimeError(
+                                f"relay head {head} has no destination group={gid} round={ri}"
+                            )
+                        submitted_at = time.time()
+                        handle = self.engine.write_async(
+                            self._relay_peer_session[head],
+                            [src],
+                            [dst],
+                            [size],
+                        )
+                        self._tstats["wire_rdma_bytes"] += size
+                        self._relay_bulk_wait_queues[(head, gid)].put(
+                            (
+                                wt,
+                                ri,
+                                state["seq"],
+                                handle,
+                                submitted_at,
+                                "trainer_head",
+                                result_q,
+                            )
+                        )
+                        state["submitted"] = True
+                        gantt.rec(
+                            "send-adapter",
+                            self._rank,
+                            wt,
+                            "relay_dispatch_gate",
+                            ri,
+                            state["pack_ready_at"],
+                            submitted_at,
+                        )
+                        progress = True
+
+                    if epoch_active is not None:
+                        if set(epoch_active) != set(states):
+                            raise RuntimeError(
+                                f"relay epoch {wt} states disagree: queued={sorted(states)} "
+                                f"declared={sorted(epoch_active)}"
+                            )
+                        if all(state["write_done"] for state in states.values()):
+                            # Heads return a DATA sequence only after local readers and the full downstream
+                            # chain consumed this group/round. This preserves wait_send_complete().
+                            with gantt.span(
+                                "send-adapter", self._rank, wt, "relay_drain", -1
+                            ):
+                                for ri, gid in epoch_active:
+                                    head = self.router.relay_group(gid)["head"]
+                                    seq = wt * self.num_rounds + ri + 1
+                                    self._poll_relay_flag(
+                                        self._RELAY_DATA_KIND,
+                                        head,
+                                        gid,
+                                        seq,
+                                    )
+                            self._flag_reaper_check()
+                            profile_output = self._take_profile_output(
+                                wt, self.num_rounds
+                            )
+                            with self._cv:
+                                self._drained_count += 1
+                                self._cv.notify_all()
+                            self._defer_profile_output(wt, profile_output)
+                            break
+
+                    if not progress:
+                        if time.time() >= deadline:
+                            pending = {
+                                key: {
+                                    field: state[field]
+                                    for field in (
+                                        "pack_ready",
+                                        "submitted",
+                                        "write_done",
+                                    )
+                                }
+                                for key, state in states.items()
+                                if not state["write_done"]
+                            }
+                            raise TimeoutError(
+                                f"trainer relay progress timeout epoch={wt} pending={pending} "
+                                f"epoch_end={epoch_active is not None}"
+                            )
+                        try:
+                            queued = self._sq.get(timeout=1e-4)
+                        except queue.Empty:
+                            continue
+                        if queued is None:
+                            raise RuntimeError(
+                                f"relay sender stopped during epoch {wt}"
+                            )
+                        ingest(queued)
+            except BaseException as exc:  # noqa: BLE001
+                with self._cv:
+                    self._werr.append(exc)
+                    self._cv.notify_all()
+                self._stop_relay_bulk_waiters()
+                return
+
+    def _relay_group_send_lane(
+        self,
+        gid: int,
+        work_q: queue.Queue,
+        done_q: queue.Queue,
+    ) -> None:
+        """Persistent trainer→head progress lane for one replica group.
+
+        Blocking pack-event, RDMA-completion, ACK, and full-delivery waits in one group never hold progress
+        for another group. Processing round tasks serially deliberately preserves the requested write r-1
+        completion dependency; the remembered parity sequence is the independent r-2 destination fence.
+        """
+        group = self.router.relay_group(gid)
+        head = group["head"]
+        parity_last: dict[int, int] = {}
+        while True:
+            task = work_q.get()
+            if task is None:
+                return
+            kind = task[0]
+            try:
+                if kind == "round":
+                    _, wt, ri, ready_event = task
+                    seq = wt * self.num_rounds + ri + 1
+                    if ready_event is not None:
+                        ready_event.synchronize()
+                    pack_ready_at = time.time()
+                    prior_seq = parity_last.get(ri % 2)
+                    if prior_seq is not None:
+                        self._poll_relay_flag(
+                            self._RELAY_ACK_KIND,
+                            head,
+                            gid,
+                            prior_seq,
+                        )
+                    size = self._relay_sizes[ri][gid]
+                    src = self._relay_send_buf[gid][ri % 2].data_ptr()
+                    dst = self._relay_send_dst[gid][ri]
+                    if dst is None:
+                        raise RuntimeError(
+                            f"relay head {head} has no destination group={gid} round={ri}"
+                        )
+                    submitted_at = time.time()
+                    handle = self.engine.write_async(
+                        self._relay_peer_session[head],
+                        [src],
+                        [dst],
+                        [size],
+                    )
+                    self._tstats["wire_rdma_bytes"] += size
+                    if handle is not None:
+                        self.engine.wait([handle])
+                    landed_at = time.time()
+                    # Preserve the data-before-DATA publication fence on this exact group lane.
+                    self._relay_emit(self._RELAY_DATA_KIND, head, gid, seq)
+                    gantt.rec(
+                        "relay-wire",
+                        self._rank,
+                        wt,
+                        f"trainer_head_peer_{head}_group_{gid}",
+                        ri,
+                        submitted_at,
+                        landed_at,
+                    )
+                    gantt.rec(
+                        "send-adapter",
+                        self._rank,
+                        wt,
+                        "relay_dispatch_gate",
+                        ri,
+                        pack_ready_at,
+                        submitted_at,
+                    )
+                    parity_last[ri % 2] = seq
+                    with self._cv:
+                        self._relay_completed.add((ri, gid))
+                        self._cv.notify_all()
+                elif kind == "epoch_end":
+                    _, wt, rounds = task
+                    with gantt.span("send-adapter", self._rank, wt, "relay_drain", -1):
+                        for ri in rounds:
+                            self._poll_relay_flag(
+                                self._RELAY_DATA_KIND,
+                                head,
+                                gid,
+                                wt * self.num_rounds + ri + 1,
+                            )
+                    done_q.put((gid, wt, None))
+                else:
+                    raise RuntimeError(f"unexpected relay group task {kind!r}")
+            except BaseException as exc:  # noqa: BLE001 - surfaced by the adapter coordinator
+                done_q.put((gid, task[1] if len(task) > 1 else -1, exc))
+                return
+
+    def _relay_send_worker(self) -> None:
+        """Fan packed rounds into one persistent progress thread per replica group."""
+        group_ids = sorted(self._relay_send_buf)
+        done_q: queue.Queue = queue.Queue()
+        group_queues = {gid: queue.Queue() for gid in group_ids}
+        threads = {
+            gid: threading.Thread(
+                target=self._relay_group_send_lane,
+                args=(gid, group_queues[gid], done_q),
+                name=f"wbridge-relay-send-g{gid}",
+                daemon=True,
+            )
+            for gid in group_ids
+        }
+        for thread in threads.values():
+            thread.start()
+        try:
+            while True:
+                item = self._sq.get()
+                if item is None:
+                    return
+                kind = item[0]
+                if kind == "relay_round":
+                    _, wt, ri, ready_event, gids = item
+                    for gid in gids:
+                        group_queues[gid].put(("round", wt, ri, ready_event))
+                    continue
+                if kind != "relay_epoch_end":
+                    raise RuntimeError(f"unexpected relay adapter item {kind!r}")
+                _, wt, active = item
+                active_by_gid: dict[int, list[int]] = {}
+                for ri, gid in active:
+                    active_by_gid.setdefault(gid, []).append(ri)
+                for gid, rounds in active_by_gid.items():
+                    group_queues[gid].put(("epoch_end", wt, rounds))
+                errors = []
+                for _ in active_by_gid:
+                    result_gid, result_wt, error = done_q.get()
+                    if result_wt != wt or result_gid not in active_by_gid:
+                        errors.append(
+                            RuntimeError(
+                                f"unexpected relay group completion gid={result_gid} wt={result_wt}; "
+                                f"expected wt={wt} groups={sorted(active_by_gid)}"
+                            )
+                        )
+                    if error is not None:
+                        errors.append(error)
+                if errors:
+                    raise errors[0]
+                self._flag_reaper_check()
+                profile_output = self._take_profile_output(wt, self.num_rounds)
+                with self._cv:
+                    self._drained_count += 1
+                    self._cv.notify_all()
+                self._defer_profile_output(wt, profile_output)
+        except BaseException as exc:  # noqa: BLE001
+            with self._cv:
+                self._werr.append(exc)
+                self._cv.notify_all()
+        finally:
+            for work_q in group_queues.values():
+                work_q.put(None)
+            for thread in threads.values():
+                thread.join(timeout=5.0)
+
+    def _relay_send(self) -> "torch.cuda.Event | None":
+        wt = self._epoch
+        with self._cv:
+            while self._drained_count < wt and not self._werr:
+                self._cv.wait()
+            if self._werr:
+                raise self._werr[0]
+            self._relay_completed = set()
+
+        if self.rank == 0 and self._fallback_receive_engines:
+            for index in self._fallback_receive_engines:
+                self._coord[index].send(json.dumps({"type": RECEIVE}).encode("utf-8"))
+            for index in self._fallback_receive_engines:
+                reply = self._coord_recv(self._coord[index], timeout_s=600.0)
+                if reply.get("status") != "success":
+                    raise RuntimeError(f"relay receive fallback failed: {reply}")
+
+        active = [
+            (ri, sorted(specs))
+            for ri, specs in enumerate(self._relay_send_specs)
+            if specs
+        ]
+        last_user: dict[tuple[int, int], tuple[int, int]] = {}
+        returned_event = None
+        previous_pack_event = None
+        active_edges: list[tuple[int, int]] = []
+        for ri, gids in active:
+            # Keep copy-engine/kernel dispatch ordered across adjacent rounds even though they use opposite
+            # parity buffers.  This is an explicit completion dependency (rather than merely relying on
+            # same-stream launch order), matching the per-edge write/assemble/consume pacing below.
+            if previous_pack_event is not None:
+                previous_pack_event.synchronize()
+            waits = {
+                last_user[(gid, ri % 2)] for gid in gids if (gid, ri % 2) in last_user
+            }
+            if waits:
+                with self._cv:
+                    while not waits <= self._relay_completed and not self._werr:
+                        self._cv.wait()
+                    if self._werr:
+                        raise self._werr[0]
+            with gantt.span("sender", self._rank, wt, "relay_pack", ri):
+                plan = self._relay_pack_plans[ri]
+                if plan is not None:
+                    plan.run()
+            ready_event = torch.cuda.Event() if torch.cuda.is_available() else None
+            if ready_event is not None:
+                ready_event.record()
+            self._sq.put(("relay_round", wt, ri, ready_event, gids))
+            for gid in gids:
+                last_user[(gid, ri % 2)] = (ri, gid)
+                active_edges.append((ri, gid))
+            returned_event = ready_event
+            previous_pack_event = ready_event
+        self._sq.put(("relay_epoch_end", wt, active_edges))
+        self._epoch += 1
+        return returned_event
+
+    def send(self) -> "torch.cuda.Event | None":
+        """Pack (+ CPU offload for sender-staging) on this thread; RDMA on the persistent Stage-2 thread.
+
+        Returns a :class:`torch.cuda.Event` that fires when packing (+ the CPU offload, under SS) is
+        complete — i.e. the model weights are safe to overwrite. The GPU->remote (SS-off) or CPU->remote
+        (SS) RDMA then finishes asynchronously on :meth:`_send_worker`; the receiver's own
+        ``poll_requests`` call gates its generation on arrival, and the NEXT send() blocks at entry until this
+        epoch has fully drained (so the wire buffers / CPU grid are free to reuse). Returns ``None`` off-GPU.
+        """
+        if (
+            not self.connected
+            or self.shard_spec is None
+            or self.router is None
+            or self.engine is None
+            or self.device is None
+        ):
+            raise RuntimeError("WeightSender.send requires connect() first")
+        if getattr(self, "_relay_enabled", False):
+            return self._relay_send()
+
+        wt = self._epoch
+        ss = self.sender_staging
+        self._trace_state("send_enter", epoch=wt)
+
+        # Gate on the previous epoch's full drain (all RDMA landed + all RECV consumed => buffers free), then
+        # reset the per-epoch round-completion set the Stage-2 thread populates (and the SS-off pack gate reads).
+        with self._cv:
+            while self._drained_count < wt and not self._werr:
+                self._trace_state(
+                    "send_previous_epoch_wait", epoch=wt, drained=self._drained_count
+                )
+                self._cv.wait()
+            if self._werr:
+                raise self._werr[0]
+            self._completed = set()
+        self._offload_ev = {}
+
+        if self.rank == 0 and self._fallback_receive_engines:
+            with gantt.span("sender", self._rank, wt, "receive_post", 0):
+                self._trace_state(
+                    "send_receive_fallback_post",
+                    epoch=wt,
+                    engines=self._fallback_receive_engines,
+                )
+                for i in self._fallback_receive_engines:
+                    self._coord[i].send(json.dumps({"type": RECEIVE}).encode("utf-8"))
+                for i in self._fallback_receive_engines:
+                    d = self._coord[i]
+                    reply = self._coord_recv(d, timeout_s=600.0)
+                    if reply.get("status") != "success":
+                        raise RuntimeError(
+                            f"wbridge receive fallback: coordinator {self.receiver_urls[i]} -> {reply}"
+                        )
+
+        router = self.router
+        rounds = [(ri, fs, ov) for ri, (fs, ov) in enumerate(router.local_rounds) if ov]
+        if self._rank == 0 and wt == 0:
+            _tot = sum(
+                self._fuse_sizes[ri].get(p, 0) for ri, _, ov in rounds for p in ov
+            )
+            logger.info(
+                "wbridge rank 0: sender RDMA = %.3f GiB/epoch over %d rounds (for BW: bytes / rdma_write span)",
+                _tot / 1024**3,
+                len(rounds),
+            )
+        last_user: dict[int, int] = {}
+        returned_ev = None
+        for ri, full_spec, overlap_specs in rounds:
+            b = ri % self._NUM_BUF
+            peers = list(overlap_specs.keys())
+            if b in last_user:  # gate reuse of GPU wire buffer b
+                if ss:
+                    # Freed by its D2H offload; make this pack's stream wait that event (GPU dep, no host block).
+                    if self._offload_ev.get(last_user[b]) is not None:
+                        torch.cuda.current_stream().wait_event(
+                            self._offload_ev[last_user[b]]
+                        )
+                else:
+                    with self._cv:  # freed when the Stage-2 RDMA read completed
+                        while last_user[b] not in self._completed and not self._werr:
+                            self._trace_state(
+                                "send_pack_buffer_wait",
+                                epoch=wt,
+                                round=ri,
+                                prior_round=last_user[b],
+                            )
+                            self._cv.wait()
+                    if self._werr:
+                        raise self._werr[0]
+            with gantt.span("sender", self._rank, wt, "pack", ri):
+                self._trace_state("send_pack", epoch=wt, round=ri, peers=peers)
+                if self._fuse_fallback[ri]:
+                    self._two_stage_save(
+                        full_spec,
+                        overlap_specs,
+                        {p: self._data_buf[p][b] for p in peers},
+                    )
+                else:
+                    self._fuse_plans[ri].run()
+            if ss:
+                # Offload each peer's packed prefix GPU wire -> CPU grid slot (one batched Local D2H hop).
+                srcs_off = [self._data_buf[p][b].data_ptr() for p in peers]
+                dsts_off = [self._cpu_grid[p][ri].data_ptr() for p in peers]
+                szs_off = [self._fuse_sizes[ri][p] for p in peers]
+                ready_ev = self.local_engine.write_async(
+                    self.local_engine.session_id(), srcs_off, dsts_off, szs_off
+                )
+                self._offload_ev[ri] = ready_ev
+                rdma_srcs = {
+                    p: self._cpu_grid[p][ri].data_ptr() for p in peers
+                }  # RDMA reads the CPU grid
+            else:
+                # Same-node peers read this buffer from another process, so give them a GPU-visible fence
+                # for "pack(ri) landed" on the stream pack ran on. Recorded before the done-flag (which
+                # Stage-2 writes only after ready_ev.synchronize()), so a puller that observes the flag can
+                # only ever wait on this record or a later one — never an earlier one.
+                for p in peers:
+                    if p in self._sn_peers:
+                        self._pack_ready_event[p].record()
+                ready_ev = torch.cuda.Event() if torch.cuda.is_available() else None
+                if ready_ev is not None:
+                    ready_ev.record()  # pack complete (default stream)
+                rdma_srcs = {
+                    p: self._data_buf[p][b].data_ptr() for p in peers
+                }  # RDMA reads the GPU wire
+            self._sq.put(("round", wt, ri, ready_ev, peers, rdma_srcs))
+            self._trace_state("send_round_queued", epoch=wt, round=ri, peers=peers)
+            returned_ev = ready_ev
+            last_user[b] = ri
+        self._sq.put(("epoch_end", wt, sorted(set(last_user.values()))))
+        self._epoch += 1
+        self._trace_state("send_enqueued", epoch=wt)
+        return returned_ev
+
+    def wait_send_complete(self) -> None:
+        """Block until the last :meth:`send`'s epoch has fully drained on the Stage-2 thread — i.e. every
+        receiver has consumed (loaded) the update, so 'weights delivered on return' holds. Used in debugging
+        mode (``--check-weight-update-equal``), where the trainer reads the rollout's weights immediately
+        after; production skips it (the rollout's own poll_requests call gates generation) so the CPU->remote
+        RDMA overlaps the trainer's next step."""
+        with self._cv:
+            while self._drained_count < self._epoch and not self._werr:
+                self._trace_state(
+                    "send_complete_wait",
+                    epoch=self._epoch - 1,
+                    drained=self._drained_count,
+                )
+                self._cv.wait()
+            if self._werr:
+                raise self._werr[0]
+        self._trace_state("send_complete", epoch=self._epoch - 1)

--- a/examples/weightbridge/wbridge/backend/tcp_control.py
+++ b/examples/weightbridge/wbridge/backend/tcp_control.py
@@ -1,0 +1,272 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Persistent low-latency TCP transport for WeightBridge sequence flags.
+
+The bulk data plane uses the selected one-sided RDMA backend. Reusing that data
+plane for an 8-byte ACK/READY/CONS word can give control messages the tail latency
+of a busy RDMA submission queue. This module instead opens one full-duplex
+connection per inter-node worker pair on the host-network address gathered during
+connection setup. Connections are established once and carry fixed 16-byte
+records for the lifetime of the endpoint.
+
+TCP is reliable and ordered, while WeightBridge sequence values are monotonic.
+There is therefore no controller queue, response, or completion handshake here:
+``send`` returns when the record has been copied into the kernel socket buffer and
+the peer's blocking receive loop publishes it into the existing flag word.
+"""
+
+from __future__ import annotations
+
+import socket
+import struct
+import threading
+import time
+from collections.abc import Callable, Mapping
+
+
+class TcpControlTransport:
+    """One persistent full-duplex TCP socket for each remote endpoint rank."""
+
+    _HELLO = struct.Struct("!I")
+    _MESSAGE = struct.Struct("!B7xQ")  # kind + padding + uint64 sequence
+
+    def __init__(
+        self,
+        rank: int,
+        host: str,
+        on_message: Callable[[int, int, int], None],
+    ) -> None:
+        self.rank = int(rank)
+        self.host = host
+        self._on_message = on_message
+        self._cv = threading.Condition()
+        self._sockets: dict[int, socket.socket] = {}
+        self._send_locks: dict[int, threading.Lock] = {}
+        self._recv_threads: dict[int, threading.Thread] = {}
+        self._expected: set[int] = set()
+        self._errors: list[BaseException] = []
+        self._closed = False
+
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind((host, 0))
+        listener.listen(128)
+        listener.settimeout(0.2)
+        self._listener = listener
+        self.endpoint = (host, int(listener.getsockname()[1]))
+        self._accept_thread = threading.Thread(
+            target=self._accept_loop,
+            name=f"wbridge-tcp-ctl-accept-{rank}",
+            daemon=True,
+        )
+        self._accept_thread.start()
+
+    @staticmethod
+    def _tune(sock: socket.socket) -> None:
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        # Linux ACKs small control records promptly.  TCP_NODELAY is the important
+        # portable setting; QUICKACK is best-effort and need not exist elsewhere.
+        quickack = getattr(socket, "TCP_QUICKACK", None)
+        if quickack is not None:
+            try:
+                sock.setsockopt(socket.IPPROTO_TCP, quickack, 1)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _recv_exact(sock: socket.socket, buf: bytearray) -> bool:
+        view = memoryview(buf)
+        pos = 0
+        while pos < len(buf):
+            got = sock.recv_into(view[pos:])
+            if got == 0:
+                return False
+            pos += got
+        return True
+
+    def _record_error(self, error: BaseException) -> None:
+        with self._cv:
+            if not self._closed:
+                self._errors.append(error)
+                self._cv.notify_all()
+
+    def _register(self, peer: int, sock: socket.socket) -> None:
+        self._tune(sock)
+        with self._cv:
+            if self._closed:
+                sock.close()
+                return
+            if peer in self._sockets:
+                sock.close()
+                return
+            self._sockets[peer] = sock
+            self._send_locks[peer] = threading.Lock()
+            thread = threading.Thread(
+                target=self._recv_loop,
+                args=(peer, sock),
+                name=f"wbridge-tcp-ctl-recv-{peer}",
+                daemon=True,
+            )
+            self._recv_threads[peer] = thread
+            thread.start()
+            self._cv.notify_all()
+
+    def _accept_loop(self) -> None:
+        while True:
+            with self._cv:
+                if self._closed:
+                    return
+            try:
+                sock, _addr = self._listener.accept()
+            except socket.timeout:
+                continue
+            except OSError as error:
+                with self._cv:
+                    if self._closed:
+                        return
+                self._record_error(error)
+                return
+            try:
+                hello = bytearray(self._HELLO.size)
+                if not self._recv_exact(sock, hello):
+                    raise ConnectionError(
+                        "TCP control peer closed during rank handshake"
+                    )
+                peer = int(self._HELLO.unpack(hello)[0])
+                self._register(peer, sock)
+            except BaseException as error:  # noqa: BLE001 - surfaced through check()
+                sock.close()
+                self._record_error(error)
+
+    def _recv_loop(self, peer: int, sock: socket.socket) -> None:
+        record = bytearray(self._MESSAGE.size)
+        try:
+            while self._recv_exact(sock, record):
+                kind, seq = self._MESSAGE.unpack(record)
+                self._on_message(int(kind), peer, int(seq))
+            raise ConnectionError(f"TCP control peer {peer} closed")
+        except BaseException as error:  # noqa: BLE001 - surfaced through check()
+            self._record_error(error)
+
+    def configure(
+        self,
+        peers: set[int] | list[int] | tuple[int, ...],
+        endpoints: Mapping[int, tuple[str, int]],
+        *,
+        timeout_s: float = 120.0,
+    ) -> None:
+        """Connect lower ranks to higher ranks, then wait for every pair.
+
+        Every listener is bound before endpoint metadata is gathered.  Choosing
+        exactly one initiator per unordered rank pair avoids duplicate sockets
+        while still allowing both directions to publish over the connection.
+        """
+        expected = {int(peer) for peer in peers}
+        with self._cv:
+            self._expected = expected
+        deadline = time.monotonic() + timeout_s
+        for peer in sorted(p for p in expected if self.rank < p):
+            endpoint = endpoints.get(peer)
+            if endpoint is None:
+                raise RuntimeError(
+                    f"peer {peer} did not publish a TCP control endpoint"
+                )
+            while True:
+                self.check()
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self._tune(sock)
+                try:
+                    # Explicit source binding keeps this channel on the host-network
+                    # interface even on nodes exposing many fabric-facing addresses.
+                    sock.bind((self.host, 0))
+                    sock.settimeout(min(1.0, max(0.05, deadline - time.monotonic())))
+                    sock.connect((str(endpoint[0]), int(endpoint[1])))
+                    sock.settimeout(None)
+                    sock.sendall(self._HELLO.pack(self.rank))
+                    self._register(peer, sock)
+                    break
+                except OSError:
+                    sock.close()
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            f"rank {self.rank}: timed out connecting TCP control peer {peer} at {endpoint}"
+                        )
+                    time.sleep(0.01)
+
+        with self._cv:
+            while not expected <= self._sockets.keys() and not self._errors:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    missing = sorted(expected - self._sockets.keys())
+                    raise TimeoutError(
+                        f"rank {self.rank}: timed out awaiting TCP control peers {missing}"
+                    )
+                self._cv.wait(min(remaining, 0.2))
+        self.check()
+
+    @property
+    def peers(self) -> set[int]:
+        with self._cv:
+            return set(self._expected)
+
+    def has_peer(self, peer: int) -> bool:
+        with self._cv:
+            return peer in self._sockets
+
+    def send(self, kind: int, peer: int, seq: int) -> None:
+        """Publish one fixed-size record without a transport completion wait."""
+        self.check()
+        # 0..2 are the legacy ACK/READY/CONS channels. 3/4 carry replica-group relay DATA/ACK
+        # tokens; their uint64 payload encodes both group id and the ordinary monotonic sequence.
+        if not 0 <= kind <= 4:
+            raise ValueError(f"invalid TCP control kind {kind}")
+        with self._cv:
+            sock = self._sockets.get(peer)
+            lock = self._send_locks.get(peer)
+        if sock is None or lock is None:
+            raise RuntimeError(f"TCP control peer {peer} is not connected")
+        record = self._MESSAGE.pack(kind, seq)
+        try:
+            # A lock is local to one peer.  It prevents byte interleaving when that
+            # peer receives READY and CONS from different progress threads without
+            # serializing unrelated destinations.
+            with lock:
+                sock.sendall(record)
+        except OSError as error:
+            self._record_error(error)
+            raise RuntimeError(f"TCP control send to peer {peer} failed") from error
+
+    def check(self) -> None:
+        with self._cv:
+            error = self._errors[0] if self._errors else None
+        if error is not None:
+            raise RuntimeError(
+                f"rank {self.rank}: TCP control transport failed"
+            ) from error
+
+    def close(self) -> None:
+        with self._cv:
+            if self._closed:
+                return
+            self._closed = True
+            sockets = list(self._sockets.values())
+            threads = list(self._recv_threads.values())
+            self._cv.notify_all()
+        try:
+            self._listener.close()
+        except OSError:
+            pass
+        for sock in sockets:
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            sock.close()
+        self._accept_thread.join(timeout=2.0)
+        for thread in threads:
+            thread.join(timeout=2.0)

--- a/examples/weightbridge/wbridge/frontend/__init__.py
+++ b/examples/weightbridge/wbridge/frontend/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Framework frontends (Megatron-Bridge, SGLang integration)."""
+
+"""Framework frontends.
+
+Only framework-agnostic classes are re-exported here. Framework-specific adapters live in their own
+modules and must be imported directly, so importing this package does not transitively pull in heavy
+framework dependencies on machines that don't have them installed.
+"""
+
+from wbridge.frontend.adapters import (
+    AdapterContext,
+    BaseAdapter,
+    ReceiverAdapter,
+    SenderAdapter,
+)
+
+__all__ = [
+    "AdapterContext",
+    "BaseAdapter",
+    "ReceiverAdapter",
+    "SenderAdapter",
+]

--- a/examples/weightbridge/wbridge/frontend/adapters.py
+++ b/examples/weightbridge/wbridge/frontend/adapters.py
@@ -1,0 +1,271 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared WeightBridge frontend adapters.
+
+:class:`BaseAdapter` runs specgen (infer + verify) in :meth:`__init__` and stores the
+resulting :class:`~wbridge.utils.data.LoadSpec`.  Framework-specific subclasses only build an
+:class:`AdapterContext` and forward it.
+
+:class:`SenderAdapter` wraps a :class:`~wbridge.backend.sender.WeightSender`; :class:`ReceiverAdapter`
+wraps a :class:`~wbridge.backend.receiver.WeightReceiver` and applies each round's partial buffer into
+``wksd`` through the receiver's ``load_weights`` callback when the scheduler calls
+:meth:`ReceiverAdapter.poll_requests`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+from wbridge.backend.receiver import WeightReceiver
+from wbridge.backend.sender import SenderArgs, WeightSender
+from wbridge.utils.data import (
+    LoadSpec,
+    logical_tensor_cap_bytes,
+    ShardSpec,
+    split_large_load_spec_sources,
+)
+from wbridge.utils.specgen import (
+    HFWeightFetcher,
+    infer_load_spec,
+    LoadWeightsFn,
+    verify_load_spec,
+    WksdFactory,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AdapterContext:
+    """Framework-specific Metadata Plane inputs every adapter needs to build / verify a LoadSpec.
+
+    Attributes:
+        hf_weights: Dict mapping HF tensor names to zero-arg callables that return the
+            tensor.  Each factory may be called multiple times (for probing, restore, verify).
+        hf_shapes: Dict mapping HF tensor names to their shapes.
+        wksd_factory: Zero-arg callable returning a fresh GPU worker state dict snapshot.
+            Called once per probe chunk so that specgen reads current parameter pointers
+            (needed when ``load_weights`` replaces parameters, e.g. SGLang MoE expert fusion).
+        load_weights: Framework callable that accepts an :data:`~wbridge.utils.specgen.HFWeightFetcher`
+            and writes into ``wksd``.  Used as a probe by
+            :func:`~wbridge.utils.specgen.infer_load_spec`.
+        rank: Adapter rank.
+    """
+
+    hf_weights: HFWeightFetcher
+    hf_shapes: dict[str, tuple[int, ...]]
+    wksd_factory: WksdFactory
+    load_weights: LoadWeightsFn
+    rank: int
+
+
+def _dtype_spec_from_load_spec(
+    load_spec: LoadSpec, wksd: dict[str, torch.Tensor]
+) -> dict[str, torch.dtype]:
+    """Per-HF-name dtypes for :class:`~wbridge.backend.receiver.WeightReceiver`.
+
+    For a source name mapped to multiple destinations, pick the widest dtype so a single buffer
+    can safely hold every destination's view.
+    """
+    return {
+        hf_name: max(
+            (wksd[wk_name].dtype for wk_name in entry), key=lambda d: d.itemsize
+        )
+        for hf_name, entry in load_spec.entries.items()
+    }
+
+
+def _dump_loadspec_if_requested(
+    role: str, rank: int, engine_id, adapter: "BaseAdapter", topo: dict
+) -> None:
+    """Diagnostic: when ``WBRIDGE_DUMP_LOADSPEC=<dir>`` is set, pickle this rank's inferred metadata
+    (LoadSpec + dtype/src-shard specs + worker tensor shapes/dtypes + topology) so a frameworkless
+    harness can rebuild and replay the exact transfer without Megatron/SGLang/specgen. Never raises
+    (diagnostics must not break a real run)."""
+    import os
+
+    d = os.environ.get("WBRIDGE_DUMP_LOADSPEC")
+    if not d:
+        return
+    try:
+        import pickle
+
+        os.makedirs(d, exist_ok=True)
+        rec = {
+            "role": role,
+            "rank": rank,
+            "engine_id": engine_id,
+            "load_spec": adapter.load_spec.entries,
+            "dtype_spec": adapter.dtype_spec,
+            "src_shard_spec": adapter.src_shard_spec.entries,
+            "wksd_meta": {
+                n: (tuple(t.shape), t.dtype, tuple(t.stride()))
+                for n, t in adapter.wksd.items()
+            },
+            **topo,
+        }
+        path = os.path.join(d, f"loadspec_{role}_r{rank}_pid{os.getpid()}.pkl")
+        with open(path, "wb") as f:
+            pickle.dump(rec, f)
+        logger.info(
+            "[wbridge] WBRIDGE_DUMP_LOADSPEC: role=%s rank=%s engine=%s -> %s (%d wksd tensors)",
+            role,
+            rank,
+            engine_id,
+            path,
+            len(rec["wksd_meta"]),
+        )
+    except Exception as e:  # noqa: BLE001 — diagnostics must never break a run
+        logger.warning("[wbridge] WBRIDGE_DUMP_LOADSPEC dump failed: %s", e)
+
+
+class BaseAdapter:
+    """Shared :class:`~wbridge.utils.data.LoadSpec` lifecycle.
+
+    Runs specgen from :meth:`__init__`: infer a LoadSpec with
+    :func:`~wbridge.utils.specgen.infer_load_spec` and verify it.
+    The resulting :class:`~wbridge.utils.data.LoadSpec`, per-HF-name dtypes (``dtype_spec``), and
+    HF wire layout (``src_shard_spec``) are stored on ``self``.
+    """
+
+    def __init__(self, ctx: AdapterContext) -> None:
+        self.ctx = ctx
+
+        self.load_spec: LoadSpec
+        self.dtype_spec: dict[str, torch.dtype]
+        self.src_shard_spec: ShardSpec
+
+        self.load_spec = infer_load_spec(
+            ctx.hf_weights,
+            ctx.hf_shapes,
+            ctx.wksd_factory,
+            ctx.load_weights,
+        )
+        verify_load_spec(ctx.hf_weights, ctx.wksd_factory, self.load_spec)
+
+        self.dtype_spec = _dtype_spec_from_load_spec(self.load_spec, ctx.wksd_factory())
+        logical_cap = logical_tensor_cap_bytes()
+        self.load_spec, self.dtype_spec, split_report = split_large_load_spec_sources(
+            self.load_spec,
+            self.dtype_spec,
+            logical_cap,
+        )
+        if split_report:
+            logger.info(
+                "[wbridge] logical tensor split: %d physical sources -> %d local logical pieces, "
+                "cap=%.1f MiB",
+                len(split_report),
+                sum(len(item["logical_names"]) for item in split_report),
+                logical_cap / 1024**2,
+            )
+        self.src_shard_spec = self.load_spec.src_shard_spec
+
+        # Snapshot wksd AFTER specgen (which may call lw and replace model
+        # parameters).  This is the live reference used for ongoing
+        # copy_fromto_params during weight transfer.
+        self.wksd = ctx.wksd_factory()
+
+
+class SenderAdapter(BaseAdapter):
+    """Trainer Worker adapter: owns a :class:`~wbridge.backend.sender.WeightSender`.
+
+    The :class:`~wbridge.backend.sender.WeightSender` is constructed in :meth:`__init__` from the
+    transport args. Call :meth:`connect` once to join the sender process group, then
+    :meth:`send_weights` per weight update.
+    """
+
+    def __init__(self, ctx: AdapterContext, args: SenderArgs) -> None:
+        super().__init__(ctx)
+        self.sender = WeightSender(
+            args,
+            ctx.rank,
+            self.src_shard_spec,
+            self.load_spec,
+            self.wksd,
+        )
+        _dump_loadspec_if_requested(
+            "sender",
+            ctx.rank,
+            None,
+            self,
+            {"world_size": args.world_size, "sender_staging": args.sender_staging},
+        )
+
+    def connect(self) -> None:
+        self.sender.connect()
+
+    def send_weights(self) -> "torch.cuda.Event | None":
+        """Pack (+ CPU offload under sender-staging) and hand the RDMA to the sender's Stage-2 thread.
+
+        Returns the CUDA event marking pack+offload completion (model weights safe to overwrite). The
+        caller waits it (standard) or defers the wait until just before it overwrites the weights.
+        """
+        return self.sender.send()
+
+    def wait_send_complete(self) -> None:
+        """Block until the last :meth:`send_weights` has been delivered+consumed by all receivers.
+        The caller uses this in debugging mode (equality check) to guarantee delivery before reading."""
+        self.sender.wait_send_complete()
+
+    def flush_profile_outputs(self) -> None:
+        """Release the latest epoch's profiling output after the caller records trainer ``block_end``."""
+        self.sender.flush_profile_outputs()
+
+
+class ReceiverAdapter(BaseAdapter):
+    """Rollout Worker adapter: owns a :class:`~wbridge.backend.receiver.WeightReceiver`.
+
+    The receiver is created eagerly in :meth:`__init__` so it can handshake with the controller
+    before any transfer begins.
+    """
+
+    def __init__(
+        self,
+        ctx: AdapterContext,
+        controller_ipc_name: str,
+        num_workers: int,
+        receiver_staging: bool = False,
+        control_hub_name: str | None = None,
+    ) -> None:
+        super().__init__(ctx)
+        self.controller_ipc_name = controller_ipc_name
+        self.receiver = WeightReceiver(
+            controller_ipc_name,
+            ctx.rank,
+            self.src_shard_spec,
+            self.dtype_spec,
+            self.load_spec,
+            self.wksd,
+            num_workers=num_workers,
+            control_hub_name=control_hub_name,
+            receiver_staging=receiver_staging,
+        )
+        _dump_loadspec_if_requested(
+            "receiver",
+            ctx.rank,
+            controller_ipc_name,
+            self,
+            {"num_workers": num_workers, "receiver_staging": receiver_staging},
+        )
+
+    def poll_requests(
+        self, before_receive: Callable[[int], None] | None = None
+    ) -> bool:
+        """Poll and service one Rollout Worker control request on the scheduler thread.
+
+        ``before_receive(epoch)`` runs only for a real weight update, after the readiness decision and
+        before model weights are mutated. Returns ``True`` only when an update was received and loaded;
+        empty polls, staging kicks, and connection setup return ``False``.
+        """
+        return self.receiver.poll_requests(before_receive=before_receive)
+
+    def flush_profile_outputs(self) -> None:
+        """Release the latest epoch's profiling output after the caller records rollout ``block_end``."""
+        self.receiver.flush_profile_outputs()

--- a/examples/weightbridge/wbridge/utils/data.py
+++ b/examples/weightbridge/wbridge/utils/data.py
@@ -1,0 +1,1705 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import copy
+import math
+import os
+from typing import Callable, Iterable, Iterator, TypeAlias
+
+import torch
+
+Shard: TypeAlias = list[tuple[int, int, int]]
+Shards: TypeAlias = list[Shard]
+# One HF↔worker region pair: source box and destination box (same flattened numel).
+ShardMapping: TypeAlias = tuple[Shard, Shard]
+
+
+DEFAULT_LOGICAL_TENSOR_CAP_BYTES = 128 * 1024**2
+LOGICAL_TENSOR_SPLIT_ENV = "WBRIDGE_LOGICAL_TENSOR_CAP_BYTES"
+_LOGICAL_TENSOR_SPLIT_MARKER = ".__wbridge_dim0_"
+
+
+def logical_tensor_cap_bytes() -> int:
+    """Configured maximum full logical-source size in bytes; zero disables splitting."""
+    raw = os.environ.get(
+        LOGICAL_TENSOR_SPLIT_ENV,
+        str(DEFAULT_LOGICAL_TENSOR_CAP_BYTES),
+    ).strip()
+    try:
+        cap = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{LOGICAL_TENSOR_SPLIT_ENV} must be an integer, got {raw!r}"
+        ) from exc
+    if cap < 0:
+        raise ValueError(f"{LOGICAL_TENSOR_SPLIT_ENV} must be non-negative, got {cap}")
+    return cap
+
+
+def logical_tensor_name(original: str, start: int, end: int) -> str:
+    """Deterministic virtual name for ``original[start:end, ...]``."""
+    if _LOGICAL_TENSOR_SPLIT_MARKER in original:
+        raise ValueError(
+            f"checkpoint tensor name {original!r} contains reserved marker "
+            f"{_LOGICAL_TENSOR_SPLIT_MARKER!r}"
+        )
+    if not 0 <= start < end:
+        raise ValueError(f"invalid logical tensor dim-0 interval [{start}, {end})")
+    return f"{original}{_LOGICAL_TENSOR_SPLIT_MARKER}{start:012d}_{end:012d}"
+
+
+def parse_logical_tensor_name(name: str) -> tuple[str, int, int] | None:
+    """Return ``(physical_name, start, end)`` for a virtual source name."""
+    original, marker, suffix = name.rpartition(_LOGICAL_TENSOR_SPLIT_MARKER)
+    if not marker:
+        return None
+    fields = suffix.split("_")
+    if not original or len(fields) != 2:
+        raise ValueError(f"malformed logical tensor name {name!r}")
+    try:
+        start, end = map(int, fields)
+    except ValueError as exc:
+        raise ValueError(f"malformed logical tensor interval in {name!r}") from exc
+    if not 0 <= start < end:
+        raise ValueError(f"invalid logical tensor interval in {name!r}")
+    return original, start, end
+
+
+def shard_shape(shard: Shard) -> tuple[int, ...]:
+    return tuple(r - l for l, r, _ in shard)
+
+
+def shard_numel(shard: Shard) -> int:
+    return math.prod(shard_shape(shard))
+
+
+def shards_numel(shards: Shards) -> int:
+    return sum(shard_numel(shard) for shard in shards)
+
+
+def shards_nbytes(shards: Shards, dtype: torch.dtype) -> int:
+    return shards_numel(shards) * dtype.itemsize
+
+
+def split_shard_evenly(shard: Shard, k: int, j: int) -> Shard | None:
+    """Sub-shard *j* of *k* from splitting *shard* evenly along its longest axis.
+
+    Used for sender-side de-replication: *k* workers holding an identical *shard* are each viewed as
+    holding one disjoint sub-range, so the shard is sent once instead of *k* times. The remainder is
+    spread over the first ``len % k`` parts, so the *k* sub-shards partition *shard* exactly. ``w``
+    (incl. transpose sign) is preserved. Returns ``None`` when sub-shard *j* is empty (``len < k`` and
+    *j* past the remainder — that member then sends nothing).
+    """
+    if k <= 1:
+        return list(shard)
+    shape = shard_shape(shard)
+    # Split the OUTERMOST axis with extent >= k so each sub-shard stays a CONTIGUOUS block (the axes before
+    # it are then singletons). A strided sub-shard (e.g. splitting the column axis of a row-major tensor)
+    # makes the wire<->model copy fall on the much slower coordinate Triton kernel instead of the
+    # contiguous fast path — the dominant cost in the receiver consume. Byte-balance per part is axis-independent
+    # for an even k-way split, so this costs nothing there. Fall back to the longest axis for a tiny tensor
+    # with no axis >= k.
+    d = next(
+        (i for i in range(len(shape)) if shape[i] >= k),
+        max(range(len(shape)), key=lambda i: shape[i]),
+    )
+    l, r, w = shard[d]
+    base, rem = divmod(r - l, k)
+    start = l + j * base + min(j, rem)
+    end = start + base + (1 if j < rem else 0)
+    if start >= end:
+        return None
+    out = list(shard)
+    out[d] = (start, end, w)
+    return out
+
+
+def _sanity_check(name: str, shards: Shards) -> None:
+    numel = None
+    assert len(shards) > 0, f"Empty shard list for {name}"
+    for shard in shards:
+        assert len(shard) > 0, f"Empty shard in list for {name}"
+        for l, r, w in shard:
+            # Negative w signals a transposed axis (see specgen transpose detection).
+            assert 0 <= l < r <= abs(w), f"Invalid shard: {l, r, w} for {name}"
+        cur_numel = math.prod(abs(w) for _, _, w in shard)
+        if numel is None:
+            numel = cur_numel
+        else:
+            assert numel == cur_numel, (
+                f"Shard {shard} does not match original total numel: {numel} != {cur_numel}!"
+            )
+
+
+def shards_iterator(
+    shards: Shards, tensor: torch.Tensor
+) -> Iterator[tuple[Shard, torch.Tensor]]:
+    """Iterate over shards and yield the corresponding tensor slices."""
+    offset = 0
+    for shard in shards:
+        length = shard_numel(shard)
+        yield shard, tensor[offset : offset + length].view(shard_shape(shard))
+        offset += length
+
+
+class ShardSpec:
+    """
+    Per-tensor shard layout and dtype for weight transfer (no tensor storage).
+
+    Format::
+
+        {
+            "name": [[(l, r, w), ...], ...],  # each value is :class:`Shards`
+            ...
+        }
+
+    Each entry value must be full multi-shard form (a :class:`Shards` list).
+    ``dtype`` may be :class:`torch.dtype` or a string (for JSON / legacy).
+
+    Tensor values are passed separately as ``dict[str, torch.Tensor]`` to
+    :meth:`__call__` (returns a :class:`BoundShardSpec`) or
+    """
+
+    def __init__(self, entries: dict[str, Shards]):
+        self.entries = dict(entries)
+
+        for name, shards in self:
+            _sanity_check(name, shards)
+
+    def __call__(self, tensors: dict[str, torch.Tensor]) -> "BoundShardSpec":
+        """Bind *tensors* to this shard spec for overlap packing / unpacking.
+
+        Returns a :class:`BoundShardSpec` for ``f[overlaps]`` /
+        ``f[overlaps] = chunks`` (see :class:`BoundShardSpec`).
+        """
+        return BoundShardSpec(self, tensors)
+
+    def __bool__(self) -> bool:
+        return bool(self.entries)
+
+    def __iter__(self) -> Iterator[tuple[str, Shards]]:
+        return iter(sorted(self.entries.items()))
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.entries
+
+    def __delitem__(self, key: str) -> None:
+        del self.entries[key]
+
+    def __getitem__(self, key: str) -> Shards:
+        return self.entries[key]
+
+    def __setitem__(self, key: str, value: Shards) -> None:
+        _sanity_check(key, value)
+        self.entries[key] = value
+
+    def nbytes(self, dtype_spec: dict[str, torch.dtype]) -> int:
+        return sum(shards_nbytes(shards, dtype_spec[name]) for name, shards in self)
+
+    def iter_with_intv(
+        self, tensors: dict[str, torch.Tensor]
+    ) -> Iterator[tuple[int, int, str, torch.dtype]]:
+        offset = 0
+        for name, shards in self:
+            length = shards_nbytes(shards, tensors[name].dtype)
+            yield offset, offset + length, name, tensors[name].dtype
+            offset += length
+
+    def clone(self) -> "ShardSpec":
+        return ShardSpec(copy.deepcopy(self.entries))
+
+    def subset(self, names: set[str]) -> "ShardSpec":
+        names &= self.entries.keys()
+        return ShardSpec({name: self[name] for name in names})
+
+    def make_named_buffer(
+        self, dtype_spec: dict[str, torch.dtype], device: str
+    ) -> dict[str, torch.Tensor]:
+        """Make a dictionary of tensors for each name in the shard spec."""
+        return {
+            name: torch.empty(
+                shards_numel(shards), dtype=dtype_spec[name], device=device
+            )
+            for name, shards in self
+        }
+
+    def make_byte_chunk(
+        self, dtype_spec: dict[str, torch.dtype], device: str
+    ) -> torch.Tensor:
+        """Return a uint8 P2P buffer covering this spec (all tensor names, layout order in :meth:`iter_with_intv`)."""
+        return torch.zeros(self.nbytes(dtype_spec), dtype=torch.uint8, device=device)
+
+    @staticmethod
+    def compute_overlap(
+        sender: "ShardSpec",
+        receiver: "ShardSpec",
+        names: Iterable[str] | None = None,
+    ) -> "ShardSpec":
+        """Return a new :class:`ShardSpec` whose entries describe the shard regions
+        where *sender* and *receiver* overlap (spec only, no tensor data).
+
+        Sender and receiver specs must already store entries as multi-box :class:`Shards`.
+        Every sender shard is paired against every
+        receiver shard and all non-empty overlaps are collected.  When *names* is
+        provided, only those tensor names are considered; names absent from either
+        spec are ignored.  This lets callers with a precomputed name intersection
+        avoid scanning the whole sender map for every rank pair.
+        """
+        result: dict[str, Shards] = {}
+        sender_items = (
+            sender
+            if names is None
+            else ((name, sender[name]) for name in names if name in sender)
+        )
+        for name, s_shards in sender_items:
+            if name not in receiver:
+                continue
+            r_shards = receiver[name]
+
+            overlap_shards: Shards = []
+            for s_shard in s_shards:
+                for r_shard in r_shards:
+                    alignment = _check_shard_compatibility(s_shard, r_shard)
+                    if alignment is None:
+                        raise ValueError(f"Shard compatibility check failed for {name}")
+
+                    overlap_dims = [
+                        (max(ls, lr), min(rs, rr), w) for ls, rs, lr, rr, w in alignment
+                    ]
+
+                    if all(lo < hi for lo, hi, _ in overlap_dims):
+                        overlap_shards.append(overlap_dims)
+
+            if overlap_shards:
+                result[name] = overlap_shards
+
+        return ShardSpec(result)
+
+
+class BoundShardSpec:
+    """``f = spec(tensors)``: overlap-indexed pack/unpack into *tensors*.
+
+    * ``v = f[c]`` — *c* maps ranks to overlap :class:`ShardSpec` entries.
+      Returns a ``dict`` of one-dimensional ``uint8`` tensors (wire layout).
+    * ``f[c] = v`` — *v* maps ranks to matching ``uint8`` flat tensors, copied
+      into *tensors* at the overlap regions (receiver layout; *shard_spec* must
+      describe *tensors*).
+    """
+
+    def __init__(self, shard_spec: ShardSpec, tensors: dict[str, torch.Tensor]) -> None:
+        self._shard_spec = shard_spec
+        self._tensors = dict(tensors)
+        self.device = tensors[list(tensors.keys())[0]].device
+
+        # Sanity check and flatten
+        for name, shards in self._shard_spec:
+            assert name in self._tensors, f"Missing tensor {name} for overlap entry"
+            tensor = self._tensors[name]
+            assert tensor.is_contiguous(), f"Tensor {name} is not contiguous"
+            assert tensor.dim() == 1, f"Tensor {name} must be 1D"
+            assert shards_numel(shards) == tensor.numel(), (
+                f"spec and tensor numel mismatch for {name}, {shards_numel(shards)} vs {tensor.numel()}"
+            )
+            self._tensors[name] = tensor.flatten()
+            assert tensor.device == self.device, (
+                f"Tensor {name} is not on the same device as other tensors"
+            )
+
+        # Drop tensors not listed in shard_spec
+        for name in list(self._tensors):
+            if name not in self._shard_spec:
+                del self._tensors[name]
+
+    @staticmethod
+    def slice_copy(
+        large: "BoundShardSpec", small: "BoundShardSpec", big2small: bool = True
+    ) -> None:
+        """
+        Copy data between two flattened buffers (resharding; no transpose here).
+        The direction is set by ``big2small``. "small" is a subset of "large".
+        Executed in O(1) CUDA kernel launches via :func:`batched_copy`.
+        """
+        batched_copy(BoundShardSpec._slice_copy_pairs(large, small, big2small))
+
+    @staticmethod
+    def _slice_copy_pairs(
+        large: "BoundShardSpec",
+        small: "BoundShardSpec",
+        big2small: bool = True,
+    ) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        """Return (dst_view, src_view) pairs for :meth:`slice_copy` without executing the copies."""
+        pairs: list[tuple[torch.Tensor, torch.Tensor]] = []
+        for name, _ in small._shard_spec:
+            assert name in large._shard_spec, f"Missing tensor {name} for large entry"
+
+            for s_shard, s_tensor in shards_iterator(
+                small._shard_spec[name], small._tensors[name]
+            ):
+                for b_shard, b_tensor in shards_iterator(
+                    large._shard_spec[name], large._tensors[name]
+                ):
+                    assert b_tensor.dtype == s_tensor.dtype, (
+                        f"Tensor dtype mismatch for {name}: {b_tensor.dtype} vs {s_tensor.dtype}"
+                    )
+                    alignment = _check_shard_compatibility(b_shard, s_shard)
+
+                    if not alignment or not all(
+                        bl <= sl and sr <= br for bl, br, sl, sr, _ in alignment
+                    ):
+                        continue
+
+                    slices = tuple(
+                        slice(sl - bl, sr - bl) for bl, _, sl, sr, _ in alignment
+                    )
+                    if big2small:
+                        pairs.append((s_tensor, b_tensor[slices]))
+                    else:
+                        pairs.append((b_tensor[slices], s_tensor))
+                    break
+        return pairs
+
+    def __getitem__(self, dst_specs: dict[int, ShardSpec]) -> dict[int, torch.Tensor]:
+        # Wire layout uses dtypes from the *full* bound tensors (per-name), not the tensor objects themselves.
+        dtype_by_name = {n: t.dtype for n, t in self._tensors.items()}
+        dst_tensors = {
+            rank: dst_spec.make_byte_chunk(dtype_by_name, str(self.device))
+            for rank, dst_spec in dst_specs.items()
+        }
+        all_pairs: list[tuple[torch.Tensor, torch.Tensor]] = []
+        for rank, dst_spec in dst_specs.items():
+            dst_tensor = dst_tensors[rank]
+            state_dict = {
+                name: dst_tensor[start:end].view(dtype)
+                for start, end, name, dtype in dst_spec.iter_with_intv(self._tensors)
+            }
+            all_pairs += BoundShardSpec._slice_copy_pairs(
+                self, dst_spec(state_dict), big2small=True
+            )
+        batched_copy(all_pairs)  # all ranks in O(1) launches
+        return dst_tensors
+
+    def setitem_pairs(
+        self,
+        src_specs: dict[int, ShardSpec],
+        src_tensors: dict[int, torch.Tensor],
+    ) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        """(dst_view, src_view) pairs for ``f[src_specs] = src_tensors`` without executing (for CopyPlan)."""
+        named_tensors: dict[int, dict[str, torch.Tensor]] = {}
+        for rank, src_spec in src_specs.items():
+            src_tensor = src_tensors[rank]
+            named_tensors[rank] = {
+                name: src_tensor[start:end].view(dtype)
+                for start, end, name, dtype in src_spec.iter_with_intv(self._tensors)
+            }
+        return self.setitem_named_pairs(src_specs, named_tensors)
+
+    def setitem_named_pairs(
+        self,
+        src_specs: dict[int, ShardSpec],
+        src_tensors: dict[int, dict[str, torch.Tensor]],
+    ) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        """Like :meth:`setitem_pairs`, with already-carved per-name source tensors.
+
+        This is useful when one packed source feeds multiple destination layouts: callers carve its original
+        wire layout once, then select whole names without pretending the filtered names start at byte zero.
+        The returned pairs still describe direct source-to-destination copies, so all destinations can be
+        executed by one :class:`CopyPlan` kernel with no intermediate dependency.
+        """
+        all_pairs: list[tuple[torch.Tensor, torch.Tensor]] = []
+        for rank, src_spec in src_specs.items():
+            all_pairs += BoundShardSpec._slice_copy_pairs(
+                self,
+                src_spec(src_tensors[rank]),
+                big2small=False,
+            )
+        return all_pairs
+
+    def __setitem__(
+        self,
+        src_specs: dict[int, ShardSpec],
+        src_tensors: dict[int, torch.Tensor],
+    ) -> None:
+        batched_copy(
+            self.setitem_pairs(src_specs, src_tensors)
+        )  # all ranks in O(1) launches
+
+    def pack_into_pairs(self, dst_spec: ShardSpec, out: torch.Tensor):
+        """Like :meth:`pack_into` but returns ``(nbytes, pairs)`` without executing the copies.
+
+        Lets the sender collect pairs across all peers of a round and run a single :func:`batched_copy`.
+        """
+        dtype_by_name = {name: t.dtype for name, t in self._tensors.items()}
+        nbytes = dst_spec.nbytes(dtype_by_name)
+        assert out.dtype == torch.uint8 and out.dim() == 1 and out.numel() >= nbytes, (
+            f"pack_into needs a 1-D uint8 buffer of >= {nbytes} bytes, got {tuple(out.shape)} {out.dtype}"
+        )
+        region = out[:nbytes]
+        state_dict = {
+            name: region[start:end].view(dtype)
+            for start, end, name, dtype in dst_spec.iter_with_intv(self._tensors)
+        }
+        return nbytes, BoundShardSpec._slice_copy_pairs(
+            self, dst_spec(state_dict), big2small=True
+        )
+
+    def pack_into(self, dst_spec: ShardSpec, out: torch.Tensor) -> int:
+        """Pack the overlap region described by *dst_spec* into a caller-owned uint8 buffer *out*.
+
+        Equivalent to ``self[{r: dst_spec}][r]`` but writes into a pre-allocated (e.g. RDMA-registered)
+        buffer. Executes the copies in O(1) launches via :func:`batched_copy`. Returns bytes packed.
+        """
+        nbytes, pairs = self.pack_into_pairs(dst_spec, out)
+        batched_copy(pairs)
+        return nbytes
+
+
+def _check_shard_compatibility(
+    s_shard: Shard, r_shard: Shard
+) -> list[tuple[int, int, int, int, int]] | None:
+    """Check whether two shard specs can be aligned to a common dimensionality.
+
+    A dimension ``(l*a, r*a, w*a)`` is equivalent to
+    ``[(l, r, w), (0, a, a)]`` — trailing full dimensions can be split off
+    or merged.  More generally, a contiguous range ``[l, r)`` within a
+    single "row" of an outer dimension can also be split.
+
+    Returns a list of ``(l1, r1, l2, r2, w)`` pairs: sender interval
+    ``[l1, r1)``, receiver interval ``[l2, r2)``, shared width ``w`` per
+    aligned dimension, or ``None`` if no valid alignment exists.
+    """
+    s_cur = next(iter(s_shard), None)
+    r_cur = next(iter(r_shard), None)
+    s_iter = iter(s_shard[1:])
+    r_iter = iter(r_shard[1:])
+    aligned: list[tuple[int, int, int, int, int]] = []
+
+    while s_cur is not None and r_cur is not None:
+        sl, sr, sw = s_cur
+        rl, rr, rw = r_cur
+        # Use absolute widths for compatibility arithmetic; sign encodes transpose.
+        asw, arw = abs(sw), abs(rw)
+
+        if asw == arw:
+            aligned.append((sl, sr, rl, rr, asw))
+            s_cur = next(s_iter, None)
+            r_cur = next(r_iter, None)
+
+        elif asw > arw:
+            if asw % arw != 0:
+                return None
+            tail = asw // arw
+            if sl % tail == 0 and sr % tail == 0:
+                aligned.append((sl // tail, sr // tail, rl, rr, arw))
+                s_cur = (0, tail, tail)
+            elif sl // tail == (sr - 1) // tail:
+                row = sl // tail
+                aligned.append((row, row + 1, rl, rr, arw))
+                s_cur = (sl - row * tail, sr - row * tail, tail)
+            else:
+                return None
+            r_cur = next(r_iter, None)
+
+        else:  # asw < arw
+            if arw % asw != 0:
+                return None
+            tail = arw // asw
+            if rl % tail == 0 and rr % tail == 0:
+                aligned.append((sl, sr, rl // tail, rr // tail, asw))
+                r_cur = (0, tail, tail)
+            elif rl // tail == (rr - 1) // tail:
+                row = rl // tail
+                aligned.append((sl, sr, row, row + 1, asw))
+                r_cur = (rl - row * tail, rr - row * tail, tail)
+            else:
+                return None
+            s_cur = next(s_iter, None)
+
+    if s_cur is not None or r_cur is not None:
+        return None
+    return aligned
+
+
+def _shard_contained_in(inner: Shard, outer: Shard) -> bool:
+    """True if *inner*'s box lies inside *outer* (same dimensionality and width metadata)."""
+    if len(inner) != len(outer):
+        return False
+    for (li, ri, wi), (lo, ro, wo) in zip(inner, outer):
+        if abs(wi) != abs(wo):
+            return False
+        if not (lo <= li < ri <= ro):
+            return False
+    return True
+
+
+def _try_merge_two_shards(a: Shard, b: Shard) -> Shard | None:
+    """If *a* and *b* match on all but one axis, and on that axis the intervals touch or overlap, return the union."""
+    if len(a) != len(b):
+        return None
+    diff_dim: int | None = None
+    for d, ((la, ra, wa), (lb, rb, wb)) in enumerate(zip(a, b)):
+        if abs(wa) != abs(wb) or (wa < 0) != (wb < 0):
+            return None
+        if (la, ra) != (lb, rb):
+            if diff_dim is not None:
+                return None
+            diff_dim = d
+    if diff_dim is None:
+        return None
+    la, ra, w = a[diff_dim]
+    lb, rb, _ = b[diff_dim]
+    if ra < lb or rb < la:
+        return None
+    ml, mr = min(la, lb), max(ra, rb)
+    if ml >= mr:
+        return None
+    out = list(a)
+    out[diff_dim] = (ml, mr, w)
+    return out
+
+
+def _merge_shards_for_src_shard_spec(shards: Shards) -> Shards:
+    """Collapse duplicate / contained shards and merge axis-aligned neighbors that differ on one axis only."""
+    keep = [True] * len(shards)
+    i = 0
+    while i < len(keep):
+        if not keep[i]:
+            i += 1
+            continue
+        cur_shard = shards[i]
+        for j in range(0, i):
+            if keep[j]:
+                shard = shards[j]
+                if _shard_contained_in(shard, cur_shard):
+                    keep[j] = False
+                elif _shard_contained_in(cur_shard, shard):
+                    keep[i] = False
+                    break
+                elif c := _try_merge_two_shards(shard, cur_shard):
+                    shards.append(c)
+                    keep.append(True)
+                    keep[i] = False
+                    keep[j] = False
+                    break
+        i += 1
+    return [shard for i, shard in enumerate(shards) if keep[i]]
+
+
+def _clip_shard_dim0(shard: Shard, start: int, end: int) -> Shard | None:
+    """Intersect *shard* with the full-tensor dim-0 interval ``[start, end)``."""
+    if not shard:
+        return None
+    left, right, width = shard[0]
+    clipped_left, clipped_right = max(left, start), min(right, end)
+    if clipped_left >= clipped_right:
+        return None
+    out = list(shard)
+    out[0] = (clipped_left, clipped_right, width)
+    return out
+
+
+def _source_full_shape(
+    entry: dict[str, list[ShardMapping]], source_name: str
+) -> tuple[int, ...]:
+    shapes = {
+        tuple(abs(width) for _left, _right, width in source_shard)
+        for mappings in entry.values()
+        for source_shard, _destination_shard in mappings
+    }
+    if len(shapes) != 1:
+        raise ValueError(
+            f"source tensor {source_name!r} has inconsistent full shapes: {sorted(shapes)}"
+        )
+    shape = next(iter(shapes))
+    if not shape:
+        raise ValueError(f"cannot logically split scalar source tensor {source_name!r}")
+    return shape
+
+
+def _mapping_permutation(source_shard: Shard) -> list[int]:
+    negative = [i for i, (_left, _right, width) in enumerate(source_shard) if width < 0]
+    positive = [
+        i for i, (_left, _right, width) in enumerate(source_shard) if width >= 0
+    ]
+    return positive + negative
+
+
+def _validate_dim0_split_mapping(
+    source_name: str,
+    source_shard: Shard,
+    destination_name: str,
+    destination_shard: Shard,
+) -> None:
+    """Prove a dim-0 source cut maps to one rectangular destination cut."""
+    if len(source_shard) != len(destination_shard):
+        raise ValueError(
+            f"cannot dim-0 split {source_name}->{destination_name}: source/destination dimensions "
+            f"differ ({len(source_shard)} vs {len(destination_shard)})"
+        )
+    source_shape = shard_shape(source_shard)
+    destination_shape = shard_shape(destination_shard)
+    permutation = _mapping_permutation(source_shard)
+    mapped_shape = tuple(source_shape[source_dim] for source_dim in permutation)
+    if mapped_shape != destination_shape:
+        raise ValueError(
+            f"cannot dim-0 split {source_name}->{destination_name}: mapped source shape "
+            f"{mapped_shape} != destination shape {destination_shape}"
+        )
+
+
+def split_large_load_spec_sources(
+    load_spec: "LoadSpec",
+    dtype_spec: dict[str, torch.dtype],
+    max_bytes: int | None = None,
+) -> tuple["LoadSpec", dict[str, torch.dtype], list[dict]]:
+    """Replace oversized checkpoint names with row-aligned logical source names.
+
+    The underlying parameter tensors and mappings are unchanged.  A logical name retains the physical
+    checkpoint coordinate system but exposes only ``physical[start:end, ...]`` through
+    :attr:`LoadSpec.src_shard_spec`.  Consequently routing treats pieces as independent tensors while fused
+    model↔wire copies continue to address the original model parameters directly.
+
+    Returns ``(translated_load_spec, translated_dtype_spec, split_report)``.  The operation is idempotent:
+    records that already contain logical names pass through unchanged.
+    """
+    cap = logical_tensor_cap_bytes() if max_bytes is None else int(max_bytes)
+    if cap < 0:
+        raise ValueError(f"logical tensor cap must be non-negative, got {cap}")
+    if cap == 0:
+        return load_spec, dict(dtype_spec), []
+
+    translated: dict[str, dict[str, list[ShardMapping]]] = {}
+    translated_dtypes: dict[str, torch.dtype] = {}
+    report: list[dict] = []
+
+    for source_name, entry in load_spec.entries.items():
+        if source_name not in dtype_spec:
+            raise KeyError(f"missing dtype for LoadSpec source {source_name!r}")
+        dtype = dtype_spec[source_name]
+        already_logical = parse_logical_tensor_name(source_name)
+        if already_logical is not None:
+            translated[source_name] = copy.deepcopy(entry)
+            translated_dtypes[source_name] = dtype
+            continue
+        if _LOGICAL_TENSOR_SPLIT_MARKER in source_name:
+            raise ValueError(
+                f"checkpoint tensor name {source_name!r} contains reserved marker "
+                f"{_LOGICAL_TENSOR_SPLIT_MARKER!r}"
+            )
+
+        full_shape = _source_full_shape(entry, source_name)
+        full_bytes = math.prod(full_shape) * dtype.itemsize
+        if full_bytes <= cap:
+            translated[source_name] = copy.deepcopy(entry)
+            translated_dtypes[source_name] = dtype
+            continue
+
+        row_bytes = math.prod(full_shape[1:]) * dtype.itemsize
+        if row_bytes > cap:
+            raise ValueError(
+                f"cannot cap {source_name!r} at {cap} bytes by splitting dim 0: one row is "
+                f"{row_bytes} bytes (shape={full_shape}, dtype={dtype})"
+            )
+        for destination_name, mappings in entry.items():
+            for source_shard, destination_shard in mappings:
+                _validate_dim0_split_mapping(
+                    source_name,
+                    source_shard,
+                    destination_name,
+                    destination_shard,
+                )
+
+        rows_per_piece = max(1, cap // row_bytes)
+        logical_names: list[str] = []
+        max_piece_bytes = 0
+        for start in range(0, full_shape[0], rows_per_piece):
+            end = min(start + rows_per_piece, full_shape[0])
+            # Pipeline stages / tensor-parallel ranks need only the logical pieces intersecting their local
+            # mappings.  All workers still derive identical names for any shared interval.
+            intersects_local_mapping = any(
+                max(source_shard[0][0], start) < min(source_shard[0][1], end)
+                for mappings in entry.values()
+                for source_shard, _destination_shard in mappings
+            )
+            if not intersects_local_mapping:
+                continue
+            logical_name = logical_tensor_name(source_name, start, end)
+            if logical_name in translated:
+                raise ValueError(f"logical tensor name collision: {logical_name!r}")
+            translated[logical_name] = copy.deepcopy(entry)
+            translated_dtypes[logical_name] = dtype
+            logical_names.append(logical_name)
+            max_piece_bytes = max(max_piece_bytes, (end - start) * row_bytes)
+
+        if not logical_names:
+            raise RuntimeError(
+                f"logical split of {source_name!r} produced no local pieces"
+            )
+        report.append(
+            {
+                "source": source_name,
+                "shape": full_shape,
+                "dtype": str(dtype),
+                "full_bytes": full_bytes,
+                "row_bytes": row_bytes,
+                "logical_names": tuple(logical_names),
+                "max_piece_bytes": max_piece_bytes,
+            }
+        )
+
+    return LoadSpec(translated), translated_dtypes, report
+
+
+def validate_logical_tensor_partitions(shard_specs: Iterable[ShardSpec]) -> None:
+    """Reject inconsistent logical split grids across workers.
+
+    Workers may own disjoint subsets of a physical tensor, so they need not list every logical piece.  But
+    any intervals visible globally must be non-overlapping (except exact duplicates), and a physical source
+    cannot appear both split and unsplit.  This catches mismatched caps before routing could silently treat
+    incompatible logical names as unrelated tensors; dtype consistency is validated separately at gather.
+    """
+    plain_names: set[str] = set()
+    intervals: dict[str, set[tuple[int, int]]] = {}
+    for spec in shard_specs:
+        for name, _shards in spec:
+            logical = parse_logical_tensor_name(name)
+            if logical is None:
+                plain_names.add(name)
+                continue
+            physical, start, end = logical
+            intervals.setdefault(physical, set()).add((start, end))
+
+    mixed = sorted(physical for physical in intervals if physical in plain_names)
+    if mixed:
+        raise ValueError(
+            "inconsistent logical tensor splitting: physical and logical names coexist for "
+            f"{mixed[:8]}"
+        )
+    for physical, unique_intervals in intervals.items():
+        ordered = sorted(unique_intervals)
+        for (left_start, left_end), (right_start, right_end) in zip(
+            ordered, ordered[1:]
+        ):
+            if right_start < left_end:
+                raise ValueError(
+                    f"inconsistent logical tensor split grid for {physical!r}: "
+                    f"[{left_start}, {left_end}) overlaps [{right_start}, {right_end})"
+                )
+
+
+class LoadSpec:
+    """
+    A transfer spec describes the correspondence between 2 sets of tensors.
+
+    The format is::
+
+        {
+            "src_name": {
+                "dst_name": [
+                    (src_shard, dst_shard),  # each is a :class:`Shard`
+                    ...
+                ],
+                ...
+            },
+            ...
+        }
+
+    Each ``(src_shard, dst_shard)`` pair maps one axis-aligned box in the source
+    tensor to one box in the destination; ``shard_numel`` must match on both
+    sides. Multiple pairs per ``(src_name, dst_name)`` are allowed (e.g. split
+    QKV blocks).
+    """
+
+    def __init__(self, entries: dict[str, dict[str, list[ShardMapping]]]) -> None:
+        self.entries = entries
+        for sname, dname, s_shard, d_shard in self:
+            _sanity_check(sname, [s_shard])
+            _sanity_check(dname, [d_shard])
+            assert shard_numel(s_shard) == shard_numel(d_shard), (
+                f"numel mismatch for {sname}->{dname}: "
+                f"{shard_numel(s_shard)} vs {shard_numel(d_shard)}"
+            )
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+    @property
+    def src_shard_spec(self) -> ShardSpec:
+        if not hasattr(self, "_src_spec"):
+            self._src_spec = self._compute_src_shard_spec()
+        return self._src_spec
+
+    def _compute_src_shard_spec(self) -> ShardSpec:
+        def _unique_shards_for_src(entry: dict[str, list[ShardMapping]]) -> Shards:
+            seen: set[tuple[tuple[int, int, int], ...]] = set()
+            out: Shards = []
+            for mappings in entry.values():
+                for s_shard, _ in mappings:
+                    key = tuple(s_shard)
+                    if key not in seen:
+                        seen.add(key)
+                        out.append(list(s_shard))
+            return _merge_shards_for_src_shard_spec(out)
+
+        result: dict[str, Shards] = {}
+        for src_name, entry in self.entries.items():
+            shards = _unique_shards_for_src(entry)
+            logical = parse_logical_tensor_name(src_name)
+            if logical is not None:
+                _physical_name, start, end = logical
+                shards = [
+                    clipped
+                    for shard in shards
+                    if (clipped := _clip_shard_dim0(shard, start, end)) is not None
+                ]
+                if not shards:
+                    raise ValueError(
+                        f"logical source {src_name!r} does not intersect any LoadSpec mapping"
+                    )
+                shards = _merge_shards_for_src_shard_spec(shards)
+            result[src_name] = shards
+        return ShardSpec(result)
+
+    def __iter__(self) -> Iterator[tuple[str, str, Shard, Shard]]:
+        for sname, entry in self.entries.items():
+            for dname, mappings in entry.items():
+                for s_shard, d_shard in mappings:
+                    yield sname, dname, s_shard, d_shard
+
+    def load_from_full(
+        self,
+        hf_fetcher: dict[str, Callable[[], torch.Tensor]],
+        dst_tensors: dict[str, torch.Tensor],
+    ) -> None:
+        """Restore *dst_tensors* from HF checkpoint via the inferred spec.
+
+        Only tensors whose HF source name appears in :attr:`entries` are
+        materialised — the rest of *hf_fetcher* is untouched.
+        """
+        physical_sources: dict[str, list[str]] = {}
+        for source_name in self.entries:
+            logical = parse_logical_tensor_name(source_name)
+            physical_name = logical[0] if logical is not None else source_name
+            physical_sources.setdefault(physical_name, []).append(source_name)
+
+        for physical_name, source_names in physical_sources.items():
+            if physical_name not in hf_fetcher:
+                continue
+            src_tensor = hf_fetcher[physical_name]()
+            for source_name in source_names:
+                logical = parse_logical_tensor_name(source_name)
+                logical_bounds = None if logical is None else logical[1:]
+                for dname, mappings in self.entries[source_name].items():
+                    assert dname in dst_tensors, f"Missing tensor {dname} for load"
+                    dst_tensor = dst_tensors[dname]
+                    for s_shard, d_shard in mappings:
+                        source_box = list(s_shard)
+                        if logical_bounds is not None:
+                            clipped = _clip_shard_dim0(source_box, *logical_bounds)
+                            if clipped is None:
+                                continue
+                            source_box = clipped
+                            _validate_dim0_split_mapping(
+                                source_name, s_shard, dname, d_shard
+                            )
+
+                        src_slices = tuple(slice(l, r) for l, r, _ in source_box)
+                        src_block = src_tensor[src_slices]
+                        if logical_bounds is None:
+                            dst_slices = tuple(slice(l, r) for l, r, _ in d_shard)
+                        else:
+                            permutation = _mapping_permutation(s_shard)
+                            worker_slices = []
+                            for worker_dim, (
+                                dst_left,
+                                _dst_right,
+                                _dst_width,
+                            ) in enumerate(d_shard):
+                                source_dim = permutation[worker_dim]
+                                source_left = s_shard[source_dim][0]
+                                box_left, box_right, _box_width = source_box[source_dim]
+                                worker_slices.append(
+                                    slice(
+                                        dst_left + box_left - source_left,
+                                        dst_left + box_right - source_left,
+                                    )
+                                )
+                            dst_slices = tuple(worker_slices)
+                        if any(width < 0 for _, _, width in s_shard):
+                            src_block = src_block.permute(
+                                _mapping_permutation(s_shard)
+                            ).contiguous()
+                        shard_full_shape = tuple(abs(width) for _, _, width in d_shard)
+                        dst_tensor.reshape(shard_full_shape)[dst_slices].copy_(
+                            src_block
+                        )
+
+    def copy_fromto_params(
+        self,
+        src_shard_spec: ShardSpec,
+        src_tensors: dict[
+            str, torch.Tensor
+        ],  # 1D comm buffers associated with src_shard_spec
+        dst_tensors: dict[str, torch.Tensor],  # parameter tensors (2D+)
+        *,
+        src_to_dst: bool,
+    ) -> None:
+        """
+        Copy data between communication buffer and parameter tensors for compute.
+
+        Only a subset of names indicated by `shard_spec` are copied.
+
+        NOTE: Only mapping whose source fully contained in shard_spec are copied. Partial overlaps are not supported.
+
+        Transpose-aware (shards with negative ``w``) and batched: the actual copies are executed in O(1)
+        CUDA kernel launches via :func:`batched_copy`.
+        """
+        batched_copy(
+            _copy_fromto_pairs(
+                self, src_shard_spec, src_tensors, dst_tensors, src_to_dst=src_to_dst
+            )
+        )
+
+    def copy_fromto_pairs(
+        self, src_shard_spec, src_tensors, dst_tensors, *, src_to_dst
+    ):
+        """(dst_view, src_view) pairs for :meth:`copy_fromto_params` without executing (for CopyPlan)."""
+        return _copy_fromto_pairs(
+            self, src_shard_spec, src_tensors, dst_tensors, src_to_dst=src_to_dst
+        )
+
+    def fuse_copy_pairs(self, ospec, wire_buf, dst_tensors, dtype_spec, *, src_to_dst):
+        """(dst_view, src_view) pairs mapping parameter tensors **directly** to a wire buffer.
+
+        Fuses the two packing stages — ``copy_fromto_params`` (model↔logical, transpose) and
+        ``pack_into``/``__setitem__`` (logical↔wire overlap reshard) — into one set of pairs, so no
+        intermediate logical buffer is needed. *ospec* is the per-peer overlap :class:`ShardSpec` (HF
+        coordinates); *wire_buf* is the peer's 1-D uint8 RDMA buffer, laid out per *ospec* using
+        *dtype_spec* (identical byte layout to the 2-stage path). ``src_to_dst=True`` loads wire→model
+        (receiver); ``False`` saves model→wire (sender). Raises :class:`FuseUnsupported` for shard shapes
+        the fast path can't map (caller falls back to the 2-stage path).
+        """
+        return _fuse_copy_pairs(
+            self, ospec, wire_buf, dst_tensors, dtype_spec, src_to_dst=src_to_dst
+        )
+
+
+# =========================================================================================
+# Batched copy: O(1) CUDA kernel launches for many strided / transposed segment copies.
+#
+# Each copy is one (dst_view, src_view) pair with matching shape/dtype; src/dst may be strided or
+# permuted views (a transpose is a permuted src view). A single Triton kernel copies all segments of a
+# given dtype in one launch, gathering/scattering across many base tensors via int64 address arrays and
+# per-segment strides. Falls back to a per-pair ``copy_`` loop when Triton/CUDA is unavailable.
+# =========================================================================================
+try:
+    import triton
+    import triton.language as tl
+
+    _HAS_TRITON = True
+except Exception:  # pragma: no cover - triton optional
+    _HAS_TRITON = False
+
+_MAXD = 6  # max dims a single copy segment may have
+
+_TL_DTYPE: dict = {}
+if _HAS_TRITON:
+    _TL_DTYPE = {
+        torch.float32: tl.float32,
+        torch.float16: tl.float16,
+        torch.bfloat16: tl.bfloat16,
+        torch.uint8: tl.uint8,
+        torch.int8: tl.int8,
+        torch.int32: tl.int32,
+        torch.int64: tl.int64,
+    }
+
+    @triton.jit
+    def _batched_copy_kernel(
+        tile_seg,
+        tile_start,
+        seg_src_base,
+        seg_dst_base,
+        seg_numel,
+        seg_shape,
+        seg_src_stride,
+        seg_dst_stride,
+        ELSIZE: tl.constexpr,
+        DTYPE: tl.constexpr,
+        BLOCK: tl.constexpr,
+        MAXD: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        seg = tl.load(tile_seg + pid)
+        start = tl.load(tile_start + pid)
+        numel = tl.load(seg_numel + seg)
+        src_base = tl.load(seg_src_base + seg)
+        dst_base = tl.load(seg_dst_base + seg)
+        e = start + tl.arange(0, BLOCK).to(tl.int64)
+        mask = e < numel
+        rem = e
+        src_off = tl.zeros([BLOCK], tl.int64)
+        dst_off = tl.zeros([BLOCK], tl.int64)
+        for d in tl.static_range(MAXD - 1, -1, -1):
+            sh = tl.load(seg_shape + seg * MAXD + d)
+            sst = tl.load(seg_src_stride + seg * MAXD + d)
+            dst_st = tl.load(seg_dst_stride + seg * MAXD + d)
+            coord = rem % sh
+            rem = rem // sh
+            src_off += coord * sst
+            dst_off += coord * dst_st
+        src_addr = (src_base + src_off * ELSIZE).to(tl.pointer_type(DTYPE))
+        dst_addr = (dst_base + dst_off * ELSIZE).to(tl.pointer_type(DTYPE))
+        val = tl.load(src_addr, mask=mask)
+        tl.store(dst_addr, val, mask=mask)
+
+    @triton.jit
+    def _flat_copy_kernel(
+        tile_seg,
+        tile_start,
+        seg_src_base,
+        seg_dst_base,
+        seg_numel,
+        ELSIZE: tl.constexpr,
+        DTYPE: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        # Fast path for segments that are contiguous in BOTH src and dst: element i of the flattened
+        # tensor is at base + i*ELSIZE, so no per-element coordinate decomposition is needed. This runs
+        # near memcpy bandwidth, unlike the substantially slower strided kernel's int64 %/​// over MAXD dims.
+        pid = tl.program_id(0)
+        seg = tl.load(tile_seg + pid)
+        start = tl.load(tile_start + pid)
+        numel = tl.load(seg_numel + seg)
+        src_base = tl.load(seg_src_base + seg)
+        dst_base = tl.load(seg_dst_base + seg)
+        e = start + tl.arange(0, BLOCK).to(tl.int64)
+        mask = e < numel
+        src_addr = (src_base + e * ELSIZE).to(tl.pointer_type(DTYPE))
+        dst_addr = (dst_base + e * ELSIZE).to(tl.pointer_type(DTYPE))
+        val = tl.load(src_addr, mask=mask)
+        tl.store(dst_addr, val, mask=mask)
+
+    @triton.jit
+    def _unified_copy_kernel(
+        tile_seg,
+        tile_start,
+        seg_src_base,
+        seg_dst_base,
+        seg_numel,
+        seg_shape,
+        seg_src_stride,
+        seg_dst_stride,
+        seg_flat,
+        ELSIZE: tl.constexpr,
+        DTYPE: tl.constexpr,
+        BLOCK: tl.constexpr,
+        MAXD: tl.constexpr,
+    ):
+        """Copy flat and transformed segments in one launch.
+
+        ``seg_flat`` is uniform for every lane in a program, so the runtime branch does not diverge. This
+        preserves the memcpy-like address path for ordinary tensors while allowing a peer's transposed or
+        strided model mappings to share the same launch. It is used by topology's per-peer internal-consume
+        plan, where launch count is part of the protocol rather than merely a local optimization.
+        """
+        pid = tl.program_id(0)
+        seg = tl.load(tile_seg + pid)
+        start = tl.load(tile_start + pid)
+        numel = tl.load(seg_numel + seg)
+        src_base = tl.load(seg_src_base + seg)
+        dst_base = tl.load(seg_dst_base + seg)
+        e = start + tl.arange(0, BLOCK).to(tl.int64)
+        mask = e < numel
+        if tl.load(seg_flat + seg):
+            src_off = e
+            dst_off = e
+        else:
+            rem = e
+            src_off = tl.zeros([BLOCK], tl.int64)
+            dst_off = tl.zeros([BLOCK], tl.int64)
+            for d in tl.static_range(MAXD - 1, -1, -1):
+                sh = tl.load(seg_shape + seg * MAXD + d)
+                sst = tl.load(seg_src_stride + seg * MAXD + d)
+                dst_st = tl.load(seg_dst_stride + seg * MAXD + d)
+                coord = rem % sh
+                rem = rem // sh
+                src_off += coord * sst
+                dst_off += coord * dst_st
+        src_addr = (src_base + src_off * ELSIZE).to(tl.pointer_type(DTYPE))
+        dst_addr = (dst_base + dst_off * ELSIZE).to(tl.pointer_type(DTYPE))
+        val = tl.load(src_addr, mask=mask)
+        tl.store(dst_addr, val, mask=mask)
+
+
+def _pad(seq, n, fill):
+    seq = list(seq)[:n]
+    return seq + [fill] * (n - len(seq))
+
+
+def batched_copy(pairs, *, block: int = 1024) -> None:
+    """One-shot element-wise ``dst <- src`` for every (dst_view, src_view) pair (builds a plan, runs it).
+
+    For repeated transfers over *static* buffers, build a :class:`CopyPlan` once and call ``.run()`` each
+    time instead — that caches the alignment + descriptors so per-transfer work is O(1), not O(segments).
+    """
+    CopyPlan(pairs, block=block).run()
+
+
+class CopyPlan:
+    """Precomputed descriptors for many strided/transposed segment copies, replayable in O(1) launches.
+
+    Building does the (Python) grouping + descriptor construction once; :meth:`run` only launches the
+    Triton kernel per dtype group (no Python scan, no descriptor rebuild). The pair views must stay valid
+    across ``run`` calls — i.e. bound to buffers whose addresses don't change (model params updated
+    in-place, reused logical/wire buffers). Falls back to a per-pair ``copy_`` loop off-CUDA/without Triton.
+    """
+
+    def __init__(
+        self,
+        pairs,
+        *,
+        block: int = 1024,
+        single_kernel: bool = False,
+        unified_dtype_kernels: bool = False,
+        source_ptrs: list[int] | None = None,
+        source_region: tuple[int, int] | None = None,
+    ) -> None:
+        self.block = block
+        self._groups: list = []  # strided/transposed segments -> coordinate kernel
+        self._flat_groups: list = []  # contiguous on both sides -> flat linear-index kernel (memcpy-speed)
+        self._unified_groups: list = []  # flat + transformed segments, exactly one supported dtype/launch
+        self._fallback: list = []
+        if single_kernel and unified_dtype_kernels:
+            raise ValueError(
+                "single_kernel and unified_dtype_kernels are mutually exclusive"
+            )
+        pairs = list(pairs)
+        if source_ptrs is not None and len(source_ptrs) != len(pairs):
+            raise ValueError(
+                f"source_ptrs has {len(source_ptrs)} entries for {len(pairs)} copy pairs"
+            )
+        triples = [
+            (d, s, int(source_ptrs[i]) if source_ptrs is not None else s.data_ptr())
+            for i, (d, s) in enumerate(pairs)
+            if d.numel() > 0
+        ]
+        self._source_base = int(source_region[0]) if source_region is not None else None
+        self._source_extent = int(source_region[1]) if source_region is not None else 0
+        if source_region is not None:
+            if self._source_extent < 0:
+                raise ValueError(f"negative source-region extent {self._source_extent}")
+            limit = self._source_base + self._source_extent
+            outside = [p for _d, _s, p in triples if not self._source_base <= p < limit]
+            if outside:
+                raise ValueError(
+                    f"CopyPlan source pointer outside rebindable region "
+                    f"[{self._source_base:#x}, {limit:#x}): {outside[0]:#x}"
+                )
+        if not triples:
+            return
+        if not (_HAS_TRITON and all(d.is_cuda and s.is_cuda for d, s, _ in triples)):
+            if source_ptrs is not None or source_region is not None:
+                raise ValueError(
+                    "raw/rebindable source pointers require CUDA Triton CopyPlan execution"
+                )
+            self._fallback = [(d, s) for d, s, _ in triples]
+            return
+        from collections import defaultdict
+
+        flat: dict = defaultdict(list)
+        strided: dict = defaultdict(list)
+        supported: dict = defaultdict(list)
+        for d, s, source_ptr in triples:
+            assert d.shape == s.shape, (
+                f"CopyPlan shape mismatch {tuple(d.shape)} vs {tuple(s.shape)}"
+            )
+            if d.dtype != s.dtype:
+                # Frameworks may deliberately keep a numerically identical checkpoint tensor in a wider
+                # runtime dtype (GLM-5's rollout DSA k_norm is FP32 while Megatron stores BF16). Triton copy
+                # descriptors are byte-preserving and therefore cannot implement this cast. Local model<->
+                # logical copies can safely use torch.copy_, which performs the required conversion. Raw
+                # pointer overrides identify peer IPC memory and cannot be represented by a normal Tensor
+                # copy, so keep rejecting that unsupported case explicitly.
+                if source_ptr != s.data_ptr() or source_region is not None:
+                    raise ValueError(
+                        f"raw/rebindable source pointer dtype conversion unsupported: "
+                        f"{s.dtype} -> {d.dtype}"
+                    )
+                self._fallback.append((d, s))
+                continue
+            assert d.dim() <= _MAXD, f"CopyPlan: {d.dim()} dims exceeds MAXD={_MAXD}"
+            if d.dtype not in _TL_DTYPE:
+                if source_ptr != s.data_ptr():
+                    raise ValueError(
+                        f"raw source pointer override unsupported for dtype {d.dtype}"
+                    )
+                self._fallback.append((d, s))
+            elif single_kernel or unified_dtype_kernels:
+                supported[d.dtype].append((d, s, source_ptr))
+            elif d.is_contiguous() and s.is_contiguous():
+                flat[d.dtype].append(
+                    (d, s, source_ptr)
+                )  # linear copy, no coordinate math
+            else:
+                strided[d.dtype].append((d, s, source_ptr))
+        if source_region is not None and self._fallback:
+            raise ValueError(
+                "rebindable CopyPlan sources do not support fallback copy segments"
+            )
+        if single_kernel or unified_dtype_kernels:
+            if self._fallback or (single_kernel and len(supported) != 1):
+                raise ValueError(
+                    "unified-kernel CopyPlan requires Triton-supported dtype groups and no fallback pairs; "
+                    f"dtypes={list(supported)} fallback={len(self._fallback)}"
+                )
+            for dtype, gp in supported.items():
+                self._unified_groups.append(self._build_unified(gp, dtype))
+            return
+        for dtype, gp in flat.items():
+            self._flat_groups.append(self._build_flat(gp, dtype))
+        for dtype, gp in strided.items():
+            self._groups.append(self._build_group(gp, dtype))
+
+    def _tile_table(self, seg_numel, dev):
+        """Map a flat program grid onto variable-size segments: BLOCK elements per program."""
+        n = seg_numel.numel()
+        ntiles = (seg_numel + self.block - 1) // self.block
+        tile_seg = torch.repeat_interleave(
+            torch.arange(n, device=dev, dtype=torch.int32), ntiles
+        )
+        seg_first_tile = torch.cumsum(ntiles, 0) - ntiles
+        within = (
+            torch.arange(tile_seg.numel(), device=dev, dtype=torch.int64)
+            - seg_first_tile[tile_seg.to(torch.int64)]
+        )
+        return tile_seg, within * self.block
+
+    def _build_flat(self, gp, dtype):
+        dev = gp[0][0].device
+        seg_src_base = torch.tensor(
+            [source_ptr for _, _, source_ptr in gp], device=dev, dtype=torch.int64
+        )
+        seg_dst_base = torch.tensor(
+            [d.data_ptr() for d, _, _ in gp], device=dev, dtype=torch.int64
+        )
+        seg_numel = torch.tensor(
+            [d.numel() for d, _, _ in gp], device=dev, dtype=torch.int64
+        )
+        tile_seg, tile_start = self._tile_table(seg_numel, dev)
+        elsize = torch.empty((), dtype=dtype).element_size()
+        return (
+            dtype,
+            elsize,
+            seg_src_base,
+            seg_dst_base,
+            seg_numel,
+            tile_seg,
+            tile_start,
+        )
+
+    def _build_group(self, gp, dtype):
+        dev = gp[0][0].device
+        seg_src_base = torch.tensor(
+            [source_ptr for _, _, source_ptr in gp], device=dev, dtype=torch.int64
+        )
+        seg_dst_base = torch.tensor(
+            [d.data_ptr() for d, _, _ in gp], device=dev, dtype=torch.int64
+        )
+        seg_numel = torch.tensor(
+            [d.numel() for d, _, _ in gp], device=dev, dtype=torch.int64
+        )
+        seg_shape = torch.tensor(
+            [_pad(d.shape, _MAXD, 1) for d, _, _ in gp], device=dev, dtype=torch.int64
+        )
+        seg_src_stride = torch.tensor(
+            [_pad(s.stride(), _MAXD, 0) for _, s, _ in gp],
+            device=dev,
+            dtype=torch.int64,
+        )
+        seg_dst_stride = torch.tensor(
+            [_pad(d.stride(), _MAXD, 0) for d, _, _ in gp],
+            device=dev,
+            dtype=torch.int64,
+        )
+        tile_seg, tile_start = self._tile_table(seg_numel, dev)
+        elsize = torch.empty((), dtype=dtype).element_size()
+        return (
+            dtype,
+            elsize,
+            seg_src_base,
+            seg_dst_base,
+            seg_numel,
+            seg_shape,
+            seg_src_stride,
+            seg_dst_stride,
+            tile_seg,
+            tile_start,
+        )
+
+    def _build_unified(self, gp, dtype):
+        dev = gp[0][0].device
+        seg_src_base = torch.tensor(
+            [source_ptr for _, _, source_ptr in gp], device=dev, dtype=torch.int64
+        )
+        seg_dst_base = torch.tensor(
+            [d.data_ptr() for d, _, _ in gp], device=dev, dtype=torch.int64
+        )
+        seg_numel = torch.tensor(
+            [d.numel() for d, _, _ in gp], device=dev, dtype=torch.int64
+        )
+        seg_shape = torch.tensor(
+            [_pad(d.shape, _MAXD, 1) for d, _, _ in gp], device=dev, dtype=torch.int64
+        )
+        seg_src_stride = torch.tensor(
+            [_pad(s.stride(), _MAXD, 0) for _, s, _ in gp],
+            device=dev,
+            dtype=torch.int64,
+        )
+        seg_dst_stride = torch.tensor(
+            [_pad(d.stride(), _MAXD, 0) for d, _, _ in gp],
+            device=dev,
+            dtype=torch.int64,
+        )
+        seg_flat = torch.tensor(
+            [d.is_contiguous() and s.is_contiguous() for d, s, _ in gp],
+            device=dev,
+            dtype=torch.int8,
+        )
+        tile_seg, tile_start = self._tile_table(seg_numel, dev)
+        elsize = torch.empty((), dtype=dtype).element_size()
+        return (
+            dtype,
+            elsize,
+            seg_src_base,
+            seg_dst_base,
+            seg_numel,
+            seg_shape,
+            seg_src_stride,
+            seg_dst_stride,
+            seg_flat,
+            tile_seg,
+            tile_start,
+        )
+
+    @property
+    def launch_count(self) -> int:
+        """Number of CUDA launches made by :meth:`run` (fallback copies count individually)."""
+        return (
+            len(self._fallback)
+            + len(self._flat_groups)
+            + len(self._groups)
+            + len(self._unified_groups)
+        )
+
+    def rebase_sources(self, new_base: int) -> None:
+        """Retarget every source descriptor to the same offsets under *new_base*.
+
+        Plans created with ``source_region=(base, size)`` can therefore outlive an epoch-scoped scratch
+        allocation. Descriptor updates are enqueued on the current CUDA stream; a subsequent :meth:`run`
+        on that stream observes them without a host synchronization.
+        """
+        if self._source_base is None:
+            raise RuntimeError("CopyPlan was not built with a rebindable source_region")
+        new_base = int(new_base)
+        delta = new_base - self._source_base
+        if delta:
+            for group in (*self._flat_groups, *self._groups, *self._unified_groups):
+                group[2].add_(delta)
+            self._source_base = new_base
+
+    def run(self) -> None:
+        for d, s in self._fallback:
+            d.copy_(s)
+        for g in self._flat_groups:
+            (dtype, elsize, ssb, sdb, sn, tseg, tstart) = g
+            _flat_copy_kernel[(tseg.numel(),)](
+                tseg,
+                tstart,
+                ssb,
+                sdb,
+                sn,
+                ELSIZE=elsize,
+                DTYPE=_TL_DTYPE[dtype],
+                BLOCK=self.block,
+            )
+        for g in self._groups:
+            (dtype, elsize, ssb, sdb, sn, sh, sss, sds, tseg, tstart) = g
+            _batched_copy_kernel[(tseg.numel(),)](
+                tseg,
+                tstart,
+                ssb,
+                sdb,
+                sn,
+                sh,
+                sss,
+                sds,
+                ELSIZE=elsize,
+                DTYPE=_TL_DTYPE[dtype],
+                BLOCK=self.block,
+                MAXD=_MAXD,
+            )
+        for g in self._unified_groups:
+            (dtype, elsize, ssb, sdb, sn, sh, sss, sds, flat, tseg, tstart) = g
+            _unified_copy_kernel[(tseg.numel(),)](
+                tseg,
+                tstart,
+                ssb,
+                sdb,
+                sn,
+                sh,
+                sss,
+                sds,
+                flat,
+                ELSIZE=elsize,
+                DTYPE=_TL_DTYPE[dtype],
+                BLOCK=self.block,
+                MAXD=_MAXD,
+            )
+
+
+def _argsort_perm(perm):
+    inv = [0] * len(perm)
+    for k, p in enumerate(perm):
+        inv[p] = k
+    return inv
+
+
+def _copy_fromto_pairs(
+    load_spec, src_shard_spec, src_tensors, dst_tensors, *, src_to_dst
+):
+    """Build (dst_view, src_view) pairs for ``LoadSpec.copy_fromto_params``, applying transpose.
+
+    A transposed mapping (some src dim has ``w<0``) is realised by permuting the *source* view so that
+    element-wise ``dst[coord] = src[coord]`` performs the transpose — mirroring ``LoadSpec.load_from_full``.
+    """
+    pairs: list[tuple[torch.Tensor, torch.Tensor]] = []
+    for sname, dname, s_shard, d_shard in load_spec:
+        if sname not in src_shard_spec or dname not in dst_tensors:
+            continue
+        dst_tensor = dst_tensors[dname]
+        neg_dims = [i for i, (_, _, w) in enumerate(s_shard) if w < 0]
+        pos_dims = [i for i, (_, _, w) in enumerate(s_shard) if w >= 0]
+        perm = pos_dims + neg_dims  # HF dim order -> worker dim order
+        inv = _argsort_perm(perm)  # worker dim order -> HF
+        logical = parse_logical_tensor_name(sname)
+        for shard, src_tensor in shards_iterator(
+            src_shard_spec[sname], src_tensors[sname]
+        ):
+            # Sender/receiver de-duplication can make ``shard`` a strict sub-box of a normal (non-logical)
+            # LoadSpec mapping.  The old two-stage fallback handled intersections only for explicitly
+            # dim-0-split logical names; for ordinary de-duplicated names it silently skipped the mapping and
+            # packed uninitialized logical bytes.  Use the same rectangular intersection path whenever the
+            # source and destination mapping dimensions are related by the recorded transpose permutation.
+            # Keep the legacy containment path below for unusual reshape-only mappings whose dimensions differ.
+            rectangular = (
+                len(shard) == len(s_shard) == len(d_shard)
+                and all(
+                    abs(sw) == abs(mw)
+                    for (_sl, _sr, sw), (_ml, _mr, mw) in zip(shard, s_shard)
+                )
+                and tuple(shard_shape(s_shard)[source_dim] for source_dim in perm)
+                == shard_shape(d_shard)
+            )
+            if logical is not None:
+                _validate_dim0_split_mapping(sname, s_shard, dname, d_shard)
+                rectangular = True
+            if rectangular:
+                inter: list[tuple[int, int]] = []
+                for (source_left, source_right, source_width), (
+                    map_left,
+                    map_right,
+                    map_width,
+                ) in zip(
+                    shard,
+                    s_shard,
+                ):
+                    if abs(source_width) != abs(map_width):
+                        raise ValueError(
+                            f"source width mismatch for {sname}->{dname}: "
+                            f"{source_width} vs {map_width}"
+                        )
+                    left, right = (
+                        max(source_left, map_left),
+                        min(source_right, map_right),
+                    )
+                    if left >= right:
+                        inter = []
+                        break
+                    inter.append((left, right))
+                if not inter:
+                    continue
+                src_slices = tuple(
+                    slice(left - shard_left, right - shard_left)
+                    for (left, right), (shard_left, _shard_right, _shard_width) in zip(
+                        inter, shard
+                    )
+                )
+                worker_slices = []
+                for worker_dim, (dst_left, _dst_right, _dst_width) in enumerate(
+                    d_shard
+                ):
+                    source_dim = perm[worker_dim]
+                    left, right = inter[source_dim]
+                    map_left = s_shard[source_dim][0]
+                    worker_slices.append(
+                        slice(
+                            dst_left + left - map_left,
+                            dst_left + right - map_left,
+                        )
+                    )
+                shard_full_shape = tuple(abs(width) for _, _, width in d_shard)
+                worker_block = dst_tensor.reshape(shard_full_shape)[
+                    tuple(worker_slices)
+                ]
+                hf_block = src_tensor[src_slices]
+                if neg_dims:
+                    if src_to_dst:
+                        pairs.append((worker_block, hf_block.permute(perm)))
+                    else:
+                        pairs.append((hf_block, worker_block.permute(inv)))
+                else:
+                    pairs.append(
+                        (worker_block, hf_block)
+                        if src_to_dst
+                        else (hf_block, worker_block)
+                    )
+                continue
+            if _shard_contained_in(s_shard, shard):
+                src_slices = tuple(
+                    slice(l - l0, r - l0)
+                    for (l, r, _), (l0, _, _) in zip(s_shard, shard)
+                )
+                dst_slices = tuple(slice(l, r) for l, r, _ in d_shard)
+                shard_full_shape = tuple(abs(w) for _, _, w in d_shard)
+                worker_block = dst_tensor.reshape(shard_full_shape)[dst_slices]
+                hf_block = src_tensor[src_slices]
+                if neg_dims:
+                    if src_to_dst:  # worker <- HF: worker = HF.permute(perm)
+                        pairs.append((worker_block, hf_block.permute(perm)))
+                    else:  # HF <- worker: HF = worker.permute(inv)
+                        pairs.append((hf_block, worker_block.permute(inv)))
+                else:
+                    pairs.append(
+                        (worker_block, hf_block)
+                        if src_to_dst
+                        else (hf_block, worker_block)
+                    )
+                break
+    return pairs
+
+
+class FuseUnsupported(Exception):
+    """A fused model↔wire mapping can't be built for a shard shape (caller falls back to the 2-stage path)."""
+
+
+def _fuse_copy_pairs(
+    load_spec, ospec, wire_buf, dst_tensors, dtype_spec, *, src_to_dst
+):
+    """Build (dst_view, src_view) pairs mapping parameter tensors **directly** to a wire buffer.
+
+    Composes the LoadSpec transpose/TP-remap (model↔HF, :func:`_copy_fromto_pairs`) with the overlap
+    reshard (HF↔wire, :meth:`BoundShardSpec._slice_copy_pairs`) without an intermediate logical buffer.
+
+    For each HF name, each overlap box ``o_box`` of *ospec* (a 1-D wire region viewed in the name's dtype,
+    HF coordinates), and each LoadSpec mapping ``(s_shard, d_shard)``: the transferred region is the
+    **intersection** of ``o_box`` with ``s_shard`` (vs. containment in :func:`_copy_fromto_pairs`). The
+    wire sub-view is sliced from ``o_box``; the model sub-view is the corresponding slice of the worker
+    tensor, permuted for transpose exactly as :func:`_copy_fromto_pairs`. Reduces to
+    :func:`_copy_fromto_pairs` when ``o_box`` contains ``s_shard``.
+
+    Only handles shards where ``o_box`` and ``s_shard`` share dimensionality and per-axis widths (all
+    real cases: TP row/col, QKV/gate_up fusion, transpose). Anything else → :class:`FuseUnsupported`.
+    """
+    pairs: list[tuple[torch.Tensor, torch.Tensor]] = []
+    # Wire byte offsets per name, identical layout to ShardSpec.iter_with_intv (uses dtype_spec).
+    offset = 0
+    for name, shards in ospec:
+        length = shards_nbytes(shards, dtype_spec[name])
+        if name in load_spec.entries:
+            dt = dtype_spec[name]
+            name_region = wire_buf[offset : offset + length].view(dt)
+            for o_box, o_view in shards_iterator(shards, name_region):
+                for dname, mappings in load_spec.entries[name].items():
+                    if dname not in dst_tensors:
+                        continue
+                    dst_tensor = dst_tensors[dname]
+                    assert dst_tensor.dtype == dt, (
+                        f"fuse dtype mismatch for {name}->{dname}: model {dst_tensor.dtype} vs wire {dt}"
+                    )
+                    neg_dims = [
+                        i for i, (_, _, w) in enumerate(mappings[0][0]) if w < 0
+                    ]
+                    pos_dims = [
+                        i for i, (_, _, w) in enumerate(mappings[0][0]) if w >= 0
+                    ]
+                    perm = pos_dims + neg_dims  # HF dim order -> worker dim order
+                    inv = _argsort_perm(perm)  # worker dim order -> HF
+                    for s_shard, d_shard in mappings:
+                        if len(s_shard) != len(o_box):
+                            raise FuseUnsupported(
+                                f"{name}->{dname}: dim mismatch {len(s_shard)} vs {len(o_box)}"
+                            )
+                        # Intersect o_box with s_shard per (HF) dim; o_box widths are abs, s may be signed.
+                        inter: list[tuple[int, int]] = []
+                        empty = False
+                        for (ol, orr, ow), (sl, sr, sw) in zip(o_box, s_shard):
+                            if abs(ow) != abs(sw):
+                                raise FuseUnsupported(
+                                    f"{name}->{dname}: width mismatch {ow} vs {sw}"
+                                )
+                            il, ir = max(ol, sl), min(orr, sr)
+                            if il >= ir:
+                                empty = True
+                                break
+                            inter.append((il, ir))
+                        if empty:
+                            continue
+                        # Wire sub-view (HF order): slice o_view to the intersection, relative to o_box.
+                        wire_sub = o_view[
+                            tuple(
+                                slice(il - ol, ir - ol)
+                                for (il, ir), (ol, _, _) in zip(inter, o_box)
+                            )
+                        ]
+                        # Model sub-view: worker dim k is fed by HF dim perm[k]; place at d_shard[k] offset.
+                        shard_full_shape = tuple(abs(w) for _, _, w in d_shard)
+                        worker_slices = []
+                        for k, (dl, _dr, _dw) in enumerate(d_shard):
+                            j = perm[k]
+                            il_j, ir_j = inter[j]
+                            sl_j = s_shard[j][0]
+                            worker_slices.append(
+                                slice(dl + (il_j - sl_j), dl + (ir_j - sl_j))
+                            )
+                        worker_full = dst_tensor.reshape(shard_full_shape)
+                        if worker_full.data_ptr() != dst_tensor.data_ptr():
+                            # Cached fused plans retain raw addresses, not the temporary Tensor produced by
+                            # a copying reshape. Such an address becomes stale after plan construction and,
+                            # on later epochs, would also read a frozen snapshot rather than the live model.
+                            # Let the sender select its immediate two-stage path instead.
+                            raise FuseUnsupported(
+                                f"{name}->{dname}: reshape {tuple(dst_tensor.shape)} "
+                                f"stride={tuple(dst_tensor.stride())} to {shard_full_shape} allocates"
+                            )
+                        worker_block = worker_full[tuple(worker_slices)]
+                        if neg_dims:
+                            if src_to_dst:  # wire -> model: model = wire.permute(perm)
+                                pairs.append((worker_block, wire_sub.permute(perm)))
+                            else:  # model -> wire: wire = model.permute(inv)
+                                pairs.append((wire_sub, worker_block.permute(inv)))
+                        else:
+                            pairs.append(
+                                (worker_block, wire_sub)
+                                if src_to_dst
+                                else (wire_sub, worker_block)
+                            )
+        offset += length
+    return pairs

--- a/examples/weightbridge/wbridge/utils/distributed.py
+++ b/examples/weightbridge/wbridge/utils/distributed.py
@@ -1,0 +1,117 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import socket
+from datetime import timedelta
+from typing import Any
+
+import torch
+from packaging.version import parse
+from torch.distributed import rendezvous
+from torch.distributed.distributed_c10d import (
+    _new_process_group_helper,
+    _world,
+    Backend,
+    default_pg_timeout,
+    PrefixStore,
+)
+
+
+def get_local_ip() -> str:
+    """Return this host's local IPv4 address (UDP connect trick to ``8.8.8.8``)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.connect(("8.8.8.8", 80))
+        return s.getsockname()[0]
+
+
+def get_full_group_port() -> int:
+    return 60000 + int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")[0]) * 100
+
+
+def init_custom_process_group(
+    backend: Backend | str | None = None,
+    init_method: str | None = None,
+    timeout: timedelta | None = None,
+    world_size: int = -1,
+    rank: int = -1,
+    store=None,
+    group_name: str | None = None,
+    pg_options: Any | None = None,
+):
+    """Create a named process group without touching the default group.
+
+    Mirrors ``slime.utils.distributed_utils.init_process_group`` and
+    ``sglang.srt.utils.common.init_custom_process_group``.
+
+    .. note::
+
+       ``device_id`` is intentionally **not** passed to
+       ``_new_process_group_helper``.  Passing it triggers
+       ``eagerConnectSingleDevice`` which deadlocks when the process already
+       holds many NCCL communicators (e.g. 14+ from SGLang TP/EP groups or
+       23+ from Megatron parallelism groups).  Without ``device_id``, NCCL
+       communicators are created lazily on the first collective — which works
+       reliably in all tested configurations (16 ranks, 2 nodes, existing PGs
+       on both sides).
+    """
+    assert (store is None) or (init_method is None), (
+        "Cannot specify both init_method and store."
+    )
+
+    if store is not None:
+        assert world_size > 0, "world_size must be positive if using store"
+        assert rank >= 0, "rank must be non-negative if using store"
+    elif init_method is None:
+        init_method = "env://"
+
+    if backend:
+        backend = Backend(backend)
+    else:
+        backend = Backend("undefined")
+
+    if timeout is None:
+        timeout = timedelta(seconds=1800)  # 30 min — inter-node NCCL PG can be slow
+
+    if store is None:
+        rendezvous_uri = init_method
+        assert rendezvous_uri is not None
+        print(
+            f"[wbridge-pg] rank {rank}/{world_size} rendezvous at {rendezvous_uri} group={group_name}",
+            flush=True,
+        )
+        rendezvous_iterator = rendezvous(
+            rendezvous_uri, rank, world_size, timeout=timeout
+        )
+        store, rank, world_size = next(rendezvous_iterator)
+        print(
+            f"[wbridge-pg] rank {rank}/{world_size} rendezvous done, creating group",
+            flush=True,
+        )
+        store.set_timeout(timeout)
+        gn = group_name
+        assert gn is not None
+        store = PrefixStore(gn, store)
+
+    # NOTE: The pg_options parameter was renamed into backend_options in PyTorch 2.6.0
+    pg_options_param_name = (
+        "backend_options" if parse(torch.__version__) >= parse("2.6") else "pg_options"
+    )
+    pg, _ = _new_process_group_helper(
+        world_size,
+        rank,
+        [],
+        backend,
+        store,
+        group_name=group_name,
+        **{pg_options_param_name: pg_options},
+        timeout=timeout,
+        # NOTE: no device_id — see docstring for why eager connect is avoided.
+    )
+    print(f"[wbridge-pg] rank {rank}/{world_size} process group created", flush=True)
+
+    _world.pg_group_ranks[pg] = {i: i for i in range(world_size)}
+    return pg

--- a/examples/weightbridge/wbridge/utils/layout.py
+++ b/examples/weightbridge/wbridge/utils/layout.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+

--- a/examples/weightbridge/wbridge/utils/specgen.py
+++ b/examples/weightbridge/wbridge/utils/specgen.py
@@ -1,0 +1,1696 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Infer a :class:`~wbridge.utils.data.LoadSpec` by probing HF weight factories
+through a ``load_weights``-style callable.
+
+Algorithm overview
+~~~~~~~~~~~~~~~~~~
+1. **Index encoding.** Each HF tensor element gets a unique structured index
+   ``name_idx | x_0 | x_1 | … | x_{d-1}`` (bit-concatenation, name in the
+   lowest bits).  Name indices are 1-based so that 0 identifies unmapped
+   worker elements.
+
+2. **Dtype-grouped probing.** Worker tensors are partitioned by dtype.  For
+   each dtype group the index tensor is chunked to the group's element width,
+   and one full ``load_weights`` call per chunk copies the encoded indices
+   into the worker state dict.  Across groups this yields O(G × C)
+   ``load_weights`` calls, where *G* is the number of distinct worker dtypes
+   (typically 1–2) and *C = ceil(max_index_bits / element_bits)* (typically
+   1–3).
+
+3. **Shard extraction.** From the per-element index map the name bits
+   identify which HF tensor each worker element came from; the coordinate
+   bits give the source position.  Axis-aligned rectangular boxes are
+   detected with the same successor / corner logic used previously.
+
+Core assumption
+~~~~~~~~~~~~~~~
+``lw`` must accept HF tensors in any dtype.  For each element whose HF
+tensor has the **same dtype** as its destination worker tensor, ``lw`` must
+preserve the element value exactly (pure bijective copy/scatter — no
+arithmetic).  Elements crossing a dtype boundary may be corrupted; only
+same-dtype pairs are relied upon.
+
+The full-iterator principle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Every ``lw`` call receives the complete dict of HF tensor name→factory
+mappings (though with probe values rather than real weights).  This avoids
+problems with ``load_weights`` implementations that perform inter-rank
+communication (e.g. broadcasting shared embeddings when PP > 1).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import time
+from collections import defaultdict
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from wbridge.utils.data import LoadSpec, logical_tensor_name, Shard, ShardMapping
+
+HFWeightFetcher = dict[str, Callable[[], torch.Tensor]]
+"""Mapping from HF tensor names to zero-arg callables that return the tensor."""
+
+LoadWeightsFn = Callable[[HFWeightFetcher], Any]
+"""A ``load_weights``-style callable that accepts an :data:`HFWeightFetcher`."""
+
+WksdFactory = Callable[[], dict[str, torch.Tensor]]
+"""Zero-arg callable returning a fresh GPU worker state dict snapshot.
+
+Frameworks that replace parameter tensors during ``load_weights`` (e.g. SGLang MoE
+expert fusion) must return a new snapshot on each call so that specgen reads correct
+values and old tensors can be freed by GC."""
+
+# Default cap on total CPU storage for HF placeholder tensors per infer batch.
+DEFAULT_MAX_HF_BYTES = 20 * 1024**3
+
+# Structured indices are represented as int64 while they are built and
+# compressed.  Keep every logical/source and worker probe slice below this
+# size; the actual arithmetic is tiled more finely to leave headroom for
+# temporary operands used by bit packing, diff2, remainder, and carry.
+DEFAULT_SPECGEN_I64_CAP_BYTES = 512 * 1024**2
+SPECGEN_I64_CAP_ENV = "WBRIDGE_SPECGEN_I64_CAP_BYTES"
+SPECGEN_PROBE_DEVICE_ENV = "WBRIDGE_SPECGEN_PROBE_DEVICE"
+_SPECGEN_BUILD_TILE_BYTES = 64 * 1024**2
+_SPECGEN_DIFF_TILE_BYTES = 64 * 1024**2
+_SPECGEN_CUDA_BUILD_RESERVE_BYTES = 512 * 1024**2
+# When complete probe sources cannot safely remain in HBM, keep the
+# loader-visible tensor on CPU but populate it using bounded CUDA row tiles.
+# This cap is based on the emitted checkpoint dtype, not the temporary int64
+# representation governed by DEFAULT_SPECGEN_I64_CAP_BYTES.
+_SPECGEN_CUDA_ROW_TILE_BYTES = 512 * 1024**2
+# SGLang's checkpoint loader may retain the current source tensor while it
+# asks the fetcher for the next one.  Budgeting only one physical source can
+# therefore pass the preflight check and still OOM on the following fetch.
+_SPECGEN_CUDA_MAX_LIVE_SOURCE_TENSORS = 2
+
+logger = logging.getLogger(__name__)
+
+
+def _select_probe_build_device(
+    hf_names: list[str],
+    source_pieces: dict[str, list["_LogicalSourcePiece"]],
+    group_dtype: torch.dtype,
+) -> torch.device:
+    """Choose whether complete loader-visible probes may remain on CUDA.
+
+    A model loader normally accepts CPU checkpoint tensors and copies only the
+    local shard to GPU.  Prefer complete CUDA probes when physical sources fit
+    with conservative scratch headroom.  A CPU result selects bounded staging:
+    probes up to :data:`_SPECGEN_CUDA_ROW_TILE_BYTES` still remain on CUDA, and
+    larger loader-visible CPU tensors are populated one CUDA-built row tile at
+    a time.  Probe arithmetic therefore remains on CUDA.  The loader is allowed
+    to retain one source while fetching the next, so auto placement budgets two
+    largest-source tensors.
+
+    ``WBRIDGE_SPECGEN_PROBE_DEVICE=cpu|cuda`` is an explicit diagnostic
+    override; the default is ``auto``.
+    """
+    requested = os.environ.get(SPECGEN_PROBE_DEVICE_ENV, "auto").strip().lower()
+    if requested not in {"auto", "cpu", "cuda"}:
+        raise ValueError(
+            f"{SPECGEN_PROBE_DEVICE_ENV} must be auto, cpu, or cuda, got {requested!r}"
+        )
+    if requested == "cpu" or not torch.cuda.is_available():
+        return torch.device("cpu")
+    if requested == "cuda":
+        return torch.device("cuda")
+
+    max_source_bytes = max(
+        (
+            math.prod(source_pieces[name][0].full_shape) * group_dtype.itemsize
+            for name in hf_names
+        ),
+        default=0,
+    )
+    # Release only unused allocator cache before measuring.  Live model and
+    # KV-cache allocations remain accounted for by mem_get_info().
+    torch.cuda.empty_cache()
+    free_bytes, _total_bytes = torch.cuda.mem_get_info()
+    required_bytes = (
+        _SPECGEN_CUDA_MAX_LIVE_SOURCE_TENSORS * max_source_bytes
+        + _SPECGEN_CUDA_BUILD_RESERVE_BYTES
+    )
+    device = torch.device("cuda" if required_bytes <= free_bytes else "cpu")
+    logger.info(
+        "specgen probe source mode=%s for %s: largest source=%.2f GiB, "
+        "CUDA free=%.2f GiB, required for %d live sources with reserve=%.2f GiB",
+        "cuda-resident" if device.type == "cuda" else "cuda-row-staged",
+        group_dtype,
+        max_source_bytes / 1024**3,
+        free_bytes / 1024**3,
+        _SPECGEN_CUDA_MAX_LIVE_SOURCE_TENSORS,
+        required_bytes / 1024**3,
+    )
+    return device
+
+
+@dataclass(frozen=True)
+class _LogicalSourcePiece:
+    """One dim-0 interval in the structured-index namespace.
+
+    ``logical_name`` gets its own encoded tensor id, but coordinates retain
+    the physical tensor's coordinate system.  This lets the load-weights
+    callable continue receiving the original tensor name and shape while the
+    final LoadSpec can be canonicalised by renaming and merging only.
+    """
+
+    physical_name: str
+    logical_name: str
+    start: int
+    end: int
+    full_shape: tuple[int, ...]
+
+
+@dataclass
+class _SparseWorkerSlice:
+    """Sparse probe chunks for one bounded flattened-row worker slice.
+
+    Worker tensors are viewed as ``(-1, shape[-1])`` for ndim >= 2.  This
+    keeps a fused expert tensor such as ``(experts, rows, cols)`` tileable
+    even when one dim-0 slab is larger than the execution-memory cap.
+    """
+
+    row_start: int
+    row_end: int
+    shape: tuple[int, ...]
+    chunks: list[torch.Tensor] = field(default_factory=list)
+
+
+def specgen_i64_cap_bytes() -> int | float:
+    """Return the configured int64 probe cap; ``inf`` disables splitting."""
+    raw = (
+        os.environ.get(
+            SPECGEN_I64_CAP_ENV,
+            str(DEFAULT_SPECGEN_I64_CAP_BYTES),
+        )
+        .strip()
+        .lower()
+    )
+    if raw in {"inf", "+inf", "infinity", "+infinity"}:
+        return math.inf
+    try:
+        cap = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{SPECGEN_I64_CAP_ENV} must be a positive integer or 'inf', got {raw!r}"
+        ) from exc
+    if cap <= 0:
+        raise ValueError(f"{SPECGEN_I64_CAP_ENV} must be positive or 'inf', got {cap}")
+    return cap
+
+
+def _resolve_i64_cap(cap: int | float | None) -> int | float:
+    resolved = specgen_i64_cap_bytes() if cap is None else cap
+    if isinstance(resolved, float) and math.isinf(resolved):
+        return math.inf
+    try:
+        resolved_int = int(resolved)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(
+            f"specgen int64 cap must be a positive integer or inf, got {resolved!r}"
+        ) from exc
+    if resolved_int <= 0:
+        raise ValueError(
+            f"specgen int64 cap must be positive or inf, got {resolved_int}"
+        )
+    return resolved_int
+
+
+def _plan_logical_sources(
+    hf_shapes: dict[str, tuple[int, ...]],
+    i64_cap_bytes: int | float,
+) -> tuple[dict[str, list[_LogicalSourcePiece]], dict[str, tuple[int, ...]]]:
+    """Split oversized encoded HF tensors on dim 0.
+
+    The logical tensor's decoded coordinates deliberately use ``full_shape``
+    rather than a piece-local shape.  Therefore its inferred source shards are
+    already expressed in physical checkpoint coordinates.
+    """
+    by_physical: dict[str, list[_LogicalSourcePiece]] = {}
+    logical_shapes: dict[str, tuple[int, ...]] = {}
+
+    for name in sorted(hf_shapes):
+        shape = hf_shapes[name]
+        numel = math.prod(shape)
+        should_split = (
+            not math.isinf(i64_cap_bytes)
+            and shape
+            and numel * torch.int64.itemsize > i64_cap_bytes
+        )
+        if not should_split:
+            piece = _LogicalSourcePiece(name, name, 0, shape[0] if shape else 1, shape)
+            by_physical[name] = [piece]
+            logical_shapes[name] = shape
+            continue
+
+        row_i64_bytes = math.prod(shape[1:]) * torch.int64.itemsize
+        if row_i64_bytes > i64_cap_bytes:
+            raise ValueError(
+                f"cannot cap structured index for {name!r} at {i64_cap_bytes} bytes by "
+                f"splitting dim 0: one row is {row_i64_bytes} bytes (shape={shape})"
+            )
+        rows_per_piece = max(1, int(i64_cap_bytes) // row_i64_bytes)
+        pieces: list[_LogicalSourcePiece] = []
+        for start in range(0, shape[0], rows_per_piece):
+            end = min(start + rows_per_piece, shape[0])
+            lname = logical_tensor_name(name, start, end)
+            piece = _LogicalSourcePiece(name, lname, start, end, shape)
+            pieces.append(piece)
+            logical_shapes[lname] = shape
+        by_physical[name] = pieces
+
+    return by_physical, logical_shapes
+
+
+def _plan_worker_slices(
+    shape: tuple[int, ...],
+    i64_cap_bytes: int | float,
+) -> list[tuple[int, int, tuple[int, ...]]]:
+    """Return bounded flattened-row slices for sparse compression.
+
+    Diff2 already treats every ndim >= 2 tensor as a matrix whose columns
+    are the physical last dimension.  Tile that same matrix by rows instead
+    of requiring a complete dim-0 slab to fit.  For fused MoE tensors this
+    changes the indivisible unit from ``rows * cols`` to only ``cols``.
+    """
+    if not shape:
+        return [(0, 1, shape)]
+    # Diff/remainder/carry have overlapping live temporaries.  A smaller
+    # execution tile than the logical cap keeps peak GPU memory predictable.
+    exec_cap = _SPECGEN_DIFF_TILE_BYTES
+    if not math.isinf(i64_cap_bytes):
+        exec_cap = min(exec_cap, int(i64_cap_bytes))
+    if len(shape) == 1:
+        rows = shape[0]
+        row_width = 1
+    else:
+        rows = math.prod(shape[:-1])
+        row_width = shape[-1]
+    row_i64_bytes = row_width * torch.int64.itemsize
+    if row_i64_bytes > exec_cap:
+        raise ValueError(
+            f"cannot bound worker structured index at {exec_cap} bytes by splitting "
+            f"flattened rows: the last dimension is {row_i64_bytes} bytes "
+            f"(shape={shape})"
+        )
+    rows_per_slice = max(1, exec_cap // row_i64_bytes)
+    return [
+        (
+            start,
+            min(start + rows_per_slice, rows),
+            (
+                (min(start + rows_per_slice, rows) - start,)
+                if len(shape) == 1
+                else (min(start + rows_per_slice, rows) - start, shape[-1])
+            ),
+        )
+        for start in range(0, rows, rows_per_slice)
+    ]
+
+
+def verify_load_spec(
+    hf_weights: HFWeightFetcher,
+    wksd_factory: WksdFactory,
+    load_spec: LoadSpec,
+) -> None:
+    """Assume ``lw`` was already run so *wksd* holds the loaded weights.
+
+    For each worker key, build a zero tensor matching *wksd*[*key*], copy *hfsd*
+    slices into it according to *load_spec*, then ``torch.equal`` against *wksd*.
+    """
+    wksd = wksd_factory()
+    assert wksd, "wksd must be non-empty"
+    expected = {k: torch.zeros_like(v, device="cpu") for k, v in wksd.items()}
+
+    load_spec.load_from_full(hf_weights, expected)
+
+    for k, v in wksd.items():
+        assert torch.equal(expected[k].to(v.device), v), (
+            f"verify_load_spec: mismatch on worker key {k}"
+        )
+    logger.info("verify_load_spec: LoadSpec verification succeeded")
+
+
+# ---------------------------------------------------------------------------
+# Index encoding helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_chunk_gpu(
+    name_idx: int,
+    shape: tuple[int, ...],
+    n_bits: int,
+    chunk_k: int,
+    ele_bits: int,
+    target_dtype: torch.dtype,
+    device: torch.device,
+    *,
+    dim0_start: int = 0,
+    dim0_end: int | None = None,
+) -> torch.Tensor:
+    """Build one physical dim-0 slice of a structured-index chunk.
+
+    Equivalent to ``_extract_chunk(_build_index_tensor(name_idx, shape, n_bits),
+    chunk_k, ele_bits, target_dtype)`` but avoids materialising the full
+    int64 tensor.  Coordinates remain relative to the full physical ``shape``;
+    only the returned tensor is sliced.  The bit-window we keep is
+    ``[chunk_k*ele_bits, (chunk_k+1)*ele_bits)``.
+
+    Construction itself is tiled so the int64 ``flat``/coordinate/packed
+    temporaries stay small even when an explicitly infinite logical cap is
+    used for equivalence testing.
+    """
+    if shape:
+        end = shape[0] if dim0_end is None else dim0_end
+        if not 0 <= dim0_start <= end <= shape[0]:
+            raise ValueError(
+                f"invalid dim-0 probe interval [{dim0_start}, {end}) for shape {shape}"
+            )
+        slice_shape = (end - dim0_start, *shape[1:])
+        row_numel = math.prod(shape[1:])
+        global_flat_start = dim0_start * row_numel
+    else:
+        if dim0_start != 0 or dim0_end not in (None, 1):
+            raise ValueError(
+                f"invalid scalar probe interval [{dim0_start}, {dim0_end})"
+            )
+        slice_shape = shape
+        global_flat_start = 0
+
+    numel = math.prod(slice_shape)
+    if numel == 0:
+        return torch.zeros(slice_shape, dtype=target_dtype, device=device)
+
+    int_dtype = getattr(torch, f"int{ele_bits}")
+    strides: list[int] = []
+    s = 1
+    for i in range(len(shape) - 1, -1, -1):
+        strides.insert(0, s)
+        s *= shape[i]
+    chunk_lo = chunk_k * ele_bits
+    chunk_hi = chunk_lo + ele_bits
+    out = torch.empty(numel, dtype=target_dtype, device=device)
+    tile_elements = max(1, _SPECGEN_BUILD_TILE_BYTES // torch.int64.itemsize)
+
+    for local_start in range(0, numel, tile_elements):
+        local_end = min(local_start + tile_elements, numel)
+        tile_numel = local_end - local_start
+        chunk = torch.zeros(tile_numel, dtype=torch.int64, device=device)
+
+        # Bind chunk as a default so the closure captures this iteration's
+        # tensor rather than the loop variable.
+        def _add(
+            value: int | torch.Tensor,
+            bit_offset: int,
+            chunk: torch.Tensor = chunk,
+        ) -> None:
+            rel = bit_offset - chunk_lo
+            if isinstance(value, int):
+                shifted = value << rel if rel >= 0 else value >> (-rel)
+                chunk.bitwise_or_(shifted)
+                return
+            shifted = value << rel if rel >= 0 else value >> (-rel)
+            chunk.bitwise_or_(shifted)
+
+        if n_bits > 0 and chunk_lo < n_bits:
+            _add(name_idx, 0)
+        flat = torch.arange(
+            global_flat_start + local_start,
+            global_flat_start + local_end,
+            dtype=torch.int64,
+            device=device,
+        )
+        bit_offset = n_bits
+        for d, dim_size in enumerate(shape):
+            if dim_size <= 1:
+                continue
+            dim_bits = (dim_size - 1).bit_length()
+            if chunk_lo < bit_offset + dim_bits and chunk_hi > bit_offset:
+                coord = (flat // strides[d]) % dim_size
+                _add(coord, bit_offset)
+                del coord
+            bit_offset += dim_bits
+
+        if ele_bits < 64:
+            chunk.bitwise_and_((1 << ele_bits) - 1)
+        encoded = chunk.to(int_dtype).view(target_dtype)
+        out[local_start:local_end].copy_(encoded)
+        del flat, chunk, encoded
+
+    return out.reshape(slice_shape)
+
+
+def _build_physical_chunk_on_device(
+    pieces: list[_LogicalSourcePiece],
+    name_to_idx: dict[str, int],
+    n_bits: int,
+    chunk_k: int,
+    ele_bits: int,
+    target_dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Assemble one loader-visible physical tensor directly on *device*."""
+    if not pieces:
+        raise ValueError("a physical source must contain at least one logical piece")
+    shape = pieces[0].full_shape
+    if len(pieces) == 1 and pieces[0].logical_name == pieces[0].physical_name:
+        piece = pieces[0]
+        return _build_chunk_gpu(
+            name_to_idx[piece.logical_name],
+            shape,
+            n_bits,
+            chunk_k,
+            ele_bits,
+            target_dtype,
+            device,
+            dim0_start=piece.start,
+            dim0_end=piece.end,
+        )
+    out = torch.empty(shape, dtype=target_dtype, device=device)
+    for piece in pieces:
+        encoded = _build_chunk_gpu(
+            name_to_idx[piece.logical_name],
+            shape,
+            n_bits,
+            chunk_k,
+            ele_bits,
+            target_dtype,
+            device,
+            dim0_start=piece.start,
+            dim0_end=piece.end,
+        )
+        if shape:
+            out[piece.start : piece.end].copy_(encoded)
+        else:
+            out.copy_(encoded)
+        del encoded
+    return out
+
+
+def _build_physical_chunk(
+    pieces: list[_LogicalSourcePiece],
+    name_to_idx: dict[str, int],
+    n_bits: int,
+    chunk_k: int,
+    ele_bits: int,
+    target_dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build a physical probe without performing probe arithmetic on CPU.
+
+    ``device=cpu`` means a complete source was too large for the conservative
+    HBM preflight.  Sources no larger than the row-tile cap are still returned
+    directly from CUDA.  Larger sources get a CPU backing tensor, while each
+    logical piece is subdivided along dim 0, built on CUDA, and copied into its
+    corresponding CPU interval.  Tile boundaries never cross logical pieces,
+    since each piece has its own encoded name id.
+
+    The direct CPU path is retained only for CUDA-less utility use; normal
+    inference requires CUDA worker tensors.
+    """
+    if not pieces:
+        raise ValueError("a physical source must contain at least one logical piece")
+    if device.type != "cpu" or not torch.cuda.is_available():
+        return _build_physical_chunk_on_device(
+            pieces,
+            name_to_idx,
+            n_bits,
+            chunk_k,
+            ele_bits,
+            target_dtype,
+            device,
+        )
+
+    shape = pieces[0].full_shape
+    source_bytes = math.prod(shape) * target_dtype.itemsize
+    cuda_device = torch.device("cuda", torch.cuda.current_device())
+    if source_bytes <= _SPECGEN_CUDA_ROW_TILE_BYTES:
+        return _build_physical_chunk_on_device(
+            pieces,
+            name_to_idx,
+            n_bits,
+            chunk_k,
+            ele_bits,
+            target_dtype,
+            cuda_device,
+        )
+
+    # A scalar cannot reach the default cap, but handle a test/configuration
+    # that lowers it below one element without falling back to CPU arithmetic.
+    if not shape:
+        return _build_physical_chunk_on_device(
+            pieces,
+            name_to_idx,
+            n_bits,
+            chunk_k,
+            ele_bits,
+            target_dtype,
+            cuda_device,
+        ).cpu()
+
+    out = torch.empty(shape, dtype=target_dtype, device="cpu")
+    row_bytes = math.prod(shape[1:]) * target_dtype.itemsize
+    # If one row itself exceeds the cap, one row is the smallest legal tile.
+    rows_per_tile = max(1, _SPECGEN_CUDA_ROW_TILE_BYTES // max(1, row_bytes))
+    for piece in pieces:
+        for row_start in range(piece.start, piece.end, rows_per_tile):
+            row_end = min(row_start + rows_per_tile, piece.end)
+            encoded = _build_chunk_gpu(
+                name_to_idx[piece.logical_name],
+                shape,
+                n_bits,
+                chunk_k,
+                ele_bits,
+                target_dtype,
+                cuda_device,
+                dim0_start=row_start,
+                dim0_end=row_end,
+            )
+            out[row_start:row_end].copy_(encoded)
+            del encoded
+    return out
+
+
+def _build_index_tensor(
+    name_idx: int, shape: tuple[int, ...], n_bits: int
+) -> torch.Tensor:
+    """Build a structured-index tensor for one HF tensor.
+
+    Each element at coordinates ``(x_0, x_1, …, x_{d-1})`` is assigned::
+
+        name_idx  |  x_0  |  x_1  |  …  |  x_{d-1}
+
+    ``|`` is bit concatenation; *name_idx* occupies the **lowest** *n_bits*.
+    """
+    numel = 1
+    for s in shape:
+        numel *= s
+    if numel == 0:
+        return torch.zeros(shape, dtype=torch.int64)
+
+    # Row-major strides
+    strides: list[int] = []
+    s = 1
+    for i in range(len(shape) - 1, -1, -1):
+        strides.insert(0, s)
+        s *= shape[i]
+
+    flat = torch.arange(numel, dtype=torch.int64)
+    result = torch.full((numel,), name_idx, dtype=torch.int64)
+
+    bit_offset = n_bits
+    for d, dim_size in enumerate(shape):
+        if dim_size <= 1:
+            continue
+        dim_bits = (dim_size - 1).bit_length()
+        coord = (flat // strides[d]) % dim_size
+        result |= coord << bit_offset
+        bit_offset += dim_bits
+
+    return result.reshape(shape)
+
+
+def _extract_chunk(
+    full_index: torch.Tensor, chunk_k: int, ele_bits: int, target_dtype: torch.dtype
+) -> torch.Tensor:
+    """Return bits ``[k*B, (k+1)*B)`` of *full_index*, reinterpreted as *target_dtype*."""
+    int_dtype = getattr(torch, f"int{ele_bits}")
+    mask = (1 << ele_bits) - 1
+    chunk = ((full_index >> (chunk_k * ele_bits)) & mask).to(int_dtype)
+    return chunk.view(target_dtype)
+
+
+def _coord_bits_for_shape(shape: tuple[int, ...]) -> int:
+    """Total coordinate bits needed for one tensor shape."""
+    return sum((d - 1).bit_length() if d > 1 else 0 for d in shape)
+
+
+def _decode_coords(val: int, hf_shape: tuple[int, ...], n_bits: int) -> tuple[int, ...]:
+    """Decode an int64 structured index into (name_idx, coord_0, coord_1, ...)."""
+    name_idx = val & ((1 << n_bits) - 1)
+    coords: list[int] = []
+    bit_offset = n_bits
+    for dim_size in hf_shape:
+        if dim_size <= 1:
+            coords.append(0)
+        else:
+            dim_bits = (dim_size - 1).bit_length()
+            coords.append((val >> bit_offset) & ((1 << dim_bits) - 1))
+            bit_offset += dim_bits
+    return (name_idx, *coords)
+
+
+def _shard_diff2(
+    r0: int,
+    r1: int,
+    c0: int,
+    c1: int,
+    val0: int,
+    stride_down: int,
+    stride_right: int,
+    H: int,
+    W: int,
+) -> list[tuple[int, int, int]]:
+    """Analytically compute the diff2 entries of a rectangular shard.
+
+    Returns sorted ``(row, col, value)`` triples for the separable 2nd-order
+    difference of ``f(r, c) = val0 + stride_down*(r-r0) + stride_right*(c-c0)``
+    over the region ``[r0:r1, c0:c1]``, with zero-padding outside.
+    At most 16 entries (4 row positions × 4 column positions).
+
+    Operates in exact int64 arithmetic — matches the probing path which
+    also diff2s in int64 (zero-extended, unshifted).
+    """
+    A, B, C = val0, stride_down, stride_right
+    span_r, span_c = r1 - r0, c1 - c0
+
+    col_params: list[tuple[int, int, int]] = [(c0, A, B)]
+    if c0 + 1 < W:
+        col_params.append((c0 + 1, C - A, -B))
+    if c1 < W:
+        col_params.append((c1, -(A + C * span_c), -B))
+    if c1 + 1 < W:
+        col_params.append((c1 + 1, A + C * (span_c - 1), B))
+
+    accum: dict[tuple[int, int], int] = {}
+    for col, alpha, beta in col_params:
+        pairs: list[tuple[int, int]] = [(r0, alpha)]
+        if r0 + 1 < H:
+            pairs.append((r0 + 1, beta - alpha))
+        if r1 < H:
+            pairs.append((r1, -(alpha + beta * span_r)))
+        if r1 + 1 < H:
+            pairs.append((r1 + 1, alpha + beta * (span_r - 1)))
+        for row, v in pairs:
+            key = (row, col)
+            accum[key] = accum.get(key, 0) + v
+
+    return [(r, c, v) for (r, c), v in sorted(accum.items()) if v != 0]
+
+
+def _extract_shards_greedy(
+    entries: list[list[int]],
+    wk_shape: tuple[int, ...],
+    H: int,
+    W: int,
+    n_bits: int,
+    idx_to_name: dict[int, str],
+    hf_shapes: dict[str, tuple[int, ...]],
+) -> dict[str, list[ShardMapping]]:
+    """Extract shard mappings from a sorted diff2 entry list.
+
+    *entries* is a mutable ``[[row, col, value], ...]`` list sorted by
+    ``(row, col)``.  Entries are consumed (removed / updated) as shards are
+    extracted.
+
+    Under the 2D-prefix invariant the first entry is the top-left corner of
+    the next shard.  Its value equals the original structured index there
+    (no contributions from above or left).  Strides are recovered from the
+    adjacent entries, boundaries from the next entry along the same row/col.
+
+    Complexity: O(n²) per tensor where n = total entries.
+    """
+    name_mask = (1 << n_bits) - 1
+    orig_ndim = len(wk_shape)
+    mappings: dict[str, list[ShardMapping]] = {}
+
+    while entries:
+        r0, c0, val0 = entries[0]
+        nid = val0 & name_mask
+        if nid == 0:
+            entries.pop(0)
+            continue
+
+        hf_name = idx_to_name[nid]
+        hf_shape = hf_shapes[hf_name]
+        hf_ndim = len(hf_shape)
+        coords0 = _decode_coords(val0, hf_shape, n_bits)
+
+        # ---- Find v_right (entry at (r0, c0+1)) and v_down (at (r0+1, c0)) ----
+        v_right = 0
+        v_down = 0
+        for e in entries:
+            if e[0] == r0 and e[1] == c0 + 1:
+                v_right = e[2]
+            elif e[0] == r0 + 1 and e[1] == c0:
+                v_down = e[2]
+            elif e[0] > r0 + 1:
+                break
+
+        stride_right = val0 + v_right
+        stride_down = val0 + v_down
+
+        # ---- Validate strides via coordinate decoding ----
+        right_valid = False
+        transposed = False
+        if hf_ndim == 1 and stride_right != 0:
+            cr = _decode_coords(val0 + stride_right, hf_shape, n_bits)
+            right_valid = cr[0] == coords0[0] and cr[1] == coords0[1] + 1
+        elif hf_ndim >= 2 and stride_right != 0:
+            cr = _decode_coords(val0 + stride_right, hf_shape, n_bits)
+            exp_normal = list(coords0[1:])
+            exp_normal[-1] += 1
+            exp_trans = list(coords0[1:])
+            exp_trans[-2] += 1
+            if list(cr[1:]) == exp_normal:
+                right_valid = True
+            elif list(cr[1:]) == exp_trans:
+                right_valid = True
+                transposed = True
+
+        down_valid = False
+        if hf_ndim == 1:
+            down_valid = True  # 1D always extends if stride is valid
+        elif hf_ndim >= 2 and stride_down != 0:
+            cd = _decode_coords(val0 + stride_down, hf_shape, n_bits)
+            if not transposed:
+                exp_down = list(coords0[1:])
+                exp_down[-2] += 1
+                exp_trans_down = list(coords0[1:])
+                exp_trans_down[-1] += 1
+                if r0 + 1 < H and list(cd[1:]) == exp_trans_down:
+                    # A transposed shard only one destination column wide has
+                    # no right-neighbour from which to infer orientation.
+                    # Its downward stride still identifies the transpose.
+                    transposed = True
+                    down_valid = True
+                else:
+                    down_valid = list(cd[1:]) == exp_down
+            else:
+                exp_down = list(coords0[1:])
+                exp_down[-1] += 1
+                down_valid = list(cd[1:]) == exp_down
+
+        # ---- Determine c1 ----
+        if right_valid:
+            # c1 = next entry in row r0 beyond c0+1, or W
+            c1 = W
+            for e in entries:
+                if e[0] == r0 and e[1] > c0 + 1:
+                    c1 = e[1]
+                    break
+                if e[0] > r0:
+                    break
+        else:
+            c1 = c0 + 1
+
+        col_span = c1 - c0
+
+        # ---- Determine r1 ----
+        if down_valid:
+            # r1 = next entry at col c0 beyond the stride entry, or H.
+            # If there's an entry at (r0+1, c0), skip it (it's the stride).
+            # The next entry at col c0 after that is the boundary.
+            skip_row = r0 + 1 if v_down != 0 else r0
+            r1 = H
+            for e in entries:
+                if e[1] == c0 and e[0] > skip_row:
+                    r1 = e[0]
+                    break
+        else:
+            r1 = r0 + 1
+
+        # For 1D HF into 2D wk, stride_down should advance by col_span coords
+        if hf_ndim == 1 and down_valid:
+            cd = _decode_coords(val0 + stride_down, hf_shape, n_bits)
+            if cd[0] != coords0[0] or cd[1] != coords0[1] + col_span:
+                down_valid = False
+                r1 = r0 + 1
+
+        # ---- Subtract shard's diff2 contribution ----
+        shard_d2 = _shard_diff2(
+            r0,
+            r1,
+            c0,
+            c1,
+            val0,
+            stride_down if down_valid else 0,
+            stride_right if right_valid else 0,
+            H,
+            W,
+        )
+        for sr, sc, sv in shard_d2:
+            found = False
+            for i in range(len(entries)):
+                if entries[i][0] == sr and entries[i][1] == sc:
+                    entries[i][2] -= sv
+                    if entries[i][2] == 0:
+                        entries.pop(i)
+                    found = True
+                    break
+                if entries[i][0] > sr or (entries[i][0] == sr and entries[i][1] > sc):
+                    break
+            if not found and sv != 0:
+                # Insert maintaining sort order
+                new_e = [sr, sc, -sv]
+                for i in range(len(entries)):
+                    if (entries[i][0] > sr) or (
+                        entries[i][0] == sr and entries[i][1] > sc
+                    ):
+                        entries.insert(i, new_e)
+                        break
+                else:
+                    entries.append(new_e)
+
+        # ---- Build shard mapping ----
+        hf_r0 = coords0[-2] if hf_ndim >= 2 else coords0[1]
+        hf_c0 = coords0[-1] if hf_ndim >= 2 else coords0[1]
+
+        if hf_ndim == 1:
+            hf_start = coords0[1]
+            hf_end = hf_start + (r1 - r0) * col_span
+            hf_shard = [(hf_start, hf_end, hf_shape[0])]
+            if orig_ndim == 1:
+                wk_shard = [(c0, c0 + (r1 - r0) * col_span, wk_shape[0])]
+            else:
+                wk_shard = [(r0, r1, H), (c0, c1, W)]
+        elif hf_ndim == 2:
+            if not transposed:
+                hf_shard = [
+                    (hf_r0, hf_r0 + (r1 - r0), hf_shape[0]),
+                    (hf_c0, hf_c0 + col_span, hf_shape[1]),
+                ]
+            else:
+                hf_shard = [
+                    (hf_r0, hf_r0 + col_span, -hf_shape[0]),
+                    (hf_c0, hf_c0 + (r1 - r0), hf_shape[1]),
+                ]
+            wk_shard = [(r0, r1, H), (c0, c1, W)]
+        else:
+            if not transposed:
+                hf_shard = [
+                    (
+                        coords0[d + 1],
+                        coords0[d + 1]
+                        + (
+                            (r1 - r0)
+                            if d == hf_ndim - 2
+                            else col_span
+                            if d == hf_ndim - 1
+                            else 1
+                        ),
+                        hf_shape[d],
+                    )
+                    for d in range(hf_ndim)
+                ]
+            else:
+                hf_shard = [
+                    (
+                        coords0[d + 1],
+                        coords0[d + 1]
+                        + (
+                            col_span
+                            if d == hf_ndim - 2
+                            else (r1 - r0)
+                            if d == hf_ndim - 1
+                            else 1
+                        ),
+                        -hf_shape[d] if d == hf_ndim - 2 else hf_shape[d],
+                    )
+                    for d in range(hf_ndim)
+                ]
+            wk_shard = [(r0, r1, H), (c0, c1, W)]
+
+        if orig_ndim == 1 and len(wk_shard) == 2:
+            flat_start = r0 * W + c0
+            flat_end = flat_start + (r1 - r0) * col_span
+            wk_shard = [(flat_start, flat_end, wk_shape[0])]
+
+        mappings.setdefault(hf_name, []).append((hf_shard, wk_shard))
+
+    return mappings
+
+
+def _diff2_inplace(t: torch.Tensor) -> torch.Tensor:
+    """Compute 2D separable 2nd-order difference in-place.
+
+    For a 2D tensor of shape ``(H, W)``::
+
+        d2[r, c] = t[r,c] - 2*t[r,c-1] + t[r,c-2]   (along cols first)
+
+    then the same along rows.  Edges assume zero-padding.
+
+    For ≥3D, the leading dimensions are flattened to rows (``(-1, last_dim)``).
+    For 1D, a row dimension of 1 is prepended.
+
+    A contiguous rectangular shard whose structured-index values are affine
+    in ``(row, col)`` produces **O(1) nonzeros** — at most 16 at the 4
+    corners of each box.  This lets us compress each chunk to a sparse COO
+    representation on CPU.
+    """
+    orig_shape = t.shape
+    if t.ndim == 0 or t.numel() == 0:
+        return t
+    if t.ndim == 1:
+        t = t.unsqueeze(0)
+    elif t.ndim > 2:
+        t = t.reshape(-1, t.shape[-1])
+
+    H, W = t.shape
+
+    # A separable diff2 is two strided diff1 passes per axis.  The vectorised
+    # diff1 helper materialises only one bounded-slice temporary per pass,
+    # rather than the multiple full-size operands in the expanded
+    # ``x - 2*x_prev + x_prev2`` expression.
+    if W >= 2:
+        _strided_diff1_2d(t, axis=1, stride=1)
+        _strided_diff1_2d(t, axis=1, stride=1)
+    if H >= 2:
+        _strided_diff1_2d(t, axis=0, stride=1)
+        _strided_diff1_2d(t, axis=0, stride=1)
+
+    return t.reshape(orig_shape)
+
+
+def _prefix_sum_2d(t: torch.Tensor) -> torch.Tensor:
+    """Reconstruct a 2D tensor from its 2nd-order difference (inverse of _diff2_inplace).
+
+    Applies prefix-sum twice along columns, then twice along rows.
+    """
+    orig_shape = t.shape
+    if t.ndim == 0 or t.numel() == 0:
+        return t
+    if t.ndim == 1:
+        t = t.unsqueeze(0)
+    elif t.ndim > 2:
+        t = t.reshape(-1, t.shape[-1])
+
+    # Undo rows first (diff2 did rows last), then columns
+    t.cumsum_(dim=0)
+    t.cumsum_(dim=0)
+    # Then undo columns
+    t.cumsum_(dim=1)
+    t.cumsum_(dim=1)
+
+    return t.reshape(orig_shape)
+
+
+def _strided_diff1_2d(t: torch.Tensor, axis: int, stride: int) -> torch.Tensor:
+    """Strided 1st-order difference along *axis*.
+
+    ``d[i] = t[i] − t[i − stride]`` for ``i >= stride``; ``d[i] = t[i]``
+    otherwise.  Operates in-place using one vectorised difference temporary.
+    """
+    if t.ndim != 2:
+        raise ValueError(
+            f"strided diff1 expects a 2D tensor, got shape {tuple(t.shape)}"
+        )
+    if axis not in (0, 1):
+        raise ValueError(f"strided diff1 axis must be 0 or 1, got {axis}")
+    if stride <= 0:
+        raise ValueError(f"strided diff1 stride must be positive, got {stride}")
+    if axis == 1:
+        if stride < t.shape[1]:
+            t[:, stride:] = t[:, stride:] - t[:, :-stride]
+    else:
+        if stride < t.shape[0]:
+            t[stride:, :] = t[stride:, :] - t[:-stride, :]
+    return t
+
+
+def _strided_prefix_sum_2d(t: torch.Tensor, axis: int, stride: int) -> torch.Tensor:
+    """Inverse of :func:`_strided_diff1_2d` — prefix sum with stride.
+
+    For each independent sub-sequence (offset 0, 1, …, stride-1) along
+    *axis*, computes cumulative sum.  Operates **in-place**.
+    """
+    if axis == 1:
+        for start in range(min(stride, t.shape[1])):
+            t[:, start::stride] = t[:, start::stride].cumsum(dim=1)
+    else:
+        for start in range(min(stride, t.shape[0])):
+            t[start::stride, :] = t[start::stride, :].cumsum(dim=0)
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Dtype-grouped probing
+# ---------------------------------------------------------------------------
+
+
+def _probe_dtype_group(
+    hf_names: list[str],
+    source_pieces: dict[str, list[_LogicalSourcePiece]],
+    name_to_idx: dict[str, int],
+    n_bits: int,
+    max_total_bits: int,
+    wksd_factory: WksdFactory,
+    wk_names: list[str],
+    group_dtype: torch.dtype,
+    lw: LoadWeightsFn,
+    i64_cap_bytes: int | float,
+) -> dict[str, list[_SparseWorkerSlice]]:
+    """Probe one wksd dtype group with carry-aware chunked diff2.
+
+    Processes chunks low-to-high.  After diff2 of each chunk the result
+    is split into a **remainder** (``raw mod M``, O(S) nnz per shard)
+    and a **carry** (``raw // M``).  The carry stays on GPU as a dense
+    tensor and is added to the next chunk's diff2 before splitting.
+    Only the remainder is transferred to CPU as sparse COO.
+
+    After the last chunk, the sign-extension carry (also O(S) nnz) is
+    stored as an extra sparse entry.
+
+    Worker tensors are independently split on flattened leading rows before
+    int64 conversion.  Each slice has its own diff2/carry stream and is
+    extracted in local coordinates later, avoiding the old full-worker int64
+    allocation.
+
+    Returns ``{wk_name: [_SparseWorkerSlice(...), ...]}``.
+    """
+    ele_bits = group_dtype.itemsize * 8
+    num_chunks = max(1, (max_total_bits + ele_bits - 1) // ele_bits)
+    M = 1 << ele_bits
+
+    logger.info(
+        "probing dtype group %s: %d wk tensors, %d chunks "
+        "(ele_bits=%d, max_idx_bits=%d)",
+        group_dtype,
+        len(wk_names),
+        num_chunks,
+        ele_bits,
+        max_total_bits,
+    )
+
+    cuda_avail = torch.cuda.is_available()
+    device = _select_probe_build_device(hf_names, source_pieces, group_dtype)
+    int_dtype = getattr(torch, f"int{ele_bits}")
+
+    initial_wksd = wksd_factory()
+    sparse_slices: dict[str, list[_SparseWorkerSlice]] = {
+        wk: [
+            _SparseWorkerSlice(start, end, slice_shape)
+            for start, end, slice_shape in _plan_worker_slices(
+                tuple(initial_wksd[wk].shape),
+                i64_cap_bytes,
+            )
+        ]
+        for wk in wk_names
+    }
+    del initial_wksd
+    # Carry tensors stored as sparse COO on CPU between chunks to avoid
+    # holding dense int64 GPU tensors for all worker-state keys simultaneously, which can exceed available
+    # memory for large MoE models.
+    prev_carry_sparse: dict[tuple[str, int], torch.Tensor | None] = {
+        (wk, slice_idx): None
+        for wk, slices in sparse_slices.items()
+        for slice_idx in range(len(slices))
+    }
+    total_nnz = 0
+
+    for chunk_k in range(num_chunks):
+        t_chunk0 = time.time()
+
+        def _make_factory(name, ck=chunk_k):
+            def _factory():
+                return _build_physical_chunk(
+                    source_pieces[name],
+                    name_to_idx,
+                    n_bits,
+                    ck,
+                    ele_bits,
+                    group_dtype,
+                    device,
+                )
+
+            return _factory
+
+        chunk_fetcher: HFWeightFetcher = {
+            name: _make_factory(name) for name in hf_names
+        }
+        t_build = time.time()
+
+        # Fresh snapshot: model.load_weights may have replaced parameter
+        # tensors on the previous chunk.  Re-snapshotting drops references
+        # to old tensors so GC can free them.
+        wksd = wksd_factory()
+        for wk in wk_names:
+            wksd[wk].zero_()
+        t_zero = time.time()
+
+        if cuda_avail:
+            _pre = torch.cuda.memory_allocated() / 1e9
+        lw(chunk_fetcher)
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        t_lw = time.time()
+        if cuda_avail:
+            _post = torch.cuda.memory_allocated() / 1e9
+            logger.info(
+                "  chunk %d/%d GPU mem: before_lw=%.2fG after_lw=%.2fG delta=%.2fG",
+                chunk_k + 1,
+                num_chunks,
+                _pre,
+                _post,
+                _post - _pre,
+            )
+
+        # Re-snapshot after lw(): model.load_weights may have replaced
+        # parameter tensors with new fused buffers (e.g. MoE experts).
+        wksd = wksd_factory()
+
+        # ── Carry-aware compression ──────────────────────────────
+        chunk_nnz = 0
+        for wk in wk_names:
+            wk_tensor = wksd[wk].detach()
+            for slice_idx, probe_slice in enumerate(sparse_slices[wk]):
+                if wk_tensor.ndim == 0:
+                    tensor_slice = wk_tensor
+                elif wk_tensor.ndim == 1:
+                    tensor_slice = wk_tensor[
+                        probe_slice.row_start : probe_slice.row_end
+                    ]
+                else:
+                    tensor_slice = wk_tensor.reshape(-1, wk_tensor.shape[-1])[
+                        probe_slice.row_start : probe_slice.row_end
+                    ]
+                if not tensor_slice.is_contiguous():
+                    tensor_slice = tensor_slice.contiguous()
+                raw = tensor_slice.view(dtype=int_dtype).to(torch.int64)
+                if ele_bits < 64:
+                    raw.bitwise_and_((1 << ele_bits) - 1)  # unsigned zero-extension
+
+                # A slice is an independent logical destination during sparse
+                # extraction.  Its local diff2 is translated and merged back
+                # into the physical worker tensor after extraction.
+                _diff2_inplace(raw)
+
+                carry_key = (wk, slice_idx)
+                prev_sp = prev_carry_sparse[carry_key]
+                if prev_sp is not None:
+                    raw.add_(prev_sp.to(raw.device).to_dense())
+                    prev_carry_sparse[carry_key] = None
+
+                # Keep two dense int64 buffers rather than raw+remainder+carry:
+                # raw is converted in-place into carry after remainder is made.
+                remainder = torch.remainder(raw, M)
+                raw.sub_(remainder).floor_divide_(M)
+
+                sp = remainder.to_sparse().cpu()
+                chunk_nnz += sp._nnz()
+                probe_slice.chunks.append(sp)
+
+                if chunk_k < num_chunks - 1:
+                    prev_carry_sparse[carry_key] = raw.to_sparse().cpu()
+                else:
+                    sign_sp = raw.to_sparse().cpu()
+                    if sign_sp._nnz() > 0:
+                        chunk_nnz += sign_sp._nnz()
+                        probe_slice.chunks.append(sign_sp)
+
+                del raw, remainder, tensor_slice
+
+        total_nnz += chunk_nnz
+        t_compress = time.time()
+
+        logger.info(
+            "  chunk %d/%d: build=%.2fs zero=%.2fs lw=%.2fs "
+            "compress=%.2fs nnz=%d total=%.2fs",
+            chunk_k + 1,
+            num_chunks,
+            t_build - t_chunk0,
+            t_zero - t_build,
+            t_lw - t_zero,
+            t_compress - t_lw,
+            chunk_nnz,
+            t_compress - t_chunk0,
+        )
+
+    logger.info(
+        "probing complete: total_nnz=%d across %d tensors × %d chunks (%.2f MB on CPU)",
+        total_nnz,
+        len(wk_names),
+        num_chunks,
+        total_nnz * 24 / 1e6,
+    )
+
+    return sparse_slices
+
+
+def _translate_worker_shard(
+    shard: Shard,
+    full_shape: tuple[int, ...],
+    flat_row_start: int,
+) -> Shard:
+    """Translate a worker-slice-local destination shard to physical coordinates."""
+    if not full_shape:
+        return list(shard)
+    if len(full_shape) == 1:
+        if len(shard) != 1:
+            raise ValueError(
+                f"expected 1D worker shard for shape {full_shape}, got {shard}"
+            )
+        left, right, _width = shard[0]
+        return [(left + flat_row_start, right + flat_row_start, full_shape[0])]
+
+    if len(shard) != 2:
+        raise ValueError(
+            f"expected flattened 2D worker shard for shape {full_shape}, got {shard}"
+        )
+    global_rows = math.prod(full_shape[:-1])
+    row_left, row_right, _row_width = shard[0]
+    col_left, col_right, col_width = shard[1]
+    return [
+        (row_left + flat_row_start, row_right + flat_row_start, global_rows),
+        (col_left, col_right, col_width),
+    ]
+
+
+def _merge_adjacent_shards(a: Shard, b: Shard) -> Shard | None:
+    """Merge boxes that are identical except for one exactly adjacent axis."""
+    if len(a) != len(b):
+        return None
+    differing: int | None = None
+    for axis, ((la, ra, wa), (lb, rb, wb)) in enumerate(zip(a, b)):
+        if wa != wb:
+            return None
+        if (la, ra) != (lb, rb):
+            if differing is not None:
+                return None
+            differing = axis
+    if differing is None:
+        return list(a)
+    la, ra, width = a[differing]
+    lb, rb, _ = b[differing]
+    if ra != lb and rb != la:
+        return None
+    merged = list(a)
+    merged[differing] = (min(la, lb), max(ra, rb), width)
+    return merged
+
+
+def _merge_consecutive_mappings(mappings: list[ShardMapping]) -> list[ShardMapping]:
+    """Coalesce consecutive source and destination boxes where both agree."""
+    pending: list[ShardMapping] = []
+    seen: set[tuple] = set()
+    for source, destination in mappings:
+        key = (tuple(source), tuple(destination))
+        if key not in seen:
+            seen.add(key)
+            pending.append((list(source), list(destination)))
+
+    while True:
+        changed = True
+        while changed:
+            changed = False
+            for i in range(len(pending)):
+                for j in range(i + 1, len(pending)):
+                    source = _merge_adjacent_shards(pending[i][0], pending[j][0])
+                    destination = _merge_adjacent_shards(pending[i][1], pending[j][1])
+                    if source is None or destination is None:
+                        continue
+                    # Identical source or destination boxes represent replication,
+                    # not consecutive shards, and must remain separate.
+                    if source == pending[i][0] or destination == pending[i][1]:
+                        continue
+                    if math.prod(r - l for l, r, _ in source) != math.prod(
+                        r - l for l, r, _ in destination
+                    ):
+                        continue
+                    pending[i] = (source, destination)
+                    pending.pop(j)
+                    changed = True
+                    break
+                if changed:
+                    break
+
+        # A one-element-wide logical remainder can make transpose impossible
+        # to identify during local extraction.  Once consecutive 1x1 boxes
+        # have coalesced, their rectangular shapes make it unambiguous.
+        orientation_changed = False
+        for index, (source, destination) in enumerate(pending):
+            if len(source) == len(destination) == 2 and all(
+                width > 0 for _left, _right, width in source
+            ):
+                source_shape = tuple(right - left for left, right, _width in source)
+                destination_shape = tuple(
+                    right - left for left, right, _width in destination
+                )
+                if (
+                    source_shape != destination_shape
+                    and source_shape[::-1] == destination_shape
+                ):
+                    source = list(source)
+                    left, right, width = source[0]
+                    source[0] = (left, right, -abs(width))
+                    pending[index] = (source, destination)
+                    orientation_changed = True
+
+        if not orientation_changed:
+            break
+
+    pending.sort(key=lambda mapping: (tuple(mapping[0]), tuple(mapping[1])))
+    return pending
+
+
+def _canonicalize_logical_sources(
+    entries: dict[str, dict[str, list[ShardMapping]]],
+    logical_to_physical: dict[str, str],
+) -> LoadSpec:
+    """Rename probe-only logical sources and merge their consecutive shards."""
+    physical_entries: dict[str, dict[str, list[ShardMapping]]] = {}
+    for logical_name, destinations in entries.items():
+        physical_name = logical_to_physical[logical_name]
+        target = physical_entries.setdefault(physical_name, {})
+        for destination_name, mappings in destinations.items():
+            target.setdefault(destination_name, []).extend(mappings)
+
+    canonical: dict[str, dict[str, list[ShardMapping]]] = {}
+    for physical_name in sorted(physical_entries):
+        destinations: dict[str, list[ShardMapping]] = {}
+        for destination_name in sorted(physical_entries[physical_name]):
+            destinations[destination_name] = _merge_consecutive_mappings(
+                physical_entries[physical_name][destination_name]
+            )
+        canonical[physical_name] = destinations
+    return LoadSpec(canonical)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def infer_load_spec(
+    hf_weights: HFWeightFetcher,
+    hf_shapes: dict[str, tuple[int, ...]],
+    wksd_factory: WksdFactory,
+    lw: LoadWeightsFn,
+    *,
+    i64_cap_bytes: int | float | None = None,
+) -> LoadSpec:
+    """Infer a :class:`~wbridge.utils.data.LoadSpec` from *hf_weights* and *wksd*.
+
+    Uses dtype-grouped, full-iterator probing with chunked index encoding.
+    ``O(G × C)`` ``load_weights`` calls, where *G* is the number of distinct
+    worker dtypes (usually 1–2) and *C = ceil(max_index_bits / element_bits)*
+    (usually 1–3).
+
+    Oversized source int64 probe tensors are split on dim 0, while worker
+    tensors are split on flattened leading rows, according to
+    ``i64_cap_bytes`` (or :data:`SPECGEN_I64_CAP_ENV`).  Probe-only logical
+    source names and worker slices are translated back to physical coordinates
+    and consecutive mappings are merged before this function returns.  If a
+    complete loader-visible source cannot remain in HBM, sources larger than
+    512 MiB are backed by CPU memory but populated exclusively from CUDA-built
+    row tiles.
+
+    Overwrites *wksd* during probing, then restores via
+    :meth:`~wbridge.utils.data.LoadSpec.load_from_full`.
+    Call :func:`verify_load_spec` after to validate the mapping.
+    """
+    resolved_i64_cap = _resolve_i64_cap(i64_cap_bytes)
+    wksd = wksd_factory()
+    assert wksd, "wksd must be non-empty"
+    assert all(v.is_cuda for v in wksd.values()), "wksd tensors must be on CUDA"
+
+    hf_names = sorted(hf_shapes.keys())
+    if not hf_names:
+        return LoadSpec({})
+
+    source_pieces, logical_shapes = _plan_logical_sources(
+        hf_shapes,
+        resolved_i64_cap,
+    )
+    logical_names = sorted(logical_shapes)
+    N = len(logical_names)
+
+    # 1-based name indices: 0 = unmapped sentinel.
+    # Compact packing: n_bits = ceil(log2(N+1)).  Cross-chunk carries
+    # from field-straddling are handled by carry-aware diff2 in
+    # _probe_dtype_group (propagation from low to high chunks).
+    n_bits = max(1, N.bit_length())
+    name_to_idx = {name: i + 1 for i, name in enumerate(logical_names)}
+
+    # Max total index bits across all HF tensors
+    max_total_bits = max(
+        n_bits + _coord_bits_for_shape(logical_shapes[name]) for name in logical_names
+    )
+
+    logger.info(
+        "infer_load_spec: %d physical/%d logical HF tensors, %d wksd tensors, "
+        "i64_cap=%s, n_bits=%d, max_total_bits=%d",
+        len(hf_names),
+        N,
+        len(wksd),
+        "inf" if math.isinf(resolved_i64_cap) else resolved_i64_cap,
+        n_bits,
+        max_total_bits,
+    )
+
+    # Free GPU cache before probing — large MoE models may leave very
+    # little GPU headroom after model + optimizer + KV cache allocation.
+    if torch.cuda.is_available():
+        import gc
+
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    # Log wksd tensor shapes for debugging (especially MoE 2D vs 3D)
+    ndim_counts: dict[int, int] = {}
+    for wk_name, wk_tensor in wksd.items():
+        nd = wk_tensor.ndim
+        ndim_counts[nd] = ndim_counts.get(nd, 0) + 1
+    logger.info(
+        "wksd ndim distribution: %s, largest: %s",
+        ndim_counts,
+        max(((v.numel(), k) for k, v in wksd.items()), key=lambda x: x[0]),
+    )
+
+    # ---- Probe and extract (corrupts wksd, restored afterward) ----
+    # ---- Group wksd by dtype ----
+    dtype_groups: dict[torch.dtype, list[str]] = defaultdict(list)
+    for wk_name, wk_tensor in wksd.items():
+        dtype_groups[wk_tensor.dtype].append(wk_name)
+
+    # Drop initial snapshot — _probe_dtype_group re-snapshots per chunk
+    del wksd
+
+    # ---- Probe each dtype group (sparse) ----
+    t0 = time.time()
+    # sparse_indices: {wk_name: [sparse_coo_chunk_0, ..., chunk_{C-1}]}
+    sparse_indices: dict[str, list[_SparseWorkerSlice]] = {}
+
+    for group_dtype, wk_names in dtype_groups.items():
+        group_sparse = _probe_dtype_group(
+            hf_names,
+            source_pieces,
+            name_to_idx,
+            n_bits,
+            max_total_bits,
+            wksd_factory,
+            wk_names,
+            group_dtype,
+            lw,
+            resolved_i64_cap,
+        )
+        sparse_indices.update(group_sparse)
+
+    t1 = time.time()
+    logger.info("probing completed in %.2fs", t1 - t0)
+
+    # ---- Extract shards from sparse diff2 entries (CPU, no dense tensors) ----
+    wksd = wksd_factory()
+    wk_shapes = {k: tuple(v.shape) for k, v in wksd.items()}
+    idx_to_name = {i + 1: name for i, name in enumerate(logical_names)}
+    entries: dict[str, dict[str, list[ShardMapping]]] = {}
+
+    for wk_name, worker_slices in sparse_indices.items():
+        full_wk_shape = wk_shapes[wk_name]
+        group_ele_bits = wksd[wk_name].dtype.itemsize * 8
+        for worker_slice in worker_slices:
+            wk_shape = worker_slice.shape
+            orig_ndim = len(wk_shape)
+            if orig_ndim == 0:
+                H, W = 1, 1
+            elif orig_ndim == 1:
+                H, W = 1, wk_shape[0]
+            elif orig_ndim == 2:
+                H, W = wk_shape
+            else:
+                W = wk_shape[-1]
+                H = math.prod(wk_shape) // W
+
+            # Collect sparse entries across chunks.  Each chunk stores diff2
+            # of unshifted values in this worker slice's local coordinates.
+            elist: list[list[int]] = []
+            for chunk_k, sp in enumerate(worker_slice.chunks):
+                shift = chunk_k * group_ele_bits
+                sp_cpu = sp.coalesce()
+                indices = sp_cpu.indices()
+                values = sp_cpu.values()
+                nnz = values.shape[0]
+                if nnz == 0:
+                    continue
+                if sp_cpu.ndim == 0:
+                    rows_l = [0] * nnz
+                    cols_l = [0] * nnz
+                elif sp_cpu.ndim == 1:
+                    rows_l = [0] * nnz
+                    cols_l = indices[0].tolist()
+                elif sp_cpu.ndim == 2:
+                    rows_l = indices[0].tolist()
+                    cols_l = indices[1].tolist()
+                else:
+                    rows_t = torch.zeros(nnz, dtype=torch.long)
+                    stride = 1
+                    for d in range(sp_cpu.ndim - 2, -1, -1):
+                        rows_t += indices[d] * stride
+                        stride *= sp_cpu.shape[d]
+                    rows_l = rows_t.tolist()
+                    cols_l = indices[-1].tolist()
+                vals_l = values.tolist()
+                for r, c, value in zip(rows_l, cols_l, vals_l):
+                    elist.append([r, c, value << shift])
+
+            elist.sort()
+            merged: list[list[int]] = []
+            for entry in elist:
+                if merged and merged[-1][:2] == entry[:2]:
+                    merged[-1][2] += entry[2]
+                else:
+                    merged.append(entry)
+            merged = [entry for entry in merged if entry[2] != 0]
+            if not merged:
+                continue
+
+            wk_mappings = _extract_shards_greedy(
+                merged,
+                wk_shape,
+                H,
+                W,
+                n_bits,
+                idx_to_name,
+                logical_shapes,
+            )
+            for logical_name, shard_list in wk_mappings.items():
+                translated = [
+                    (
+                        source_shard,
+                        _translate_worker_shard(
+                            destination_shard,
+                            full_wk_shape,
+                            worker_slice.row_start,
+                        ),
+                    )
+                    for source_shard, destination_shard in shard_list
+                ]
+                entries.setdefault(logical_name, {}).setdefault(wk_name, []).extend(
+                    translated
+                )
+
+    t2 = time.time()
+    logger.info("shard extraction completed in %.2fs", t2 - t1)
+
+    logical_to_physical = {
+        piece.logical_name: physical_name
+        for physical_name, pieces in source_pieces.items()
+        for piece in pieces
+    }
+    result = _canonicalize_logical_sources(entries, logical_to_physical)
+
+    # Restore wksd from real weights (specgen probing corrupted them).
+    # Use LoadSpec.load_from_full instead of lw(hf_weights) — the latter
+    # calls model.load_weights which for large MoE models
+    # allocates GPU temporaries for expert routing that are not freed.
+    # load_from_full takes an HFWeightFetcher and only materialises the
+    # tensors it needs, keeping only a small fraction of the checkpoint resident for a typical rank.
+    t3 = time.time()
+    wksd = wksd_factory()
+    result.load_from_full(hf_weights, wksd)
+    logger.info("wksd restore via LoadSpec completed in %.2fs", time.time() - t3)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint → HFWeightFetcher builder
+# ---------------------------------------------------------------------------
+
+
+def hf_weights_from_checkpoint(
+    hf_path: str,
+) -> tuple[HFWeightFetcher, dict[str, tuple[int, ...]]]:
+    """Build ``(hf_weights, hf_shapes)`` from a HF checkpoint directory.
+
+    Scans safetensors metadata to discover names and shapes (no tensor data
+    loaded).  Each factory does a single targeted ``safe_open`` /
+    ``get_tensor`` call — O(1) per invocation, no full-checkpoint scans.
+
+    Falls back to ``pytorch_model*.bin`` if no safetensors files are found.
+    """
+    from pathlib import Path
+
+    root = Path(hf_path)
+    st_files = sorted(root.glob("*.safetensors"))
+
+    if st_files:
+        from safetensors import safe_open
+
+        # Build name→file index and collect shapes in one pass (metadata only)
+        name_to_file: dict[str, str] = {}
+        shapes: dict[str, tuple[int, ...]] = {}
+        for fp in st_files:
+            with safe_open(str(fp), framework="pt", device="cpu") as sf:
+                for k in sf.keys():
+                    name_to_file[k] = str(fp)
+                    shapes[k] = tuple(sf.get_slice(k).get_shape())
+
+        def _make_st_factory(name: str, filepath: str):
+            def _load() -> torch.Tensor:
+                with safe_open(filepath, framework="pt", device="cpu") as sf:
+                    return sf.get_tensor(name).contiguous()
+
+            return _load
+
+        fetcher: HFWeightFetcher = {
+            name: _make_st_factory(name, name_to_file[name]) for name in shapes
+        }
+        return fetcher, shapes
+
+    # Fallback: pytorch_model*.bin
+    bins = sorted(root.glob("pytorch_model*.bin"))
+    if len(bins) == 1:
+        try:
+            blob = torch.load(bins[0], map_location="cpu", weights_only=True)
+        except TypeError:
+            blob = torch.load(bins[0], map_location="cpu")
+        if not isinstance(blob, dict):
+            raise TypeError(f"Expected state_dict in {bins[0]}")
+        shapes = {}
+        fetcher = {}
+        for k, v in blob.items():
+            if torch.is_tensor(v):
+                shapes[k] = tuple(v.shape)
+                fetcher[k] = lambda t=v: t.clone().contiguous()
+        return fetcher, shapes
+
+    raise FileNotFoundError(
+        f"No *.safetensors or single pytorch_model*.bin under {hf_path!r} "
+        "(needed for LoadSpec inference)."
+    )
+
+
+__all__ = [
+    "DEFAULT_MAX_HF_BYTES",
+    "DEFAULT_SPECGEN_I64_CAP_BYTES",
+    "HFWeightFetcher",
+    "LoadWeightsFn",
+    "SPECGEN_I64_CAP_ENV",
+    "WksdFactory",
+    "hf_weights_from_checkpoint",
+    "infer_load_spec",
+    "specgen_i64_cap_bytes",
+    "verify_load_spec",
+]


### PR DESCRIPTION
Summary:
Adds a snapshot of the WeightBridge library under `examples/weightbridge/`.

WeightBridge performs one-sided RDMA weight transfer from a trainer to
inference workers. It builds a LoadSpec that maps source shards onto each
destination worker's layout once, then reuses that plan to move only the bytes
each worker needs. Its `protocol="monarch"` transport runs over Monarch, which
is why the library sits alongside the other examples.

83 files: the library itself (`wbridge/`), plus its own `examples/`, `tests/`,
`docs/` and `pyproject.toml`.

BSD license headers were added to the 72 Python files and to
`tests/run_multi_group_topology_host.sh`, matching the rest of this repository.
The library carried no headers of its own.

Nothing builds or imports this yet. It is source only, added so the code can be
read and referenced in one place.

Differential Revision: D117766258
