### PR TITLE
return Python stacks when py-spy can't read native frames (#4782)

### DIFF
--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -223,9 +223,11 @@
 //!   subprocess inside the worker to `MESH_ADMIN_PYSPY_TIMEOUT`
 //!   (default 10s). The budget is sized for `--native --native-all`
 //!   which unwinds native stacks via libunwind — significantly
-//!   slower than Python-only capture on loaded hosts. On expiry the
-//!   child is killed and reaped, and the worker returns
-//!   `Failed { stderr: "…timed out…" }`.
+//!   slower than Python-only capture on loaded hosts. Each child
+//!   leads its own process group. On timeout or cancellation the
+//!   group is killed so descendants cannot retain inherited pipes;
+//!   the direct-child reap has its own one-second bound. The worker
+//!   returns `Failed { stderr: "…timed out…" }` on timeout.
 //! - **PS-6 (bridge timeout):** The HTTP bridge uses a separate
 //!   `MESH_ADMIN_PYSPY_BRIDGE_TIMEOUT` (default 13s), which must
 //!   exceed `MESH_ADMIN_PYSPY_TIMEOUT` so the subprocess kill/reap
@@ -244,20 +246,25 @@
 //!   runs independently.
 //! - **PS-10 (nonblocking retry):** In nonblocking mode, `try_exec`
 //!   retries up to 3 times with 100ms backoff on failure, because
-//!   py-spy can segfault reading mutating process memory. All
-//!   attempts share a single deadline bounded by
-//!   `MESH_ADMIN_PYSPY_TIMEOUT` (PS-5).
+//!   py-spy can segfault reading mutating process memory. Attempts
+//!   and backoff share the `MESH_ADMIN_PYSPY_TIMEOUT` deadline;
+//!   timeout cleanup has the separate one-second reap bound in PS-5.
 //! - **PS-11a (native-all-immediate-downgrade):** If py-spy rejects
 //!   `--native-all` with the recognized unsupported-flag signature
-//!   (exit code 2, stderr mentions `--native-all`), `try_exec`
-//!   retries immediately with `native_all = false` in the same outer
-//!   attempt.
+//!   (exit code 2, stderr mentions `--native-all`), `try_exec` retries
+//!   immediately with `native_all = false` and `native = true` in the
+//!   same outer attempt. This also preserves native capture for an
+//!   actor caller that supplied `native_all = true, native = false`.
 //! - **PS-11b (native-all-no-retry-consumption):** That downgrade
 //!   retry does not consume an outer nonblocking retry slot (PS-10)
 //!   and does not incur the 100ms inter-attempt backoff.
 //! - **PS-11c (native-all-downgrade-warning):** A successful
-//!   downgraded result includes the warning `"--native-all
-//!   unsupported by this py-spy; fell back to --native"`.
+//!   downgraded result includes
+//!   `pyspy::native_all_downgrade_warning(label)`, which names how
+//!   the py-spy binary was resolved — PS-3 means the caller cannot
+//!   otherwise tell which one ran. The warning survives failed
+//!   downgraded outer retries and is attached to any eventual
+//!   successful result.
 //! - **PS-11d (native-all-failure-passthrough):** If the downgraded
 //!   retry also fails, the failure flows through the normal
 //!   nonblocking retry logic (PS-10) unchanged.
@@ -289,6 +296,31 @@
 //!   transient per-request machinery (spawned on `PySpyDump`,
 //!   stopped after replying) and is not part of the reachability
 //!   contract.
+//! - **PS-15a (native-immediate-downgrade):** Native frames matter —
+//!   a proc stuck in a collective or an allocator shows nothing
+//!   useful without them — but a partial dump beats no dump. If a
+//!   capture that requested `--native` or `--native-all` returns
+//!   `Failed` for any reason other than the PS-11a unsupported-flag
+//!   signature — libunwind rejecting the target with `UNW_EINVAL`,
+//!   say — `try_exec` drops both native flags and retries
+//!   Python-only in the same outer attempt, and PS-15c says so in
+//!   the result.
+//! - **PS-15b (native-no-retry-consumption):** That downgrade retry
+//!   does not consume an outer nonblocking retry slot (PS-10) and
+//!   does not incur the 100ms inter-attempt backoff.
+//! - **PS-15c (native-downgrade-warning):** A successful downgraded
+//!   result includes `pyspy::native_downgrade_warning(label)`, so a
+//!   caller can tell a Python-only dump from a full one. It is the
+//!   only signal that native frames are missing, so it names both
+//!   the py-spy that fell short and the remedy: point the
+//!   `PYSPY_BIN` environment variable on the dumped proc at a build
+//!   that can unwind the target. The warning survives failed
+//!   Python-only outer retries and is attached to any eventual
+//!   successful result.
+//! - **PS-15d (native-sticky-downgrade):** Once native capture has
+//!   failed, `effective_opts.native` and `effective_opts.native_all`
+//!   remain `false` for all subsequent outer retries. Native is not
+//!   re-tested on later attempts.
 //!
 //! v1 contract notes:
 //! - The current py-spy bridge expects a ProcAddr-form reference and
@@ -321,10 +353,10 @@
 //! - **PP-3 (temp file lifecycle):** `py-spy record` writes to a
 //!   temp file; the worker reads it after successful exit and
 //!   deletes via tempfile drop. On failure or timeout, stderr is
-//!   captured. On timeout, the child is explicitly killed and
-//!   reaped via `start_kill()` + `wait().await`. If the file is
-//!   missing, empty, or unreadable after successful exit, the
-//!   result is `OutputMissing`, `OutputEmpty`, or
+//!   captured. On timeout or cancellation, the child process group
+//!   is killed; the direct-child reap has its own one-second bound.
+//!   If the file is missing, empty, or unreadable after successful
+//!   exit, the result is `OutputMissing`, `OutputEmpty`, or
 //!   `OutputReadFailure`, not `Ok`.
 //! - **PP-4 (target locality):** Inherits PS-1 — always targets
 //!   `std::process::id()`, never a caller-supplied PID.

--- a/hyperactor_mesh/src/mesh_admin_skill.md
+++ b/hyperactor_mesh/src/mesh_admin_skill.md
@@ -121,6 +121,11 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
   - `{"BinaryNotFound": {"searched": [...]}}` — py-spy not available
   - `{"Failed": {"pid": N, "binary": "...", "exit_code": N, "stderr": "..."}}` — py-spy error
 
+  Native frames are requested server-side and are best-effort: on
+  failure the server retries python-only and still returns `Ok`, so
+  a degraded dump is only distinguishable via `warnings`. See
+  "py-spy: missing native frames".
+
   The endpoint supports worker procs and the service proc. A
   proc supports py-spy iff its stable handler actor is
   reachable: the service proc requires `host_agent`; non-service
@@ -138,10 +143,17 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
 - `POST {base}/v1/pyspy_profile_svg/{proc_reference}`
   Profiles the process for a requested duration and returns an SVG
   flamegraph. POST body is JSON `PySpyProfileOpts`:
-  `{"duration_s": 5, "rate_hz": 100, "native": true, "threads": false, "nonblocking": false}`
+  `{"duration_s": 5, "rate_hz": 100, "native": false, "threads": false, "nonblocking": false}`
 
   Returns `image/svg+xml` on success. Long-running — timeout scales
   with `duration_s`. Max duration is configurable (default 300s).
+
+  `native` is caller-controlled for profiles. Unlike stack dumps, a
+  profile requested with `native: true` does not fall back to
+  Python-only sampling when native capture fails; it returns
+  `profile_failed`. Use `native: false` when a Python-only flamegraph
+  is acceptable, or configure a py-spy binary that can capture native
+  frames.
 
   Error responses:
   - 400 — invalid `duration_s` or `rate_hz`
@@ -246,12 +258,85 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
   {"sql": "SELECT * FROM pyspy_dumps WHERE dump_id = '550e8400-...'"}
   ```
 
+  `pyspy_dumps.warnings_json` preserves the result's warnings as a JSON
+  string array. Read it before interpreting a stored dump; a native-capture
+  fallback is recorded there.
+
   Error handling follows the same conventions as
   `GET /v1/pyspy/{proc_reference}`: `not_found` if the target
   agent is unreachable, `gateway_timeout` on timeout.
 
+  Runs the same native-frame capture as `GET /v1/pyspy`, with the
+  same best-effort fallback. See "py-spy: missing native frames".
+
 - `GET {base}/SKILL.md`
   This document.
+
+### py-spy: missing native frames
+
+**If every frame in a dump is a `.py` file, read `warnings` before
+drawing any conclusion about the process.** An all-Python stack is
+ambiguous: it may be the truth, or it may be a degraded capture.
+
+This matters because a proc blocked in a collective, an allocator, or a
+hyperactor C++ path shows nothing useful in Python-only frames -- one
+opaque call into an extension module, the real state invisible. Reading
+"idle" or "stuck in `<some .py line>`" off a degraded dump is the
+mistake this prevents.
+
+`GET /v1/pyspy` and `POST /v1/pyspy_dump` request native frames
+(`--native --native-all`) server-side, so a healthy dump interleaves
+interpreter and extension frames with the Python ones:
+
+```
+0x7f237a20189a       libpython3.12.so.1.0:0
+<your frame>         your_module.py:118
+task_step_impl       _asyncio.cpython-312-x86_64-linux-gnu.so:0
+```
+
+#### Recognizing the loss
+
+For stack dumps, native capture is best-effort: on failure the server
+retries python-only rather than erroring, so you get `200`, an `Ok`
+result, and no error anywhere. `warnings` is the only signal:
+
+- `native capture failed; fell back to python-only frames. py-spy
+  (<resolution>) could not unwind native frames …` — Python-only. Do not
+  treat the stack as complete.
+- `--native-all unsupported by py-spy (<resolution>); fell back to
+  --native` — native frames are present; the stack is usable.
+
+`<resolution>` is how py-spy was found: `PYSPY_BIN=/path` if set, else
+`py-spy on PATH`. A `PYSPY_BIN=…` prefix means the variable is already
+set to a build that cannot unwind — repoint it, do not set it.
+
+In the admin TUI the warning renders under the `pid`/`binary` header,
+above the first thread.
+
+#### Recovering native frames
+
+py-spy 0.4.0 fails with `UNW_EINVAL` on fbcode Python binaries; 0.4.1
+unwinds them. Install 0.4.1 from PyPI (wheel sha256
+`6a80ec05eb8a6883863a367c6a4d4f2d57de68466f7956b6367d4edd5c61bb29`):
+
+```
+mkdir -p /tmp/pyspy041 && cd /tmp/pyspy041
+curl -sSfL -o py_spy.whl https://files.pythonhosted.org/packages/68/fb/bc7f639aed026bca6e7beb1e33f6951e16b7d315594e7635a4f7d21d63f4/py_spy-0.4.1-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl
+echo '6a80ec05eb8a6883863a367c6a4d4f2d57de68466f7956b6367d4edd5c61bb29  py_spy.whl' | sha256sum -c -
+python3 -c "import zipfile,os; z=zipfile.ZipFile('py_spy.whl'); open('py-spy','wb').write(z.read('py_spy-0.4.1.data/scripts/py-spy')); os.chmod('py-spy',0o755)"
+```
+
+Point `PYSPY_BIN` at it **in the environment of the proc being dumped** --
+resolution happens there, at dump time, so it must precede that proc
+starting:
+
+```
+PYSPY_BIN=/tmp/pyspy041/py-spy <workload command>
+```
+
+`monarch.config.configure(pyspy_bin=...)` also works and reaches procs
+spawned afterwards. Neither route affects a running proc. 0.4.1 has no
+`--native-all`, so expect that warning; the frames are still native.
 
 ## Response: NodePayload
 
@@ -427,36 +512,3 @@ Compare across sessions. A score regression after a SKILL.md
 change means the edit made the document harder to follow. A
 score regression after a server change means the API or schema
 drifted. Use the schema `$id` to correlate.
-
-## py-spy validation
-
-Automated integration test (runs all three modes — cpu, block,
-mixed — sequentially):
-
-```
-buck2 test fbcode//monarch/hyperactor_mesh:pyspy_integration_test
-```
-
-Manual verification against a live mesh:
-
-1. Start the py-spy workload:
-
-```
-buck2 run fbcode//monarch/python/examples:pyspy_workload -- \
-  --mode cpu --work-ms 500 --concurrency 3
-```
-
-2. Run the verification script (exit codes: 0 PASS, 1 FAIL,
-   2 SKIP when py-spy is unavailable):
-
-```
-buck2 run fbcode//monarch/python/examples:verify_pyspy -- \
-  --admin-url <url> --mode cpu --samples 10 \
-  --cacert /var/facebook/rootcanal/ca.pem \
-  --cert /var/facebook/x509_identities/server.pem \
-  --key /var/facebook/x509_identities/server.pem
-```
-
-Modes: `cpu` (iterative CPU burn), `block` (blocking sleep),
-`mixed` (alternating CPU + async). The verifier checks for
-mode-specific evidence frames in py-spy stacks.

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -25,6 +25,8 @@ use typeuri::Named;
 use crate::config::MESH_ADMIN_PYSPY_TIMEOUT;
 use crate::config::PYSPY_BIN;
 
+const SUBPROCESS_REAP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Result of a py-spy stack dump request.
 ///
 /// See PS-2, PS-4 in `introspect` module doc.
@@ -484,6 +486,7 @@ impl PySpyRunner {
             searched.push(label.clone());
             if let Some(result) = try_exec(
                 binary,
+                label,
                 pid,
                 opts,
                 hyperactor_config::global::get(MESH_ADMIN_PYSPY_TIMEOUT),
@@ -660,6 +663,77 @@ fn build_command(binary: &str, pid: u32, opts: &PySpyOpts) -> tokio::process::Co
     cmd
 }
 
+/// A spawned subprocess whose process-group cleanup invariant is established
+/// by construction.
+struct GuardedSubprocess {
+    group: ProcessGroupGuard,
+    child: tokio::process::Child,
+}
+
+/// Keeps the process group killable until the direct child has been reaped.
+/// Dropping this guard covers cancellation of the async collector.
+struct ProcessGroupGuard {
+    pgid: Option<i32>,
+}
+
+impl ProcessGroupGuard {
+    fn kill(&self) {
+        #[cfg(unix)]
+        if let Some(pgid) = self.pgid {
+            // SAFETY: the child was spawned with `process_group(0)`, so its
+            // positive pid names a process group owned by this invocation.
+            unsafe {
+                libc::killpg(pgid, libc::SIGKILL);
+            }
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.pgid = None;
+    }
+}
+
+impl Drop for ProcessGroupGuard {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}
+
+/// Spawn a subprocess in its own process group and return it coupled to the
+/// guard that owns group cleanup.
+fn spawn_guarded_subprocess(
+    mut command: tokio::process::Command,
+) -> std::io::Result<GuardedSubprocess> {
+    #[cfg(unix)]
+    command.process_group(0);
+    command.kill_on_drop(true);
+    let child = command.spawn()?;
+    let group = ProcessGroupGuard {
+        pgid: child
+            .id()
+            .and_then(|pid| i32::try_from(pid).ok())
+            .filter(|pid| *pid > 0),
+    };
+    Ok(GuardedSubprocess { group, child })
+}
+
+/// Kill the process tree and wait a bounded interval for the direct child.
+async fn kill_and_reap(subprocess: &mut GuardedSubprocess) -> Option<String> {
+    subprocess.group.kill();
+    let _ = subprocess.child.start_kill();
+    match tokio::time::timeout(SUBPROCESS_REAP_TIMEOUT, subprocess.child.wait()).await {
+        Ok(Ok(_)) => {
+            subprocess.group.disarm();
+            None
+        }
+        Ok(Err(error)) => Some(format!("failed to reap killed py-spy subprocess: {error}")),
+        Err(_) => Some(format!(
+            "timed out after {}s waiting to reap killed py-spy subprocess",
+            SUBPROCESS_REAP_TIMEOUT.as_secs()
+        )),
+    }
+}
+
 /// Map a process::Output to a PySpyResult, parsing the `--json`
 /// output into structured `PySpyStackTrace` values.
 /// See PS-2, PS-4 in `introspect` module doc.
@@ -704,6 +778,28 @@ fn is_unsupported_native_all(result: &PySpyResult) -> bool {
     )
 }
 
+/// The warning attached to a result that dropped `--native-all`
+/// because the py-spy binary does not support it (PS-11c). Takes the
+/// candidate's resolution label (`PYSPY_BIN=…` or `py-spy on PATH`)
+/// rather than the bare argv0, so the reader learns which candidate
+/// PS-3 picked and how.
+fn native_all_downgrade_warning(label: &str) -> String {
+    format!("--native-all unsupported by py-spy ({label}); fell back to --native")
+}
+
+/// The warning attached to a result that fell back to Python-only
+/// frames after native capture failed (PS-15c). This is the only
+/// signal an operator gets that native frames are missing, so it
+/// names the candidate that fell short -- by resolution label, so a
+/// `PYSPY_BIN` that is already set is visible -- and the remedy.
+fn native_downgrade_warning(label: &str) -> String {
+    format!(
+        "native capture failed; fell back to python-only frames. py-spy ({label}) could not \
+         unwind native frames on this target. py-spy 0.4.1 or newer (PyPI wheel) can; to restore \
+         them, point PYSPY_BIN on the dumped proc at such a binary"
+    )
+}
+
 /// Result of a single spawn → collect execution step.
 enum ExecOnce {
     /// py-spy produced a result (success or failure).
@@ -732,8 +828,8 @@ async fn exec_once(
             stderr: format!("py-spy subprocess timed out after {}s", timeout.as_secs()),
         });
     }
-    let child = match build_command(binary, pid, opts).spawn() {
-        Ok(child) => child,
+    let subprocess = match spawn_guarded_subprocess(build_command(binary, pid, opts)) {
+        Ok(subprocess) => subprocess,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return ExecOnce::NotFound,
         Err(e) => {
             return ExecOnce::Result(PySpyResult::Failed {
@@ -744,7 +840,7 @@ async fn exec_once(
             });
         }
     };
-    ExecOnce::Result(collect_with_timeout(child, pid, binary, remaining).await)
+    ExecOnce::Result(collect_with_timeout(subprocess, pid, binary, remaining).await)
 }
 
 /// Try to execute py-spy with the given binary path. Returns `None`
@@ -753,15 +849,22 @@ async fn exec_once(
 ///
 /// In nonblocking mode, retries up to 3 times with 100ms backoff
 /// because py-spy can segfault reading mutating process memory
-/// (PS-10). All attempts share a single deadline so total wall time
-/// never exceeds the caller's timeout budget (PS-5).
+/// (PS-10). Attempts and backoff share one deadline; timeout cleanup
+/// has a separate bounded reap interval (PS-5).
 ///
 /// If `native_all` is requested but the py-spy binary does not
 /// support `--native-all` (exit code 2), the flag is dropped and the
 /// command is retried immediately within the same attempt (PS-11a
 /// through PS-11e).
+///
+/// If native capture fails for any other reason — libunwind cannot
+/// unwind the target, say — both native flags are dropped and the
+/// command is retried Python-only (PS-15a through PS-15d). Native
+/// frames are not optional to a caller debugging a stuck proc, but a
+/// partial dump beats no dump, and the result says which it is.
 async fn try_exec(
     binary: &str,
+    label: &str,
     pid: u32,
     opts: &PySpyOpts,
     timeout: std::time::Duration,
@@ -770,10 +873,15 @@ async fn try_exec(
     let retries = if opts.nonblocking { 3 } else { 1 };
     let mut last_result = None;
     let mut effective_opts = opts.clone();
+    let mut fallback_warnings = Vec::new();
 
     for attempt in 0..retries {
         if attempt > 0 {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            let wake_at = tokio::time::Instant::now() + std::time::Duration::from_millis(100);
+            if wake_at >= deadline {
+                break;
+            }
+            tokio::time::sleep_until(wake_at).await;
         }
         let mut result = match exec_once(binary, pid, &effective_opts, deadline, timeout).await {
             ExecOnce::NotFound => return None,
@@ -786,18 +894,37 @@ async fn try_exec(
             // PS-11e: sticky downgrade — later outer retries keep
             // native_all = false.
             effective_opts.native_all = false;
+            // `native_all` implies native capture. Preserve that intent when
+            // an older py-spy requires the flags to be expressed separately.
+            effective_opts.native = true;
+            fallback_warnings.push(native_all_downgrade_warning(label));
             result = match exec_once(binary, pid, &effective_opts, deadline, timeout).await {
                 ExecOnce::NotFound => return None,
                 ExecOnce::Result(r) => r,
             };
-            // PS-11c: inject warning on successful downgraded result.
-            if let PySpyResult::Ok { warnings, .. } = &mut result {
-                warnings.push(
-                    "--native-all unsupported by this py-spy; fell back to --native".to_string(),
-                );
-            }
             // PS-11d: if the downgraded retry also failed, fall
-            // through to the normal last_result path below.
+            // through to the native downgrade below.
+        }
+        // PS-15a: native capture failed; drop the native flags and
+        // retry Python-only in the same attempt (PS-15b: no backoff,
+        // no retry slot consumed).
+        let native_requested = effective_opts.native || effective_opts.native_all;
+        if native_requested && matches!(result, PySpyResult::Failed { .. }) {
+            // PS-15d: sticky downgrade — later outer retries stay
+            // Python-only.
+            effective_opts.native = false;
+            effective_opts.native_all = false;
+            fallback_warnings.push(native_downgrade_warning(label));
+            result = match exec_once(binary, pid, &effective_opts, deadline, timeout).await {
+                ExecOnce::NotFound => return None,
+                ExecOnce::Result(r) => r,
+            };
+        }
+        // PS-11c, PS-15c: warnings describe the effective capture mode, so
+        // they survive failed downgraded attempts and are attached to any
+        // later successful outer retry.
+        if let PySpyResult::Ok { warnings, .. } = &mut result {
+            warnings.extend(fallback_warnings.iter().cloned());
         }
         match &result {
             PySpyResult::Ok { .. } => return Some(result),
@@ -810,45 +937,49 @@ async fn try_exec(
     last_result
 }
 
-/// Collect stdout/stderr from a spawned child concurrently with wait,
-/// bounded by `timeout`. On expiry the child is killed and reaped.
+/// Drain stdout/stderr concurrently and wait for the child, all bounded by
+/// `timeout`. On expiry the child process group is killed and the direct child
+/// is given a separate bounded interval to be reaped.
 ///
-/// Reads stdout/stderr concurrently with wait to avoid pipe-buffer
-/// deadlock. Keeps the `Child` handle alive so we can `start_kill`
-/// and `wait` on timeout for deterministic termination and reaping.
+/// Draining both pipes before waiting prevents pipe-buffer deadlock while
+/// keeping an exited group leader unreaped until inherited descriptors close.
+/// The process-group guard handles cancellation before explicit cleanup runs.
 ///
 /// See PS-5 in `introspect` module doc.
 async fn collect_with_timeout(
-    mut child: tokio::process::Child,
+    mut subprocess: GuardedSubprocess,
     pid: u32,
     binary: &str,
     timeout: std::time::Duration,
 ) -> PySpyResult {
-    let mut stdout_handle = child.stdout.take();
-    let mut stderr_handle = child.stderr.take();
+    // `subprocess` already owns its guard before this future is created. If a
+    // caller cancels before the first poll, dropping it still kills the group.
+    let mut stdout_handle = subprocess.child.stdout.take();
+    let mut stderr_handle = subprocess.child.stderr.take();
+    let mut stdout_bytes = Vec::new();
+    let mut stderr_bytes = Vec::new();
 
     let collect = async {
         let stdout_fut = async {
-            let mut buf = Vec::new();
             if let Some(ref mut r) = stdout_handle {
-                let _ = tokio::io::AsyncReadExt::read_to_end(r, &mut buf).await;
+                let _ = tokio::io::AsyncReadExt::read_to_end(r, &mut stdout_bytes).await;
             }
-            buf
         };
         let stderr_fut = async {
-            let mut buf = Vec::new();
             if let Some(ref mut r) = stderr_handle {
-                let _ = tokio::io::AsyncReadExt::read_to_end(r, &mut buf).await;
+                let _ = tokio::io::AsyncReadExt::read_to_end(r, &mut stderr_bytes).await;
             }
-            buf
         };
-        let (stdout_bytes, stderr_bytes, status) =
-            tokio::join!(stdout_fut, stderr_fut, child.wait());
-        (stdout_bytes, stderr_bytes, status)
+        tokio::join!(stdout_fut, stderr_fut);
+        let status = subprocess.child.wait().await;
+        if status.is_ok() {
+            subprocess.group.disarm();
+        }
+        status
     };
 
     match tokio::time::timeout(timeout, collect).await {
-        Ok((stdout_bytes, stderr_bytes, Ok(status))) => {
+        Ok(Ok(status)) => {
             let output = std::process::Output {
                 status,
                 stdout: stdout_bytes,
@@ -856,21 +987,31 @@ async fn collect_with_timeout(
             };
             map_output(output, pid, binary)
         }
-        Ok((_, _, Err(e))) => PySpyResult::Failed {
-            pid,
-            binary: binary.to_string(),
-            exit_code: None,
-            stderr: format!("failed to wait for child: {}", e),
-        },
-        Err(_) => {
-            // Timeout — kill and reap deterministically.
-            let _ = child.start_kill();
-            let _ = child.wait().await;
+        Ok(Err(e)) => {
+            let cleanup = kill_and_reap(&mut subprocess).await;
             PySpyResult::Failed {
                 pid,
                 binary: binary.to_string(),
                 exit_code: None,
-                stderr: format!("py-spy subprocess timed out after {}s", timeout.as_secs()),
+                stderr: match cleanup {
+                    Some(cleanup) => format!("failed to wait for child: {e}; {cleanup}"),
+                    None => format!("failed to wait for child: {e}"),
+                },
+            }
+        }
+        Err(_) => {
+            let cleanup = kill_and_reap(&mut subprocess).await;
+            PySpyResult::Failed {
+                pid,
+                binary: binary.to_string(),
+                exit_code: None,
+                stderr: match cleanup {
+                    Some(cleanup) => format!(
+                        "py-spy subprocess timed out after {}s; {cleanup}",
+                        timeout.as_secs()
+                    ),
+                    None => format!("py-spy subprocess timed out after {}s", timeout.as_secs()),
+                },
             }
         }
     }
@@ -911,51 +1052,63 @@ fn build_record_command(
     cmd
 }
 
-/// Collect stderr and wait for exit, bounded by `timeout`. On
-/// expiry the child is explicitly killed and reaped. See PP-2, PP-3.
+/// Drain stderr and wait for exit, bounded by `timeout`. On expiry the child
+/// process group is killed and the direct child is given a separate bounded
+/// interval to be reaped. See PP-2, PP-3.
 async fn collect_profile_with_timeout(
-    mut child: tokio::process::Child,
+    mut subprocess: GuardedSubprocess,
     pid: u32,
     binary: &str,
     timeout: std::time::Duration,
 ) -> Result<(std::process::ExitStatus, String), ProfileExecOutcome> {
-    // Drain stderr on a separate task so it does not block the
-    // child.wait() path and so `child` stays in this scope for
-    // explicit kill/reap on timeout.
-    let stderr_handle = child.stderr.take();
-    let stderr_task = tokio::spawn(async move {
-        let mut buf = Vec::new();
-        if let Some(mut r) = stderr_handle {
-            let _ = tokio::io::AsyncReadExt::read_to_end(&mut r, &mut buf).await;
+    // As with dump collection, the guard exists before the first poll.
+    let mut stderr_handle = subprocess.child.stderr.take();
+    let mut stderr_bytes = Vec::new();
+    let collect = async {
+        if let Some(ref mut stderr) = stderr_handle {
+            let _ = tokio::io::AsyncReadExt::read_to_end(stderr, &mut stderr_bytes).await;
         }
-        buf
-    });
+        let status = subprocess.child.wait().await;
+        if status.is_ok() {
+            subprocess.group.disarm();
+        }
+        status
+    };
 
-    match tokio::time::timeout(timeout, child.wait()).await {
+    match tokio::time::timeout(timeout, collect).await {
         Ok(Ok(status)) => {
-            let stderr_bytes = stderr_task.await.unwrap_or_default();
             let stderr = String::from_utf8_lossy(&stderr_bytes).into_owned();
             Ok((status, stderr))
         }
         Ok(Err(e)) => {
-            stderr_task.abort();
+            let cleanup = kill_and_reap(&mut subprocess).await;
             Err(ProfileExecOutcome::WaitFailure {
                 pid,
                 binary: binary.to_string(),
-                error: e.to_string(),
+                error: match cleanup {
+                    Some(cleanup) => format!("{e}; {cleanup}"),
+                    None => e.to_string(),
+                },
             })
         }
         Err(_) => {
-            // Timeout — explicit kill and reap.
-            let _ = child.start_kill();
-            let _ = child.wait().await;
-            let stderr_bytes = stderr_task.await.unwrap_or_default();
+            let cleanup = kill_and_reap(&mut subprocess).await;
+            let drain_stderr = async {
+                if let Some(ref mut stderr) = stderr_handle {
+                    let _ = tokio::io::AsyncReadExt::read_to_end(stderr, &mut stderr_bytes).await;
+                }
+            };
+            let _ = tokio::time::timeout(SUBPROCESS_REAP_TIMEOUT, drain_stderr).await;
             let stderr = String::from_utf8_lossy(&stderr_bytes).into_owned();
             Err(ProfileExecOutcome::TimedOut {
                 pid,
                 binary: binary.to_string(),
                 timeout,
-                stderr,
+                stderr: match cleanup {
+                    Some(cleanup) if stderr.is_empty() => cleanup,
+                    Some(cleanup) => format!("{stderr}; {cleanup}"),
+                    None => stderr,
+                },
             })
         }
     }
@@ -981,22 +1134,24 @@ async fn try_profile(
     };
     let svg_path = tmp_dir.path().join("profile.svg");
 
-    let child = match build_record_command(binary, pid, request, &svg_path).spawn() {
-        Ok(c) => c,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
-        Err(e) => {
-            return Some(ProfileExecOutcome::SubprocessSpawnFailure {
-                pid,
-                binary: binary.to_string(),
-                error: e.to_string(),
-            });
-        }
-    };
+    let subprocess =
+        match spawn_guarded_subprocess(build_record_command(binary, pid, request, &svg_path)) {
+            Ok(subprocess) => subprocess,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                return Some(ProfileExecOutcome::SubprocessSpawnFailure {
+                    pid,
+                    binary: binary.to_string(),
+                    error: e.to_string(),
+                });
+            }
+        };
 
-    let (status, stderr) = match collect_profile_with_timeout(child, pid, binary, timeout).await {
-        Ok(pair) => pair,
-        Err(outcome) => return Some(outcome),
-    };
+    let (status, stderr) =
+        match collect_profile_with_timeout(subprocess, pid, binary, timeout).await {
+            Ok(pair) => pair,
+            Err(outcome) => return Some(outcome),
+        };
 
     if !status.success() {
         return Some(ProfileExecOutcome::ExitFailure {
@@ -1036,11 +1191,24 @@ mod tests {
     use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
     use std::os::unix::process::ExitStatusExt;
+    use std::path::Path;
     use std::time::Duration;
 
     use tokio::process::Command;
 
     use super::*;
+
+    // PS-* verification map:
+    // - PS-1: `output_preserves_caller_pid`; actor target locality is fixed by
+    //   `dump_self` and exercised through the mesh-admin integration tests.
+    // - PS-2, PS-4: `output_*` and `exec_*` result-shape tests.
+    // - PS-3: `candidates_*` and `exec_missing_binary_returns_none`.
+    // - PS-5: dump/profile timeout and immediate-cancellation tests.
+    // - PS-6 through PS-9 and PS-12 through PS-14: source-grounded actor and
+    //   bridge contracts exercised by the mesh-admin integration tests.
+    // - PS-10: the sticky downgrade tests exercise outer retries.
+    // - PS-11a through PS-11e: `native_all_downgrade_*`.
+    // - PS-15a through PS-15d: `native_downgrade_*`.
 
     #[test]
     fn pyspy_result_wirevalue_roundtrip() {
@@ -1073,6 +1241,35 @@ mod tests {
         let any: wirevalue::Any = wirevalue::Any::serialize(&original).expect("serialize");
         let restored: PySpyResult = any.deserialized().expect("deserialize");
         assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn warnings_report_the_resolution_label() {
+        // Both candidate labels from resolve_candidates must read as a
+        // sentence subject, and an already-set PYSPY_BIN must be
+        // visible -- the remedy text tells the reader to point that
+        // variable somewhere, which is confusing if it is already set
+        // and they cannot tell.
+        let candidates = resolve_candidates(Some("/tmp/py-spy".to_string()));
+        let env_label = candidates[0].1.clone();
+        let path_label = candidates[1].1.clone();
+
+        let env = native_downgrade_warning(&env_label);
+        assert!(
+            env.contains("py-spy (PYSPY_BIN=/tmp/py-spy) could not unwind"),
+            "unexpected: {env}"
+        );
+
+        let looked_up = native_downgrade_warning(&path_label);
+        assert!(
+            looked_up.contains("py-spy (py-spy on PATH) could not unwind"),
+            "unexpected: {looked_up}"
+        );
+
+        assert_eq!(
+            native_all_downgrade_warning(&path_label),
+            "--native-all unsupported by py-spy (py-spy on PATH); fell back to --native"
+        );
     }
 
     #[test]
@@ -1227,6 +1424,7 @@ mod tests {
         // PS-3: NotFound from exec → None (triggers fallback).
         let result = try_exec(
             "/definitely/not/a/real/binary",
+            "PYSPY_BIN=/definitely/not/a/real/binary",
             1,
             &default_opts(),
             std::time::Duration::from_secs(5),
@@ -1241,6 +1439,7 @@ mod tests {
         // py-spy JSON. We expect a Failed result from parse error.
         let result = try_exec(
             "true",
+            "PYSPY_BIN=true",
             1,
             &default_opts(),
             std::time::Duration::from_secs(5),
@@ -1257,24 +1456,31 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn collect_timeout_kills_child_and_returns_failed() {
-        // PS-5: subprocess that hangs past timeout → Failed with
-        // "timed out" message; child is killed and reaped.
-        let child = Command::new("sleep")
-            .arg("100")
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .expect("sleep must be available");
+        // PS-5: a subprocess that hangs past its timeout returns even when a
+        // descendant inherited both output descriptors. Killing only the
+        // direct shell would leave those descriptors open and strand cleanup.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ready = dir.path().join("grandchild-ready");
+        let survived = dir.path().join("grandchild-survived");
+        let mut target_command = Command::new("sleep");
+        target_command.arg("60");
+        let mut unrelated_target =
+            spawn_guarded_subprocess(target_command).expect("spawn target-process fixture");
+        let target_pid = unrelated_target
+            .child
+            .id()
+            .expect("target process must have a pid");
+        let child = spawn_process_tree(&ready, &survived).await;
 
-        let result = collect_with_timeout(
-            child,
-            std::process::id(),
-            "sleep",
-            std::time::Duration::from_millis(100),
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            collect_with_timeout(child, target_pid, "sh", Duration::from_millis(200)),
         )
-        .await;
+        .await
+        .expect("timeout cleanup must itself be bounded");
 
         match result {
             PySpyResult::Failed { stderr, .. } => {
@@ -1285,6 +1491,83 @@ mod tests {
             }
             other => panic!("expected Failed, got {:?}", other),
         }
+        assert!(
+            ready.exists(),
+            "grandchild must start before timeout cleanup"
+        );
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        assert!(
+            !survived.exists(),
+            "grandchild outlived py-spy timeout cleanup"
+        );
+        assert!(
+            unrelated_target
+                .child
+                .try_wait()
+                .expect("inspect target process")
+                .is_none(),
+            "py-spy timeout cleanup killed a process in an unrelated group"
+        );
+        let cleanup = kill_and_reap(&mut unrelated_target).await;
+        assert!(cleanup.is_none(), "target cleanup failed: {cleanup:?}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn collect_cancellation_kills_descendants() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ready = dir.path().join("grandchild-ready");
+        let survived = dir.path().join("grandchild-survived");
+        let child = spawn_process_tree(&ready, &survived).await;
+
+        let task = tokio::spawn(collect_with_timeout(
+            child,
+            std::process::id(),
+            "sh",
+            Duration::from_secs(30),
+        ));
+        task.abort();
+        let join_error = tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("cancelled collector must return within the bound")
+            .expect_err("collector task must be cancelled");
+        assert!(
+            join_error.is_cancelled(),
+            "unexpected task error: {join_error}"
+        );
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        assert!(
+            !survived.exists(),
+            "grandchild outlived collector cancellation"
+        );
+    }
+
+    #[cfg(unix)]
+    async fn spawn_process_tree(ready: &Path, survived: &Path) -> GuardedSubprocess {
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("echo diag >&2; ( touch \"$1\"; sleep 2; touch \"$2\" ) & wait")
+            .arg("pyspy-process-tree-test")
+            .arg(ready)
+            .arg(survived)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        let subprocess = spawn_guarded_subprocess(command).expect("spawn process-tree fixture");
+        wait_for_file(ready).await;
+        subprocess
+    }
+
+    #[cfg(unix)]
+    async fn wait_for_file(path: &Path) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while tokio::fs::metadata(path).await.is_err() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("grandchild did not start");
     }
 
     #[tokio::test]
@@ -1292,6 +1575,7 @@ mod tests {
         // "false" exists on all unix systems and exits 1.
         let result = try_exec(
             "false",
+            "PYSPY_BIN=false",
             42,
             &default_opts(),
             std::time::Duration::from_secs(5),
@@ -1363,8 +1647,10 @@ exit 0
             native_all: true,
             nonblocking: false,
         };
+        let label = format!("PYSPY_BIN={}", script.to_str().unwrap());
         let result = try_exec(
             script.to_str().unwrap(),
+            &label,
             1,
             &opts,
             std::time::Duration::from_secs(5),
@@ -1374,9 +1660,10 @@ exit 0
         let result = result.expect("expected Some");
         match &result {
             PySpyResult::Ok { warnings, .. } => {
+                let expected = native_all_downgrade_warning(&label);
                 assert!(
-                    warnings.iter().any(|w| w.contains("fell back to --native")),
-                    "PS-11c: expected fallback warning, got: {warnings:?}"
+                    warnings.contains(&expected),
+                    "PS-11c: expected fallback warning naming the binary, got: {warnings:?}"
                 );
             }
             other => panic!("expected Ok, got: {other:?}"),
@@ -1397,6 +1684,54 @@ exit 0
         assert!(
             !log[1].contains("--native-all"),
             "PS-11a: second invocation must NOT include --native-all, got: {}",
+            log[1]
+        );
+        assert!(
+            log[1].contains("--native"),
+            "PS-11a: second invocation must retain native capture, got: {}",
+            log[1]
+        );
+    }
+
+    #[tokio::test]
+    async fn native_all_downgrade_enables_native() {
+        let script = write_fake_pyspy(
+            r#"
+echo "$@" >> "$0.log"
+for arg in "$@"; do
+    if [ "$arg" = "--native-all" ]; then
+        echo "unrecognized option --native-all" >&2
+        exit 2
+    fi
+done
+echo "[]"
+exit 0
+"#,
+        );
+        let opts = PySpyOpts {
+            threads: false,
+            native: false,
+            native_all: true,
+            nonblocking: false,
+        };
+        let label = format!("PYSPY_BIN={}", script.to_str().unwrap());
+        let result = try_exec(
+            script.to_str().unwrap(),
+            &label,
+            1,
+            &opts,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("expected Some");
+        assert!(matches!(result, PySpyResult::Ok { .. }));
+
+        let log = read_log(&script);
+        assert_eq!(log.len(), 2, "expected one native-all downgrade");
+        assert!(log[0].contains("--native-all"));
+        assert!(
+            log[1].contains("--native") && !log[1].contains("--native-all"),
+            "native-all fallback must retain native capture: {}",
             log[1]
         );
     }
@@ -1424,8 +1759,10 @@ exit 1
             native_all: true,
             nonblocking: true, // 3 outer retries
         };
+        let label = format!("PYSPY_BIN={}", script.to_str().unwrap());
         let result = try_exec(
             script.to_str().unwrap(),
+            &label,
             1,
             &opts,
             std::time::Duration::from_secs(10),
@@ -1445,45 +1782,285 @@ exit 1
             }
             other => panic!("expected Failed, got: {other:?}"),
         }
-        // Check invocation log: 4 calls total.
-        //   Attempt 0: --native-all (fail) → downgrade (fail)
-        //   Attempt 1: without --native-all (fail)
-        //   Attempt 2: without --native-all (fail)
+        // Check invocation log: 5 calls total.
+        //   Attempt 0: --native-all (fail) → --native (fail)
+        //              → python-only (fail)
+        //   Attempt 1: python-only (fail)
+        //   Attempt 2: python-only (fail)
         let log = read_log(&script);
-        assert_eq!(log.len(), 4, "expected 4 invocations, got {}", log.len());
+        assert_eq!(log.len(), 5, "expected 5 invocations, got {}", log.len());
         assert!(
             log[0].contains("--native-all"),
             "PS-11a: first invocation must include --native-all, got: {}",
             log[0]
         );
+        assert!(
+            log[1].contains("--native") && !log[1].contains("--native-all"),
+            "PS-11a: second invocation must keep --native but drop --native-all, got: {}",
+            log[1]
+        );
+        for (i, line) in log[2..].iter().enumerate() {
+            assert!(
+                !line.contains("--native"),
+                "PS-15d: invocation {} must be python-only, got: {}",
+                i + 2,
+                line
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn native_all_downgrade_warnings_survive_outer_retry() {
+        let script = write_fake_pyspy(
+            r#"
+echo "$@" >> "$0.log"
+for arg in "$@"; do
+    if [ "$arg" = "--native-all" ]; then
+        echo "unrecognized option --native-all" >&2
+        exit 2
+    fi
+done
+for arg in "$@"; do
+    if [ "$arg" = "--native" ]; then
+        echo "native capture failed" >&2
+        exit 1
+    fi
+done
+attempt=$(wc -l < "$0.log")
+if [ "$attempt" -eq 3 ]; then
+    echo "transient python-only failure" >&2
+    exit 1
+fi
+echo "[]"
+exit 0
+"#,
+        );
+        let opts = PySpyOpts {
+            threads: false,
+            native: true,
+            native_all: true,
+            nonblocking: true,
+        };
+        let label = format!("PYSPY_BIN={}", script.to_str().unwrap());
+        let result = try_exec(
+            script.to_str().unwrap(),
+            &label,
+            1,
+            &opts,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("expected Some");
+
+        match result {
+            PySpyResult::Ok { warnings, .. } => assert_eq!(
+                warnings,
+                vec![
+                    native_all_downgrade_warning(&label),
+                    native_downgrade_warning(&label),
+                ]
+            ),
+            other => panic!("expected Ok, got: {other:?}"),
+        }
+
+        let log = read_log(&script);
+        assert_eq!(
+            log.len(),
+            4,
+            "expected native-all, native, and two Python-only attempts"
+        );
+        assert!(log[0].contains("--native-all"));
+        assert!(log[1].contains("--native") && !log[1].contains("--native-all"));
+        assert!(log[2..].iter().all(|line| !line.contains("--native")));
+    }
+
+    /// PS-15a, PS-15b, PS-15c: a native capture that fails for a
+    /// reason other than the unsupported-flag signature downgrades to
+    /// python-only in the same attempt, and the successful result
+    /// carries the fallback warning.
+    #[tokio::test]
+    async fn native_downgrade_succeeds() {
+        let script = write_fake_pyspy(
+            r#"
+echo "$@" >> "$0.log"
+for arg in "$@"; do
+    if [ "$arg" = "--native" ]; then
+        echo "Error: UNW_EINVAL: unsupported operation or bad value" >&2
+        exit 1
+    fi
+done
+echo "[]"
+exit 0
+"#,
+        );
+        let opts = PySpyOpts {
+            threads: false,
+            native: true,
+            native_all: false,
+            nonblocking: false,
+        };
+        let label = format!("PYSPY_BIN={}", script.to_str().unwrap());
+        let result = try_exec(
+            script.to_str().unwrap(),
+            &label,
+            1,
+            &opts,
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+        let result = result.expect("expected Some");
+        match &result {
+            PySpyResult::Ok { warnings, .. } => {
+                let expected = native_downgrade_warning(&label);
+                assert!(
+                    warnings.contains(&expected),
+                    "PS-15c: expected native fallback warning naming the binary, got: {warnings:?}"
+                );
+            }
+            other => panic!("expected Ok, got: {other:?}"),
+        }
+        let log = read_log(&script);
+        assert_eq!(
+            log.len(),
+            2,
+            "PS-15b: expected exactly 2 invocations, got {}",
+            log.len()
+        );
+        assert!(
+            log[0].contains("--native"),
+            "PS-15a: first invocation must include --native, got: {}",
+            log[0]
+        );
+        assert!(
+            !log[1].contains("--native"),
+            "PS-15a: second invocation must be python-only, got: {}",
+            log[1]
+        );
+    }
+
+    /// PS-15d: once native capture has failed, later nonblocking
+    /// retries stay python-only rather than re-testing native.
+    #[tokio::test]
+    async fn native_downgrade_is_sticky_across_retries() {
+        let script = write_fake_pyspy(
+            r#"
+echo "$@" >> "$0.log"
+echo "Permission denied" >&2
+exit 1
+"#,
+        );
+        let opts = PySpyOpts {
+            threads: false,
+            native: true,
+            native_all: false,
+            nonblocking: true, // 3 outer retries
+        };
+        let label = format!("PYSPY_BIN={}", script.to_str().unwrap());
+        let result = try_exec(
+            script.to_str().unwrap(),
+            &label,
+            1,
+            &opts,
+            std::time::Duration::from_secs(10),
+        )
+        .await;
+        assert!(
+            matches!(result, Some(PySpyResult::Failed { .. })),
+            "expected Failed, got: {result:?}"
+        );
+        // Attempt 0: --native (fail) → python-only (fail).
+        // Attempts 1 and 2: python-only only.
+        let log = read_log(&script);
+        assert_eq!(log.len(), 4, "expected 4 invocations, got {}", log.len());
+        assert!(
+            log[0].contains("--native"),
+            "PS-15a: first invocation must include --native, got: {}",
+            log[0]
+        );
         for (i, line) in log[1..].iter().enumerate() {
             assert!(
-                !line.contains("--native-all"),
-                "PS-11e: invocation {} must NOT include --native-all, got: {}",
+                !line.contains("--native"),
+                "PS-15d: invocation {} must be python-only, got: {}",
                 i + 1,
                 line
             );
         }
     }
 
-    /// PP-2: subprocess timeout yields `TimedOut` with partial stderr.
+    #[tokio::test]
+    async fn native_downgrade_warning_survives_outer_retry() {
+        let script = write_fake_pyspy(
+            r#"
+echo "$@" >> "$0.log"
+for arg in "$@"; do
+    if [ "$arg" = "--native" ]; then
+        echo "Error: UNW_EINVAL: unsupported operation or bad value" >&2
+        exit 1
+    fi
+done
+attempt=$(wc -l < "$0.log")
+if [ "$attempt" -eq 2 ]; then
+    echo "transient python-only failure" >&2
+    exit 1
+fi
+echo "[]"
+exit 0
+"#,
+        );
+        let opts = PySpyOpts {
+            threads: false,
+            native: true,
+            native_all: false,
+            nonblocking: true,
+        };
+        let label = format!("PYSPY_BIN={}", script.to_str().unwrap());
+        let result = try_exec(
+            script.to_str().unwrap(),
+            &label,
+            1,
+            &opts,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("expected Some");
+        match result {
+            PySpyResult::Ok { warnings, .. } => {
+                assert_eq!(warnings, vec![native_downgrade_warning(&label)]);
+            }
+            other => panic!("expected Ok, got: {other:?}"),
+        }
+
+        let log = read_log(&script);
+        assert_eq!(
+            log.len(),
+            3,
+            "expected native plus two Python-only attempts"
+        );
+        assert!(log[0].contains("--native"));
+        assert!(log[1..].iter().all(|line| !line.contains("--native")));
+    }
+
+    /// PP-2: subprocess timeout yields `TimedOut` with partial stderr and
+    /// kills descendants that inherited the stderr descriptor.
+    #[cfg(unix)]
     #[tokio::test]
     async fn profile_collect_timeout_returns_timed_out() {
-        let child = Command::new("sh")
-            .arg("-c")
-            .arg("echo diag >&2; sleep 60")
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .expect("sh must be available");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ready = dir.path().join("grandchild-ready");
+        let survived = dir.path().join("grandchild-survived");
+        let child = spawn_process_tree(&ready, &survived).await;
 
-        let result = collect_profile_with_timeout(
-            child,
-            std::process::id(),
-            "sh",
-            std::time::Duration::from_millis(200),
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            collect_profile_with_timeout(
+                child,
+                std::process::id(),
+                "sh",
+                Duration::from_millis(200),
+            ),
         )
-        .await;
+        .await
+        .expect("profile timeout cleanup must itself be bounded");
 
         match result {
             Err(ProfileExecOutcome::TimedOut { stderr, .. }) => {
@@ -1494,6 +2071,48 @@ exit 1
             }
             other => panic!("expected TimedOut, got: {other:?}"),
         }
+        assert!(
+            ready.exists(),
+            "grandchild must start before timeout cleanup"
+        );
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        assert!(
+            !survived.exists(),
+            "grandchild outlived py-spy profile timeout cleanup"
+        );
+    }
+
+    /// PP-3: cancellation before the collector's first poll still kills the
+    /// process group, including descendants that inherited stderr.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn profile_collect_cancellation_kills_descendants() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ready = dir.path().join("grandchild-ready");
+        let survived = dir.path().join("grandchild-survived");
+        let child = spawn_process_tree(&ready, &survived).await;
+
+        let task = tokio::spawn(collect_profile_with_timeout(
+            child,
+            std::process::id(),
+            "sh",
+            Duration::from_secs(30),
+        ));
+        task.abort();
+        let join_error = tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("cancelled profile collector must return within the bound")
+            .expect_err("profile collector task must be cancelled");
+        assert!(
+            join_error.is_cancelled(),
+            "unexpected task error: {join_error}"
+        );
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        assert!(
+            !survived.exists(),
+            "grandchild outlived profile collector cancellation"
+        );
     }
 
     fn test_request() -> ValidatedProfileRequest {

--- a/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
@@ -23,6 +23,7 @@ use hyperactor_mesh::mesh_admin::ApiErrorEnvelope;
 use hyperactor_mesh::pyspy::PySpyFrame;
 use hyperactor_mesh::pyspy::PySpyProfileOpts;
 use hyperactor_mesh::pyspy::PySpyResult;
+use hyperactor_mesh::pyspy::PySpyStackTrace;
 
 use crate::harness;
 use crate::harness::WorkloadFixture;
@@ -375,6 +376,41 @@ async fn check_preflight(s: &PyspyScenario) {
     }
 }
 
+const RESULT_DIAGNOSTIC_CHAR_LIMIT: usize = 1024;
+
+fn truncate_diagnostic(value: String) -> String {
+    if value.chars().count() <= RESULT_DIAGNOSTIC_CHAR_LIMIT {
+        return value;
+    }
+
+    let mut truncated = value
+        .chars()
+        .take(RESULT_DIAGNOSTIC_CHAR_LIMIT)
+        .collect::<String>();
+    truncated.push('…');
+    truncated
+}
+
+/// Render a bounded result summary without including the stack payload.
+pub(crate) fn describe_result(result: &PySpyResult) -> String {
+    let summary = match result {
+        PySpyResult::Ok { warnings, .. } => format!("Ok(warnings={warnings:?})"),
+        PySpyResult::BinaryNotFound { searched } => {
+            format!("BinaryNotFound(searched: {})", searched.join(", "))
+        }
+        PySpyResult::Failed {
+            pid,
+            binary,
+            exit_code,
+            stderr,
+        } => format!(
+            "Failed(pid={pid}, binary={binary}, exit_code={exit_code:?}, stderr={})",
+            stderr.trim()
+        ),
+    };
+    truncate_diagnostic(summary)
+}
+
 /// MIT-16, MIT-17, MIT-18, MIT-19: Evidence-frame sampling over
 /// worker procs.
 async fn check_evidence(s: &PyspyScenario) {
@@ -386,6 +422,7 @@ async fn check_evidence(s: &PyspyScenario) {
     let mut total_not_found: usize = 0;
     let mut total_failed: usize = 0;
     let mut total_evidence: usize = 0;
+    let mut diagnostics: Vec<String> = Vec::new();
 
     for proc_ref in &s.workers {
         let encoded = urlencoding::encode(proc_ref);
@@ -398,8 +435,9 @@ async fn check_evidence(s: &PyspyScenario) {
             let result: PySpyResult =
                 match s.fixture.get_json(&format!("/v1/pyspy/{encoded}")).await {
                     Ok(r) => r,
-                    Err(_) => {
+                    Err(e) => {
                         failed += 1;
+                        diagnostics.push(format!("transport: {e:#}"));
                         continue;
                     }
                 };
@@ -419,9 +457,11 @@ async fn check_evidence(s: &PyspyScenario) {
                 }
                 PySpyResult::BinaryNotFound { .. } => {
                     not_found += 1;
+                    diagnostics.push(describe_result(&result));
                 }
                 PySpyResult::Failed { .. } => {
                     failed += 1;
+                    diagnostics.push(describe_result(&result));
                 }
             }
         }
@@ -432,11 +472,13 @@ async fn check_evidence(s: &PyspyScenario) {
         total_evidence += proc_evidence;
     }
 
+    let reasons = diagnostics.join("\n  ");
+
     // MIT-18: BinaryNotFound is unexpected under Buck-provisioned
     // PYSPY_BIN.
     if total_ok == 0 && total_failed == 0 && total_not_found > 0 {
         panic!(
-            "MIT-18: no Ok responses for mode={} and all {} sample(s) were BinaryNotFound despite harness-provisioned PYSPY_BIN",
+            "MIT-18: no Ok responses for mode={} and all {} sample(s) were BinaryNotFound despite harness-provisioned PYSPY_BIN\n  {reasons}",
             s.mode, total_not_found
         );
     }
@@ -444,7 +486,7 @@ async fn check_evidence(s: &PyspyScenario) {
     // All failures (or mix of Failed + BinaryNotFound), no Ok responses.
     if total_ok == 0 {
         panic!(
-            "MIT-17: no Ok responses for mode={} ({} failed, {} not-found)",
+            "MIT-17: no Ok responses for mode={} ({} failed, {} not-found)\n  {reasons}",
             s.mode, total_failed, total_not_found
         );
     }
@@ -481,6 +523,53 @@ async fn check_evidence(s: &PyspyScenario) {
             );
         }
     }
+}
+
+#[test]
+fn describe_result_omits_stack_payload() {
+    let result = PySpyResult::Ok {
+        pid: 1,
+        binary: "py-spy".to_string(),
+        stack_traces: vec![PySpyStackTrace {
+            pid: 1,
+            thread_id: 2,
+            thread_name: Some("payload-thread".to_string()),
+            os_thread_id: Some(3),
+            active: true,
+            owns_gil: true,
+            frames: vec![PySpyFrame {
+                name: "payload-frame".to_string(),
+                filename: "payload.py".to_string(),
+                module: None,
+                short_filename: None,
+                line: 4,
+                locals: None,
+                is_entry: false,
+            }],
+        }],
+        warnings: vec!["python-only".to_string()],
+    };
+
+    let description = describe_result(&result);
+    assert_eq!(description, "Ok(warnings=[\"python-only\"])");
+    assert!(!description.contains("payload-frame"));
+}
+
+#[test]
+fn describe_result_bounds_failure_stderr() {
+    let result = PySpyResult::Failed {
+        pid: 1,
+        binary: "py-spy".to_string(),
+        exit_code: Some(1),
+        stderr: "x".repeat(RESULT_DIAGNOSTIC_CHAR_LIMIT * 2),
+    };
+
+    let description = describe_result(&result);
+    assert_eq!(
+        description.chars().count(),
+        RESULT_DIAGNOSTIC_CHAR_LIMIT + 1
+    );
+    assert!(description.ends_with('…'));
 }
 
 // Integration tests (one scoped PyspyScenario per mode)

--- a/hyperactor_mesh/test/mesh_admin_integration/telemetry.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/telemetry.rs
@@ -20,6 +20,7 @@ use hyperactor_mesh::mesh_admin::ApiErrorEnvelope;
 use hyperactor_mesh::mesh_admin::PyspyDumpAndStoreResponse;
 use hyperactor_mesh::mesh_admin::QueryRequest;
 use hyperactor_mesh::mesh_admin::QueryResponse;
+use hyperactor_mesh::pyspy::PySpyResult;
 
 use crate::harness;
 use crate::harness::WorkloadFixture;
@@ -149,22 +150,40 @@ pub async fn run_pyspy_dump_and_query() {
             "/v1/query",
             &QueryRequest {
                 sql: format!(
-                    "SELECT dump_id, proc_ref FROM pyspy_dumps WHERE dump_id = '{dump_id}'"
+                    "SELECT dump_id, proc_ref, warnings_json FROM pyspy_dumps WHERE dump_id = '{dump_id}'"
                 ),
             },
         )
         .await
         .expect("pyspy_dumps query should succeed");
     let rows = resp.rows.as_array().expect("rows should be an array");
-    assert!(
-        !rows.is_empty(),
-        "expected dump_id '{dump_id}' in pyspy_dumps table"
-    );
+    if rows.is_empty() {
+        // A missing row means either the dump never reached `Ok`, or
+        // the store/query path is broken: `store_pyspy_dump` writes
+        // rows only for `PySpyResult::Ok`, while `/v1/pyspy_dump`
+        // returns a dump_id either way. Re-dump to tell them apart --
+        // `Failed` indicts py-spy, `Ok` points downstream.
+        let observed = fixture
+            .get_json::<PySpyResult>(&format!("/v1/pyspy/{encoded}"))
+            .await;
+        let diagnostic = match &observed {
+            Ok(result) => crate::pyspy::describe_result(result),
+            Err(error) => format!("transport: {error:#}"),
+        };
+        panic!(
+            "expected dump_id '{dump_id}' in pyspy_dumps table; live py-spy dump for {proc_ref}: {diagnostic}"
+        );
+    }
     assert_eq!(
         rows[0]["proc_ref"].as_str().unwrap(),
         proc_ref,
         "proc_ref should match the queried proc"
     );
+    let warnings_json = rows[0]["warnings_json"]
+        .as_str()
+        .expect("warnings_json should be a string");
+    let _: Vec<String> =
+        serde_json::from_str(warnings_json).expect("warnings_json should be a JSON string array");
 
     fixture.shutdown().await;
 }

--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -1090,6 +1090,31 @@ pub(crate) fn pyspy_json_to_lines(
         lines.push(Line::from(header));
         lines.push(Line::from("")); // blank separator
 
+        // PY-6: warnings lead. A non-fatal warning explains why the
+        // frames below look the way they do -- a native-capture
+        // downgrade yields python-only frames -- and the overlay opens
+        // at scroll 0 while the stacks routinely run past a screen. A
+        // trailing warning is one the reader has to already suspect to
+        // go find.
+        let warnings = ok
+            .get("warnings")
+            .and_then(|v| v.as_array())
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let mut wrote_warning = false;
+        for w in warnings {
+            if let Some(s) = w.as_str() {
+                lines.push(Line::from(Span::styled(
+                    format!("warn: {s}"),
+                    scheme.detail_status_warn,
+                )));
+                wrote_warning = true;
+            }
+        }
+        if wrote_warning {
+            lines.push(Line::from("")); // blank separator
+        }
+
         let traces = ok
             .get("stack_traces")
             .and_then(|v| v.as_array())
@@ -1159,21 +1184,6 @@ pub(crate) fn pyspy_json_to_lines(
                 )));
             }
             lines.push(Line::from("")); // blank separator between threads
-        }
-
-        // Render non-fatal warnings (e.g., --native-all fallback).
-        let warnings = ok
-            .get("warnings")
-            .and_then(|v| v.as_array())
-            .map(Vec::as_slice)
-            .unwrap_or_default();
-        for w in warnings {
-            if let Some(s) = w.as_str() {
-                lines.push(Line::from(Span::styled(
-                    format!("warn: {s}"),
-                    scheme.detail_status_warn,
-                )));
-            }
         }
 
         return lines;

--- a/hyperactor_mesh_admin_tui/src/lib.rs
+++ b/hyperactor_mesh_admin_tui/src/lib.rs
@@ -126,6 +126,12 @@
 //!   `Diagnostics` variant (dropping any live `PySpy` receiver);
 //!   Esc calls `dismiss_job`; `recv_active_job` fires only for the
 //!   variant currently stored.
+//! - **PY-6 (warnings-lead):** Non-fatal warnings on an `Ok` result
+//!   render immediately after the metadata header, before the first
+//!   thread, and are emitted even when there are no stack traces. A
+//!   warning explains the frames beneath it, and the overlay opens at
+//!   scroll 0 while stacks routinely exceed a screen, so a trailing
+//!   warning is unreadable in practice.
 //!
 //! Config overlay invariants:
 //!

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -1470,6 +1470,9 @@ fn refresh_churn_large_differential() {
 // PY-5 (overlay-isolation): covered by parse_error_envelope_* tests and
 //   the cancellation sites; the cross-overlay race (p then d) is
 //   manual-verification only until an async event-loop test is added.
+// PY-6 (warnings-lead): covered by pyspy_json_to_lines_warning_precedes_stack,
+//   pyspy_json_to_lines_warning_with_empty_stack, and
+//   pyspy_json_to_lines_no_warnings_no_padding.
 //
 
 /// Join all span content in a line into a single string for assertion.
@@ -1702,6 +1705,82 @@ fn pyspy_json_to_lines_ok_empty_stack() {
     assert_eq!(lines.len(), 3); // header + blank + sentinel
     assert_eq!(line_text(&lines[0]), "pid: 1  binary: py-spy");
     assert_eq!(line_text(&lines[1]), "");
+    assert_eq!(line_text(&lines[2]), "(empty stack)");
+}
+
+// PY-6: a warning renders before the first thread, not after the last
+// frame, so it is visible when the overlay opens at scroll 0.
+#[test]
+fn pyspy_json_to_lines_warning_precedes_stack() {
+    let json = serde_json::json!({"Ok": {
+        "pid": 1,
+        "binary": "py-spy",
+        "warnings": ["native capture failed; fell back to python-only frames"],
+        "stack_traces": [{
+            "pid": 1,
+            "thread_id": 0,
+            "thread_name": null,
+            "os_thread_id": null,
+            "active": false,
+            "owns_gil": false,
+            "frames": [{
+                "name": "foo",
+                "filename": "foo.py",
+                "module": null,
+                "short_filename": null,
+                "line": 1,
+                "locals": null,
+                "is_entry": false
+            }]
+        }]
+    }});
+    let scheme = ColorScheme::nord();
+    let lines = pyspy_json_to_lines(&json, &scheme);
+    // header + blank + warning + blank + thread header + frame + trailing blank
+    assert_eq!(lines.len(), 7);
+    assert_eq!(line_text(&lines[0]), "pid: 1  binary: py-spy");
+    assert_eq!(line_text(&lines[1]), "");
+    assert_eq!(
+        line_text(&lines[2]),
+        "warn: native capture failed; fell back to python-only frames"
+    );
+    assert_eq!(line_text(&lines[3]), "");
+    assert_eq!(line_text(&lines[4]), "Thread 0x0");
+}
+
+// PY-6: a warning survives an empty stack. The pre-PY-6 ordering
+// returned at the "(empty stack)" sentinel and dropped it entirely.
+#[test]
+fn pyspy_json_to_lines_warning_with_empty_stack() {
+    let json = serde_json::json!({"Ok": {
+        "pid": 1,
+        "binary": "py-spy",
+        "warnings": ["native capture failed; fell back to python-only frames"],
+        "stack_traces": []
+    }});
+    let scheme = ColorScheme::nord();
+    let lines = pyspy_json_to_lines(&json, &scheme);
+    // header + blank + warning + blank + sentinel
+    assert_eq!(lines.len(), 5);
+    assert_eq!(
+        line_text(&lines[2]),
+        "warn: native capture failed; fell back to python-only frames"
+    );
+    assert_eq!(line_text(&lines[4]), "(empty stack)");
+}
+
+// PY-6: no warnings means no blank-line padding is introduced.
+#[test]
+fn pyspy_json_to_lines_no_warnings_no_padding() {
+    let json = serde_json::json!({"Ok": {
+        "pid": 1,
+        "binary": "py-spy",
+        "warnings": [],
+        "stack_traces": []
+    }});
+    let scheme = ColorScheme::nord();
+    let lines = pyspy_json_to_lines(&json, &scheme);
+    assert_eq!(lines.len(), 3); // header + blank + sentinel
     assert_eq!(line_text(&lines[2]), "(empty stack)");
 }
 

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -831,7 +831,7 @@ impl DatabaseScanner {
     /// Parse a py-spy result JSON and store data in normalized py-spy tables.
     ///
     /// Populates four tables matching the `hyperactor_mesh::pyspy` structs:
-    /// - `pyspy_dumps`: one row per dump
+    /// - `pyspy_dumps`: one row per dump, including warnings as JSON
     /// - `pyspy_stack_traces`: one row per thread (matches `PySpyStackTrace`)
     /// - `pyspy_frames`: one row per frame (matches `PySpyFrame`)
     /// - `pyspy_local_variables`: one row per local variable (matches `PySpyLocalVariable`)
@@ -876,6 +876,12 @@ impl DatabaseScanner {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
+        let warnings = ok
+            .get("warnings")
+            .and_then(|value| value.as_array())
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let warnings_json = serde_json::to_string(warnings)?;
         let traces = ok.get("stack_traces").and_then(|v| v.as_array());
 
         let now_us = timestamp_to_micros(&SystemTime::now());
@@ -888,6 +894,7 @@ impl DatabaseScanner {
             pid,
             binary,
             proc_ref: proc_ref.to_string(),
+            warnings_json,
         });
         Self::push_batch_to_tables(
             &self.table_data,
@@ -1845,7 +1852,7 @@ mod tests {
                          ], "is_entry": true}
                     ]
                 }],
-                "warnings": []
+                "warnings": ["native capture failed; fell back to python-only frames"]
             }
         }"#;
 
@@ -1883,10 +1890,20 @@ mod tests {
             .as_any()
             .downcast_ref::<StringArray>()
             .unwrap();
+        let warnings_json = batch
+            .column_by_name("warnings_json")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         assert_eq!(dump_ids.value(0), "dump-1");
         assert_eq!(pids.value(0), 1234);
         assert_eq!(binaries.value(0), "python3");
         assert_eq!(proc_refs.value(0), "proc[0]");
+        assert_eq!(
+            warnings_json.value(0),
+            r#"["native capture failed; fell back to python-only frames"]"#
+        );
 
         // Verify pyspy_stack_traces content
         let batches = table_batches(&scanner, "pyspy_stack_traces");

--- a/monarch_distributed_telemetry/src/pyspy_table.rs
+++ b/monarch_distributed_telemetry/src/pyspy_table.rs
@@ -9,7 +9,7 @@
 //! DataFusion table schemas for py-spy stack trace data.
 //!
 //! Four normalized tables matching the structures in `hyperactor_mesh::pyspy`:
-//! - `pyspy_dumps`: one row per dump (top-level `PySpyResult::Ok` metadata)
+//! - `pyspy_dumps`: one row per dump (top-level `PySpyResult::Ok` metadata and warnings)
 //! - `pyspy_stack_traces`: one row per thread (matches `PySpyStackTrace`)
 //! - `pyspy_frames`: one row per frame (matches `PySpyFrame`)
 //! - `pyspy_local_variables`: one row per local variable (matches `PySpyLocalVariable`)
@@ -29,6 +29,9 @@ pub struct PySpyDump {
     pub pid: i32,
     pub binary: String,
     pub proc_ref: String,
+    /// JSON array of non-fatal capture warnings. An empty array means the dump
+    /// completed without a reported fallback.
+    pub warnings_json: String,
 }
 
 /// Row data for the pyspy_stack_traces table.


### PR DESCRIPTION
Summary:

this is an omnibus fix for mesh admin's py-spy support.

mesh admin py-spy requests include native frames, but the py-spy binary provisioned in Meta CI cannot capture them from fbcode Python binaries. mesh admin now returns a Python-only dump with a warning instead of returning nothing. if `--native-all` is unavailable, it tries `--native` first.

warnings survive retries, appear prominently in the admin TUI, and are stored in `pyspy_dumps.warnings_json`. tests now show py-spy's error when a dump fails, and `SKILL.md` explains how to restore native capture.

py-spy subprocesses and their children are stopped on timeout or cancellation. cleanup is bounded and does not affect the process being inspected.

this only changes py-spy capture, diagnostics, display, storage, and documentation. the other telemetry tables are unchanged.

Reviewed By: thedavekwon

Differential Revision: D118522403


