### PR TITLE
avoid telemetry port collisions

### DIFF
--- a/python/examples/execution_workload.py
+++ b/python/examples/execution_workload.py
@@ -62,7 +62,7 @@ import sys
 from monarch._src.actor.actor_mesh import Channel, Port, PortReceiver
 from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, concurrent_endpoint, context, endpoint
-from monarch.job import ProcessJob
+from monarch.job import ProcessJob, TelemetryConfig
 
 logger: logging.Logger = logging.getLogger("execution_workload")
 logger.addHandler(TracingForwarder())
@@ -211,7 +211,7 @@ async def _hold_task(actor, id: str, entered_port: "Port[str]") -> None:
 
 
 async def async_main() -> None:
-    job = ProcessJob({"hosts": 1}).enable_telemetry()
+    job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(dashboard_port=0))
     # In-flight held invocations, tracked so they can be cancelled at
     # shutdown.
     holds: dict[str, asyncio.Task] = {}

--- a/python/examples/inbound_ordering_workload.py
+++ b/python/examples/inbound_ordering_workload.py
@@ -51,7 +51,7 @@ import urllib.parse
 
 from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, context, endpoint
-from monarch.job import ProcessJob
+from monarch.job import ProcessJob, TelemetryConfig
 
 logger: logging.Logger = logging.getLogger("inbound_ordering_workload")
 logger.addHandler(TracingForwarder())
@@ -102,7 +102,7 @@ class Sender(Actor):
 
 
 async def async_main(args: argparse.Namespace) -> None:
-    job = ProcessJob({"hosts": 1}).enable_telemetry()
+    job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(dashboard_port=0))
     try:
         state = job.state(cached_path=None)
         host = state.hosts


### PR DESCRIPTION
Summary:
bug-fix. `test_execution_workload` and `test_inbound_ordering_workload` used the fixed telemetry port 8265. parallel runs could not all bind that port, so workload startup failed with a misleading connection-refused error.

use an OS-selected telemetry port in both workloads. they can now run concurrently without competing for 8265.

this only changes these two test workloads; production telemetry defaults are unchanged.

Differential Revision: D118540413


