### PR TITLE
Exclude docker artifacts while uploading pypi wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: "!*.dockerbuild"
           path: dist
           merge-multiple: true
 


### PR DESCRIPTION
Summary: We don't need to upload docker artifacts for pypi wheels. Not sure if this is the root cause, but there is 1 artifact that is failing.

Differential Revision: D118496502


