### PR TITLE
characterize when RDMA submit and drop take effect (#4768)

### DIFF
--- a/python/tests/test_rdma_initialization.py
+++ b/python/tests/test_rdma_initialization.py
@@ -6,14 +6,15 @@
 
 # pyre-unsafe
 """
-Tests for RDMA manager initialization and its failure surfaces.
+Tests for RDMA initialization, readiness, and public operation boundaries.
 
 These tests cover the owner-backed binding from local and remote actors,
-production readiness caching and validation, public buffer operations, and
-backend configuration errors.
+production readiness caching and validation, public buffer operations, when
+submit and drop take effect, and backend configuration errors.
 """
 
 import gc
+import re
 import sys
 import threading
 import weakref
@@ -34,6 +35,10 @@ from monarch.rdma import RDMABuffer
 
 _PUBLIC_PATH_INITIAL = b"rdma-public-path-a"
 _PUBLIC_PATH_UPDATED = b"rdma-public-path-b"
+
+_SUBMIT_INITIAL = b"rdma-submit-before"
+_SUBMIT_UPDATED = b"rdma-submit-after!"
+_DROP_INITIAL = b"rdma-drop-initial!"
 
 
 class _RdmaInitProbe(Actor):
@@ -67,7 +72,10 @@ class _RdmaInitProbe(Actor):
 
         try:
             RDMABuffer(memoryview(bytearray(b"rdma")))
-        except RdmaInitError as error:
+        except Exception as error:
+            assert type(error) is RdmaInitError, (
+                f"buffer creation must raise RdmaInitError exactly, got {type(error)}"
+            )
             buffer_error = str(error)
         else:
             raise AssertionError(
@@ -76,7 +84,10 @@ class _RdmaInitProbe(Actor):
 
         try:
             await RDMAAction().submit()
-        except RdmaInitError as error:
+        except Exception as error:
+            assert type(error) is RdmaInitError, (
+                f"submit must raise RdmaInitError exactly, got {type(error)}"
+            )
             submit_error = str(error)
         else:
             raise AssertionError("public submit unexpectedly ignored failed readiness")
@@ -109,6 +120,201 @@ class _RdmaPublicPathProbe(Actor):
         assert self.buffer is not None
         assert bytes(self.data) == _PUBLIC_PATH_UPDATED
         assert await self.buffer.drop() is None
+
+
+class _RdmaDiscardedSubmitOwner(Actor):
+    """Holds the target bytes so an independent read can observe them."""
+
+    def __init__(self) -> None:
+        self.data = bytearray(_SUBMIT_INITIAL)
+        self.buffer: RDMABuffer | None = None
+
+    @endpoint
+    async def create_buffer(self) -> RDMABuffer:
+        from monarch.rdma import RDMAAction
+
+        # An empty action crosses after_ready but submits no transfer. Use it
+        # as an explicit readiness barrier before registering the target.
+        assert await RDMAAction().submit() is None
+        self.buffer = RDMABuffer(memoryview(self.data))
+        return self.buffer
+
+    @endpoint
+    async def owner_bytes(self) -> bytes:
+        return bytes(self.data)
+
+    @endpoint
+    async def release(self) -> None:
+        assert self.buffer is not None
+        assert await self.buffer.drop() is None
+
+
+class _RdmaDiscardedSubmitConsumer(Actor):
+    """Builds one action, discards its first submit, then reuses that action."""
+
+    def __init__(self) -> None:
+        self.source = bytearray(_SUBMIT_UPDATED)
+        self.action = None
+
+    @endpoint
+    async def build_and_discard(self, buffer: RDMABuffer) -> None:
+        from monarch.rdma import RDMAAction
+
+        # Prime this proc's readiness with an empty action, which crosses
+        # after_ready but submits nothing. The discarded nonempty action below
+        # then isolates its own lock and transfer.
+        assert await RDMAAction().submit() is None
+        self.action = RDMAAction().write_remote(buffer, memoryview(self.source))
+        discarded = self.action.submit()
+        # Future has no destructor that drives its stored task, so deleting the
+        # unobserved wrapper abandons the transfer before its first poll.
+        del discarded
+
+    @endpoint
+    async def submit_same_action(self) -> None:
+        assert self.action is not None
+        assert await self.action.submit() is None
+
+
+class _RdmaDiscardedDropOwner(Actor):
+    """Runs the drop witness from the owning actor.
+
+    The release and every barrier request then originate from this actor and
+    address the same `RdmaManagerActor` mailbox, which is what makes a later
+    request/reply a handler-completion barrier for an earlier release.
+    """
+
+    @endpoint
+    async def exercise(self) -> str:
+        from monarch.config import get_global_config
+
+        assert get_global_config()["enable_dest_actor_reordering_buffer"] is True, (
+            "receive-side reordering must be pinned on; without it the barrier "
+            "stops ordering the release against the later request"
+        )
+
+        data = bytearray(_DROP_INITIAL)
+        first = RDMABuffer(memoryview(data))
+        barriers: list[RDMABuffer] = []
+        try:
+            discarded = first.drop()
+            # Future has no destructor that drives its stored task, so deleting
+            # the unobserved wrapper abandons the release before its first poll.
+            del discarded
+
+            barriers.append(self._barrier(first, b"rdma-drop-barrier-1"))
+
+            readback = bytearray(len(_DROP_INITIAL))
+            assert await first.read_into(memoryview(readback)) is None
+            assert bytes(readback) == _DROP_INITIAL, (
+                "a discarded drop must publish no release, so the registration "
+                f"is still readable; got {bytes(readback)!r}"
+            )
+
+            assert await first.drop() is None
+
+            barriers.append(self._barrier(first, b"rdma-drop-barrier-2"))
+
+            try:
+                await first.read_into(memoryview(bytearray(len(_DROP_INITIAL))))
+            except Exception as error:
+                assert type(error) is Exception, (
+                    f"a released buffer must fail as base Exception, got {type(error)}"
+                )
+                return str(error)
+            raise AssertionError("reading a released registration must fail")
+        finally:
+            for barrier in barriers:
+                await barrier.drop()
+
+    def _barrier(self, first: RDMABuffer, payload: bytes) -> RDMABuffer:
+        """A request/reply through the same manager, used to order the release."""
+        barrier = RDMABuffer(memoryview(bytearray(payload)))
+        assert barrier.owner == first.owner, (
+            "the barrier must address the same manager as the release; "
+            f"{barrier.owner} != {first.owner}"
+        )
+        return barrier
+
+
+class _RdmaSettingsProbe(Actor):
+    @endpoint
+    async def retained_settings(self) -> tuple[bool, bool, str]:
+        from monarch.config import get_global_config
+
+        config = get_global_config()
+        return (
+            config["rdma_disable_ibverbs"],
+            config["rdma_allow_tcp_fallback"],
+            config["rdma_ibverbs_target"],
+        )
+
+
+class _RdmaDropReadinessOwner(_RdmaSettingsProbe):
+    def __init__(self) -> None:
+        self.data = bytearray(_DROP_INITIAL)
+        self.buffer: RDMABuffer | None = None
+
+    @endpoint
+    async def create_buffer(self) -> RDMABuffer:
+        self.buffer = RDMABuffer(memoryview(self.data))
+        return self.buffer
+
+    @endpoint
+    async def still_usable(self) -> bool:
+        assert self.buffer is not None
+        readback = bytearray(len(_DROP_INITIAL))
+        assert await self.buffer.read_into(memoryview(readback)) is None
+        return bytes(readback) == _DROP_INITIAL
+
+    @endpoint
+    async def release(self) -> None:
+        assert self.buffer is not None
+        assert await self.buffer.drop() is None
+
+
+class _RdmaDropReadinessConsumer(_RdmaSettingsProbe):
+    @endpoint
+    async def drop_and_report(self, buffer: RDMABuffer) -> str:
+        from monarch._rust_bindings.rdma import RdmaInitError
+
+        try:
+            await buffer.drop()
+        except Exception as error:
+            assert type(error) is RdmaInitError, (
+                f"a failed readiness must surface exactly, got {type(error)}"
+            )
+            return str(error)
+        raise AssertionError("drop must not ignore a failed readiness")
+
+
+class _RdmaSubmitTimeoutProbe(Actor):
+    @endpoint
+    async def submit_with_zero_timeout(self) -> str:
+        from monarch.rdma import RDMAAction
+
+        data = bytearray(_SUBMIT_INITIAL)
+        source = bytearray(_SUBMIT_UPDATED)
+        buffer = RDMABuffer(memoryview(data))
+        try:
+            # An empty action crosses the same readiness gate but returns
+            # before the operation deadline. Use it as a separate readiness
+            # control for the timeout failure below.
+            assert await RDMAAction().submit() is None
+            # Keep this action nonempty: native submit returns before checking
+            # the deadline for an empty batch, so only a queued operation can
+            # reach the zero-deadline guard this test pins.
+            action = RDMAAction().write_remote(buffer, memoryview(source))
+            try:
+                await action.submit(timeout=0)
+            except Exception as error:
+                assert type(error) is Exception, (
+                    f"a post-readiness failure must be base Exception, got {type(error)}"
+                )
+                return str(error)
+            raise AssertionError("a zero submit deadline must fail after readiness")
+        finally:
+            await buffer.drop()
 
 
 def test_manager_init_cache_reuses_handle_without_retaining_mesh(monkeypatch) -> None:
@@ -324,6 +530,180 @@ async def test_public_rdma_paths() -> None:
                 await consumer_proc.stop()
         finally:
             await producer_proc.stop()
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+async def test_discarded_submit_leaves_bytes_unchanged_and_same_action_runnable() -> (
+    None
+):
+    """Submitting captures readiness and the action, but the transfer itself
+    rides on the returned Future. Discarding that Future before it is driven
+    writes nothing and leaves the very same action runnable."""
+    from monarch.actor import this_host
+
+    with configured(
+        rdma_disable_ibverbs=True,
+        rdma_allow_tcp_fallback=True,
+        rdma_ibverbs_target="",
+    ):
+        # ProcMesh.spawn creates an actor across the whole mesh. Two one-proc
+        # meshes keep the owner and consumer as single actors while still
+        # exercising a cross-proc transfer, without a multi-proc mesh and
+        # explicit rank slices obscuring the witness.
+        owner_proc = this_host().spawn_procs(per_host={"cpus": 1})
+        try:
+            consumer_proc = this_host().spawn_procs(per_host={"cpus": 1})
+            try:
+                owner = owner_proc.spawn(
+                    "rdma_discarded_submit_owner", _RdmaDiscardedSubmitOwner
+                )
+                consumer = consumer_proc.spawn(
+                    "rdma_discarded_submit_consumer", _RdmaDiscardedSubmitConsumer
+                )
+
+                buffer = await owner.create_buffer.call_one()
+                assert await consumer.build_and_discard.call_one(buffer) is None
+                assert await owner.owner_bytes.call_one() == _SUBMIT_INITIAL, (
+                    "a discarded submit must not transfer bytes"
+                )
+
+                assert await consumer.submit_same_action.call_one() is None
+                assert await owner.owner_bytes.call_one() == _SUBMIT_UPDATED, (
+                    "the same action must remain runnable after its first "
+                    "Future was discarded"
+                )
+
+                assert await owner.release.call_one() is None
+            finally:
+                await consumer_proc.stop()
+        finally:
+            await owner_proc.stop()
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+async def test_discarded_drop_leaves_buffer_usable() -> None:
+    """Dropping publishes a one-way release only when the Future is driven.
+    A discarded Future publishes nothing, proven by a same-manager barrier
+    rather than by the drop result, which acknowledges publication only."""
+    from monarch.actor import this_host
+
+    with configured(
+        rdma_disable_ibverbs=True,
+        rdma_allow_tcp_fallback=True,
+        rdma_ibverbs_target="",
+        enable_dest_actor_reordering_buffer=True,
+    ):
+        proc = this_host().spawn_procs(per_host={"cpus": 1})
+        try:
+            owner = proc.spawn("rdma_discarded_drop_owner", _RdmaDiscardedDropOwner)
+            message = await owner.exercise.call_one()
+            assert message.startswith("RdmaAction.submit failed:"), (
+                f"the released-buffer read must be a wrapped submit failure: {message}"
+            )
+            assert re.search(r"\(Tcp\) buffer \d+ not found(?:\n|$)", message), (
+                "the cause must name the released registration, not any other "
+                f"lookup failure: {message}"
+            )
+        finally:
+            await proc.stop()
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+async def test_drop_propagates_readiness_failure_without_releasing_buffer() -> None:
+    """A consumer whose readiness fails surfaces the exact RdmaInitError from
+    drop, and the owner's registration survives because readiness is awaited
+    before the release is published."""
+    from monarch.actor import this_host
+
+    owner_proc = None
+    consumer_proc = None
+    try:
+        # This test makes drop() fail during readiness, before it can release
+        # the owner's buffer. The owner needs a working TCP backend to register
+        # the buffer and later prove that registration remains usable. The
+        # consumer needs no available backend so its readiness fails before
+        # drop() can publish ReleaseBuffer.
+        #
+        # configured() changes process-global state, so these roles cannot
+        # share one scope. spawn_procs() snapshots that state asynchronously;
+        # awaiting each child's initialization inside its scope ensures that
+        # it retains the configuration required for its role.
+        with configured(
+            rdma_disable_ibverbs=True,
+            rdma_allow_tcp_fallback=True,
+            rdma_ibverbs_target="",
+        ):
+            owner_proc = this_host().spawn_procs(per_host={"cpus": 1})
+            assert await owner_proc.initialized is True
+        with configured(
+            rdma_disable_ibverbs=True,
+            rdma_allow_tcp_fallback=False,
+            rdma_ibverbs_target="",
+        ):
+            consumer_proc = this_host().spawn_procs(per_host={"cpus": 1})
+            assert await consumer_proc.initialized is True
+
+        owner = owner_proc.spawn("rdma_drop_readiness_owner", _RdmaDropReadinessOwner)
+        consumer = consumer_proc.spawn(
+            "rdma_drop_readiness_consumer", _RdmaDropReadinessConsumer
+        )
+
+        # Both scopes have restored the parent's ambient configuration. Ask
+        # each child what it retained so fixture drift fails here instead of
+        # looking like a failure in drop().
+        assert await owner.retained_settings.call_one() == (True, True, ""), (
+            "the owner proc must retain the configuration active when it spawned"
+        )
+        assert await consumer.retained_settings.call_one() == (True, False, ""), (
+            "the consumer proc must retain its own forced no-backend settings"
+        )
+
+        buffer = await owner.create_buffer.call_one()
+        message = await consumer.drop_and_report.call_one(buffer)
+        assert "no RDMA backend available" in message, (
+            f"the readiness cause must survive the drop Future: {message}"
+        )
+
+        assert await owner.still_usable.call_one() is True, (
+            "a readiness failure must occur before any release is published"
+        )
+        assert await owner.release.call_one() is None
+    finally:
+        try:
+            if consumer_proc is not None:
+                await consumer_proc.stop()
+        finally:
+            if owner_proc is not None:
+                await owner_proc.stop()
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+async def test_submit_wraps_post_readiness_operation_failure() -> None:
+    """A zero submit deadline fails inside the submitted operation, after
+    readiness has already succeeded, and is wrapped as a base Exception."""
+    from monarch.actor import this_host
+
+    with configured(
+        rdma_disable_ibverbs=True,
+        rdma_allow_tcp_fallback=True,
+        rdma_ibverbs_target="",
+    ):
+        proc = this_host().spawn_procs(per_host={"cpus": 1})
+        try:
+            probe = proc.spawn("rdma_submit_timeout_probe", _RdmaSubmitTimeoutProbe)
+            message = await probe.submit_with_zero_timeout.call_one()
+            assert message.startswith("RdmaAction.submit failed:"), (
+                f"the operation failure must carry the submit prefix: {message}"
+            )
+            assert "tcp submit timed out" in message, (
+                f"the cause must be the TCP submit deadline: {message}"
+            )
+        finally:
+            await proc.stop()
 
 
 # The tests below cover the owner-driven binding

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -2580,14 +2580,19 @@ constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyRdmaAction::submit"
 consumer = "RDMAAction.submit via Future._from_coro"
 driver = "awaited by the caller through the public Future"
-start_point = "gated on RDMA readiness, then lazy until driven"
-abandonment = "possible; a caller may drop the returned Future"
-eager_effect = "starts a side effect"
-drop_behavior = "the transfer is never submitted"
-unobserved_error = "surfaced on observation"
-disposition = "intentionally become eager"
+start_point = "call time obtains or starts readiness and retains an observer; readiness wait, action lock, and transfer submission begin only when the returned Future is first driven"
+abandonment = "possible before first drive; async observation and timed get() are non-abortable after spawn, while untimed get() drives inline"
+eager_effect = "starts a side effect: an eager conversion would drive the retained readiness observer and then take the action lock and submit the queued operations even if the returned observer is discarded"
+drop_behavior = "discarding before first drive submits nothing and leaves the same action runnable"
+unobserved_error = "no operation error exists until driven; readiness retains exact RdmaInitError, and later operation failure is exact base Exception with RdmaAction.submit failed:"
+disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "test_rdma submit coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_discarded_submit_leaves_bytes_unchanged_and_same_action_runnable",
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_public_submit_and_drop_resolve_to_none_after_tcp_init",
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_public_paths_propagate_readiness_failure",
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_submit_wraps_post_readiness_operation_failure",
+]
 
 [[site]]
 id = "np.lib.PyRdmaBuffer.drop"
@@ -2603,14 +2608,18 @@ constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyRdmaBuffer::drop"
 consumer = "RDMABuffer.drop via Future._from_coro"
 driver = "awaited by the caller through the public Future"
-start_point = "gated on RDMA readiness, then lazy until driven"
-abandonment = "possible; a caller may drop the returned Future"
-eager_effect = "starts a side effect"
-drop_behavior = "the buffer registration is never released"
-unobserved_error = "surfaced on observation"
-disposition = "intentionally become eager"
+start_point = "call time obtains or starts readiness and retains an observer plus cloned buffer state; readiness wait and release publication begin only when the returned Future is first driven"
+abandonment = "possible before first drive; async observation and timed get() are non-abortable after spawn, while untimed get() drives inline"
+eager_effect = "starts a side effect: an eager conversion would drive the retained readiness observer and then publish ReleaseBuffer even if the returned observer is discarded"
+drop_behavior = "discarding before first drive publishes no release and leaves the registration usable"
+unobserved_error = "no release error exists until driven; readiness retains exact RdmaInitError, while handler execution and delivery failures after the one-way post are outside this Future's result"
+disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "test_rdma drop coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_discarded_drop_leaves_buffer_usable",
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_public_submit_and_drop_resolve_to_none_after_tcp_init",
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_drop_propagates_readiness_failure_without_releasing_buffer",
+]
 
 [[site]]
 id = "im.actor_mesh.module"


### PR DESCRIPTION
Summary:

today, `RDMAAction.submit()` and `RDMABuffer.drop()` return lazy Futures. the calls can begin or reuse RDMA initialization, but the transfer or buffer release does not happen until the Future is driven. replacing that lazy task with an eager completion object would therefore change behavior: an ignored return value could submit bytes or release a buffer.

this adds public-path tests that pin the existing boundary. discarding a submit Future leaves the destination unchanged and the same action runnable. discarding a drop Future leaves the buffer usable; after a driven drop, a request and reply through the same RDMA manager acts as a barrier before the test verifies that the registration is gone. this matters because drop reports that it published a one-way release message, not that the manager processed it.

the tests also distinguish failure during RDMA initialization from failure after submission starts, and preserve the successful `None` result. the census links both producers to these exact tests and marks their migration timing as an explicit design decision rather than assuming eager execution.

this changes tests and migration metadata only. no production behavior changes.

Differential Revision: D118302643


