### PR TITLE
characterize actor mesh name and initialization wrappers

### DIFF
--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -885,3 +885,263 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
     hyperactor_mod.add_class::<PyActorSupervisionEvent>()?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+    use std::panic::AssertUnwindSafe;
+    use std::panic::catch_unwind;
+
+    use hyperactor::ActorRef;
+    use hyperactor::ProcAddr;
+    use hyperactor::ProcId;
+    use hyperactor::channel::ChannelAddr;
+    use hyperactor::id::Label;
+    use hyperactor::id::Uid;
+    use hyperactor_mesh::host_mesh::HostMeshRef;
+    use hyperactor_mesh::mesh_id::ActorMeshId;
+    use hyperactor_mesh::mesh_id::HostMeshId;
+    use ndslice::extent;
+
+    use super::*;
+
+    /// The text both name wrappers assert on when handed a data mesh.
+    const MANAGED_ONLY_NAME: &str = "Python actor mesh names require a managed mesh";
+
+    /// A mesh id no implementation could return by accident: `instance` draws a
+    /// fresh uid, so a hard-coded name cannot match it.
+    fn fixture_mesh_id() -> ActorMeshId {
+        ActorMeshId::instance(Label::new("mesh_name_fixture").expect("test label should be valid"))
+    }
+
+    /// A managed `ActorMeshRef<PythonActor>` carrying `id`, obtained through the
+    /// public deserializer.
+    ///
+    /// `ActorMeshRef::new_managed` is not public outside `hyperactor_mesh`.
+    /// Starting a real mesh merely to obtain this value would introduce runtime
+    /// resources, so this fixture instead uses the public serde representation.
+    /// `HostMeshRef::from_hosts` is a synchronous constructor whose embedded
+    /// host-agent mesh is managed with no controller. The actor type occurs in
+    /// the managed wire form only in that absent controller field, which makes
+    /// the serialized value safe to decode as `ActorMeshRef<PythonActor>`. No
+    /// host is contacted and the local address is never connected.
+    ///
+    /// `ActorMeshRefRepr::Managed` is externally tagged and serializes as the
+    /// four-element tuple `(id, proc_mesh_id, controller, cast_domain)`. The
+    /// `HostMeshRef` constructor supplies a valid value for every element, but
+    /// always uses the fixed `host_agent` id. The fixture replaces tuple element
+    /// zero only; otherwise a name implementation incorrectly hard-coded to
+    /// `host_agent` would satisfy the test.
+    ///
+    /// The field lookup, variant lookup, and arity assertion below deliberately
+    /// make this dependency on the wire format explicit. A field, tag, or tuple
+    /// layout change fails before mutation, and the post-decode assertion proves
+    /// that the public deserializer retained the caller-selected id.
+    fn managed_mesh_ref(id: &ActorMeshId) -> ActorMeshRef<PythonActor> {
+        let host_mesh = HostMeshRef::from_hosts(
+            HostMeshId::singleton(Label::strip("managed_name_fixture")),
+            vec![ChannelAddr::Local(1)],
+        );
+        let mut wire = serde_json::to_value(&host_mesh).expect("HostMeshRef should serialize");
+        let payload = wire
+            .get_mut("host_agent_mesh")
+            .and_then(|mesh| mesh.get_mut("Managed"))
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("the host agent mesh should encode as the managed variant");
+        assert_eq!(
+            payload.len(),
+            4,
+            "the managed payload should be the (id, proc mesh, controller, cast domain) tuple"
+        );
+        payload[0] = serde_json::to_value(id).expect("ActorMeshId should serialize");
+
+        let mesh_ref: ActorMeshRef<PythonActor> =
+            serde_json::from_value(wire["host_agent_mesh"].clone())
+                .expect("the host agent mesh should decode as an ActorMeshRef");
+        assert_eq!(
+            mesh_ref
+                .as_managed()
+                .expect("the fixture must decode as the managed variant")
+                .id(),
+            id,
+            "the fixture must carry the caller-selected id, not the constructor default"
+        );
+        mesh_ref
+    }
+
+    /// A data `ActorMeshRef<PythonActor>`: the variant both name wrappers
+    /// reject. Its single member is never messaged.
+    fn data_mesh_ref() -> ActorMeshRef<PythonActor> {
+        let proc_addr = ProcAddr::new(
+            ProcId::new(
+                Uid::Instance(1, None),
+                Some(Label::new("local").expect("test label should be valid")),
+            ),
+            ChannelAddr::Local(1).into(),
+        );
+        let member: ActorRef<PythonActor> = ActorRef::attest(proc_addr.actor_addr("member"));
+        ActorMeshRef::try_new_data(extent!(members = 1).into(), vec![member])
+            .expect("a one-rank data mesh should be valid")
+    }
+
+    /// Drive a wrapper task to completion and return the string it yields.
+    fn drive_name(task: PyResult<PyPythonTask>) -> String {
+        let mut task = task.expect("name() should return a task");
+        let value = get_tokio_runtime()
+            .block_on(task.take_task().expect("a fresh task is not consumed"))
+            .expect("the name task should resolve");
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            value
+                .extract::<String>(py)
+                .expect("name() should resolve to a string")
+        })
+    }
+
+    fn panic_message(payload: &(dyn Any + Send)) -> String {
+        payload
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| {
+                payload
+                    .downcast_ref::<&str>()
+                    .map(|text| (*text).to_string())
+            })
+            .unwrap_or_else(|| "<non-string panic payload>".to_string())
+    }
+
+    // Both managed name wrappers yield the mesh id, and discarding a wrapper
+    // consumes nothing: a later wrapper reports the same id.
+    //
+    // What these assertions establish and what they do not. They prove the
+    // value is repeatable across a discarded observation. They do NOT prove
+    // dynamically that the id is read at call time rather than inside the
+    // returned future; an implementation that cloned the mesh and read the id
+    // when driven would pass too. Call-time computation is source-grounded --
+    // both bodies compute the string and then move it into
+    // `PyPythonTask::new(async move { Ok(name) })` -- and its synchronous half
+    // is witnessed dynamically by the data-mesh panic below, which happens
+    // before any task exists. Nor is the returned task first-poll ready:
+    // `PyPythonTask::new` converts its result through `monarch_with_gil`, which
+    // may wait on the process-global GIL lock, so observation is not free.
+    #[test]
+    fn discarded_managed_name_wrappers_leave_exact_name_repeatable() {
+        pyo3::Python::initialize();
+        let id = fixture_mesh_id();
+        let mesh_ref = managed_mesh_ref(&id);
+        let mesh_impl = PythonActorMeshImpl::new_ref(mesh_ref.clone());
+        let expected = id.to_string();
+
+        drop(
+            <ActorMeshRef<PythonActor> as ActorMeshProtocol>::name(&mesh_ref)
+                .expect("the ref wrapper should return a task"),
+        );
+        drop(
+            <PythonActorMeshImpl as ActorMeshProtocol>::name(&mesh_impl)
+                .expect("the impl wrapper should return a task"),
+        );
+
+        assert_eq!(
+            drive_name(<ActorMeshRef<PythonActor> as ActorMeshProtocol>::name(
+                &mesh_ref
+            )),
+            expected,
+            "discarding a ref-wrapper task must not disturb the next one"
+        );
+        assert_eq!(
+            drive_name(<PythonActorMeshImpl as ActorMeshProtocol>::name(&mesh_impl)),
+            expected,
+            "discarding an impl-wrapper task must not disturb the next one"
+        );
+    }
+
+    // KNOWN-BAD CURRENT BEHAVIOR, recorded so a later conversion decides
+    // deliberately rather than by accident: a data mesh has no name, and both
+    // wrappers assert instead of returning a task that fails. The panic happens
+    // in the call itself, so no task ever reaches the caller.
+    #[test]
+    fn data_name_wrappers_panic_before_returning_a_task() {
+        pyo3::Python::initialize();
+        let mesh_ref = data_mesh_ref();
+        let mesh_impl = PythonActorMeshImpl::new_ref(mesh_ref.clone());
+
+        let from_ref = catch_unwind(AssertUnwindSafe(|| {
+            <ActorMeshRef<PythonActor> as ActorMeshProtocol>::name(&mesh_ref).map(|_| ())
+        }));
+        let from_impl = catch_unwind(AssertUnwindSafe(|| {
+            <PythonActorMeshImpl as ActorMeshProtocol>::name(&mesh_impl).map(|_| ())
+        }));
+
+        for (outcome, which) in [(from_ref, "ref"), (from_impl, "impl")] {
+            let payload = outcome
+                .err()
+                .unwrap_or_else(|| panic!("the {which} wrapper must panic on a data mesh"));
+            let message = panic_message(payload.as_ref());
+            assert!(
+                message.contains(MANAGED_ONLY_NAME),
+                "the {which} wrapper must fail the managed-mesh assertion, got: {message}"
+            );
+        }
+    }
+
+    // The trait-default `initialized` wrapper resolves to None and leaves the
+    // mesh usable, on both implementors that inherit it.
+    //
+    // What this establishes and what it does not. The absence of domain work is
+    // a property of the default's source body, `async { Ok(None::<()>) }`, not
+    // something these assertions measure: driving through `block_on` would also
+    // pass if the future yielded or did unrelated non-mutating work first, and
+    // `PyPythonTask::new` converts its result through `monarch_with_gil`, which
+    // may wait on the process-global GIL lock. So this is not a first-poll-ready
+    // claim. Re-reading the name afterwards shows the mesh is still usable; it
+    // is not a work counter.
+    //
+    // No Python-visible call reaches this default today, though not because
+    // every `PythonActorMesh` wraps an `AsyncActorMesh`. The pending
+    // `__reduce__` branch builds one directly over the resolved
+    // `PythonActorMeshImpl`, which inherits this default; that object is only
+    // ever consumed by the pickler, never handed to Python code that calls
+    // `initialized()`. Both inheriting implementors are exercised directly here
+    // because neither has a caller to exercise them through.
+    #[test]
+    fn default_initialized_wrappers_return_none_and_leave_mesh_usable() {
+        pyo3::Python::initialize();
+        let id = fixture_mesh_id();
+        let mesh_ref = managed_mesh_ref(&id);
+        let mesh_impl = PythonActorMeshImpl::new_ref(mesh_ref.clone());
+
+        drop(
+            <ActorMeshRef<PythonActor> as ActorMeshProtocol>::initialized(&mesh_ref)
+                .expect("the ref default should return a task"),
+        );
+        drop(
+            <PythonActorMeshImpl as ActorMeshProtocol>::initialized(&mesh_impl)
+                .expect("the impl default should return a task"),
+        );
+
+        for (task, which) in [
+            (
+                <ActorMeshRef<PythonActor> as ActorMeshProtocol>::initialized(&mesh_ref),
+                "ref",
+            ),
+            (
+                <PythonActorMeshImpl as ActorMeshProtocol>::initialized(&mesh_impl),
+                "impl",
+            ),
+        ] {
+            let mut task = task.expect("initialized() should return a task");
+            let value = get_tokio_runtime()
+                .block_on(task.take_task().expect("a fresh task is not consumed"))
+                .expect("the default initialized task should resolve");
+            assert!(
+                monarch_with_gil_blocking(GilSite::Test, |py| value.is_none(py)),
+                "the default {which} initialized wrapper must resolve to None"
+            );
+        }
+
+        assert_eq!(
+            drive_name(<PythonActorMeshImpl as ActorMeshProtocol>::name(&mesh_impl)),
+            id.to_string(),
+            "observing the default initialized wrapper must leave the mesh usable"
+        );
+    }
+}

--- a/python/tests/test_rdma_initialization.py
+++ b/python/tests/test_rdma_initialization.py
@@ -6,14 +6,15 @@
 
 # pyre-unsafe
 """
-Tests for RDMA manager initialization and its failure surfaces.
+Tests for RDMA initialization, readiness, and public operation boundaries.
 
 These tests cover the owner-backed binding from local and remote actors,
-production readiness caching and validation, public buffer operations, and
-backend configuration errors.
+production readiness caching and validation, public buffer operations, when
+submit and drop take effect, and backend configuration errors.
 """
 
 import gc
+import re
 import sys
 import threading
 import weakref
@@ -34,6 +35,10 @@ from monarch.rdma import RDMABuffer
 
 _PUBLIC_PATH_INITIAL = b"rdma-public-path-a"
 _PUBLIC_PATH_UPDATED = b"rdma-public-path-b"
+
+_SUBMIT_INITIAL = b"rdma-submit-before"
+_SUBMIT_UPDATED = b"rdma-submit-after!"
+_DROP_INITIAL = b"rdma-drop-initial!"
 
 
 class _RdmaInitProbe(Actor):
@@ -67,7 +72,10 @@ class _RdmaInitProbe(Actor):
 
         try:
             RDMABuffer(memoryview(bytearray(b"rdma")))
-        except RdmaInitError as error:
+        except Exception as error:
+            assert type(error) is RdmaInitError, (
+                f"buffer creation must raise RdmaInitError exactly, got {type(error)}"
+            )
             buffer_error = str(error)
         else:
             raise AssertionError(
@@ -76,7 +84,10 @@ class _RdmaInitProbe(Actor):
 
         try:
             await RDMAAction().submit()
-        except RdmaInitError as error:
+        except Exception as error:
+            assert type(error) is RdmaInitError, (
+                f"submit must raise RdmaInitError exactly, got {type(error)}"
+            )
             submit_error = str(error)
         else:
             raise AssertionError("public submit unexpectedly ignored failed readiness")
@@ -109,6 +120,201 @@ class _RdmaPublicPathProbe(Actor):
         assert self.buffer is not None
         assert bytes(self.data) == _PUBLIC_PATH_UPDATED
         assert await self.buffer.drop() is None
+
+
+class _RdmaDiscardedSubmitOwner(Actor):
+    """Holds the target bytes so an independent read can observe them."""
+
+    def __init__(self) -> None:
+        self.data = bytearray(_SUBMIT_INITIAL)
+        self.buffer: RDMABuffer | None = None
+
+    @endpoint
+    async def create_buffer(self) -> RDMABuffer:
+        from monarch.rdma import RDMAAction
+
+        # An empty action crosses after_ready but submits no transfer. Use it
+        # as an explicit readiness barrier before registering the target.
+        assert await RDMAAction().submit() is None
+        self.buffer = RDMABuffer(memoryview(self.data))
+        return self.buffer
+
+    @endpoint
+    async def owner_bytes(self) -> bytes:
+        return bytes(self.data)
+
+    @endpoint
+    async def release(self) -> None:
+        assert self.buffer is not None
+        assert await self.buffer.drop() is None
+
+
+class _RdmaDiscardedSubmitConsumer(Actor):
+    """Builds one action, discards its first submit, then reuses that action."""
+
+    def __init__(self) -> None:
+        self.source = bytearray(_SUBMIT_UPDATED)
+        self.action = None
+
+    @endpoint
+    async def build_and_discard(self, buffer: RDMABuffer) -> None:
+        from monarch.rdma import RDMAAction
+
+        # Prime this proc's readiness with an empty action, which crosses
+        # after_ready but submits nothing. The discarded nonempty action below
+        # then isolates its own lock and transfer.
+        assert await RDMAAction().submit() is None
+        self.action = RDMAAction().write_remote(buffer, memoryview(self.source))
+        discarded = self.action.submit()
+        # Future has no destructor that drives its stored task, so deleting the
+        # unobserved wrapper abandons the transfer before its first poll.
+        del discarded
+
+    @endpoint
+    async def submit_same_action(self) -> None:
+        assert self.action is not None
+        assert await self.action.submit() is None
+
+
+class _RdmaDiscardedDropOwner(Actor):
+    """Runs the drop witness from the owning actor.
+
+    The release and every barrier request then originate from this actor and
+    address the same `RdmaManagerActor` mailbox, which is what makes a later
+    request/reply a handler-completion barrier for an earlier release.
+    """
+
+    @endpoint
+    async def exercise(self) -> str:
+        from monarch.config import get_global_config
+
+        assert get_global_config()["enable_dest_actor_reordering_buffer"] is True, (
+            "receive-side reordering must be pinned on; without it the barrier "
+            "stops ordering the release against the later request"
+        )
+
+        data = bytearray(_DROP_INITIAL)
+        first = RDMABuffer(memoryview(data))
+        barriers: list[RDMABuffer] = []
+        try:
+            discarded = first.drop()
+            # Future has no destructor that drives its stored task, so deleting
+            # the unobserved wrapper abandons the release before its first poll.
+            del discarded
+
+            barriers.append(self._barrier(first, b"rdma-drop-barrier-1"))
+
+            readback = bytearray(len(_DROP_INITIAL))
+            assert await first.read_into(memoryview(readback)) is None
+            assert bytes(readback) == _DROP_INITIAL, (
+                "a discarded drop must publish no release, so the registration "
+                f"is still readable; got {bytes(readback)!r}"
+            )
+
+            assert await first.drop() is None
+
+            barriers.append(self._barrier(first, b"rdma-drop-barrier-2"))
+
+            try:
+                await first.read_into(memoryview(bytearray(len(_DROP_INITIAL))))
+            except Exception as error:
+                assert type(error) is Exception, (
+                    f"a released buffer must fail as base Exception, got {type(error)}"
+                )
+                return str(error)
+            raise AssertionError("reading a released registration must fail")
+        finally:
+            for barrier in barriers:
+                await barrier.drop()
+
+    def _barrier(self, first: RDMABuffer, payload: bytes) -> RDMABuffer:
+        """A request/reply through the same manager, used to order the release."""
+        barrier = RDMABuffer(memoryview(bytearray(payload)))
+        assert barrier.owner == first.owner, (
+            "the barrier must address the same manager as the release; "
+            f"{barrier.owner} != {first.owner}"
+        )
+        return barrier
+
+
+class _RdmaSettingsProbe(Actor):
+    @endpoint
+    async def retained_settings(self) -> tuple[bool, bool, str]:
+        from monarch.config import get_global_config
+
+        config = get_global_config()
+        return (
+            config["rdma_disable_ibverbs"],
+            config["rdma_allow_tcp_fallback"],
+            config["rdma_ibverbs_target"],
+        )
+
+
+class _RdmaDropReadinessOwner(_RdmaSettingsProbe):
+    def __init__(self) -> None:
+        self.data = bytearray(_DROP_INITIAL)
+        self.buffer: RDMABuffer | None = None
+
+    @endpoint
+    async def create_buffer(self) -> RDMABuffer:
+        self.buffer = RDMABuffer(memoryview(self.data))
+        return self.buffer
+
+    @endpoint
+    async def still_usable(self) -> bool:
+        assert self.buffer is not None
+        readback = bytearray(len(_DROP_INITIAL))
+        assert await self.buffer.read_into(memoryview(readback)) is None
+        return bytes(readback) == _DROP_INITIAL
+
+    @endpoint
+    async def release(self) -> None:
+        assert self.buffer is not None
+        assert await self.buffer.drop() is None
+
+
+class _RdmaDropReadinessConsumer(_RdmaSettingsProbe):
+    @endpoint
+    async def drop_and_report(self, buffer: RDMABuffer) -> str:
+        from monarch._rust_bindings.rdma import RdmaInitError
+
+        try:
+            await buffer.drop()
+        except Exception as error:
+            assert type(error) is RdmaInitError, (
+                f"a failed readiness must surface exactly, got {type(error)}"
+            )
+            return str(error)
+        raise AssertionError("drop must not ignore a failed readiness")
+
+
+class _RdmaSubmitTimeoutProbe(Actor):
+    @endpoint
+    async def submit_with_zero_timeout(self) -> str:
+        from monarch.rdma import RDMAAction
+
+        data = bytearray(_SUBMIT_INITIAL)
+        source = bytearray(_SUBMIT_UPDATED)
+        buffer = RDMABuffer(memoryview(data))
+        try:
+            # An empty action crosses the same readiness gate but returns
+            # before the operation deadline. Use it as a separate readiness
+            # control for the timeout failure below.
+            assert await RDMAAction().submit() is None
+            # Keep this action nonempty: native submit returns before checking
+            # the deadline for an empty batch, so only a queued operation can
+            # reach the zero-deadline guard this test pins.
+            action = RDMAAction().write_remote(buffer, memoryview(source))
+            try:
+                await action.submit(timeout=0)
+            except Exception as error:
+                assert type(error) is Exception, (
+                    f"a post-readiness failure must be base Exception, got {type(error)}"
+                )
+                return str(error)
+            raise AssertionError("a zero submit deadline must fail after readiness")
+        finally:
+            await buffer.drop()
 
 
 def test_manager_init_cache_reuses_handle_without_retaining_mesh(monkeypatch) -> None:
@@ -324,6 +530,180 @@ async def test_public_rdma_paths() -> None:
                 await consumer_proc.stop()
         finally:
             await producer_proc.stop()
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+async def test_discarded_submit_leaves_bytes_unchanged_and_same_action_runnable() -> (
+    None
+):
+    """Submitting captures readiness and the action, but the transfer itself
+    rides on the returned Future. Discarding that Future before it is driven
+    writes nothing and leaves the very same action runnable."""
+    from monarch.actor import this_host
+
+    with configured(
+        rdma_disable_ibverbs=True,
+        rdma_allow_tcp_fallback=True,
+        rdma_ibverbs_target="",
+    ):
+        # ProcMesh.spawn creates an actor across the whole mesh. Two one-proc
+        # meshes keep the owner and consumer as single actors while still
+        # exercising a cross-proc transfer, without a multi-proc mesh and
+        # explicit rank slices obscuring the witness.
+        owner_proc = this_host().spawn_procs(per_host={"cpus": 1})
+        try:
+            consumer_proc = this_host().spawn_procs(per_host={"cpus": 1})
+            try:
+                owner = owner_proc.spawn(
+                    "rdma_discarded_submit_owner", _RdmaDiscardedSubmitOwner
+                )
+                consumer = consumer_proc.spawn(
+                    "rdma_discarded_submit_consumer", _RdmaDiscardedSubmitConsumer
+                )
+
+                buffer = await owner.create_buffer.call_one()
+                assert await consumer.build_and_discard.call_one(buffer) is None
+                assert await owner.owner_bytes.call_one() == _SUBMIT_INITIAL, (
+                    "a discarded submit must not transfer bytes"
+                )
+
+                assert await consumer.submit_same_action.call_one() is None
+                assert await owner.owner_bytes.call_one() == _SUBMIT_UPDATED, (
+                    "the same action must remain runnable after its first "
+                    "Future was discarded"
+                )
+
+                assert await owner.release.call_one() is None
+            finally:
+                await consumer_proc.stop()
+        finally:
+            await owner_proc.stop()
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+async def test_discarded_drop_leaves_buffer_usable() -> None:
+    """Dropping publishes a one-way release only when the Future is driven.
+    A discarded Future publishes nothing, proven by a same-manager barrier
+    rather than by the drop result, which acknowledges publication only."""
+    from monarch.actor import this_host
+
+    with configured(
+        rdma_disable_ibverbs=True,
+        rdma_allow_tcp_fallback=True,
+        rdma_ibverbs_target="",
+        enable_dest_actor_reordering_buffer=True,
+    ):
+        proc = this_host().spawn_procs(per_host={"cpus": 1})
+        try:
+            owner = proc.spawn("rdma_discarded_drop_owner", _RdmaDiscardedDropOwner)
+            message = await owner.exercise.call_one()
+            assert message.startswith("RdmaAction.submit failed:"), (
+                f"the released-buffer read must be a wrapped submit failure: {message}"
+            )
+            assert re.search(r"\(Tcp\) buffer \d+ not found(?:\n|$)", message), (
+                "the cause must name the released registration, not any other "
+                f"lookup failure: {message}"
+            )
+        finally:
+            await proc.stop()
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+async def test_drop_propagates_readiness_failure_without_releasing_buffer() -> None:
+    """A consumer whose readiness fails surfaces the exact RdmaInitError from
+    drop, and the owner's registration survives because readiness is awaited
+    before the release is published."""
+    from monarch.actor import this_host
+
+    owner_proc = None
+    consumer_proc = None
+    try:
+        # This test makes drop() fail during readiness, before it can release
+        # the owner's buffer. The owner needs a working TCP backend to register
+        # the buffer and later prove that registration remains usable. The
+        # consumer needs no available backend so its readiness fails before
+        # drop() can publish ReleaseBuffer.
+        #
+        # configured() changes process-global state, so these roles cannot
+        # share one scope. spawn_procs() snapshots that state asynchronously;
+        # awaiting each child's initialization inside its scope ensures that
+        # it retains the configuration required for its role.
+        with configured(
+            rdma_disable_ibverbs=True,
+            rdma_allow_tcp_fallback=True,
+            rdma_ibverbs_target="",
+        ):
+            owner_proc = this_host().spawn_procs(per_host={"cpus": 1})
+            assert await owner_proc.initialized is True
+        with configured(
+            rdma_disable_ibverbs=True,
+            rdma_allow_tcp_fallback=False,
+            rdma_ibverbs_target="",
+        ):
+            consumer_proc = this_host().spawn_procs(per_host={"cpus": 1})
+            assert await consumer_proc.initialized is True
+
+        owner = owner_proc.spawn("rdma_drop_readiness_owner", _RdmaDropReadinessOwner)
+        consumer = consumer_proc.spawn(
+            "rdma_drop_readiness_consumer", _RdmaDropReadinessConsumer
+        )
+
+        # Both scopes have restored the parent's ambient configuration. Ask
+        # each child what it retained so fixture drift fails here instead of
+        # looking like a failure in drop().
+        assert await owner.retained_settings.call_one() == (True, True, ""), (
+            "the owner proc must retain the configuration active when it spawned"
+        )
+        assert await consumer.retained_settings.call_one() == (True, False, ""), (
+            "the consumer proc must retain its own forced no-backend settings"
+        )
+
+        buffer = await owner.create_buffer.call_one()
+        message = await consumer.drop_and_report.call_one(buffer)
+        assert "no RDMA backend available" in message, (
+            f"the readiness cause must survive the drop Future: {message}"
+        )
+
+        assert await owner.still_usable.call_one() is True, (
+            "a readiness failure must occur before any release is published"
+        )
+        assert await owner.release.call_one() is None
+    finally:
+        try:
+            if consumer_proc is not None:
+                await consumer_proc.stop()
+        finally:
+            if owner_proc is not None:
+                await owner_proc.stop()
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+async def test_submit_wraps_post_readiness_operation_failure() -> None:
+    """A zero submit deadline fails inside the submitted operation, after
+    readiness has already succeeded, and is wrapped as a base Exception."""
+    from monarch.actor import this_host
+
+    with configured(
+        rdma_disable_ibverbs=True,
+        rdma_allow_tcp_fallback=True,
+        rdma_ibverbs_target="",
+    ):
+        proc = this_host().spawn_procs(per_host={"cpus": 1})
+        try:
+            probe = proc.spawn("rdma_submit_timeout_probe", _RdmaSubmitTimeoutProbe)
+            message = await probe.submit_with_zero_timeout.call_one()
+            assert message.startswith("RdmaAction.submit failed:"), (
+                f"the operation failure must carry the submit prefix: {message}"
+            )
+            assert "tcp submit timed out" in message, (
+                f"the cause must be the TCP submit deadline: {message}"
+            )
+        finally:
+            await proc.stop()
 
 
 # The tests below cover the owner-driven binding

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -2580,14 +2580,19 @@ constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyRdmaAction::submit"
 consumer = "RDMAAction.submit via Future._from_coro"
 driver = "awaited by the caller through the public Future"
-start_point = "gated on RDMA readiness, then lazy until driven"
-abandonment = "possible; a caller may drop the returned Future"
-eager_effect = "starts a side effect"
-drop_behavior = "the transfer is never submitted"
-unobserved_error = "surfaced on observation"
-disposition = "intentionally become eager"
+start_point = "call time obtains or starts readiness and retains an observer; readiness wait, action lock, and transfer submission begin only when the returned Future is first driven"
+abandonment = "possible before first drive; async observation and timed get() are non-abortable after spawn, while untimed get() drives inline"
+eager_effect = "starts a side effect: an eager conversion would drive the retained readiness observer and then take the action lock and submit the queued operations even if the returned observer is discarded"
+drop_behavior = "discarding before first drive submits nothing and leaves the same action runnable"
+unobserved_error = "no operation error exists until driven; readiness retains exact RdmaInitError, and later operation failure is exact base Exception with RdmaAction.submit failed:"
+disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "test_rdma submit coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_discarded_submit_leaves_bytes_unchanged_and_same_action_runnable",
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_public_submit_and_drop_resolve_to_none_after_tcp_init",
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_public_paths_propagate_readiness_failure",
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_submit_wraps_post_readiness_operation_failure",
+]
 
 [[site]]
 id = "np.lib.PyRdmaBuffer.drop"
@@ -2603,14 +2608,18 @@ constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyRdmaBuffer::drop"
 consumer = "RDMABuffer.drop via Future._from_coro"
 driver = "awaited by the caller through the public Future"
-start_point = "gated on RDMA readiness, then lazy until driven"
-abandonment = "possible; a caller may drop the returned Future"
-eager_effect = "starts a side effect"
-drop_behavior = "the buffer registration is never released"
-unobserved_error = "surfaced on observation"
-disposition = "intentionally become eager"
+start_point = "call time obtains or starts readiness and retains an observer plus cloned buffer state; readiness wait and release publication begin only when the returned Future is first driven"
+abandonment = "possible before first drive; async observation and timed get() are non-abortable after spawn, while untimed get() drives inline"
+eager_effect = "starts a side effect: an eager conversion would drive the retained readiness observer and then publish ReleaseBuffer even if the returned observer is discarded"
+drop_behavior = "discarding before first drive publishes no release and leaves the registration usable"
+unobserved_error = "no release error exists until driven; readiness retains exact RdmaInitError, while handler execution and delivery failures after the one-way post are outside this Future's result"
+disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "test_rdma drop coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_discarded_drop_leaves_buffer_usable",
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_public_submit_and_drop_resolve_to_none_after_tcp_init",
+  "fbcode//monarch/python/tests:test_rdma_initialization::test_drop_propagates_readiness_failure_without_releasing_buffer",
+]
 
 [[site]]
 id = "im.actor_mesh.module"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -2059,16 +2059,19 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from <ActorMeshRef<PythonActor> as ActorMeshProtocol>::name"
-consumer = "ActorMesh._name via Future._from_coro"
-driver = "awaited by the Python ActorMesh._name coroutine"
-start_point = "already complete; the name is read from the mesh ref before the future is built"
-abandonment = "possible; a caller may drop the returned task"
+consumer = "none in tree; both call sites that reach ActorMeshProtocol::name go through Arc<dyn SupervisableActorMesh>, and ActorMeshRef<PythonActor> implements neither Supervisable nor SupervisableActorMesh"
+driver = "none in tree; driven only by the in-crate characterization tests"
+start_point = "no deferred domain work; for a managed ref the id is read synchronously before the task is built, though observing the task still performs Python result conversion under the GIL. A data ref panics at the managed-only assertion before any task exists"
+abandonment = "possible in principle, but no in-tree caller holds a task to drop"
 eager_effect = "only wraps a ready value"
 drop_behavior = "no effect; the name was already computed"
-unobserved_error = "none"
+unobserved_error = "none through the task; a data ref fails as a synchronous panic instead"
 disposition = "replace with a direct value"
 semantic_class = "ready_no_op_wrapper"
-oracle = "actor mesh naming coverage"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::actor_mesh::tests::discarded_managed_name_wrappers_leave_exact_name_repeatable",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::actor_mesh::tests::data_name_wrappers_panic_before_returning_a_task",
+]
 
 [[site]]
 id = "np.actor_mesh.AsyncActorMesh_as_ActorMeshProtocol.__reduce__"
@@ -2174,16 +2177,19 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from <PythonActorMeshImpl as ActorMeshProtocol>::name"
-consumer = "ActorMesh._name via Future._from_coro"
-driver = "awaited by the Python ActorMesh._name coroutine"
-start_point = "already complete; the name is read from the mesh ref before the future is built"
-abandonment = "possible; a caller may drop the returned task"
+consumer = "the queued closure in <AsyncActorMesh as ActorMeshProtocol>::name, which calls mesh.await?.name()?.take_task()?.await in the same frame"
+driver = "the per-mesh queue task, which takes and awaits the returned task immediately"
+start_point = "no deferred domain work; for a managed mesh the id is read synchronously before the task is built, though observing the task still performs Python result conversion under the GIL. A data mesh panics at the managed-only assertion before any task exists"
+abandonment = "not reachable publicly; the queued frame consumes the task in the same expression, so only the outer one-shot observer can be discarded"
 eager_effect = "only wraps a ready value"
 drop_behavior = "no effect; the name was already computed"
-unobserved_error = "none"
+unobserved_error = "none through the task; a data mesh fails as a synchronous panic instead"
 disposition = "replace with a direct value"
 semantic_class = "ready_no_op_wrapper"
-oracle = "actor mesh naming coverage"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::actor_mesh::tests::discarded_managed_name_wrappers_leave_exact_name_repeatable",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::actor_mesh::tests::data_name_wrappers_panic_before_returning_a_task",
+]
 
 [[site]]
 id = "np.actor_mesh.PythonActorMeshImpl_as_ActorMeshProtocol.stop"
@@ -2220,16 +2226,18 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from initialized"
-consumer = "ActorMesh.initialized via Future._from_coro"
-driver = "awaited by the Python ActorMesh.initialized coroutine"
-start_point = "already complete; the trait default resolves to None without work"
-abandonment = "possible; a caller may drop the returned task"
+consumer = "none in tree. PythonActorMesh::initialized forwards to its inner mesh, and AsyncActorMesh overrides this default rather than delegating to it. The one PythonActorMesh built over a bare PythonActorMeshImpl, in the pending AsyncActorMesh::__reduce__ branch, is consumed only by the pickler and never receives an initialized() call"
+driver = "none in tree; driven only by the in-crate characterization test"
+start_point = "no domain work; the default body resolves to None immediately, though observing the task still performs Python result conversion under the GIL"
+abandonment = "possible in principle, but no in-tree caller holds a task to drop"
 eager_effect = "only wraps a ready value"
 drop_behavior = "no effect; there is no underlying operation"
 unobserved_error = "none; resolves to Ok(None)"
 disposition = "replace with a direct value"
 semantic_class = "ready_no_op_wrapper"
-oracle = "actor mesh readiness coverage"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::actor_mesh::tests::default_initialized_wrappers_return_none_and_leave_mesh_usable",
+]
 
 [[site]]
 id = "np.bootstrap.attach_to_workers"


### PR DESCRIPTION
Summary:
three actor-mesh methods return a `PyPythonTask` even though they defer no mesh operation. both name methods read the mesh id before returning, while the default `initialized()` method only produces `None`. driving these tasks still performs normal Python result conversion.

this adds focused tests for those boundaries. discarding either returned name task does not consume mesh state, and a later call returns the exact caller-selected id. the tests also cover references that contain actor addresses but no mesh-level identity: asking either wrapper to name one currently panics before returning a task. this records the existing edge case without endorsing it.

the default `initialized()` implementation returns `None` for both Rust implementations that inherit it, and the mesh remains usable afterward. the name fixture uses the public deserializer with a generated id, ensuring that an implementation returning a hard-coded name cannot pass.

the census now records each task’s actual consumer and links all three rows to their exact tests.

this changes tests and migration metadata only. no production behavior changes.

Differential Revision: D118334937


