### PR TITLE
Cover identity-aware attached host refs (#4760)

### DIFF
--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -118,6 +118,17 @@ impl Location {
         Location::Via(uid, Box::new(self))
     }
 
+    /// Append `uid` to the serialized via list, making it the innermost hop
+    /// while preserving the route through all existing gateways.
+    pub fn append_via(self, uid: Uid) -> Self {
+        match self {
+            Location::Addr(addr) => Location::Addr(addr).with_via(uid),
+            Location::Via(outer_uid, inner) => {
+                Location::Via(outer_uid, Box::new(inner.append_via(uid)))
+            }
+        }
+    }
+
     /// Pop the outermost via hop. Returns `Ok((uid, inner))` when this
     /// is a `Via`, or `Err(self)` when it is a terminal `Addr`, so the
     /// caller can recover the unchanged location.
@@ -887,6 +898,24 @@ mod tests {
     fn test_location_debug_same_as_display() {
         let loc: Location = ChannelAddr::Local(7).into();
         assert_eq!(format!("{:?}", loc), format!("{}", loc));
+    }
+
+    #[test]
+    fn test_location_append_via_preserves_existing_route_order() {
+        let outer = Uid::instance(Label::strip("outer"));
+        let inner = Uid::instance(Label::strip("inner"));
+        let location = Location::from(ChannelAddr::Local(7)).with_via(outer.clone());
+
+        assert_eq!(
+            location.append_via(inner.clone()),
+            Location::Via(
+                outer,
+                Box::new(Location::Via(
+                    inner,
+                    Box::new(Location::Addr(ChannelAddr::Local(7))),
+                )),
+            )
+        );
     }
 
     #[test]

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -528,16 +528,12 @@ impl<M: ProcManager> Host<M> {
                 return Err(HostError::ProcExists(name));
             }
 
-            // Advertise the child with a `Via(child_uid, host_location)`
-            // location so peers source-route through this host: the outer
-            // hop matches the peer entry installed below, and gets peeled
-            // to deliver to the child's gateway. The host location comes
-            // from the gateway's active routing state, so a later
-            // `serve`/`serve_via` controls newly spawned child refs.
+            // Preserve the route to this host, then append the child hop that
+            // is peeled by this host's gateway.
             let resource_id = ResourceId::from_name(&name);
             let proc_uid = resource_id.uid().clone();
             let proc_id =
-                resource_id.proc_addr(gateway.default_location().with_via(proc_uid.clone()));
+                resource_id.proc_addr(gateway.default_location().append_via(proc_uid.clone()));
             let handle = manager.spawn(proc_id.clone(), backend_addr, config).await?;
             let mut proc_handle_guard = ProcHandleKillGuard {
                 handle: Some(handle),

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -160,8 +160,12 @@ pub(crate) fn legacy_host_agent_ref(host_addr: ChannelAddr) -> ActorRef<HostAgen
 }
 
 fn named_proc_on_host(agent: &ActorRef<HostAgent>, id: &ResourceId) -> ProcAddr {
-    let location =
-        hyperactor::Location::from(agent.actor_addr().addr().clone()).with_via(id.uid().clone());
+    let location = agent
+        .actor_addr()
+        .proc_addr()
+        .location()
+        .clone()
+        .append_via(id.uid().clone());
     id.proc_addr(location)
 }
 
@@ -922,24 +926,9 @@ impl HostMeshRef {
         })
     }
 
-    /// Create a unit HostMeshRef from a host mesh agent.
-    ///
-    /// Retains the service proc identity while canonicalizing the location to
-    /// its terminal dial address. Client-only via routes must not propagate
-    /// into addresses of procs spawned through this mesh.
+    /// Create a unit HostMeshRef that retains the host agent's complete location.
     pub fn from_host_agent(id: HostMeshId, agent: ActorRef<HostAgent>) -> crate::Result<Self> {
-        let region = Extent::unity().into();
-        let service_proc = agent.actor_addr().proc_addr();
-        let agent = host_agent_ref(ProcAddr::new(
-            service_proc.id().clone(),
-            service_proc.addr().clone().into_dial_addr().into(),
-        ));
-        let host_agent_mesh = Self::host_agent_mesh_ref_from_agents(&region, vec![agent])?;
-        Ok(Self {
-            id,
-            host_agent_mesh,
-            bootstrap_command: None,
-        })
+        Self::from_host_agents(id, vec![agent])
     }
 
     /// Return a new `HostMeshRef` that will use `cmd` when spawning procs,
@@ -2455,14 +2444,17 @@ mod tests {
     }
 
     #[test]
-    fn test_host_mesh_ref_from_host_agent_preserves_identity_and_uses_direct_location() {
+    fn test_host_mesh_ref_from_host_agent_preserves_identity_and_location() {
         let dial_addr = ChannelAddr::from_zmq_url("tcp://127.0.0.1:26600").unwrap();
         let service_proc_id: ProcId = "service<2>".parse().unwrap();
         let via_uid = ProcId::instance(Label::strip("client-gateway"))
             .uid()
             .clone();
         let service_location = hyperactor::Location::from(dial_addr.clone()).with_via(via_uid);
-        let agent = host_agent_ref(ProcAddr::new(service_proc_id.clone(), service_location));
+        let agent = host_agent_ref(ProcAddr::new(
+            service_proc_id.clone(),
+            service_location.clone(),
+        ));
 
         let mesh = HostMeshRef::from_host_agent(
             HostMeshId::singleton(Label::new("explicit-service").unwrap()),
@@ -2477,7 +2469,7 @@ mod tests {
         );
         assert_eq!(
             round_trip_agent.actor_addr().proc_addr().location(),
-            &hyperactor::Location::from(dial_addr)
+            &service_location
         );
     }
 

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -795,6 +795,10 @@ class EchoActor(Actor):
     async def echo(self, msg: str) -> str:
         return msg
 
+    @endpoint
+    async def getenv(self, name: str) -> Optional[str]:
+        return os.environ.get(name)
+
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
@@ -870,12 +874,32 @@ def test_client_attach_addr_this_host_and_this_proc() -> None:
         assert proc is not None
         host = this_host()
         assert host is not None
-        assert host is proc.host_mesh
+        assert host.region == proc.host_mesh.region
 
         # Verify the meshes are usable by spawning an actor.
         am = proc.spawn("echo2", EchoActor)
         result = am.echo.call_one("ping").get()
         assert result == "ping"
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_client_attach_addr_this_host_spawn_runs_on_client_host() -> None:
+    worker_marker = "MONARCH_TEST_ATTACHED_WORKER"
+    assert worker_marker not in os.environ
+    job = DuplexProcessJob(env={worker_marker: "1"})
+    job.apply()
+    attach(job.duplex_addr)
+    with scoped_state(job, cached_path=None):
+        context()
+
+        actor = (
+            this_host()
+            .spawn_procs(per_host={"local": 1})
+            .spawn("local_origin", EchoActor)
+        )
+
+        assert actor.getenv.call_one(worker_marker).get() is None
 
 
 class RelayActor(Actor):

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 import cloudpickle
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.proc import ProcId, Uid
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Point, Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, attach, context
@@ -726,9 +727,11 @@ class DuplexProcessJob(ProcessJob):
         self,
         meshes: Optional[Dict[str, int]] = None,
         env: Optional[Dict[str, str]] = None,
+        service_proc_id: Optional[ProcId] = None,
     ) -> None:
         super().__init__(meshes or {"hosts": 1}, env)
         self._duplex_addr: Optional[str] = None
+        self._service_proc_id = service_proc_id
 
     def _create(self, client_script: Optional[str]) -> None:
         if client_script is not None:
@@ -740,6 +743,11 @@ class DuplexProcessJob(ProcessJob):
             for i in range(count):
                 host_key = f"{mesh_name}_{i}"
                 addr = f"ipc://{self._tmpdir}/{host_key}"
+                worker_addr = (
+                    addr
+                    if self._service_proc_id is None
+                    else f"{self._service_proc_id}@{addr}"
+                )
                 worker_env = {**os.environ, "HYPERACTOR_PROCESS_NAME": host_key}
                 if self._env is not None:
                     worker_env.update(self._env)
@@ -748,11 +756,11 @@ class DuplexProcessJob(ProcessJob):
                     sys.executable,
                     "-c",
                     "from monarch.actor import run_worker_loop_forever; "
-                    f'run_worker_loop_forever(address="{addr}", '
+                    f"run_worker_loop_forever(address={worker_addr!r}, "
                     'ca="trust_all_connections")',
                 ]
                 proc = subprocess.Popen(cmd, env=worker_env, start_new_session=True)
-                self._host_to_pid[host_key] = ProcessState(proc.pid, addr)
+                self._host_to_pid[host_key] = ProcessState(proc.pid, worker_addr)
 
         # Wait for the first worker's frontend socket to appear.
         # The duplex server is now on the same address as the frontend.
@@ -911,6 +919,28 @@ class RelayActor(Actor):
     @endpoint
     async def relay(self, msg: str) -> str:
         return await self._target.echo.call_one(msg)
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_client_attach_service_instance_spawns_on_client_host() -> None:
+    worker_marker = "MONARCH_TEST_ATTACHED_WORKER"
+    assert worker_marker not in os.environ
+    job = DuplexProcessJob(
+        env={worker_marker: "1"},
+        service_proc_id=ProcId(Uid.instance("service")),
+    )
+    job.apply()
+    attach(job.duplex_addr)
+    with scoped_state(job, cached_path=None):
+        context()
+
+        local_echo = (
+            this_host()
+            .spawn_procs(per_host={"local": 1})
+            .spawn("local_echo", EchoActor)
+        )
+        assert local_echo.getenv.call_one(worker_marker).get() is None
 
 
 @pytest.mark.timeout(120)


### PR DESCRIPTION
Summary:

Add identity-aware coverage above D117896360. The duplex fixture can launch a service proc with an explicit instance `ProcId`, and the attach regression verifies that `this_host()` actually spawns the actor on the client host through the advertised `Via` route.

The production behavior change and the lower-level Rust regression live in the parent diff.

Reviewed By: pzhan9

Differential Revision: D117877682


