### PR TITLE
expose pyspy_bin in the typed configure surface

### DIFF
--- a/docs/source/api/monarch.config.rst
+++ b/docs/source/api/monarch.config.rst
@@ -455,6 +455,30 @@ Mesh Admin
     ``MeshAdminAgent``, and as the default address assumed by admin
     clients connecting via ``mast_conda:///``.
 
+``pyspy_bin``
+    Path to the py-spy binary used by the mesh admin py-spy endpoints.
+
+    - **Type**: ``str``
+    - **Default**: ``""`` (empty; ``py-spy`` on ``PATH`` is used instead)
+    - **Environment**: ``PYSPY_BIN``
+
+    Tried ahead of ``py-spy`` on ``PATH``. The environment variable is
+    ``PYSPY_BIN`` rather than ``HYPERACTOR_*``, for compatibility with
+    deployments that already set it.
+
+    Resolved in the proc being dumped, not in the client, and read when
+    the dump runs -- so it has to be in place before that proc is
+    spawned. Setting it via :func:`configure` reaches procs spawned
+    afterwards; it does not change procs that are already running.
+
+    .. code-block:: python
+
+        from monarch.config import configure
+
+        # Some py-spy builds cannot unwind native frames on a given
+        # target; point at one that can.
+        configure(pyspy_bin="/path/to/py-spy")
+
 
 Mesh Attach
 -----------

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -79,6 +79,7 @@ def configure(
     mesh_admin_addr: str = ...,
     mesh_attach_config_timeout: str = ...,
     mesh_orphan_timeout: str = ...,
+    pyspy_bin: str = ...,
     rdma_allow_tcp_fallback: bool = ...,
     rdma_disable_ibverbs: bool = ...,
     rdma_max_chunk_size_mb: int = ...,
@@ -173,6 +174,11 @@ def configure(
             HTTP server (e.g. "[::]:1729", "0.0.0.0:8080")
         mesh_attach_config_timeout: Timeout for the config-push barrier
             during attach_to_workers() (humantime, default "10s")
+        pyspy_bin: Path to the py-spy binary used by the mesh admin
+            py-spy endpoints. Tried ahead of "py-spy" on PATH; empty
+            uses PATH alone. Resolved in the proc being dumped, so it
+            must be set before that proc is spawned. The environment
+            variable is PYSPY_BIN, not HYPERACTOR_*.
         rdma_allow_tcp_fallback: Allow TCP fallback when ibverbs RDMA
             hardware is unavailable. When True (default), RDMA operations
             fall back to chunked hyperactor messaging over the default

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
             mesh_admin_addr: NotRequired[str]
             mesh_attach_config_timeout: NotRequired[str]
             mesh_orphan_timeout: NotRequired[str]
+            pyspy_bin: NotRequired[str]
             rdma_allow_tcp_fallback: NotRequired[bool]
             rdma_disable_ibverbs: NotRequired[bool]
             rdma_max_chunk_size_mb: NotRequired[int]
@@ -178,6 +179,14 @@ def configure(**kwargs: "ConfigureKwargsType") -> None:
             mesh_attach_config_timeout: Timeout for the config-push barrier
                 during ``attach_to_workers()`` (humantime, default ``"10s"``).
                 Best-effort: if exceeded, a warning is logged and attach continues.
+
+        Diagnostics:
+            pyspy_bin: Path to the py-spy binary used by the mesh admin
+                py-spy endpoints. Tried ahead of ``py-spy`` on ``PATH``;
+                empty uses ``PATH`` alone. Resolved in the proc being
+                dumped, so it must be set before that proc is spawned.
+                The environment variable is ``PYSPY_BIN``, not
+                ``HYPERACTOR_*``.
 
         RDMA configuration:
             rdma_allow_tcp_fallback: Allow TCP fallback when ibverbs RDMA

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -148,6 +148,17 @@ def test_rdma_runtime_worker_threads_round_trip() -> None:
     assert get_global_config()["rdma_runtime_worker_threads"] == 16
 
 
+def test_pyspy_bin_round_trip() -> None:
+    # Empty means the mesh admin py-spy path falls back to PATH.
+    assert get_global_config()["pyspy_bin"] == ""
+
+    path = "/tmp/py-spy"
+    with configured(pyspy_bin=path) as config:
+        assert config["pyspy_bin"] == path
+
+    assert get_global_config()["pyspy_bin"] == ""
+
+
 @isolate_in_subprocess
 def test_codec_max_frame_length_exceeds_default() -> None:
     """Test that sending 4 chunks of 256KiB fails with a 1 MiB limit."""


### PR DESCRIPTION
Summary:
`PYSPY_BIN` picks the py-spy binary that the mesh admin py-spy endpoints
run. `configure()` has always accepted it — `KEY_BY_NAME` is generated from
each attr's `py_name`, and `PYSPY_BIN` declares `pyspy_bin` — but it was
absent from the typed surface, so it was undiscoverable and pyre rejected
it.

add `pyspy_bin` to the `configure()` stub signature and to `ConfigureArgs`,
document it alongside the other keys, and add a round-trip test.

no behavior change; the key was already accepted at runtime.

the docs call out the part that is easy to get wrong: the value is read in
the proc being dumped, at dump time, so it has to be set before that proc
is spawned. `configure()` reaches procs spawned afterwards and does not
affect procs already running.

Differential Revision: D118468400


