### PR TITLE
Stop telemetry queries from generating telemetry

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2155,20 +2155,26 @@ impl MailboxSender for Mailbox {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
-        metrics::MAILBOX_POSTS.add(
-            1,
-            hyperactor_telemetry::kv_pairs!(
-                "actor_id" => envelope.sender.to_string(),
-                "dest_actor_id" => envelope.dest.actor_addr().to_string(),
-            ),
-        );
-        tracing::trace!(
-            name = "post",
-            actor_name = envelope.sender.label().map_or("?", |l| l.as_str()),
-            actor_id = envelope.sender.to_string(),
-            "posting message to {}",
-            envelope.dest
-        );
+        let suppress_telemetry = envelope
+            .headers()
+            .get(crate::mailbox::headers::SUPPRESS_TELEMETRY)
+            .unwrap_or(false);
+        if !suppress_telemetry {
+            metrics::MAILBOX_POSTS.add(
+                1,
+                hyperactor_telemetry::kv_pairs!(
+                    "actor_id" => envelope.sender.to_string(),
+                    "dest_actor_id" => envelope.dest.actor_addr().to_string(),
+                ),
+            );
+            tracing::trace!(
+                name = "post",
+                actor_name = envelope.sender.label().map_or("?", |l| l.as_str()),
+                actor_id = envelope.sender.to_string(),
+                "posting message to {}",
+                envelope.dest
+            );
+        }
 
         if envelope.dest().actor_id() != self.inner.actor_id.id() {
             let failure = DeliveryFailure::new(InvalidReference::new(
@@ -2258,26 +2264,33 @@ impl MailboxSender for Mailbox {
             return_undeliverable,
         } = metadata;
 
-        let to_actor_id = hash_to_u64(dest.actor_addr().id());
-        let message_id = hyperactor_telemetry::generate_message_id(to_actor_id);
-        headers.set(crate::mailbox::headers::TELEMETRY_MESSAGE_ID, message_id);
-        // A cast leaf stamps its trusted logical origin before this boundary.
-        // For other deliveries, the envelope sender is the logical origin.
-        if !headers.contains_key(crate::mailbox::headers::SENDER_ACTOR_ID_HASH) {
-            crate::mailbox::headers::stamp_sender_actor_id_hash(&mut headers, &sender);
-        }
-        headers.set(crate::mailbox::headers::TELEMETRY_PORT_INDEX, dest.index());
+        let message_id = if suppress_telemetry {
+            None
+        } else {
+            let to_actor_id = hash_to_u64(dest.actor_addr().id());
+            let message_id = hyperactor_telemetry::generate_message_id(to_actor_id);
+            headers.set(crate::mailbox::headers::TELEMETRY_MESSAGE_ID, message_id);
+            // A cast leaf stamps its trusted logical origin before this boundary.
+            // For other deliveries, the envelope sender is the logical origin.
+            if !headers.contains_key(crate::mailbox::headers::SENDER_ACTOR_ID_HASH) {
+                crate::mailbox::headers::stamp_sender_actor_id_hash(&mut headers, &sender);
+            }
+            headers.set(crate::mailbox::headers::TELEMETRY_PORT_INDEX, dest.index());
+            Some(message_id)
+        };
 
         match port_sender.send_serialized(headers, data) {
             Ok(disposition) => {
-                hyperactor_telemetry::notify_message_status(
-                    hyperactor_telemetry::MessageStatusEvent {
-                        timestamp: std::time::SystemTime::now(),
-                        id: hyperactor_telemetry::generate_status_event_id(message_id),
-                        message_id,
-                        status: "queued".to_string(),
-                    },
-                );
+                if let Some(message_id) = message_id {
+                    hyperactor_telemetry::notify_message_status(
+                        hyperactor_telemetry::MessageStatusEvent {
+                            timestamp: std::time::SystemTime::now(),
+                            id: hyperactor_telemetry::generate_status_event_id(message_id),
+                            message_id,
+                            status: "queued".to_string(),
+                        },
+                    );
+                }
 
                 if disposition == SerializedSendDisposition::DeliveredAndExhausted {
                     self.inner.ports.remove(&port);
@@ -5604,8 +5617,6 @@ mod tests {
             actor1,
             port_id: _,
             port_id1,
-            port_id2: _,
-            port_id2_1: _,
             ..
         } = setup_split_port_ids(
             Some(accum::sum::<u64>().reducer_spec().unwrap()),
@@ -5648,8 +5659,6 @@ mod tests {
             actor1,
             port_id: _,
             port_id1,
-            port_id2: _,
-            port_id2_1: _,
             ..
         } = setup_split_port_ids(
             Some(accum::sum::<u64>().reducer_spec().unwrap()),

--- a/hyperactor/src/mailbox/headers.rs
+++ b/hyperactor/src/mailbox/headers.rs
@@ -57,6 +57,10 @@ declare_attrs! {
     /// Port index the message was delivered to, injected in post_unchecked().
     pub attr TELEMETRY_PORT_INDEX: u64;
 
+    /// Suppress telemetry generated while delivering this message and its reply.
+    @meta(OPERATION_CONTEXT_HEADER = true)
+    pub attr SUPPRESS_TELEMETRY: bool;
+
     // Operation-context headers (see `OPERATION_CONTEXT_HEADER` in
     // `hyperactor_config::attrs`). Carried from the caller's outgoing
     // request onto the reply envelope by a consumer-side helper that

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1041,7 +1041,7 @@ impl<A: Referable> ManagedActorMeshRef<A> {
         A: RemoteHandles<M>,
         M: RemoteMessage + Clone,
     {
-        self.emit_sent_message_telemetry(cx, self.region());
+        self.emit_sent_message_telemetry(cx, self.region(), caller_headers);
 
         let mut headers = caller_headers.clone();
         headers.set(
@@ -1081,6 +1081,7 @@ impl<A: Referable> ManagedActorMeshRef<A> {
                 ndslice::Slice::new(0, Vec::new(), Vec::new())
                     .expect("zero-dimensional slice is valid"),
             ),
+            caller_headers,
         );
 
         let num_ranks = self.cast_domain.region().num_ranks();
@@ -1108,7 +1109,18 @@ impl<A: Referable> ManagedActorMeshRef<A> {
         self.post_cast_direct(cx, point, actor, message, caller_headers)
     }
 
-    fn emit_sent_message_telemetry(&self, cx: &impl context::Actor, region: &Region) {
+    fn emit_sent_message_telemetry(
+        &self,
+        cx: &impl context::Actor,
+        region: &Region,
+        headers: &Flattrs,
+    ) {
+        if headers
+            .get(hyperactor::mailbox::headers::SUPPRESS_TELEMETRY)
+            .unwrap_or(false)
+        {
+            return;
+        }
         hyperactor_telemetry::notify_sent_message(hyperactor_telemetry::SentMessageEvent {
             timestamp: std::time::SystemTime::now(),
             sender_actor_id: hyperactor_telemetry::hash_to_u64(cx.mailbox().actor_addr().id()),

--- a/hyperactor_telemetry/src/config.rs
+++ b/hyperactor_telemetry/src/config.rs
@@ -87,8 +87,8 @@ declare_attrs! {
 /// Build a `Targets` filter for tracing sinks.
 ///
 /// Reads the log level from `MONARCH_FILE_LOG_LEVEL` (defaulting to "info")
-/// and disables noisy internal targets (`hyperactor_telemetry`, `message`,
-/// `execution`, `opentelemetry`).
+/// and disables noisy internal targets (`hyperactor_telemetry`,
+/// `monarch_distributed_telemetry`, `message`, `execution`, `opentelemetry`).
 pub(crate) fn get_tracing_targets() -> Targets {
     let level = LevelFilter::from_level({
         let log_level_str = hyperactor_config::global::try_get_cloned(MONARCH_FILE_LOG_LEVEL)
@@ -97,6 +97,7 @@ pub(crate) fn get_tracing_targets() -> Targets {
     });
     Targets::new()
         .with_target("hyperactor_telemetry", LevelFilter::OFF)
+        .with_target("monarch_distributed_telemetry", LevelFilter::OFF)
         .with_target("message", LevelFilter::OFF)
         .with_target("execution", LevelFilter::OFF)
         .with_target("opentelemetry", LevelFilter::OFF)

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -348,6 +348,7 @@ async fn collect_valuemesh(
     extent: Extent,
     rx: OncePortReceiver<PythonMessage>,
     attrs: Arc<EndpointAttrs>,
+    record_telemetry: bool,
     supervision_monitor: Option<Arc<dyn Supervisable>>,
     instance: &Instance<PythonActor>,
     qualified_endpoint_name: Option<String>,
@@ -356,7 +357,8 @@ async fn collect_valuemesh(
 
     let expected_count = extent.num_ranks();
 
-    let record_guard = RecordEndpointGuard::new(start, attrs, EndpointAdverb::Call);
+    let record_guard =
+        record_telemetry.then(|| RecordEndpointGuard::new(start, attrs, EndpointAdverb::Call));
 
     enum RaceResult {
         Collected(Box<PythonMessage>),
@@ -429,7 +431,9 @@ async fn collect_valuemesh(
                                 parts.extend(range.clone().map(|_| part.clone()));
                             }
                             PythonResponseMessage::Exception { .. } => {
-                                record_guard.mark_error();
+                                if let Some(record_guard) = &record_guard {
+                                    record_guard.mark_error();
+                                }
                                 return Err(PyErr::from_value(
                                     payload.decode(py, instance)?.into_bound(py),
                                 ));
@@ -450,7 +454,9 @@ async fn collect_valuemesh(
                             objects.extend(range.clone().map(|_| obj.clone_ref(py)));
                         }
                         PythonResponseMessage::Exception { .. } => {
-                            record_guard.mark_error();
+                            if let Some(record_guard) = &record_guard {
+                                record_guard.mark_error();
+                            }
                             return Err(PyErr::from_value(
                                 payload.decode(py, instance)?.into_bound(py),
                             ));
@@ -464,14 +470,18 @@ async fn collect_valuemesh(
             })
         }
         RaceResult::RecvError(e) => {
-            record_guard.mark_error();
+            if let Some(record_guard) = &record_guard {
+                record_guard.mark_error();
+            }
             Err(pyo3::exceptions::PyEOFError::new_err(format!(
                 "Port closed: {}",
                 e
             )))
         }
         RaceResult::SupervisionError(err) => {
-            record_guard.mark_error();
+            if let Some(record_guard) = &record_guard {
+                record_guard.mark_error();
+            }
             Err(supervision_error_to_pyerr(err, &qualified_endpoint_name))
         }
     }
@@ -484,13 +494,14 @@ fn value_collector(
     instance: Instance<PythonActor>,
     qualified_endpoint_name: Option<String>,
     adverb: EndpointAdverb,
-    span_guard: SpanGuard,
+    span_guard: Option<SpanGuard>,
+    record_telemetry: bool,
 ) -> PyResult<PyPythonTask> {
     Ok(PythonTask::new(async move {
         let _span_guard = span_guard;
         let start = tokio::time::Instant::now();
 
-        let record_guard = RecordEndpointGuard::new(start, attrs, adverb);
+        let record_guard = record_telemetry.then(|| RecordEndpointGuard::new(start, attrs, adverb));
 
         match collect_value(
             &mut receiver,
@@ -508,7 +519,9 @@ fn value_collector(
                 state.unpickle_with_receiver(py, &instance)
             }),
             Err(e) => {
-                record_guard.mark_error();
+                if let Some(record_guard) = &record_guard {
+                    record_guard.mark_error();
+                }
                 Err(e)
             }
         }
@@ -534,6 +547,7 @@ pub struct PyValueStream {
     qualified_endpoint_name: Option<String>,
     start: tokio::time::Instant,
     future_class: Py<PyAny>,
+    record_telemetry: bool,
 }
 
 #[pymethods]
@@ -555,9 +569,11 @@ impl PyValueStream {
         let qualified_endpoint_name = self.qualified_endpoint_name.clone();
         let start = self.start;
         let attrs = self.attrs.clone();
+        let record_telemetry = self.record_telemetry;
 
         let task: PyPythonTask = PythonTask::new(async move {
-            let record_guard = RecordEndpointGuard::new(start, attrs, EndpointAdverb::Stream);
+            let record_guard = record_telemetry
+                .then(|| RecordEndpointGuard::new(start, attrs, EndpointAdverb::Stream));
 
             let mut rx_guard = receiver.lock().await;
 
@@ -577,7 +593,9 @@ impl PyValueStream {
                     state.unpickle_with_receiver(py, &instance)
                 }),
                 Err(e) => {
-                    record_guard.mark_error();
+                    if let Some(record_guard) = &record_guard {
+                        record_guard.mark_error();
+                    }
                     Err(e)
                 }
             }
@@ -607,6 +625,11 @@ pub(crate) trait Endpoint {
     /// once per endpoint; the adverbs hand a clone to the tasks that outlive
     /// the borrow of `self`.
     fn metric_attrs(&self) -> &Arc<EndpointAttrs>;
+
+    /// Whether calls to this endpoint should generate telemetry.
+    fn record_telemetry(&self) -> bool {
+        true
+    }
 
     /// Create and send a message with the given args/kwargs.
     fn send_message<'py>(
@@ -657,6 +680,9 @@ pub(crate) trait Endpoint {
         );
         let mut headers = hyperactor_config::Flattrs::new();
         crate::operation_context::stamp_operation_context(&mut headers, &attrs);
+        if !self.record_telemetry() {
+            headers.set(hyperactor::mailbox::headers::SUPPRESS_TELEMETRY, true);
+        }
         headers
     }
 
@@ -707,7 +733,9 @@ pub(crate) trait Endpoint {
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
         let instance = self.get_current_instance(py)?;
-        let span_guard = self.enter_endpoint_span(EndpointAdverb::Call, instance.self_addr());
+        let record_telemetry = self.record_telemetry();
+        let span_guard = record_telemetry
+            .then(|| self.enter_endpoint_span(EndpointAdverb::Call, instance.self_addr()));
 
         let extent = self.get_extent(py)?;
         let attrs = self.metric_attrs().clone();
@@ -734,6 +762,7 @@ pub(crate) trait Endpoint {
                 extent,
                 receiver,
                 attrs,
+                record_telemetry,
                 supervision_monitor,
                 &instance_for_task,
                 qualified_endpoint_name,
@@ -757,7 +786,9 @@ pub(crate) trait Endpoint {
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
         let instance = self.get_current_instance(py)?;
-        let span_guard = self.enter_endpoint_span(EndpointAdverb::Choose, instance.self_addr());
+        let record_telemetry = self.record_telemetry();
+        let span_guard = record_telemetry
+            .then(|| self.enter_endpoint_span(EndpointAdverb::Choose, instance.self_addr()));
         let (port_ref, receiver) = self.open_response_port(&instance);
 
         let caller_headers = self.build_operation_context_headers(EndpointAdverb::Choose);
@@ -779,6 +810,7 @@ pub(crate) trait Endpoint {
             self.get_qualified_name(),
             EndpointAdverb::Choose,
             span_guard,
+            record_telemetry,
         )?;
 
         wrap_in_future(py, task)
@@ -801,7 +833,9 @@ pub(crate) trait Endpoint {
         }
 
         let instance = self.get_current_instance(py)?;
-        let span_guard = self.enter_endpoint_span(EndpointAdverb::CallOne, instance.self_addr());
+        let record_telemetry = self.record_telemetry();
+        let span_guard = record_telemetry
+            .then(|| self.enter_endpoint_span(EndpointAdverb::CallOne, instance.self_addr()));
         let (port_ref, receiver) = self.open_response_port(&instance);
 
         let caller_headers = self.build_operation_context_headers(EndpointAdverb::CallOne);
@@ -823,6 +857,7 @@ pub(crate) trait Endpoint {
             self.get_qualified_name(),
             EndpointAdverb::CallOne,
             span_guard,
+            record_telemetry,
         )?;
 
         wrap_in_future(py, task)
@@ -857,7 +892,10 @@ pub(crate) trait Endpoint {
         let qualified_endpoint_name = self.get_qualified_name();
         let future_class = make_future(py).unbind();
 
-        ENDPOINT_STREAM_THROUGHPUT.add(1, self.metric_attrs().as_slice());
+        let record_telemetry = self.record_telemetry();
+        if record_telemetry {
+            ENDPOINT_STREAM_THROUGHPUT.add(1, self.metric_attrs().as_slice());
+        }
 
         let stream = PyValueStream {
             receiver: Arc::new(tokio::sync::Mutex::new(receiver)),
@@ -868,6 +906,7 @@ pub(crate) trait Endpoint {
             qualified_endpoint_name,
             start,
             future_class,
+            record_telemetry,
         };
 
         Ok(stream.into_pyobject(py)?.unbind().into())
@@ -882,14 +921,32 @@ pub(crate) trait Endpoint {
     ) -> PyResult<()> {
         let instance = self.get_current_instance(py)?;
         let attributes = self.metric_attrs().as_slice();
+        let record_telemetry = self.record_telemetry();
 
-        match self.send_message(py, args, kwargs, None, AllOrChoose::All, &instance) {
+        let mut caller_headers = hyperactor_config::Flattrs::new();
+        if !record_telemetry {
+            caller_headers.set(hyperactor::mailbox::headers::SUPPRESS_TELEMETRY, true);
+        }
+        let result = self.send_message_with_headers(
+            py,
+            args,
+            kwargs,
+            None,
+            AllOrChoose::All,
+            &instance,
+            caller_headers,
+        );
+        match result {
             Ok(()) => {
-                ENDPOINT_BROADCAST_THROUGHPUT.add(1, attributes);
+                if record_telemetry {
+                    ENDPOINT_BROADCAST_THROUGHPUT.add(1, attributes);
+                }
                 Ok(())
             }
             Err(e) => {
-                ENDPOINT_BROADCAST_ERROR.add(1, attributes);
+                if record_telemetry {
+                    ENDPOINT_BROADCAST_ERROR.add(1, attributes);
+                }
                 Err(e)
             }
         }
@@ -911,6 +968,7 @@ pub struct ActorEndpoint {
     /// An endpoint outlives every invocation on it, so building its attributes
     /// once here keeps the per-invocation metrics allocation-free.
     attrs: Arc<EndpointAttrs>,
+    record_telemetry: bool,
 }
 
 impl ActorEndpoint {
@@ -943,7 +1001,10 @@ impl ActorEndpoint {
         let mut pending: PyRefMut<'_, PendingMessage> = result.extract()?;
         let message = pending.take()?;
 
-        ENDPOINT_MESSAGE_SIZE_HISTOGRAM.record(message.payload_len() as f64, self.attrs.as_slice());
+        if self.record_telemetry {
+            ENDPOINT_MESSAGE_SIZE_HISTOGRAM
+                .record(message.payload_len() as f64, self.attrs.as_slice());
+        }
 
         Ok(message)
     }
@@ -960,6 +1021,10 @@ impl Endpoint for ActorEndpoint {
 
     fn metric_attrs(&self) -> &Arc<EndpointAttrs> {
         &self.attrs
+    }
+
+    fn record_telemetry(&self) -> bool {
+        self.record_telemetry
     }
 
     fn send_message<'py>(
@@ -1009,7 +1074,7 @@ impl Endpoint for ActorEndpoint {
 impl ActorEndpoint {
     /// Create a new ActorEndpoint.
     #[new]
-    #[pyo3(signature = (actor_mesh, method, shape, mesh_name, signature=None, proc_mesh=None, propagator=None))]
+    #[pyo3(signature = (actor_mesh, method, shape, mesh_name, signature=None, proc_mesh=None, propagator=None, record_telemetry=true))]
     fn new(
         actor_mesh: PythonActorMesh,
         method: MethodSpecifier,
@@ -1018,6 +1083,7 @@ impl ActorEndpoint {
         signature: Option<Py<PyAny>>,
         proc_mesh: Option<Py<PyAny>>,
         propagator: Option<Py<PyAny>>,
+        record_telemetry: bool,
     ) -> Self {
         // `mesh_name` is the raw name Python spawned the mesh under, so it takes
         // the same stripping that produced the actors' own label. Only the
@@ -1034,6 +1100,7 @@ impl ActorEndpoint {
             proc_mesh,
             propagator,
             attrs,
+            record_telemetry,
         }
     }
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/endpoint.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/endpoint.pyi
@@ -76,6 +76,7 @@ class ActorEndpoint(Generic[P, R]):
         signature: Any | None = None,
         proc_mesh: Any | None = None,
         propagator: Any | None = None,
+        record_telemetry: bool = True,
     ) -> None: ...
     def _call_name(self) -> Any:
         """Something to use in InputChecker to represent calling this thingy."""

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1351,6 +1351,7 @@ class _Actor:
 
     def __init__(self) -> None:
         self.instance: object | None = None
+        self._record_telemetry: bool = True
         # TODO: (@pzhang) remove this with T229200522
         self._saved_error: ActorError | None = None
         self._method_cache: Dict[str, Tuple[Callable[..., Any], bool, bool]] = {}
@@ -1365,7 +1366,8 @@ class _Actor:
         mesh_references: List[Any],
         response_port: "PortProtocol[Any]",
     ) -> None:
-        MESSAGES_HANDLED.add(1)
+        if self._record_telemetry:
+            MESSAGES_HANDLED.add(1)
 
         # Initialize method_name before try block so it's always defined
         method_name = method.name
@@ -1389,6 +1391,7 @@ class _Actor:
                     (args,) = args
                     init_args = cast(ActorInitArgs, args)
                     Class = init_args.Class
+                    self._record_telemetry = getattr(Class, "_record_telemetry", True)
                     ins.proc_mesh = cast("ProcMesh", init_args.proc_mesh)
                     ins._controller_controller = cast(
                         "_ControllerController", init_args.controller_controller
@@ -1445,7 +1448,9 @@ class _Actor:
                 should_instrument = False
 
                 if isinstance(the_method, EndpointProperty):
-                    should_instrument = the_method._instrument
+                    should_instrument = (
+                        the_method._instrument and self._record_telemetry
+                    )
                     the_method = functools.partial(the_method._method, self.instance)
 
                 self._method_cache[method_name] = (
@@ -1487,7 +1492,8 @@ class _Actor:
             else:
                 await response
         except Exception as e:
-            log_endpoint_exception(e, method_name, ctx.actor_instance.actor_id)
+            if self._record_telemetry:
+                log_endpoint_exception(e, method_name, ctx.actor_instance.actor_id)
             self._post_mortem_debug(e.__traceback__)
             response_port.exception(
                 ActorError(
@@ -1874,6 +1880,7 @@ class ActorMesh(MeshTrait, Generic[T]):
             inspect.signature(impl),
             self._proc_mesh,
             propagator,
+            getattr(self._class, "_record_telemetry", True),
         )
 
     def __reduce_ex__(

--- a/python/monarch/_src/job/telemetry_actor.py
+++ b/python/monarch/_src/job/telemetry_actor.py
@@ -62,6 +62,10 @@ def telemetry_socket_path(apply_id: str) -> str:
 class TelemetryActor(Actor):
     """Host-local telemetry collector actor."""
 
+    # ActorMesh reads this for caller instrumentation; PythonActor reads it for
+    # receiver instrumentation. Observing queries would change their results.
+    _record_telemetry = False
+
     def __init__(self, apply_id: str, retention_secs: int) -> None:
         # Job-instance identifier; namespaces the per-host socket path under
         # /tmp so concurrent jobs on the same host do not collide.

--- a/python/monarch/monarch_dashboard/frontend/src/components/overview/OverviewView.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/overview/OverviewView.tsx
@@ -264,10 +264,6 @@ function ActivityPanel({ s, activity }: { s: Summary; activity: MessageActivity 
       <div className="panel-body">
         <EChart option={option} height={130} />
         <SessionTimeline start={start} end={end} errors={s.errors} failureOnset={fo} />
-        <div className="chart-note">
-          <IconEye size={12} />
-          <span>Live polling adds a small amount of <code>scan</code> telemetry traffic.</span>
-        </div>
       </div>
     </div>
   );

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -2770,3 +2770,88 @@ def test_public_custom_trace_is_queryable() -> None:
         assert result.get("name") == ["python_user_span"]
         fields = json.loads(result["fields_json"][0])
         assert fields["name"] == trace_name
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_query_does_not_generate_telemetry() -> None:
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
+        cached_path=None,
+    ) as state:
+        _assert_sidecar(state)
+
+        scan_sql = "SELECT COUNT(*) AS count FROM messages WHERE endpoint = 'scan'"
+        mailbox_posts_sql = (
+            "SELECT COALESCE(SUM(sum_u64), 0) AS count FROM metric_sums "
+            "WHERE name = 'mailbox.posts' "
+            'AND attributes_json LIKE \'%"dest_actor_id":"telemetry<%\''
+        )
+        scan_counts = []
+        for _ in range(4):
+            rows = _sidecar_query_rows(state, scan_sql)
+            scan_counts.append(rows[0]["count"])
+            time.sleep(1)
+
+        assert scan_counts == [0, 0, 0, 0]
+
+        deadline = time.monotonic() + 10
+        mailbox_posts_before = 0
+        while mailbox_posts_before == 0 and time.monotonic() < deadline:
+            rows = _sidecar_query_rows(state, mailbox_posts_sql)
+            mailbox_posts_before = int(rows[0]["count"])
+            time.sleep(0.2)
+        assert mailbox_posts_before > 0
+
+        time.sleep(2)
+        rows = _sidecar_query_rows(state, mailbox_posts_sql)
+        mailbox_posts_before = int(rows[0]["count"])
+        for _ in range(3):
+            _sidecar_query_rows(state, mailbox_posts_sql)
+        time.sleep(2)
+        rows = _sidecar_query_rows(state, mailbox_posts_sql)
+        assert int(rows[0]["count"]) == mailbox_posts_before
+
+        query_telemetry_counts = {
+            "sent messages": (
+                "SELECT COUNT(*) AS count FROM sent_messages sent "
+                "JOIN meshes mesh ON sent.actor_mesh_id = mesh.id "
+                "WHERE mesh.given_name = 'telemetry'"
+            ),
+            "message statuses": (
+                "SELECT COUNT(*) AS count FROM message_status_events status "
+                "JOIN messages msg ON status.message_id = msg.id "
+                "WHERE msg.endpoint = 'scan'"
+            ),
+            "events": (
+                "SELECT COUNT(*) AS count FROM events "
+                "WHERE target IN ("
+                "'monarch_distributed_telemetry::database_scanner', "
+                "'monarch_distributed_telemetry::query_engine')"
+            ),
+            "spans": (
+                "SELECT COUNT(*) AS count FROM spans "
+                'WHERE fields_json LIKE \'%"method":"scan"%\' '
+                'OR fields_json LIKE \'%"name":"scan"%\''
+            ),
+            "span events": (
+                "SELECT COUNT(*) AS count FROM span_events span_event "
+                "JOIN spans span ON span_event.process_id = span.process_id "
+                "AND span_event.id = span.id "
+                'WHERE span.fields_json LIKE \'%"method":"scan"%\' '
+                'OR span.fields_json LIKE \'%"name":"scan"%\''
+            ),
+            "metric sums": (
+                "SELECT COUNT(*) AS count FROM metric_sums "
+                'WHERE attributes_json LIKE \'%"actor":"telemetry"%\' '
+                'AND attributes_json LIKE \'%"method":"scan"%\''
+            ),
+            "metric histograms": (
+                "SELECT COUNT(*) AS count FROM metric_histograms "
+                'WHERE attributes_json LIKE \'%"actor":"telemetry"%\' '
+                'AND attributes_json LIKE \'%"method":"scan"%\''
+            ),
+        }
+        for label, sql in query_telemetry_counts.items():
+            rows = _sidecar_query_rows(state, sql)
+            assert rows == [{"count": 0}], f"unexpected {label}: {rows}"


### PR DESCRIPTION
Summary:
Telemetry queries call `TelemetryActor.scan`, so they currently write into the tables they are reading. A real job on master showed each table scan added 1 `messages` row, 3 `message_status_events` rows, 2 `spans` rows, 4 query/scanner `events` rows, and 3 `mailbox.posts`. Four repeated queries returned scan message counts `[0, 1, 2, 3]` and mailbox-post totals `[83, 86, 89, 92]`.

Mark `TelemetryActor` endpoints as non-recording. The same class flag disables caller-side endpoint instrumentation and receiver-side actor instrumentation, while `SUPPRESS_TELEMETRY` follows requests and replies. Suppressed envelopes also skip mailbox metrics and tracing. Exclude `monarch_distributed_telemetry` events from all tracing sinks. Application telemetry remains enabled. Remove the obsolete dashboard caveat.

The Admin `/v1/query` proxy uses the fixed path. `/v1/tree` still generates topology traffic: 3 calls changed `Resolve` messages from 328 to 447. Track that separately in T286999638.

Differential Revision: D118294147


