### PR TITLE
route shared CQ completions by queue pair (#4787)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4894,7 +4894,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "backoff",
  "bytes",
  "dashmap",
  "erased-serde",

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -10,7 +10,6 @@ license = "BSD-3-Clause"
 [dependencies]
 anyhow = "1.0.104"
 async-trait = "0.1.92"
-backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = { version = "1.12.1", features = ["serde"] }
 dashmap = { version = "6.2.1", features = ["rayon", "serde"] }
 erased-serde = "0.4.10"

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -14,6 +14,8 @@
 // Nothing outside the tests below uses this module.
 #![allow(dead_code)]
 
+use tokio::sync::mpsc;
+
 use super::primitives::IbvCq;
 use super::primitives::IbvWc;
 use super::queue_pair::PollCompletionError;
@@ -95,6 +97,49 @@ impl IbvCompletionQueue for IbvCq {
     }
 }
 
+pub(super) type CompletionResult = Result<IbvWc, WorkRequestError>;
+
+/// Producer-side route used by a CQ poller to deliver one queue pair's
+/// completions directly to its data-plane task.
+#[derive(Clone, Debug)]
+pub(super) struct CompletionRoute {
+    sender: mpsc::UnboundedSender<CompletionResult>,
+}
+
+/// Consumer-side queue owned by a queue pair's data-plane task.
+#[derive(Debug)]
+pub(super) struct CompletionInbox {
+    receiver: mpsc::UnboundedReceiver<CompletionResult>,
+}
+
+impl CompletionInbox {
+    pub(super) fn new() -> (Self, CompletionRoute) {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        (Self { receiver }, CompletionRoute { sender })
+    }
+
+    pub(super) async fn recv(&mut self) -> Option<CompletionResult> {
+        self.receiver.recv().await
+    }
+
+    pub(super) fn try_recv(&mut self) -> Result<CompletionResult, mpsc::error::TryRecvError> {
+        self.receiver.try_recv()
+    }
+}
+
+impl CompletionRoute {
+    #[cfg(test)]
+    pub(super) fn sender_for_test(&self) -> mpsc::UnboundedSender<CompletionResult> {
+        self.sender.clone()
+    }
+
+    fn deliver(&self, qp_num: u32, cq_id: CqId, result: CompletionResult) {
+        if let Err(error) = self.sender.send(result) {
+            tracing::error!(qp_num, ?cq_id, %error, "queueing a completion for a queue pair failed");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +166,40 @@ mod tests {
         // handed and so nothing else polls.
         unsafe { cq.poll(&mut consumed) }.expect("polling an empty CQ should succeed");
         assert!(consumed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn completion_inbox_preserves_order() {
+        let (mut inbox, route) = CompletionInbox::new();
+        route.deliver(7, CqId(1), Ok(IbvWc::for_test(100, true)));
+        route.deliver(7, CqId(1), Ok(IbvWc::for_test(200, true)));
+        assert_eq!(
+            inbox
+                .recv()
+                .await
+                .expect("first completion")
+                .expect("successful completion")
+                .wr_id(),
+            100,
+        );
+        assert_eq!(
+            inbox
+                .recv()
+                .await
+                .expect("second completion")
+                .expect("successful completion")
+                .wr_id(),
+            200,
+        );
+    }
+
+    #[tokio::test]
+    async fn completion_inbox_closes_when_its_route_is_dropped() {
+        let (mut inbox, route) = CompletionInbox::new();
+        drop(route);
+        assert!(
+            inbox.recv().await.is_none(),
+            "dropping the producer must close the completion channel",
+        );
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -14,6 +14,11 @@
 // Nothing outside the tests below uses this module.
 #![allow(dead_code)]
 
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
 use tokio::sync::mpsc;
 
 use super::primitives::IbvCq;
@@ -25,7 +30,7 @@ use super::queue_pair::WorkRequestError;
 const CQES_PER_POLL: usize = 64;
 
 /// Identifies one CQ, distinct from every other live one.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) struct CqId(usize);
 
 /// One completion a poll consumed: the queue pair it completed on, and either the
@@ -140,13 +145,198 @@ impl CompletionRoute {
     }
 }
 
+/// One queue pair reporting on a CQ.
+#[derive(Debug)]
+struct QpSlot {
+    route: CompletionRoute,
+    /// Number of WRs the queue pair has posted. The queue pair increments this
+    /// before waking the poller.
+    posted: Arc<AtomicU64>,
+    /// Number of CQEs the poller has consumed for this queue pair.
+    consumed: u64,
+}
+
+impl QpSlot {
+    fn expects_completions(&self) -> bool {
+        // This count only decides whether polling is useful. A relaxed load is
+        // sufficient because the producer calls `unpark` after incrementing its
+        // posted count. A subsequent wake from `park` on the consumer is then
+        // guaranteed to see the most recent value.
+        self.posted.load(Ordering::Relaxed) > self.consumed
+    }
+}
+
+/// One CQ and the routes for queue pairs that report completions on it.
+#[derive(Debug)]
+struct CqSlot<Cq> {
+    cq: Arc<Cq>,
+    queue_pairs: HashMap<u32, QpSlot>,
+}
+
+impl<Cq: IbvCompletionQueue> CqSlot<Cq> {
+    fn expects_completions(&self) -> bool {
+        self.queue_pairs.values().any(QpSlot::expects_completions)
+    }
+
+    fn route(&mut self, cq_id: CqId, consumed: &mut Vec<Completion>) -> anyhow::Result<()> {
+        for Completion { qp_num, result } in consumed.drain(..) {
+            let qp = self.queue_pairs.get_mut(&qp_num).ok_or_else(|| {
+                anyhow::anyhow!("CQ {cq_id:?} completed for unattached queue pair {qp_num}")
+            })?;
+            // Increment unconditionally, even if the delivery ultimately fails.
+            // Delivery can fail only if the QP actor is stopped or dead, so it
+            // shouldn't be possible to hang the QP actor.
+            qp.consumed += 1;
+            qp.route.deliver(qp_num, cq_id, result);
+        }
+        Ok(())
+    }
+}
+
+/// Completion queues and per-QP routes owned by one poller.
+#[derive(Debug)]
+struct PollerState<Cq> {
+    completion_queues: HashMap<CqId, CqSlot<Cq>>,
+    consumed: Vec<Completion>,
+}
+
+impl<Cq: IbvCompletionQueue> PollerState<Cq> {
+    fn new() -> Self {
+        Self {
+            completion_queues: HashMap::new(),
+            consumed: Vec::with_capacity(CQES_PER_POLL),
+        }
+    }
+
+    fn attach(
+        &mut self,
+        cq: Arc<Cq>,
+        qp_num: u32,
+        route: CompletionRoute,
+        posted: Arc<AtomicU64>,
+    ) -> anyhow::Result<()> {
+        let cq_id = cq.cq_id();
+        let slot = self
+            .completion_queues
+            .entry(cq_id)
+            .or_insert_with(|| CqSlot {
+                cq,
+                queue_pairs: HashMap::new(),
+            });
+        if slot.queue_pairs.contains_key(&qp_num) {
+            return Err(anyhow::anyhow!(
+                "queue pair {qp_num} is already attached to CQ {cq_id:?}"
+            ));
+        }
+        slot.queue_pairs.insert(
+            qp_num,
+            QpSlot {
+                route,
+                posted,
+                consumed: 0,
+            },
+        );
+        Ok(())
+    }
+
+    fn expects_completions(&self) -> bool {
+        self.completion_queues
+            .values()
+            .any(CqSlot::expects_completions)
+    }
+
+    fn poll_round(&mut self) -> anyhow::Result<()> {
+        for (cq_id, slot) in &mut self.completion_queues {
+            if !slot.expects_completions() {
+                continue;
+            }
+            self.consumed.clear();
+            // SAFETY: the poller exclusively owns every CQ in
+            // `completion_queues`; each `Arc<Cq>` keeps its CQ live.
+            if let Err(error) = unsafe { slot.cq.poll(&mut self.consumed) } {
+                tracing::warn!(?cq_id, %error, "consuming from a CQ failed");
+                continue;
+            }
+            slot.route(*cq_id, &mut self.consumed)?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
     use super::*;
     use crate::backend::ibverbs::device::IbvDevice;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
     use crate::backend::ibverbs::primitives::IbvDeviceInfo;
+
+    #[derive(Debug)]
+    struct MockCq {
+        cq_id: CqId,
+        batch: usize,
+        inner: Mutex<MockCqInner>,
+    }
+
+    #[derive(Debug, Default)]
+    struct MockCqInner {
+        queued: VecDeque<Completion>,
+        poll_errors: VecDeque<PollCompletionError>,
+        polls: usize,
+    }
+
+    impl MockCq {
+        fn new(cq_id: usize, batch: usize) -> Arc<Self> {
+            Arc::new(Self {
+                cq_id: CqId(cq_id),
+                batch,
+                inner: Mutex::new(MockCqInner::default()),
+            })
+        }
+
+        fn queue_completion(&self, qp_num: u32, wr_id: u64) {
+            self.inner
+                .lock()
+                .expect("mock CQ lock poisoned")
+                .queued
+                .push_back(Completion {
+                    qp_num,
+                    result: Ok(IbvWc::for_test(wr_id, true)),
+                });
+        }
+
+        fn queue_poll_error(&self, message: &str) {
+            self.inner
+                .lock()
+                .expect("mock CQ lock poisoned")
+                .poll_errors
+                .push_back(PollCompletionError::new(message.to_owned()));
+        }
+
+        fn polls(&self) -> usize {
+            self.inner.lock().expect("mock CQ lock poisoned").polls
+        }
+    }
+
+    impl IbvCompletionQueue for MockCq {
+        fn cq_id(&self) -> CqId {
+            self.cq_id
+        }
+
+        unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError> {
+            let mut inner = self.inner.lock().expect("mock CQ lock poisoned");
+            inner.polls += 1;
+            if let Some(error) = inner.poll_errors.pop_front() {
+                return Err(error);
+            }
+            let consumed = inner.queued.len().min(self.batch);
+            out.extend(inner.queued.drain(..consumed));
+            Ok(())
+        }
+    }
 
     /// Polling a real, empty CQ consumes nothing, and distinct CQs have distinct ids.
     #[test]
@@ -200,6 +390,86 @@ mod tests {
         assert!(
             inbox.recv().await.is_none(),
             "dropping the producer must close the completion channel",
+        );
+    }
+
+    #[tokio::test]
+    async fn poller_routes_a_shared_cq_by_queue_pair() {
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let (mut first_inbox, first_route) = CompletionInbox::new();
+        let (mut second_inbox, second_route) = CompletionInbox::new();
+        let first_posted = Arc::new(AtomicU64::new(1));
+        let second_posted = Arc::new(AtomicU64::new(1));
+        let mut poller = PollerState::new();
+        poller
+            .attach(Arc::clone(&cq), 7, first_route, first_posted)
+            .expect("first queue pair should attach");
+        poller
+            .attach(Arc::clone(&cq), 8, second_route, second_posted)
+            .expect("second queue pair should attach");
+        cq.queue_completion(8, 200);
+        cq.queue_completion(7, 100);
+
+        poller.poll_round().expect("polling should succeed");
+
+        assert_eq!(
+            first_inbox
+                .try_recv()
+                .expect("first completion")
+                .expect("successful completion")
+                .wr_id(),
+            100,
+        );
+        assert_eq!(
+            second_inbox
+                .try_recv()
+                .expect("second completion")
+                .expect("successful completion")
+                .wr_id(),
+            200,
+        );
+    }
+
+    #[test]
+    fn poller_leaves_idle_completion_queues_alone() {
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let (_inbox, route) = CompletionInbox::new();
+        let mut poller = PollerState::new();
+        poller
+            .attach(Arc::clone(&cq), 7, route, Arc::new(AtomicU64::new(0)))
+            .expect("queue pair should attach");
+        cq.queue_completion(7, 100);
+
+        poller.poll_round().expect("polling should succeed");
+
+        assert_eq!(cq.polls(), 0, "an idle queue pair must not trigger a poll");
+    }
+
+    #[test]
+    fn poller_retries_after_a_poll_error() {
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let (mut inbox, route) = CompletionInbox::new();
+        let posted = Arc::new(AtomicU64::new(1));
+        let mut poller = PollerState::new();
+        poller
+            .attach(Arc::clone(&cq), 7, route, posted)
+            .expect("queue pair should attach");
+        cq.queue_poll_error("temporary failure");
+        cq.queue_completion(7, 100);
+
+        poller.poll_round().expect("a CQ poll error is recoverable");
+        assert!(
+            matches!(inbox.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+            "a failed poll must not fabricate a completion",
+        );
+        poller.poll_round().expect("the next poll should succeed");
+        assert_eq!(
+            inbox
+                .try_recv()
+                .expect("completion after retry")
+                .expect("successful completion")
+                .wr_id(),
+            100,
         );
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -33,11 +33,11 @@ use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
 use hyperactor::OncePortRef;
-use hyperactor::PortHandle;
 use hyperactor::actor::Referable;
 use rand::seq::IteratorRandom;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::mpsc;
 use typeuri::Named;
 
 use super::IbvOp;
@@ -108,7 +108,7 @@ wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<EfaDevice>>);
 /// [`OpResult`] values.
 pub(super) struct SubmitOps<I: IbvDeviceImpl> {
     pub(super) ops: Vec<IbvOp<IbvManagerActor<I>>>,
-    pub(super) reply: PortHandle<OpResult>,
+    pub(super) reply: mpsc::UnboundedSender<OpResult>,
 }
 
 /// Local-only message: create a fresh, unconnected legacy
@@ -543,26 +543,20 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
             let local_mrs = match self.resolve_local_mrs(&op.local_memory) {
                 Ok(mrs) => mrs,
                 Err(e) => {
-                    reply.try_post(
-                        cx,
-                        OpResult {
-                            op_idx: i,
-                            result: Err(e.to_string()),
-                        },
-                    )?;
+                    let _ = reply.send(OpResult {
+                        op_idx: i,
+                        result: Err(e.to_string()),
+                    });
                     continue;
                 }
             };
             let (local, remote) = match self.pick_peer_pair(&local_mrs, &op.remote_buffers) {
                 Ok((local, remote)) => (local.clone(), remote.clone()),
                 Err(e) => {
-                    reply.try_post(
-                        cx,
-                        OpResult {
-                            op_idx: i,
-                            result: Err(e.to_string()),
-                        },
-                    )?;
+                    let _ = reply.send(OpResult {
+                        op_idx: i,
+                        result: Err(e.to_string()),
+                    });
                     continue;
                 }
             };
@@ -574,13 +568,10 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
             let handle = match self.ensure_qp_actor(cx, &qp_key, op.remote_manager) {
                 Ok(h) => h,
                 Err(e) => {
-                    reply.try_post(
-                        cx,
-                        OpResult {
-                            op_idx: i,
-                            result: Err(e.to_string()),
-                        },
-                    )?;
+                    let _ = reply.send(OpResult {
+                        op_idx: i,
+                        result: Err(e.to_string()),
+                    });
                     continue;
                 }
             };
@@ -826,7 +817,7 @@ where
         }
         let n = ibv_ops.len();
 
-        let (reply, mut reply_rx) = cx.mailbox().open_port::<OpResult>();
+        let (reply, mut reply_rx) = mpsc::unbounded_channel();
 
         self.0.try_post(
             cx,
@@ -851,14 +842,15 @@ where
                 }
                 recv = reply_rx.recv() => {
                     match recv {
-                        Ok(OpResult { result: Ok(()), .. }) => received += 1,
-                        Ok(OpResult { op_idx, result: Err(e) }) => {
+                        Some(OpResult { result: Ok(()), .. }) => received += 1,
+                        Some(OpResult { op_idx, result: Err(e) }) => {
                             received += 1;
                             failures.push((op_idx, e));
                         }
-                        Err(e) => {
+                        None => {
                             terminal = Some(format!(
-                                "SubmitOps reply port closed after {received}/{n} replies with {} failures: {e}",
+                                "operation result channel closed after {received}/{n} replies with {} failures: \
+                                some built-in RDMA actor likely stopped or failed, see logs for more details",
                                 failures.len()
                             ));
                             break;

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -35,12 +35,12 @@ use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::PortHandle;
 use hyperactor::actor::Referable;
 use hyperactor::actor::RemoteHandles;
 use hyperactor::context::Mailbox;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::mpsc;
 use typeuri::Named;
 
 use super::cq_pool::CqLease;
@@ -846,13 +846,7 @@ pub(super) trait Manager:
 
 impl<T> Manager for T where T: Actor + Referable + RemoteHandles<CreatePeerQueuePair<T>> {}
 
-/// Per-op completion reply emitted by [`QueuePairActor`] back to the
-/// manager via [`ProcessOps::reply`]. A named newtype (rather than a
-/// raw `(usize, Result<…>)` tuple) so the manager can identify
-/// undeliverable `OpResult`s by type name in
-/// `handle_undeliverable_message` and absorb them when the original
-/// caller has gone away (typical at test teardown).
-#[allow(dead_code)] // not yet referenced by IbvManagerActor
+/// Per-op completion result sent from a queue-pair actor to the submitter.
 #[derive(Debug)]
 pub(super) struct OpResult {
     pub(super) op_idx: usize,
@@ -881,7 +875,7 @@ pub(super) struct QueuePairOp {
 #[derive(Debug)]
 pub(super) struct ProcessOps {
     pub(super) items: Vec<QueuePairOp>,
-    pub(super) reply: PortHandle<OpResult>,
+    pub(super) reply: mpsc::UnboundedSender<OpResult>,
 }
 
 /// Local-only self-message that drives one round of the scheduler.
@@ -892,7 +886,7 @@ struct Tick;
 #[derive(Debug)]
 struct PendingOp {
     op: QueuePairOp,
-    reply: PortHandle<OpResult>,
+    reply: mpsc::UnboundedSender<OpResult>,
     /// WR count this op will issue when posted, computed once at
     /// construction so retries from a credit head-block don't redo
     /// the work.
@@ -909,7 +903,7 @@ struct PostedOpEntry {
     /// Kept alive so the memory *registration* outlives every in-flight
     /// WR touching it.
     _local_mrv: IbvMemoryRegionView,
-    reply: PortHandle<OpResult>,
+    reply: mpsc::UnboundedSender<OpResult>,
     /// First per-WR error observed for this op. The op's final reply is
     /// held back until `pending_wrs.is_empty()`, so the two fields above
     /// outlive every WR still in flight.
@@ -1021,7 +1015,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
     /// * `Err(_)` — `qp.put`/`qp.get` failed (e.g. the QP is in
     ///   error state). Fatal: the actor's handler returns this,
     ///   which raises a supervision event.
-    fn try_post_head(&mut self, cx: &Instance<Self>) -> Result<bool, anyhow::Error> {
+    fn try_post_head(&mut self) -> Result<bool, anyhow::Error> {
         let pending = self.queue.pop_front().expect("non-empty queue");
         let PendingOp { op, reply, wrs } = pending;
         let op_idx = op.op_idx;
@@ -1032,13 +1026,10 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 "op too large for this QP [op_idx={}, qp_key={:?}, op_type={:?}, wrs={}, max_send_wr={}, local: {:?}, remote: {:?}]",
                 op_idx, self.qp_key, op.op_type, wrs, self.max_send_wr, op.local_memory, op.remote,
             );
-            reply.try_post(
-                cx,
-                OpResult {
-                    op_idx,
-                    result: Err(err),
-                },
-            )?;
+            let _ = reply.send(OpResult {
+                op_idx,
+                result: Err(err),
+            });
             return Ok(true);
         }
 
@@ -1103,7 +1094,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         // 1. Post from the queue head until either it's empty or
         //    the head is credit-blocked.
         while !self.queue.is_empty() {
-            if !self.try_post_head(cx)? {
+            if !self.try_post_head()? {
                 break;
             }
         }
@@ -1151,13 +1142,10 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                     Some(err) => Err(err),
                     None => Ok(()),
                 };
-                entry.reply.try_post(
-                    cx,
-                    OpResult {
-                        op_idx: entry.op_idx,
-                        result,
-                    },
-                )?;
+                let _ = entry.reply.send(OpResult {
+                    op_idx: entry.op_idx,
+                    result,
+                });
             }
         }
         if progressed {
@@ -2189,14 +2177,14 @@ mod tests {
         }
     }
 
-    /// Open a multi-shot port and send a `ProcessOps` batch. Returns
+    /// Open a result channel and send a `ProcessOps` batch. Returns
     /// the receiver so the caller can await per-op results.
     fn submit_ops(
         harness: &QpaHarness,
         actor: &ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
         items: Vec<QueuePairOp>,
-    ) -> Result<hyperactor::mailbox::PortReceiver<OpResult>> {
-        let (reply, rx) = harness.client.mailbox().open_port::<OpResult>();
+    ) -> Result<mpsc::UnboundedReceiver<OpResult>> {
+        let (reply, rx) = mpsc::unbounded_channel();
         actor.try_post(&harness.client, ProcessOps { items, reply })?;
         Ok(rx)
     }
@@ -2204,7 +2192,7 @@ mod tests {
     /// Collect exactly `n` replies with a per-recv timeout, sorted
     /// by op_idx for deterministic comparison.
     async fn collect_replies(
-        rx: &mut hyperactor::mailbox::PortReceiver<OpResult>,
+        rx: &mut mpsc::UnboundedReceiver<OpResult>,
         n: usize,
     ) -> Vec<(usize, Result<(), String>)> {
         let mut out = Vec::with_capacity(n);
@@ -2212,7 +2200,7 @@ mod tests {
             let m = tokio::time::timeout(Duration::from_secs(5), rx.recv())
                 .await
                 .expect("timed out waiting for ProcessOps reply")
-                .expect("ProcessOps reply port closed");
+                .expect("ProcessOps result channel closed");
             out.push((m.op_idx, m.result));
         }
         out.sort_by_key(|(i, _)| *i);
@@ -2222,12 +2210,12 @@ mod tests {
     /// Try to recv with a short timeout, returning `None` on timeout
     /// so callers can assert "no reply yet".
     async fn try_recv(
-        rx: &mut hyperactor::mailbox::PortReceiver<OpResult>,
+        rx: &mut mpsc::UnboundedReceiver<OpResult>,
         wait: Duration,
     ) -> Option<(usize, Result<(), String>)> {
         match tokio::time::timeout(wait, rx.recv()).await {
-            Ok(Ok(m)) => Some((m.op_idx, m.result)),
-            Ok(Err(e)) => panic!("ProcessOps reply port closed: {e}"),
+            Ok(Some(m)) => Some((m.op_idx, m.result)),
+            Ok(None) => panic!("ProcessOps result channel closed"),
             Err(_) => None,
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -22,12 +22,8 @@ use std::io::Error;
 use std::result::Result;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
 
 use async_trait::async_trait;
-use backoff::ExponentialBackoff;
-use backoff::ExponentialBackoffBuilder;
-use backoff::backoff::Backoff;
 use hyperactor::Actor;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
@@ -775,68 +771,6 @@ impl IbvQueuePair for RCQueuePair {
     }
 }
 
-/// Adaptive backoff for the scheduler's `Tick` self-message. Use
-/// [`Self::next_interval`] to ask "how long should I wait before the
-/// next poll attempt?"; call [`Self::reset`] whenever the previous
-/// poll observed completions (so the actor stays tight while work
-/// is making progress).
-///
-/// While the elapsed time since the first non-zero interval is below
-/// `yield_window`, the policy returns `Duration::ZERO` so the actor
-/// just re-sends `Tick` to itself with no delay — keeping latency
-/// tight when WRs are about to complete. Past the window, it walks
-/// an exponential backoff (1ms initial, doubling, capped at 10ms)
-/// so a long-running op doesn't keep the runtime spinning. When
-/// `yield_window` is `None` (the default for
-/// `RDMA_CQ_BUSY_POLL_WINDOW`) the policy always returns
-/// `Duration::ZERO`.
-#[derive(Debug)]
-struct PollSleepPolicy {
-    yield_window: Option<Duration>,
-    started_at: Option<Instant>,
-    backoff: Option<ExponentialBackoff>,
-}
-
-impl PollSleepPolicy {
-    fn new() -> Self {
-        let yield_window = hyperactor_config::global::get(crate::config::RDMA_CQ_BUSY_POLL_WINDOW);
-        Self {
-            yield_window,
-            started_at: None,
-            backoff: None,
-        }
-    }
-
-    /// Forget all accumulated backoff state. Called after a poll
-    /// returns completions, so the next idle stretch starts fresh.
-    fn reset(&mut self) {
-        self.started_at = None;
-        self.backoff = None;
-    }
-
-    /// Suggested delay before the next `Tick`. `Duration::ZERO`
-    /// means "send `Tick` immediately".
-    fn next_interval(&mut self) -> Duration {
-        let Some(window) = self.yield_window else {
-            return Duration::ZERO;
-        };
-        let started = *self.started_at.get_or_insert_with(Instant::now);
-        if started.elapsed() < window {
-            return Duration::ZERO;
-        }
-        let backoff = self.backoff.get_or_insert_with(|| {
-            ExponentialBackoffBuilder::new()
-                .with_initial_interval(Duration::from_millis(1))
-                .with_max_interval(Duration::from_millis(10))
-                .with_multiplier(2.0)
-                .with_randomization_factor(0.0)
-                .with_max_elapsed_time(None)
-                .build()
-        });
-        backoff.next_backoff().unwrap_or(Duration::ZERO)
-    }
-}
-
 /// Bundle of trait bounds for an actor type that can serve as the
 /// peer manager — i.e. the recipient of [`CreatePeerQueuePair`].
 pub(super) trait Manager:
@@ -910,29 +844,11 @@ struct PostedOpEntry {
     first_error: Option<String>,
 }
 
-/// Per-peer queue-pair actor.
-///
-/// Generic over the manager actor type `M` (so tests can swap in a
-/// mock) and the queue-pair type `Qp` (so unit tests run without
-/// RDMA hardware). The QP is constructed by the spawning manager
-/// and handed in as a spawn param; the actor owns it for life and
-/// drops it when the actor stops.
+/// Owns one queue pair and the state used to schedule and complete its work.
 #[derive(Debug)]
-pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
+struct QueuePairState<Qp: IbvQueuePair> {
     qp_key: QpKey,
-    /// Filled into [`CreatePeerQueuePair::sender`] so the peer can
-    /// build its own [`QpKey`] from our identity.
-    local_manager: ActorRef<M>,
-    /// Recipient of [`CreatePeerQueuePair`].
-    peer_manager: ActorRef<M>,
     qp: Qp,
-    /// `true` when the peer QP is colocated with this actor's QP —
-    /// i.e. both endpoints live in the same `IbvManagerActor` *and*
-    /// target the same RDMA device. In that case `init` connects
-    /// the QP to its own endpoint and skips the cross-actor
-    /// handshake.
-    is_loopback: bool,
-    init_timeout: Duration,
     /// QP-wide cap on outstanding send-queue WRs (reads + writes).
     max_send_wr: u32,
     /// Single FIFO of ops awaiting their first post attempt. If the head
@@ -941,7 +857,7 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// future work.
     queue: VecDeque<PendingOp>,
     /// op-id → entry, for tracking WR completion. op-ids are local
-    /// to this actor (monotonic counter); they exist so we can
+    /// to this queue pair (monotonic counter); they exist so we can
     /// route per-WR completions to the right `PostedOpEntry`
     /// without making any assumptions about uniqueness of `op_idx`
     /// across batches.
@@ -952,10 +868,33 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// WRs posted to the send queue and not yet reaped:
     /// what `max_send_wr` gates against.
     in_flight: u32,
+}
+
+/// Per-peer queue-pair actor.
+///
+/// Generic over the manager actor type `M` (so tests can swap in a
+/// mock) and the queue-pair type `Qp` (so unit tests run without
+/// RDMA hardware). The QP is constructed by the spawning manager
+/// and handed in as a spawn param; the actor owns it for life and
+/// drops it when the actor stops.
+#[derive(Debug)]
+pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
+    /// Filled into [`CreatePeerQueuePair::sender`] so the peer can
+    /// build its own [`QpKey`] from our identity.
+    local_manager: ActorRef<M>,
+    /// Recipient of [`CreatePeerQueuePair`].
+    peer_manager: ActorRef<M>,
+    state: QueuePairState<Qp>,
+    /// `true` when the peer QP is colocated with this actor's QP —
+    /// i.e. both endpoints live in the same `IbvManagerActor` *and*
+    /// target the same RDMA device. In that case `init` connects
+    /// the QP to its own endpoint and skips the cross-actor
+    /// handshake.
+    is_loopback: bool,
+    init_timeout: Duration,
     /// `true` while a `Tick` self-message is already in flight; the
     /// flag prevents stacking redundant ticks.
     tick_armed: bool,
-    poll_policy: PollSleepPolicy,
     /// This queue pair's lease on the device's completion queue. Never read: it
     /// is held so the lease -- and the completion queue itself -- outlive the
     /// queue pair, which drops with this actor. This placement is temporary and
@@ -978,30 +917,56 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
     ) -> Self {
         let init_timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
         Self {
-            qp_key,
+            state: QueuePairState::new(qp_key, qp, max_send_wr),
             local_manager,
             peer_manager,
-            qp,
             is_loopback,
             init_timeout,
+            tick_armed: false,
+            _cq_lease: cq_lease,
+        }
+    }
+
+    /// One scheduler round: post everything that fits, poll for
+    /// completions, emit replies for finished ops, and re-arm
+    /// `Tick` if work remains. Returns `Err` for fatal QP-level
+    /// failures; the surrounding handler propagates the error so
+    /// supervision tears the actor down.
+    fn advance(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
+        self.state.post_ready()?;
+
+        self.state.poll_completions()?;
+
+        if self.state.has_work() && !self.tick_armed {
+            self.tick_armed = true;
+            cx.handle().try_post(cx, Tick)?;
+        }
+        Ok(())
+    }
+}
+
+impl<Qp: IbvQueuePair> QueuePairState<Qp> {
+    fn new(qp_key: QpKey, qp: Qp, max_send_wr: u32) -> Self {
+        Self {
+            qp_key,
+            qp,
             max_send_wr,
             queue: VecDeque::new(),
             posted: HashMap::new(),
             wr_to_op: HashMap::new(),
             next_op_id: 0,
             in_flight: 0,
-            tick_armed: false,
-            poll_policy: PollSleepPolicy::new(),
-            _cq_lease: cq_lease,
         }
     }
 
-    /// Number of WRs the QP will issue for an op that targets
-    /// `local_size` bytes. The QP splits large transfers into
-    /// [`IbvQueuePair::max_msg_size`]-bound chunks; a zero-byte op still
-    /// consumes one WR.
-    fn wr_count(&self, local_size: usize) -> u32 {
-        local_size.div_ceil(self.qp.max_msg_size()).max(1) as u32
+    fn enqueue(&mut self, message: ProcessOps) {
+        let max_msg_size = self.qp.max_msg_size();
+        self.queue
+            .extend(message.items.into_iter().map(|op| PendingOp {
+                wrs: op.local_memory.size().div_ceil(max_msg_size).max(1) as u32,
+                op,
+                reply: message.reply.clone(),
+            }));
     }
 
     /// Try to post the head of `queue`.
@@ -1085,26 +1050,17 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         Ok(true)
     }
 
-    /// One scheduler round: post everything that fits, poll for
-    /// completions, emit replies for finished ops, and re-arm
-    /// `Tick` if work remains. Returns `Err` for fatal QP-level
-    /// failures; the surrounding handler propagates the error so
-    /// supervision tears the actor down.
-    fn advance(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
-        // 1. Post from the queue head until either it's empty or
-        //    the head is credit-blocked.
+    fn post_ready(&mut self) -> Result<(), anyhow::Error> {
         while !self.queue.is_empty() {
             if !self.try_post_head()? {
                 break;
             }
         }
+        Ok(())
+    }
 
-        // 2. Drain the send CQ. Each completion identifies its WR by
-        //    `wr_id`; we correlate it back to its op and, once every WR
-        //    for an op has reported, emit the op's reply. Polling only
-        //    while WRs are outstanding keeps the loop from spinning on an
-        //    empty queue, and draining to `None` ensures no completion is
-        //    left behind.
+    /// Drain the send CQ and return whether any completion was observed.
+    fn poll_completions(&mut self) -> Result<bool, anyhow::Error> {
         let mut progressed = false;
         while !self.wr_to_op.is_empty() {
             let completion = self
@@ -1148,22 +1104,11 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 });
             }
         }
-        if progressed {
-            self.poll_policy.reset();
-        }
+        Ok(progressed)
+    }
 
-        // 3. Re-arm Tick if any work remains.
-        let pending_work = !self.queue.is_empty() || !self.posted.is_empty();
-        if pending_work && !self.tick_armed {
-            self.tick_armed = true;
-            let interval = self.poll_policy.next_interval();
-            if interval.is_zero() {
-                cx.handle().try_post(cx, Tick)?;
-            } else {
-                cx.post_after(cx, Tick, interval);
-            }
-        }
-        Ok(())
+    fn has_work(&self) -> bool {
+        !self.queue.is_empty() || !self.posted.is_empty()
     }
 }
 
@@ -1171,8 +1116,8 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
 impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         this.set_system();
-        let local_info = self.qp.get_qp_info().map_err(|e| {
-            tracing::error!(qp_key = ?self.qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
+        let local_info = self.state.qp.get_qp_info().map_err(|e| {
+            tracing::error!(qp_key = ?self.state.qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
             anyhow::anyhow!("could not extract local QP info: {e}")
         })?;
 
@@ -1186,8 +1131,8 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 this,
                 CreatePeerQueuePair {
                     sender: self.local_manager.clone(),
-                    sender_device: self.qp_key.self_device.clone(),
-                    receiver_device: self.qp_key.other_device.clone(),
+                    sender_device: self.state.qp_key.self_device.clone(),
+                    receiver_device: self.state.qp_key.other_device.clone(),
                     sender_info: local_info,
                     reply: reply.bind(),
                 },
@@ -1196,7 +1141,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 Ok(Ok(Ok(info))) => info,
                 Ok(Ok(Err(e))) => {
                     tracing::error!(
-                        qp_key = ?self.qp_key,
+                        qp_key = ?self.state.qp_key,
                         peer_manager = ?self.peer_manager,
                         error = %e,
                         "QueuePairActor init: peer manager rejected CreatePeerQueuePair",
@@ -1205,7 +1150,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 }
                 Ok(Err(e)) => {
                     tracing::error!(
-                        qp_key = ?self.qp_key,
+                        qp_key = ?self.state.qp_key,
                         peer_manager = ?self.peer_manager,
                         error = %e,
                         "QueuePairActor init: peer reply port closed",
@@ -1214,7 +1159,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 }
                 Err(_) => {
                     tracing::error!(
-                        qp_key = ?self.qp_key,
+                        qp_key = ?self.state.qp_key,
                         peer_manager = ?self.peer_manager,
                         timeout = ?self.init_timeout,
                         "QueuePairActor init: timed out waiting for peer reply",
@@ -1227,9 +1172,9 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
             }
         };
 
-        self.qp.connect(&peer_info).map_err(|e| {
+        self.state.qp.connect(&peer_info).map_err(|e| {
             tracing::error!(
-                qp_key = ?self.qp_key,
+                qp_key = ?self.state.qp_key,
                 peer_info = ?peer_info,
                 error = %e,
                 "QueuePairActor init: connect failed",
@@ -1254,14 +1199,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
 #[async_trait]
 impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps> for QueuePairActor<M, Qp> {
     async fn handle(&mut self, cx: &Context<Self>, msg: ProcessOps) -> Result<(), anyhow::Error> {
-        for op in msg.items.into_iter() {
-            let wrs = self.wr_count(op.local_memory.size());
-            self.queue.push_back(PendingOp {
-                op,
-                reply: msg.reply.clone(),
-                wrs,
-            });
-        }
+        self.state.enqueue(msg);
         // If a tick is already armed it will pick up the new ops on
         // its next round; advancing here would just duplicate work.
         if !self.tick_armed {

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -57,18 +57,6 @@ declare_attrs! {
     ))
     pub attr RDMA_TCP_FALLBACK_PARALLELISM: usize = 1;
 
-    /// Cooperative-yield window for the ibverbs CQ poll loop. While
-    /// the policy is within this window it calls
-    /// `tokio::task::yield_now` between polls; past it, polls fall
-    /// into an exponential backoff sleep (1ms initial, x2, capped at
-    /// 10ms). `None` (the default) disables the cutoff entirely:
-    /// the loop only ever yields, never sleeps.
-    @meta(CONFIG = ConfigAttr::new(
-        Some("MONARCH_RDMA_CQ_BUSY_POLL_WINDOW".to_string()),
-        Some("rdma_cq_busy_poll_window".to_string()),
-    ))
-    pub attr RDMA_CQ_BUSY_POLL_WINDOW: Option<Duration> = None;
-
     /// Per-side budget for the `QueuePairInitializer` handshake. The
     /// timer arms once when we send `EnsureQueuePair` and is rearmed
     /// after we hit RTS while still waiting for the peer's


### PR DESCRIPTION
Summary:

Add the single-owner state that maps completion queues to their queue pairs and routes each CQE to the matching per-QP completion channel. Posted-versus-consumed counters keep idle CQs out of polling. CQ poll errors remain recoverable; completions for unknown queue pairs are rejected.

This commit does not start a polling thread or change the production completion path.

Reviewed By: zdevito

Differential Revision: D118533138


