### PR TITLE
Add Python bindings to trace tools (#4780)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4634,6 +4634,7 @@ dependencies = [
  "monarch_hyperactor",
  "monarch_introspection_snapshot",
  "monarch_messages",
+ "monarch_perfetto_trace",
  "monarch_rdma_extension",
  "monarch_tensor_worker",
  "nccl-sys",
@@ -4792,7 +4793,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "humantime",
  "prost",
  "reqwest 0.13.4",
  "serde",

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -30,6 +30,7 @@ monarch_gil = { version = "0.0.0", path = "../monarch_gil" }
 monarch_hyperactor = { version = "0.0.0", path = "../monarch_hyperactor" }
 monarch_introspection_snapshot = { version = "0.0.0", path = "../monarch_introspection_snapshot", optional = true }
 monarch_messages = { version = "0.0.0", path = "../monarch_messages", optional = true, default-features = false }
+monarch_perfetto_trace = { version = "0.0.0", path = "../monarch_perfetto_trace" }
 monarch_rdma_extension = { version = "0.0.0", path = "../monarch_rdma/extension", optional = true }
 monarch_tensor_worker = { version = "0.0.0", path = "../monarch_tensor_worker", optional = true, default-features = false }
 nccl-sys = { version = "0.0.0", path = "../nccl-sys", optional = true }

--- a/monarch_extension/src/trace.rs
+++ b/monarch_extension/src/trace.rs
@@ -6,6 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::path::PathBuf;
+
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 
@@ -14,8 +17,53 @@ fn get_or_create_trace_id() -> String {
     hyperactor_telemetry::trace::get_or_create_trace_id()
 }
 
+#[pyfunction]
+#[pyo3(signature = (telemetry_url, start_us, end_us, output = None, upload = false))]
+fn export_profile(
+    py: Python<'_>,
+    telemetry_url: String,
+    start_us: i64,
+    end_us: i64,
+    output: Option<String>,
+    upload: bool,
+) -> PyResult<String> {
+    let path = py
+        .detach(move || {
+            monarch_perfetto_trace::profile::export_profile(
+                &telemetry_url,
+                start_us,
+                end_us,
+                output.map(PathBuf::from),
+            )
+        })
+        .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+
+    #[cfg(fbcode_build)]
+    if upload {
+        return py
+            .detach(move || -> anyhow::Result<String> {
+                eprintln!("Uploading {} to Manifold...", path.display());
+                let manifold_path = trace_upload::upload_trace_file(&path)?;
+                Ok(trace_upload::perfetto_trace_url(&manifold_path))
+            })
+            .map_err(|error| PyRuntimeError::new_err(error.to_string()));
+    }
+
+    #[cfg(not(fbcode_build))]
+    let _ = upload;
+
+    Ok(path.to_string_lossy().into_owned())
+}
+
 pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     let f = wrap_pyfunction!(get_or_create_trace_id, module)?;
+    f.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_extension.trace",
+    )?;
+    module.add_function(f)?;
+
+    let f = wrap_pyfunction!(export_profile, module)?;
     f.setattr(
         "__module__",
         "monarch._rust_bindings.monarch_extension.trace",

--- a/monarch_perfetto_trace/Cargo.toml
+++ b/monarch_perfetto_trace/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.104"
 clap = { version = "4.6.2", features = ["derive", "env", "string", "unicode", "wrap_help"] }
-humantime = "2.4.0"
 prost = { version = "0.14.4", default-features = false }
 reqwest = { version = "0.13.2", features = ["blocking", "charset", "cookies", "gzip", "http2", "json", "multipart", "rustls", "socks", "stream", "system-proxy"], default-features = false }
 serde = { version = "1.0.229", features = ["derive", "rc"] }

--- a/monarch_perfetto_trace/src/profile.rs
+++ b/monarch_perfetto_trace/src/profile.rs
@@ -14,8 +14,6 @@ use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -138,33 +136,33 @@ impl PartialOrd for Boundary {
     }
 }
 
-/// Collect distributed user telemetry for `duration` and write a Perfetto trace.
+/// Export a completed telemetry interval to a Perfetto trace.
 ///
 /// `output` selects the destination file. When it is absent, the trace is written
-/// under `/tmp/$USER/monarch_profiles`. The destination is checked before the
-/// collection interval starts and is never overwritten.
-pub fn collect_profile(
+/// under `/tmp/$USER/monarch_profiles`. The destination is never overwritten.
+pub fn export_profile(
     telemetry_url: &str,
-    duration: Duration,
+    start_us: i64,
+    end_us: i64,
     output: Option<PathBuf>,
 ) -> Result<PathBuf> {
-    if duration.is_zero() {
-        bail!("--time must be greater than zero");
+    if start_us < 0 || end_us <= start_us {
+        bail!("profile interval must satisfy 0 <= start_us < end_us");
     }
 
-    let output_timestamp_us = timestamp_us()?;
-    let output = resolve_output_path(output, output_timestamp_us)?;
-    validate_output_path(&output)?;
+    let output = resolve_output_path(output, start_us)?;
+    if output.exists() {
+        bail!("output already exists: {}", output.display());
+    }
+    export_profile_to_path(telemetry_url, start_us, end_us, output)
+}
 
-    eprintln!(
-        "Collecting traces for {}...",
-        humantime::format_duration(duration)
-    );
-
-    let start_us = timestamp_us()?;
-    std::thread::sleep(duration);
-    let end_us = timestamp_us()?;
-
+fn export_profile_to_path(
+    telemetry_url: &str,
+    start_us: i64,
+    end_us: i64,
+    output: PathBuf,
+) -> Result<PathBuf> {
     std::thread::sleep(DRAIN_DELAY);
 
     let rows = query_spans(telemetry_url, start_us, end_us)?;
@@ -488,15 +486,6 @@ fn micros_to_nanos(timestamp_us: i64) -> Result<u64> {
         .context("trace timestamp exceeds the Perfetto range")
 }
 
-fn timestamp_us() -> Result<i64> {
-    let micros = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .context("system clock is before the Unix epoch")?
-        .as_micros();
-
-    i64::try_from(micros).context("system clock exceeds the telemetry timestamp range")
-}
-
 fn resolve_output_path(output: Option<PathBuf>, filename_timestamp_us: i64) -> Result<PathBuf> {
     let output = match output {
         Some(output) => output,
@@ -520,13 +509,6 @@ fn resolve_output_path(output: Option<PathBuf>, filename_timestamp_us: i64) -> R
     Ok(std::env::current_dir()
         .context("failed to get the current directory")?
         .join(output))
-}
-
-fn validate_output_path(output: &Path) -> Result<()> {
-    if output.exists() {
-        bail!("output already exists: {}", output.display());
-    }
-    create_output_parent(output)
 }
 
 fn create_output_file(output: &Path) -> Result<fs::File> {

--- a/python/monarch/_rust_bindings/monarch_extension/trace.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/trace.pyi
@@ -11,3 +11,13 @@ def get_or_create_trace_id() -> str:
     Get the trace id or create a new one if it doesn't exist.
     """
     ...
+
+def export_profile(
+    telemetry_url: str,
+    start_us: int,
+    end_us: int,
+    output: str | None = None,
+    upload: bool = False,
+) -> str:
+    """Export a distributed telemetry interval and return its path or URL."""
+    ...


### PR DESCRIPTION
Summary:

Here we expose `export_profile` so that it can be called from Python

Reviewed By: thedavekwon

Differential Revision: D118069972
