### PR TITLE
Create API for querying tracing from Distributed SQL (#4764)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,7 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
+ "brotli",
  "bzip2",
  "compression-core",
  "flate2",
@@ -2849,6 +2850,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3408,6 +3424,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.11.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -4792,7 +4824,9 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "humantime",
  "prost",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tracing",
@@ -4944,6 +4978,23 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nccl-sys"
@@ -5267,10 +5318,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -6599,11 +6687,13 @@ dependencies = [
  "http-body-util",
  "hyper 1.11.0",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -6614,6 +6704,7 @@ dependencies = [
  "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -7869,6 +7960,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/monarch_perfetto_trace/Cargo.toml
+++ b/monarch_perfetto_trace/Cargo.toml
@@ -14,7 +14,9 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.104"
 clap = { version = "4.6.2", features = ["derive", "env", "string", "unicode", "wrap_help"] }
+humantime = "2.4.0"
 prost = { version = "0.14.4", default-features = false }
+reqwest = { version = "0.13.2", features = ["blocking", "brotli", "charset", "cookies", "deflate", "gzip", "http2", "json", "multipart", "native-tls", "rustls", "socks", "stream", "system-proxy", "zstd"], default-features = false }
 serde = { version = "1.0.229", features = ["derive", "rc"] }
 serde_json = { version = "1.0.151", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/monarch_perfetto_trace/src/lib.rs
+++ b/monarch_perfetto_trace/src/lib.rs
@@ -7,6 +7,7 @@
  */
 
 pub mod local;
+pub mod profile;
 
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;

--- a/monarch_perfetto_trace/src/local.rs
+++ b/monarch_perfetto_trace/src/local.rs
@@ -240,27 +240,46 @@ fn offset_packet_uuids(packet: &mut TracePacket, offset: u64) {
 /// A [`Sink`] that writes trace packets to a file, flushing every 100 packets.
 pub struct Collector {
     trace: Trace,
-    path: String,
+    destination: CollectorDestination,
+}
+
+enum CollectorDestination {
+    Path(String),
+    File(fs::File),
 }
 
 impl Collector {
     pub fn new(path: &Path) -> Self {
         Self {
-            path: path.to_string_lossy().to_string(),
             trace: Trace::default(),
+            destination: CollectorDestination::Path(path.to_string_lossy().to_string()),
+        }
+    }
+
+    pub(crate) fn from_file(file: fs::File) -> Self {
+        Self {
+            trace: Trace::default(),
+            destination: CollectorDestination::File(file),
         }
     }
 
     pub fn flush(&mut self) -> Result<()> {
         let tr = std::mem::take(&mut self.trace);
-        let mut file = fs::OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(&self.path)?;
-
         let bytes = prost::Message::encode_to_vec(&tr);
-        file.write_all(&bytes)?;
-        file.flush()?;
+        match &mut self.destination {
+            CollectorDestination::Path(path) => {
+                let mut file = fs::OpenOptions::new()
+                    .append(true)
+                    .create(true)
+                    .open(path)?;
+                file.write_all(&bytes)?;
+                file.flush()?;
+            }
+            CollectorDestination::File(file) => {
+                file.write_all(&bytes)?;
+                file.flush()?;
+            }
+        }
         Ok(())
     }
 }

--- a/monarch_perfetto_trace/src/profile.rs
+++ b/monarch_perfetto_trace/src/profile.rs
@@ -1,0 +1,557 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use reqwest::blocking::Client;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Map;
+use serde_json::Value;
+
+use crate::Ctx;
+use crate::local::Collector;
+
+const DRAIN_DELAY: Duration = Duration::from_millis(500);
+const ENDPOINT_TELEMETRY_TARGET: &str = "monarch_hyperactor::telemetry::endpoint";
+const QUERY_TIMEOUT: Duration = Duration::from_secs(120);
+
+struct IncompleteTraceFile<'a> {
+    path: &'a Path,
+    complete: bool,
+}
+
+impl<'a> IncompleteTraceFile<'a> {
+    fn new(path: &'a Path) -> Self {
+        Self {
+            path,
+            complete: false,
+        }
+    }
+
+    fn mark_complete(&mut self) {
+        self.complete = true;
+    }
+}
+
+impl Drop for IncompleteTraceFile<'_> {
+    fn drop(&mut self) {
+        if !self.complete {
+            let _ = fs::remove_file(self.path);
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct QueryEnvelope {
+    #[serde(default)]
+    rows: Vec<SpanRow>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct QueryRequest<'a> {
+    sql: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpanRow {
+    process_id: String,
+    id: u64,
+    name: String,
+    target: String,
+    fields_json: String,
+    start_us: Option<i64>,
+    end_us: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct ActorTrack {
+    proc_id: String,
+    actor_id: String,
+}
+
+#[derive(Debug)]
+struct PreparedSpan {
+    process_id: String,
+    id: u64,
+    name: String,
+    target: String,
+    fields: Map<String, Value>,
+    track: ActorTrack,
+    original_start_us: i64,
+    original_end_us: Option<i64>,
+    start_clipped: bool,
+    end_clipped: bool,
+    start_ns: u64,
+    end_ns: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BoundaryKind {
+    Begin,
+    End,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Boundary {
+    timestamp_ns: u64,
+    span_index: usize,
+    kind: BoundaryKind,
+}
+
+impl Ord for Boundary {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.timestamp_ns
+            .cmp(&other.timestamp_ns)
+            .then_with(|| match (self.kind, other.kind) {
+                (BoundaryKind::Begin, BoundaryKind::End) => Ordering::Greater,
+                (BoundaryKind::End, BoundaryKind::Begin) => Ordering::Less,
+                (BoundaryKind::Begin, BoundaryKind::Begin) => {
+                    self.span_index.cmp(&other.span_index)
+                }
+                (BoundaryKind::End, BoundaryKind::End) => other.span_index.cmp(&self.span_index),
+            })
+    }
+}
+
+impl PartialOrd for Boundary {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Collect distributed user telemetry for `duration` and write a Perfetto trace.
+///
+/// `output` selects the destination file. When it is absent, the trace is written
+/// under `/tmp/$USER/monarch_profiles`. The destination is checked before the
+/// collection interval starts and is never overwritten.
+pub fn collect_profile(
+    telemetry_url: &str,
+    duration: Duration,
+    output: Option<PathBuf>,
+) -> Result<PathBuf> {
+    if duration.is_zero() {
+        bail!("--time must be greater than zero");
+    }
+
+    let output_timestamp_us = timestamp_us()?;
+    let output = resolve_output_path(output, output_timestamp_us)?;
+    validate_output_path(&output)?;
+
+    eprintln!(
+        "Collecting traces for {}...",
+        humantime::format_duration(duration)
+    );
+
+    let start_us = timestamp_us()?;
+    std::thread::sleep(duration);
+    let end_us = timestamp_us()?;
+
+    std::thread::sleep(DRAIN_DELAY);
+
+    let rows = query_spans(telemetry_url, start_us, end_us)?;
+    let (span_count, actor_count, proc_count, skipped_count) =
+        write_trace_to_output(rows, start_us, end_us, &output)?;
+
+    eprintln!(
+        "Wrote {} spans from {} actors on {} procs.",
+        span_count, actor_count, proc_count
+    );
+
+    if skipped_count > 0 {
+        eprintln!("Skipped {skipped_count} rows without usable actor span data.");
+    }
+
+    Ok(output)
+}
+
+fn query_spans(telemetry_url: &str, start_us: i64, end_us: i64) -> Result<Vec<SpanRow>> {
+    let client = Client::builder()
+        .no_proxy()
+        .timeout(QUERY_TIMEOUT)
+        .build()
+        .context("failed to create telemetry HTTP client")?;
+
+    let response = {
+        let sql = profile_sql(start_us, end_us);
+        let url = format!("{}/api/query", telemetry_url.trim_end_matches('/'));
+
+        client
+            .post(&url)
+            .json(&QueryRequest { sql: &sql })
+            .send()
+            .with_context(|| format!("failed to query {url}"))
+    }?;
+
+    let status = response.status();
+
+    let body = response
+        .text()
+        .with_context(|| format!("failed to read telemetry query response with status {status}"))?;
+
+    if !status.is_success() {
+        bail!("telemetry query failed with {status}: {body}");
+    }
+
+    let envelope: QueryEnvelope =
+        serde_json::from_str(&body).context("failed to decode telemetry query response")?;
+
+    if let Some(error) = envelope.error {
+        bail!("telemetry query failed: {error}");
+    }
+
+    Ok(envelope.rows)
+}
+
+fn profile_sql(start_us: i64, end_us: i64) -> String {
+    format!(
+        "WITH profile_spans AS ( \
+         SELECT s.process_id, s.id, s.name, s.target, s.fields_json, \
+         MIN(CASE WHEN e.event_type = 'enter' THEN e.timestamp_us END) AS start_us, \
+         MAX(CASE WHEN e.event_type = 'exit' THEN e.timestamp_us END) AS end_us \
+         FROM spans s LEFT JOIN span_events e \
+         ON s.process_id = e.process_id AND s.id = e.id \
+         WHERE s.timestamp_us < {end_us} \
+         GROUP BY s.process_id, s.id, s.name, s.target, s.fields_json \
+         ) SELECT process_id, id, name, target, fields_json, start_us, end_us \
+         FROM profile_spans WHERE start_us < {end_us} \
+         AND COALESCE(end_us, {end_us}) > {start_us}"
+    )
+}
+
+fn write_trace_to_output(
+    rows: Vec<SpanRow>,
+    window_start_us: i64,
+    window_end_us: i64,
+    output: &Path,
+) -> Result<(usize, usize, usize, usize)> {
+    let output_file = create_output_file(output)?;
+    let mut incomplete_output = IncompleteTraceFile::new(output);
+    let summary = write_trace(rows, window_start_us, window_end_us, output_file)?;
+    incomplete_output.mark_complete();
+    Ok(summary)
+}
+
+fn write_trace(
+    rows: Vec<SpanRow>,
+    window_start_us: i64,
+    window_end_us: i64,
+    output: fs::File,
+) -> Result<(usize, usize, usize, usize)> {
+    let row_count = rows.len();
+    let mut spans = rows
+        .into_iter()
+        .filter_map(|row| prepare_span(row, window_start_us, window_end_us))
+        .collect::<Vec<_>>();
+
+    spans.sort_by(|left, right| {
+        left.track
+            .cmp(&right.track)
+            .then_with(|| left.original_start_us.cmp(&right.original_start_us))
+            .then_with(|| {
+                right
+                    .original_end_us
+                    .unwrap_or(i64::MAX)
+                    .cmp(&left.original_end_us.unwrap_or(i64::MAX))
+            })
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    let proc_ids = spans
+        .iter()
+        .map(|span| span.track.proc_id.clone())
+        .collect::<BTreeSet<_>>();
+
+    let actor_tracks = spans
+        .iter()
+        .map(|span| span.track.clone())
+        .collect::<BTreeSet<_>>();
+
+    let process_count = i32::try_from(proc_ids.len()).context("too many process tracks")?;
+
+    let collector = Collector::from_file(output);
+    let mut ctx = Ctx::new(collector);
+
+    let mut process_track_ids = HashMap::new();
+    for (pid, proc_id) in (1..=process_count).zip(&proc_ids) {
+        let track_id = ctx.new_process_with_name(pid, proc_id.clone());
+        process_track_ids.insert(proc_id.clone(), track_id);
+    }
+
+    let mut actor_track_ids = HashMap::new();
+    for actor_track in &actor_tracks {
+        let process_track = process_track_ids
+            .get(&actor_track.proc_id)
+            .copied()
+            .expect("each actor should have a registered process track");
+
+        let track_id = ctx.next_uuid();
+
+        ctx.new_track(track_id)
+            .name(&actor_track.actor_id)
+            .parent(process_track)
+            .consume();
+
+        actor_track_ids.insert(actor_track.clone(), track_id);
+    }
+
+    let mut boundaries = spans
+        .iter()
+        .enumerate()
+        .flat_map(|(span_index, span)| {
+            [
+                Boundary {
+                    timestamp_ns: span.start_ns,
+                    span_index,
+                    kind: BoundaryKind::Begin,
+                },
+                Boundary {
+                    timestamp_ns: span.end_ns,
+                    span_index,
+                    kind: BoundaryKind::End,
+                },
+            ]
+        })
+        .collect::<Vec<_>>();
+
+    boundaries.sort_unstable();
+
+    for boundary in boundaries {
+        let span = &spans[boundary.span_index];
+        let track_id = actor_track_ids
+            .get(&span.track)
+            .copied()
+            .expect("each span should have a registered actor track");
+
+        match boundary.kind {
+            BoundaryKind::Begin => {
+                let mut event = ctx
+                    .start_slice(track_id, boundary.timestamp_ns)
+                    .name(&span.name);
+
+                event = event.add_annotation("process_id", &Value::from(span.process_id.clone()));
+                event = event.add_annotation("span_id", &Value::from(span.id.to_string()));
+                event = event.add_annotation("target", &Value::from(span.target.clone()));
+
+                if span.start_clipped {
+                    event = event.add_annotation("profile.start_clipped", &Value::Bool(true));
+                    event = event.add_annotation(
+                        "profile.original_start_us",
+                        &Value::from(span.original_start_us),
+                    );
+                }
+
+                if span.end_clipped {
+                    event = event.add_annotation("profile.end_clipped", &Value::Bool(true));
+                    if let Some(original_end_us) = span.original_end_us {
+                        event = event.add_annotation(
+                            "profile.original_end_us",
+                            &Value::from(original_end_us),
+                        );
+                    } else {
+                        event =
+                            event.add_annotation("profile.end_event_missing", &Value::Bool(true));
+                    }
+                }
+                for (name, value) in &span.fields {
+                    event = event.add_annotation(name, value);
+                }
+                event.consume();
+            }
+            BoundaryKind::End => ctx.end_slice(track_id, boundary.timestamp_ns).consume(),
+        }
+    }
+
+    let summary = (
+        spans.len(),
+        actor_tracks.len(),
+        proc_ids.len(),
+        row_count - spans.len(),
+    );
+
+    let mut collector = ctx.sink();
+
+    collector.flush()?;
+
+    Ok(summary)
+}
+
+fn prepare_span(row: SpanRow, window_start_us: i64, window_end_us: i64) -> Option<PreparedSpan> {
+    let original_start_us = row.start_us?;
+    let original_end_us = row.end_us;
+
+    let start_clipped = original_start_us < window_start_us;
+    let end_clipped = original_end_us.is_none_or(|end_us| end_us > window_end_us);
+
+    let start_us = original_start_us.max(window_start_us);
+    if start_us >= window_end_us {
+        return None;
+    }
+
+    let end_us = original_end_us.unwrap_or(window_end_us).min(window_end_us);
+    if end_us <= start_us {
+        return None;
+    }
+
+    let fields = match serde_json::from_str::<Value>(&row.fields_json) {
+        Ok(Value::Object(fields)) => fields,
+        Ok(_) | Err(_) => return None,
+    };
+    let actor_id = fields.get("actor_id").and_then(Value::as_str)?;
+    let track = parse_actor_track(actor_id)?;
+
+    let start_ns = micros_to_nanos(start_us).ok()?;
+    let end_ns = micros_to_nanos(end_us).ok()?;
+    let name = display_name(&row, &fields);
+
+    Some(PreparedSpan {
+        process_id: row.process_id,
+        id: row.id,
+        name,
+        target: row.target,
+        fields,
+        track,
+        original_start_us,
+        original_end_us,
+        start_clipped,
+        end_clipped,
+        start_ns,
+        end_ns,
+    })
+}
+
+fn display_name(row: &SpanRow, fields: &Map<String, Value>) -> String {
+    if row.target == ENDPOINT_TELEMETRY_TARGET {
+        let mesh = fields.get("mesh").and_then(Value::as_str);
+        let method = fields.get("method").and_then(Value::as_str);
+        let call_name = fields.get("call_name").and_then(Value::as_str);
+
+        return match (mesh, method, call_name) {
+            (Some(mesh), Some(method), _) => format!("{mesh}.{method}.{}()", row.name),
+            (_, _, Some(call_name)) if !call_name.is_empty() => {
+                format!("{call_name}.{}()", row.name)
+            }
+            _ => row.name.clone(),
+        };
+    }
+
+    fields
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or(&row.name)
+        .to_string()
+}
+
+fn parse_actor_track(actor_addr: &str) -> Option<ActorTrack> {
+    let actor_addr = actor_addr
+        .rsplit_once(',')
+        .map(|(_, suffix)| suffix)
+        .unwrap_or(actor_addr)
+        .trim();
+
+    let actor_id = actor_addr
+        .split_once('@')
+        .map(|(id, _)| id)
+        .unwrap_or(actor_addr);
+    // ActorId displays as `<actor_uid>.<proc_id>`, so the first component is
+    // the actor and the complete remainder is the process ID.
+    let (_, proc_id) = actor_id.split_once('.')?;
+
+    Some(ActorTrack {
+        proc_id: proc_id.to_string(),
+        actor_id: actor_id.to_string(),
+    })
+}
+
+fn micros_to_nanos(timestamp_us: i64) -> Result<u64> {
+    u64::try_from(timestamp_us)
+        .context("trace timestamp is before the Unix epoch")?
+        .checked_mul(1_000)
+        .context("trace timestamp exceeds the Perfetto range")
+}
+
+fn timestamp_us() -> Result<i64> {
+    let micros = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?
+        .as_micros();
+
+    i64::try_from(micros).context("system clock exceeds the telemetry timestamp range")
+}
+
+fn resolve_output_path(output: Option<PathBuf>, filename_timestamp_us: i64) -> Result<PathBuf> {
+    let output = match output {
+        Some(output) => output,
+        None => {
+            let user = std::env::var("USER")
+                .ok()
+                .filter(|user| !user.is_empty())
+                .context("USER is not set; pass an explicit output path")?;
+
+            PathBuf::from("/tmp")
+                .join(user)
+                .join("monarch_profiles")
+                .join(format!("monarch-profile-{filename_timestamp_us}.pftrace"))
+        }
+    };
+
+    if output.is_absolute() {
+        return Ok(output);
+    }
+
+    Ok(std::env::current_dir()
+        .context("failed to get the current directory")?
+        .join(output))
+}
+
+fn validate_output_path(output: &Path) -> Result<()> {
+    if output.exists() {
+        bail!("output already exists: {}", output.display());
+    }
+    create_output_parent(output)
+}
+
+fn create_output_file(output: &Path) -> Result<fs::File> {
+    create_output_parent(output)?;
+
+    match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(output)
+    {
+        Ok(file) => Ok(file),
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+            bail!("output already exists: {}", output.display())
+        }
+        Err(error) => Err(error).with_context(|| format!("failed to create {}", output.display())),
+    }
+}
+
+fn create_output_parent(output: &Path) -> Result<()> {
+    if let Some(parent) = output.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Summary:

We want to create a new perfetto tool to address the limitations of `expanse`, and we will start with some rust functions that we will call from the monarch_cli python tool.

`expanse` works by reading perfetto trace files in a directory, aggregating traces together into a single file, and uploading that file to manifold.

This works great on a single host where traces can easily be dumped into a single directory, but has difficulty with multi-host jobs, because it requires that trace files from every process must eventually be moved/copied into a single directory.

This can be done with a NFS like OILFS, but we can't count on every single user having NFS configured, and even if they did they would need to configure their job to point the monarch perfetto file writer to their NFS dir. We want to provide a more batteries included option that just works everywhere.

Distributed telemetry is the ideal source that fits this scenario. All we have to do is run a job with distributed telemetry enabled, and point the tool to the distributed telemetry url.

The user specifies a time duration (or it will default to 10s), and during that duration, the tool will collect traces and print the directory the traces were written to. This also makes it easy for the user to pipe into and other command to do something like upload their trace somewhere.

This is also a live tool, where during a running job, a user can just run the tool and get traces for the next specified duration.

Spans that are active during the profiled duration but start before the profiled duration are included but clipped to the beginning
{F1995329666} {F1995329668}

Reviewed By: thedavekwon

Differential Revision: D118069970


