### PR TITLE
Install fuse3 in published images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-c"]
 
 # System dependencies.
 RUN apt-get update -y && \
-    apt-get install curl clang liblzma-dev libunwind-dev libibverbs-dev librdmacm-dev protobuf-compiler -y
+    apt-get install curl clang fuse3 liblzma-dev libunwind-dev libibverbs-dev librdmacm-dev protobuf-compiler -y
 
 # Install monarch w/ kubernetes.
 RUN pip install "torchmonarch[kubernetes]==${MONARCH_VERSION}" --break-system-packages

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -12,7 +12,7 @@ SHELL ["/bin/bash", "-c"]
 
 # System dependencies.
 RUN apt-get update -y && \
-    apt-get install curl clang liblzma-dev libunwind-dev libibverbs-dev librdmacm-dev protobuf-compiler -y
+    apt-get install curl clang fuse3 liblzma-dev libunwind-dev libibverbs-dev librdmacm-dev protobuf-compiler -y
 
 RUN python --version
 RUN ls -la ./dist


### PR DESCRIPTION
Summary:
RemoteMount requires fusermount3 on workers. Install fuse3 in both the release and nightly images so it works without modifying the container at startup.

___

Differential Revision: D118291226


