### PR TITLE
Include process name in distributed sql table (#4763)

### DIFF
--- a/hyperactor_telemetry/src/unix_sink.rs
+++ b/hyperactor_telemetry/src/unix_sink.rs
@@ -27,6 +27,7 @@ use std::io::Write;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::sync::atomic::AtomicU64;
@@ -81,6 +82,26 @@ use crate::generate_sent_message_id;
 
 /// Maximum queued table batches before the tracing path starts dropping frames.
 const WORKER_QUEUE_CAPACITY: usize = 10_000;
+const HYPERACTOR_PROCESS_NAME_ENV: &str = "HYPERACTOR_PROCESS_NAME";
+const HOSTNAME_ENV: &str = "HOSTNAME";
+
+fn fallback_process_id() -> String {
+    let pid = std::process::id();
+    let hostname = std::env::var(HOSTNAME_ENV)
+        .ok()
+        .filter(|hostname| !hostname.is_empty())
+        .unwrap_or_else(|| format!("{:032x}", rand::random::<u128>()));
+
+    format!("unnamed@{hostname}:{pid}")
+}
+
+/// Namespace for process-local span IDs after distributed aggregation.
+static PROCESS_ID: LazyLock<String> = LazyLock::new(|| {
+    std::env::var(HYPERACTOR_PROCESS_NAME_ENV)
+        .ok()
+        .filter(|process_id| !process_id.is_empty())
+        .unwrap_or_else(fallback_process_id)
+});
 
 /// Process-global sink installed with the tracing subscriber and activated later.
 static UNIX_SOCKET_SINK: OnceLock<Arc<UnixSocketSink>> = OnceLock::new();
@@ -279,6 +300,7 @@ impl UnixSocketSink {
                 line,
             } => {
                 inner.spans_buffer.insert(Span {
+                    process_id: PROCESS_ID.as_str(),
                     id: *id,
                     name: name.to_string(),
                     target: target.to_string(),
@@ -293,6 +315,7 @@ impl UnixSocketSink {
             }
             TraceEvent::SpanEnter { id, timestamp, .. } => {
                 inner.span_events_buffer.insert(SpanEvent {
+                    process_id: PROCESS_ID.as_str(),
                     id: *id,
                     timestamp_us: timestamp_to_micros(timestamp),
                     event_type: "enter".to_string(),
@@ -300,6 +323,7 @@ impl UnixSocketSink {
             }
             TraceEvent::SpanExit { id, timestamp, .. } => {
                 inner.span_events_buffer.insert(SpanEvent {
+                    process_id: PROCESS_ID.as_str(),
                     id: *id,
                     timestamp_us: timestamp_to_micros(timestamp),
                     event_type: "exit".to_string(),
@@ -307,6 +331,7 @@ impl UnixSocketSink {
             }
             TraceEvent::SpanClose { id, timestamp } => {
                 inner.span_events_buffer.insert(SpanEvent {
+                    process_id: PROCESS_ID.as_str(),
                     id: *id,
                     timestamp_us: timestamp_to_micros(timestamp),
                     event_type: "close".to_string(),

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -1299,6 +1299,7 @@ mod tests {
         let mut spans = SpanBuffer::default();
         for (id, timestamp_us, parent_id) in [(9, old_us, None), (10, fresh_us, Some(9))] {
             spans.insert(Span {
+                process_id: "test",
                 id,
                 name: format!("span-{id}"),
                 target: "test".to_string(),
@@ -1316,6 +1317,7 @@ mod tests {
         let mut span_events = SpanEventBuffer::default();
         for (timestamp_us, event_type) in [(old_us, "enter"), (fresh_us, "close")] {
             span_events.insert(SpanEvent {
+                process_id: "test",
                 id: 9,
                 timestamp_us,
                 event_type: event_type.to_string(),

--- a/monarch_record_batch_macros/src/lib.rs
+++ b/monarch_record_batch_macros/src/lib.rs
@@ -193,6 +193,10 @@ fn get_arrow_type_and_conversion(
             quote! { datafusion::arrow::datatypes::DataType::Utf8 },
             quote! { datafusion::arrow::array::StringArray::from },
         ),
+        "&'staticstr" => (
+            quote! { datafusion::arrow::datatypes::DataType::Utf8 },
+            quote! { datafusion::arrow::array::StringArray::from },
+        ),
         "bool" => (
             quote! { datafusion::arrow::datatypes::DataType::Boolean },
             quote! { datafusion::arrow::array::BooleanArray::from },

--- a/monarch_telemetry_schema/src/lib.rs
+++ b/monarch_telemetry_schema/src/lib.rs
@@ -93,6 +93,7 @@ pub mod trace_tables {
     /// Row data for the spans table.
     #[derive(RecordBatchRow)]
     pub struct Span {
+        pub process_id: &'static str,
         pub id: u64,
         pub name: String,
         pub target: String,
@@ -108,6 +109,7 @@ pub mod trace_tables {
     /// Row data for the span events table.
     #[derive(RecordBatchRow)]
     pub struct SpanEvent {
+        pub process_id: &'static str,
         pub id: u64,
         pub timestamp_us: i64,
         pub event_type: String,
@@ -354,6 +356,7 @@ mod tests {
     fn serialize_batch_round_trips_one_record_batch() {
         let mut buffer = SpanBuffer::default();
         buffer.insert(Span {
+            process_id: "process",
             id: 7,
             name: "span".to_string(),
             target: "target".to_string(),


### PR DESCRIPTION
Summary:

This is important information for spans when we want to aggregate them from many processes

Reviewed By: thedavekwon

Differential Revision: D118069969


