### PR TITLE
retain detached queue pairs until CQ drain (#4789)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4894,7 +4894,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "backoff",
  "bytes",
  "dashmap",
  "erased-serde",

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -10,7 +10,6 @@ license = "BSD-3-Clause"
 [dependencies]
 anyhow = "1.0.104"
 async-trait = "0.1.92"
-backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = { version = "1.12.1", features = ["serde"] }
 dashmap = { version = "6.2.1", features = ["rayon", "serde"] }
 erased-serde = "0.4.10"

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -15,10 +15,26 @@
 #![allow(dead_code)]
 
 use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::sync::mpsc as std_mpsc;
+use std::thread::JoinHandle;
+use std::thread::Thread;
+use std::time::Duration;
+use std::time::Instant;
 
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::Context;
+use hyperactor::Handler;
+use hyperactor::Instance;
+use hyperactor::OncePortHandle;
+use hyperactor::PortHandle;
+use hyperactor::actor::ActorError;
 use tokio::sync::mpsc;
 
 use super::primitives::IbvCq;
@@ -28,6 +44,7 @@ use super::queue_pair::WorkRequestError;
 
 /// The number of CQEs requested in each `ibv_poll_cq` call.
 const CQES_PER_POLL: usize = 64;
+const BUSY_POLL_WINDOW: Duration = Duration::from_millis(100);
 
 /// Identifies one CQ, distinct from every other live one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -263,10 +280,292 @@ impl<Cq: IbvCompletionQueue> PollerState<Cq> {
     }
 }
 
+#[derive(Debug, Default)]
+struct PollerSignal {
+    cancelled: AtomicBool,
+    thread: OnceLock<Thread>,
+}
+
+impl PollerSignal {
+    fn notify(&self) -> anyhow::Result<()> {
+        self.thread
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("CQ polling thread has not started"))?
+            .unpark();
+        Ok(())
+    }
+
+    fn cancel(&self) {
+        // Release publishes cancellation to the poller's acquire checks.
+        self.cancelled.store(true, Ordering::Release);
+        if let Some(thread) = self.thread.get() {
+            thread.unpark();
+        }
+    }
+
+    fn install_thread(&self, thread: Thread) {
+        self.thread
+            .set(thread)
+            .expect("the CQ polling thread is installed only once");
+    }
+}
+
+/// A cheap wake-up handle for notifying the dedicated CQ polling thread.
+#[derive(Clone, Debug)]
+pub(super) struct PollerWake {
+    signal: Arc<PollerSignal>,
+}
+
+impl PollerWake {
+    pub(super) fn notify(&self) -> anyhow::Result<()> {
+        self.signal.notify()
+    }
+}
+
+/// Installs the route for completions `qp_num` produces on `cq`.
+#[derive(Debug)]
+pub(super) struct Attach<Cq: IbvCompletionQueue> {
+    pub(super) cq: Arc<Cq>,
+    pub(super) qp_num: u32,
+    pub(super) route: CompletionRoute,
+    pub(super) posted: Arc<AtomicU64>,
+    pub(super) reply: OncePortHandle<PollerWake>,
+}
+
+#[derive(Debug)]
+enum PollerCommand<Cq> {
+    Attach {
+        cq: Arc<Cq>,
+        qp_num: u32,
+        route: CompletionRoute,
+        posted: Arc<AtomicU64>,
+        reply: Box<OncePortHandle<PollerWake>>,
+    },
+}
+
+#[derive(Debug)]
+struct Poller<Cq> {
+    state: PollerState<Cq>,
+    commands: std_mpsc::Receiver<PollerCommand<Cq>>,
+    signal: Arc<PollerSignal>,
+}
+
+impl<Cq: IbvCompletionQueue> Poller<Cq> {
+    fn new(commands: std_mpsc::Receiver<PollerCommand<Cq>>, signal: Arc<PollerSignal>) -> Self {
+        Self {
+            state: PollerState::new(),
+            commands,
+            signal,
+        }
+    }
+
+    fn run(mut self) -> anyhow::Result<()> {
+        let mut last_work = Instant::now();
+        loop {
+            // Acquire pairs with `cancel`'s release store so the poller sees
+            // everything that happened before cancellation.
+            if self.signal.cancelled.load(Ordering::Acquire) {
+                return Ok(());
+            }
+            self.process_commands()?;
+            if self.state.expects_completions() {
+                self.state.poll_round()?;
+                last_work = Instant::now();
+                continue;
+            }
+            if last_work.elapsed() < BUSY_POLL_WINDOW {
+                std::hint::spin_loop();
+                continue;
+            }
+            // `unpark` leaves a one-bit permit when it runs before `park`, so a
+            // producer cannot miss this transition into sleep. Its release
+            // synchronizes with `park`'s acquire return; spurious returns are
+            // harmless because the loop checks all work again.
+            std::thread::park();
+        }
+    }
+
+    fn process_commands(&mut self) -> anyhow::Result<()> {
+        loop {
+            match self.commands.try_recv() {
+                Ok(PollerCommand::Attach {
+                    cq,
+                    qp_num,
+                    route,
+                    posted,
+                    reply,
+                }) => {
+                    self.state.attach(cq, qp_num, route, posted)?;
+                    if let Err(error) = reply.try_post(
+                        Instance::<CompletionQueueActor<Cq>>::self_client(),
+                        PollerWake {
+                            signal: Arc::clone(&self.signal),
+                        },
+                    ) {
+                        tracing::warn!(qp_num, %error, "failed to deliver Attach reply");
+                    }
+                }
+                Err(std_mpsc::TryRecvError::Empty) => return Ok(()),
+                Err(std_mpsc::TryRecvError::Disconnected) => {
+                    return Err(anyhow::anyhow!("CQ poller control channel disconnected"));
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PollerFailed {
+    error: String,
+}
+
+/// Owns and supervises a native thread that polls a set of completion queues.
+#[derive(Debug)]
+pub(super) struct CompletionQueueActor<Cq> {
+    commands: std_mpsc::Sender<PollerCommand<Cq>>,
+    command_rx: Option<std_mpsc::Receiver<PollerCommand<Cq>>>,
+    wake: PollerWake,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl<Cq: IbvCompletionQueue> CompletionQueueActor<Cq> {
+    pub(super) fn new() -> Self {
+        let (commands, command_rx) = std_mpsc::channel();
+        let signal = Arc::new(PollerSignal::default());
+        Self {
+            commands,
+            command_rx: Some(command_rx),
+            wake: PollerWake { signal },
+            thread: None,
+        }
+    }
+
+    fn send_command(&self, command: PollerCommand<Cq>) -> anyhow::Result<()> {
+        self.commands
+            .send(command)
+            .map_err(|_| anyhow::anyhow!("CQ polling thread stopped"))?;
+        self.wake.notify()
+    }
+
+    fn cancel(&self) {
+        self.wake.signal.cancel();
+    }
+}
+
+impl<Cq> Drop for CompletionQueueActor<Cq> {
+    fn drop(&mut self) {
+        self.wake.signal.cancel();
+        // In theory, joining the thread here could block the tokio runtime,
+        // but in practice, it should be safe. The polling loop should break
+        // and return quickly after cancellation.
+        if let Some(thread) = self.thread.take()
+            && thread.join().is_err()
+        {
+            tracing::error!("joining CQ polling thread during actor drop failed");
+        }
+    }
+}
+
+fn run_poller<Cq: IbvCompletionQueue>(poller: Poller<Cq>, failed: PortHandle<PollerFailed>) {
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| poller.run()));
+    let error = match result {
+        Ok(Ok(())) => return,
+        Ok(Err(error)) => error.to_string(),
+        Err(_) => "CQ polling thread panicked".to_owned(),
+    };
+    let error_for_log = error.clone();
+    if let Err(post_error) = failed.try_post(
+        Instance::<CompletionQueueActor<Cq>>::self_client(),
+        PollerFailed { error },
+    ) {
+        tracing::error!(
+            error = %error_for_log,
+            %post_error,
+            "reporting CQ polling thread failure failed",
+        );
+    }
+}
+
+#[async_trait]
+impl<Cq: IbvCompletionQueue> Actor for CompletionQueueActor<Cq> {
+    async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
+        let commands = self
+            .command_rx
+            .take()
+            .expect("the CQ polling thread has not been started");
+        let poller = Poller::new(commands, Arc::clone(&self.wake.signal));
+        let failed = this.handle().port::<PollerFailed>();
+        let thread = std::thread::Builder::new()
+            .name("monarch-rdma-cq".to_owned())
+            .spawn(move || run_poller(poller, failed))?;
+        self.wake.signal.install_thread(thread.thread().clone());
+        self.thread = Some(thread);
+        Ok(())
+    }
+
+    async fn cleanup(
+        &mut self,
+        _this: &Instance<Self>,
+        _err: Option<&ActorError>,
+    ) -> anyhow::Result<()> {
+        self.cancel();
+        let Some(thread) = self.thread.take() else {
+            return Ok(());
+        };
+        tokio::task::spawn_blocking(move || thread.join())
+            .await
+            .map_err(|error| anyhow::anyhow!("joining CQ polling thread failed: {error}"))?
+            .map_err(|_| anyhow::anyhow!("CQ polling thread panicked"))
+    }
+
+    fn spawn_server_task<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        crate::rdma_runtime::spawn_on_rdma_runtime(future)
+    }
+}
+
+#[async_trait]
+impl<Cq: IbvCompletionQueue> Handler<Attach<Cq>> for CompletionQueueActor<Cq> {
+    async fn handle(&mut self, _cx: &Context<Self>, message: Attach<Cq>) -> anyhow::Result<()> {
+        let Attach {
+            cq,
+            qp_num,
+            route,
+            posted,
+            reply,
+        } = message;
+        self.send_command(PollerCommand::Attach {
+            cq,
+            qp_num,
+            route,
+            posted,
+            reply: Box::new(reply),
+        })
+    }
+}
+
+#[async_trait]
+impl<Cq: IbvCompletionQueue> Handler<PollerFailed> for CompletionQueueActor<Cq> {
+    async fn handle(&mut self, _cx: &Context<Self>, message: PollerFailed) -> anyhow::Result<()> {
+        Err(anyhow::anyhow!(
+            "CQ polling thread failed: {}",
+            message.error
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
     use std::sync::Mutex;
+
+    use anyhow::Result;
+    use hyperactor::ActorHandle;
+    use hyperactor::context::Mailbox;
+    use hyperactor::proc::Proc;
 
     use super::*;
     use crate::backend::ibverbs::device::IbvDevice;
@@ -335,6 +634,127 @@ mod tests {
             let consumed = inner.queued.len().min(self.batch);
             out.extend(inner.queued.drain(..consumed));
             Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockParent {
+        supervision_tx: mpsc::UnboundedSender<hyperactor::supervision::ActorSupervisionEvent>,
+    }
+
+    #[async_trait]
+    impl Actor for MockParent {
+        async fn handle_supervision_event(
+            &mut self,
+            _this: &Instance<Self>,
+            event: &hyperactor::supervision::ActorSupervisionEvent,
+        ) -> Result<bool> {
+            self.supervision_tx
+                .send(event.clone())
+                .map_err(|error| anyhow::anyhow!("sending supervision event failed: {error}"))?;
+            Ok(true)
+        }
+    }
+
+    #[derive(Debug)]
+    struct SpawnPoller {
+        reply: OncePortHandle<ActorHandle<CompletionQueueActor<MockCq>>>,
+    }
+
+    #[async_trait]
+    impl Handler<SpawnPoller> for MockParent {
+        async fn handle(&mut self, cx: &Context<Self>, message: SpawnPoller) -> Result<()> {
+            message
+                .reply
+                .try_post(cx, cx.spawn(CompletionQueueActor::<MockCq>::new()))?;
+            Ok(())
+        }
+    }
+
+    struct TestRoute {
+        inbox: CompletionInbox,
+        posted: Arc<AtomicU64>,
+        wake: PollerWake,
+    }
+
+    struct CqaHarness {
+        proc: Proc,
+        parent: ActorHandle<MockParent>,
+        client: hyperactor::Client,
+        supervision_rx: mpsc::UnboundedReceiver<hyperactor::supervision::ActorSupervisionEvent>,
+    }
+
+    impl CqaHarness {
+        fn new() -> Self {
+            let proc = Proc::anonymous();
+            let (supervision_tx, supervision_rx) = mpsc::unbounded_channel();
+            let parent = proc.spawn_with_label("parent", MockParent { supervision_tx });
+            let client = proc.client("client");
+            Self {
+                proc,
+                parent,
+                client,
+                supervision_rx,
+            }
+        }
+
+        async fn spawn_poller(&self) -> Result<ActorHandle<CompletionQueueActor<MockCq>>> {
+            let (reply, receiver) = self.client.mailbox().open_once_port();
+            self.parent.try_post(&self.client, SpawnPoller { reply })?;
+            Ok(receiver.recv().await?)
+        }
+
+        async fn attach(
+            &self,
+            poller: &ActorHandle<CompletionQueueActor<MockCq>>,
+            cq: &Arc<MockCq>,
+            qp_num: u32,
+        ) -> Result<TestRoute> {
+            let (inbox, route) = CompletionInbox::new();
+            let posted = Arc::new(AtomicU64::new(0));
+            let (reply, receiver) = self.client.mailbox().open_once_port();
+            poller.try_post(
+                &self.client,
+                Attach {
+                    cq: Arc::clone(cq),
+                    qp_num,
+                    route,
+                    posted: Arc::clone(&posted),
+                    reply,
+                },
+            )?;
+            let wake = receiver.recv().await?;
+            Ok(TestRoute {
+                inbox,
+                posted,
+                wake,
+            })
+        }
+
+        fn post(route: &TestRoute, count: u64) -> Result<()> {
+            route.posted.fetch_add(count, Ordering::Relaxed);
+            route.wake.notify()
+        }
+
+        async fn next_supervision_failure(
+            &mut self,
+        ) -> hyperactor::supervision::ActorSupervisionEvent {
+            tokio::time::timeout(Duration::from_secs(5), self.supervision_rx.recv())
+                .await
+                .expect("timed out waiting for child failure event")
+                .expect("supervision channel closed")
+        }
+
+        async fn teardown(mut self) {
+            self.proc
+                .destroy_and_wait(Duration::from_secs(30), "test teardown")
+                .await
+                .expect("destroy_and_wait failed");
+            self.supervision_rx.close();
+            assert!(
+                self.supervision_rx.recv().await.is_none(),
+                "unexpected supervision event during teardown",
+            );
         }
     }
 
@@ -471,5 +891,75 @@ mod tests {
                 .wr_id(),
             100,
         );
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn native_poller_wakes_for_new_work() -> Result<()> {
+        let harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut route = harness.attach(&poller, &cq, 7).await?;
+
+        tokio::time::sleep(BUSY_POLL_WINDOW + Duration::from_millis(25)).await;
+        let polls_before_post = cq.polls();
+        cq.queue_completion(7, 100);
+        CqaHarness::post(&route, 1)?;
+
+        let completion = tokio::time::timeout(Duration::from_secs(5), route.inbox.recv())
+            .await
+            .expect("timed out waiting for completion")
+            .expect("completion channel closed")
+            .expect("completion should succeed");
+        assert_eq!(completion.wr_id(), 100);
+        assert!(
+            cq.polls() > polls_before_post,
+            "posting work must wake the native poller",
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn native_poller_drains_more_than_one_poll_batch() -> Result<()> {
+        let harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut route = harness.attach(&poller, &cq, 7).await?;
+        let count = CQES_PER_POLL as u64 + 1;
+        for wr_id in 0..count {
+            cq.queue_completion(7, wr_id);
+        }
+        CqaHarness::post(&route, count)?;
+
+        for expected in 0..count {
+            let completion = tokio::time::timeout(Duration::from_secs(5), route.inbox.recv())
+                .await
+                .expect("timed out waiting for completion")
+                .expect("completion channel closed")
+                .expect("completion should succeed");
+            assert_eq!(completion.wr_id(), expected);
+        }
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn native_poller_failure_reaches_supervisor() -> Result<()> {
+        let mut harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let route = harness.attach(&poller, &cq, 7).await?;
+        cq.queue_completion(8, 100);
+        CqaHarness::post(&route, 1)?;
+
+        let event = harness.next_supervision_failure().await;
+        assert_eq!(&event.actor_id, poller.actor_addr());
+        let report = event.failure_report().expect("event should be a failure");
+        assert!(
+            report.contains("unattached queue pair 8"),
+            "unexpected failure report: {report}",
+        );
+        harness.teardown().await;
+        Ok(())
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -14,6 +14,8 @@
 // Nothing outside the tests below uses this module.
 #![allow(dead_code)]
 
+use tokio::sync::mpsc;
+
 use super::primitives::IbvCq;
 use super::primitives::IbvWc;
 use super::queue_pair::PollCompletionError;
@@ -95,6 +97,49 @@ impl IbvCompletionQueue for IbvCq {
     }
 }
 
+pub(super) type CompletionResult = Result<IbvWc, WorkRequestError>;
+
+/// Producer-side route used by a CQ poller to deliver one queue pair's
+/// completions directly to its data-plane task.
+#[derive(Clone, Debug)]
+pub(super) struct CompletionRoute {
+    sender: mpsc::UnboundedSender<CompletionResult>,
+}
+
+/// Consumer-side queue owned by a queue pair's data-plane task.
+#[derive(Debug)]
+pub(super) struct CompletionInbox {
+    receiver: mpsc::UnboundedReceiver<CompletionResult>,
+}
+
+impl CompletionInbox {
+    pub(super) fn new() -> (Self, CompletionRoute) {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        (Self { receiver }, CompletionRoute { sender })
+    }
+
+    pub(super) async fn recv(&mut self) -> Option<CompletionResult> {
+        self.receiver.recv().await
+    }
+
+    pub(super) fn try_recv(&mut self) -> Result<CompletionResult, mpsc::error::TryRecvError> {
+        self.receiver.try_recv()
+    }
+}
+
+impl CompletionRoute {
+    #[cfg(test)]
+    pub(super) fn sender_for_test(&self) -> mpsc::UnboundedSender<CompletionResult> {
+        self.sender.clone()
+    }
+
+    fn deliver(&self, qp_num: u32, cq_id: CqId, result: CompletionResult) {
+        if let Err(error) = self.sender.send(result) {
+            tracing::error!(qp_num, ?cq_id, %error, "queueing a completion for a queue pair failed");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +166,40 @@ mod tests {
         // handed and so nothing else polls.
         unsafe { cq.poll(&mut consumed) }.expect("polling an empty CQ should succeed");
         assert!(consumed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn completion_inbox_preserves_order() {
+        let (mut inbox, route) = CompletionInbox::new();
+        route.deliver(7, CqId(1), Ok(IbvWc::for_test(100, true)));
+        route.deliver(7, CqId(1), Ok(IbvWc::for_test(200, true)));
+        assert_eq!(
+            inbox
+                .recv()
+                .await
+                .expect("first completion")
+                .expect("successful completion")
+                .wr_id(),
+            100,
+        );
+        assert_eq!(
+            inbox
+                .recv()
+                .await
+                .expect("second completion")
+                .expect("successful completion")
+                .wr_id(),
+            200,
+        );
+    }
+
+    #[tokio::test]
+    async fn completion_inbox_closes_when_its_route_is_dropped() {
+        let (mut inbox, route) = CompletionInbox::new();
+        drop(route);
+        assert!(
+            inbox.recv().await.is_none(),
+            "dropping the producer must close the completion channel",
+        );
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -6,10 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Consuming completions from a completion queue (CQ).
+//! Polling and routing completions from shared completion queues (CQs).
 //!
-//! [`IbvCompletionQueue`] is what a CQ offers a consumer: one call hands back a
-//! bounded batch, each completion naming the queue pair it completed on.
+//! Each queue pair attaches a direct completion route. A dedicated native
+//! thread polls the CQs and dispatches each completion to the queue pair that
+//! produced it. Detached queue-pair resources remain alive until their final
+//! CQEs have been consumed.
 
 // Nothing outside the tests below uses this module.
 #![allow(dead_code)]
@@ -37,6 +39,7 @@ use hyperactor::PortHandle;
 use hyperactor::actor::ActorError;
 use tokio::sync::mpsc;
 
+use super::cq_pool::CqLease;
 use super::primitives::IbvCq;
 use super::primitives::IbvWc;
 use super::queue_pair::PollCompletionError;
@@ -69,8 +72,7 @@ pub(super) trait IbvCompletionQueue: std::fmt::Debug + Send + Sync + 'static {
     ///
     /// # Safety
     ///
-    /// The CQ must be live -- a null `ibv_cq` does not qualify -- and no other
-    /// thread may poll it for the duration.
+    /// The CQ must be live and no other thread may poll it for the duration.
     unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError>;
 }
 
@@ -79,11 +81,29 @@ impl IbvCompletionQueue for IbvCq {
         CqId(self.as_ptr().addr())
     }
 
+    /// A null CQ is rejected in production and treated as an empty placeholder
+    /// in unit tests.
     unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError> {
         let cq = self.as_ptr();
-        // SAFETY: `cq` is a live `ibv_cq` (caller contract), which holds its device
-        // context alive; we invoke that context's `poll_cq` verb through the ops
-        // table.
+
+        #[cfg(test)]
+        {
+            // Test-only placeholder CQs cannot produce completions.
+            if cq.is_null() {
+                return Ok(());
+            }
+        }
+
+        #[cfg(not(test))]
+        {
+            if cq.is_null() {
+                return Err(PollCompletionError::new("cannot poll null CQ".into()));
+            }
+        }
+
+        // SAFETY: `cq` is non-null and therefore a live `ibv_cq` (caller
+        // contract), which holds its device context alive; invoke that context's
+        // `poll_cq` verb through the ops table.
         let poll_cq = unsafe {
             (*(*cq).context)
                 .ops
@@ -165,21 +185,39 @@ impl CompletionRoute {
 /// One queue pair reporting on a CQ.
 #[derive(Debug)]
 struct QpSlot {
-    route: CompletionRoute,
+    /// Where completions go, or `None` after the queue pair detaches.
+    route: Option<CompletionRoute>,
     /// Number of WRs the queue pair has posted. The queue pair increments this
     /// before waking the poller.
     posted: Arc<AtomicU64>,
     /// Number of CQEs the poller has consumed for this queue pair.
     consumed: u64,
+    /// Resources transferred by `Detach` and retained until all CQEs drain.
+    qp: Option<DetachedQueuePair>,
+    _lease: Option<CqLease>,
 }
 
 impl QpSlot {
-    fn expects_completions(&self) -> bool {
-        // This count only decides whether polling is useful. A relaxed load is
-        // sufficient because the producer calls `unpark` after incrementing its
-        // posted count. A subsequent wake from `park` on the consumer is then
-        // guaranteed to see the most recent value.
-        self.posted.load(Ordering::Relaxed) > self.consumed
+    fn outstanding(&self) -> u64 {
+        // This count is used for two purposes:
+        // (1) To decide whether polling is useful. A relaxed load is sufficient
+        //  because the producer calls `unpark` after incrementing its posted
+        //  count. A subsequent wake from `park` on the consumer is then guaranteed
+        //  to see the most recent value.
+        // (2) To decide whether it is safe to drop the QP because no more work
+        //  is left. We have to ensure that it isn't possible for the poller to
+        //  observe that `posted` increased after it received the detach signal
+        //  from the QP. Once the QP sends the detach signal over the actor port,
+        //  it never posts again; when the poller receives the message, it
+        //  synchronizes-with the QP's thread and so is guaranteed to see the final
+        //  value for `posted`, even with this relaxed load.
+        self.posted
+            .load(Ordering::Relaxed)
+            .saturating_sub(self.consumed)
+    }
+
+    fn is_live(&self) -> bool {
+        self.route.is_some() || self.outstanding() > 0
     }
 }
 
@@ -192,19 +230,38 @@ struct CqSlot<Cq> {
 
 impl<Cq: IbvCompletionQueue> CqSlot<Cq> {
     fn expects_completions(&self) -> bool {
-        self.queue_pairs.values().any(QpSlot::expects_completions)
+        self.queue_pairs.values().any(|qp| qp.outstanding() > 0)
     }
 
     fn route(&mut self, cq_id: CqId, consumed: &mut Vec<Completion>) -> anyhow::Result<()> {
         for Completion { qp_num, result } in consumed.drain(..) {
-            let qp = self.queue_pairs.get_mut(&qp_num).ok_or_else(|| {
-                anyhow::anyhow!("CQ {cq_id:?} completed for unattached queue pair {qp_num}")
-            })?;
-            // Increment unconditionally, even if the delivery ultimately fails.
-            // Delivery can fail only if the QP actor is stopped or dead, so it
-            // shouldn't be possible to hang the QP actor.
-            qp.consumed += 1;
-            qp.route.deliver(qp_num, cq_id, result);
+            let remove = {
+                // It is impossible to observe a CQE for a QP that is untracked, since
+                // we hold detached QPs until `consumed == posted`, and by the time
+                // the poller receives a detached QP, `posted` has necessarily settled
+                // at its true value.
+                let qp = self.queue_pairs.get_mut(&qp_num).ok_or_else(|| {
+                    anyhow::anyhow!("CQ {cq_id:?} completed for unattached queue pair {qp_num}")
+                })?;
+                // Increment unconditionally, even if the delivery ultimately fails.
+                // Delivery can fail only if the QP actor is stopped or dead, so it
+                // shouldn't be possible to hang the QP actor.
+                qp.consumed += 1;
+                if let Some(route) = &qp.route {
+                    route.deliver(qp_num, cq_id, result);
+                } else {
+                    tracing::warn!(
+                        qp_num,
+                        ?cq_id,
+                        ?result,
+                        "received work completion after detach"
+                    );
+                }
+                !qp.is_live()
+            };
+            if remove {
+                self.queue_pairs.remove(&qp_num);
+            }
         }
         Ok(())
     }
@@ -240,6 +297,8 @@ impl<Cq: IbvCompletionQueue> PollerState<Cq> {
                 cq,
                 queue_pairs: HashMap::new(),
             });
+        // Fail even if the queue pair is detached. A detached queue pair
+        // may still produce CQEs, leaving the poller unable to disambiguate.
         if slot.queue_pairs.contains_key(&qp_num) {
             return Err(anyhow::anyhow!(
                 "queue pair {qp_num} is already attached to CQ {cq_id:?}"
@@ -248,11 +307,40 @@ impl<Cq: IbvCompletionQueue> PollerState<Cq> {
         slot.queue_pairs.insert(
             qp_num,
             QpSlot {
-                route,
+                route: Some(route),
                 posted,
                 consumed: 0,
+                qp: None,
+                _lease: None,
             },
         );
+        Ok(())
+    }
+
+    fn detach(
+        &mut self,
+        cq_id: CqId,
+        qp_num: u32,
+        qp: DetachedQueuePair,
+        lease: CqLease,
+    ) -> anyhow::Result<()> {
+        let slot = self.completion_queues.get_mut(&cq_id).ok_or_else(|| {
+            anyhow::anyhow!(
+                "detach for queue pair {qp_num} on CQ {cq_id:?}, which this poller does not hold"
+            )
+        })?;
+        let qp_slot = slot.queue_pairs.get_mut(&qp_num).ok_or_else(|| {
+            anyhow::anyhow!("detach for queue pair {qp_num}, which is not attached to CQ {cq_id:?}")
+        })?;
+        qp_slot.route = None;
+        qp_slot.qp = Some(qp);
+        qp_slot._lease = Some(lease);
+        if !qp_slot.is_live() {
+            slot.queue_pairs.remove(&qp_num);
+        }
+        if slot.queue_pairs.is_empty() {
+            self.completion_queues.remove(&cq_id);
+        }
         Ok(())
     }
 
@@ -263,20 +351,35 @@ impl<Cq: IbvCompletionQueue> PollerState<Cq> {
     }
 
     fn poll_round(&mut self) -> anyhow::Result<()> {
-        for (cq_id, slot) in &mut self.completion_queues {
-            if !slot.expects_completions() {
-                continue;
+        let mut failure = None;
+        let Self {
+            completion_queues,
+            consumed,
+        } = self;
+        completion_queues.retain(|cq_id, slot| {
+            if failure.is_some() || !slot.expects_completions() {
+                return true;
             }
-            self.consumed.clear();
-            // SAFETY: the poller exclusively owns every CQ in
-            // `completion_queues`; each `Arc<Cq>` keeps its CQ live.
-            if let Err(error) = unsafe { slot.cq.poll(&mut self.consumed) } {
-                tracing::warn!(?cq_id, %error, "consuming from a CQ failed");
-                continue;
+            consumed.clear();
+            // SAFETY: the poller exclusively polls every CQ in
+            // `completion_queues`; each `Arc<Cq>` keeps its CQ live until the
+            // final detached queue pair drains.
+            if let Err(error) = unsafe { slot.cq.poll(consumed) } {
+                failure = Some(anyhow::anyhow!(
+                    "consuming from CQ {cq_id:?} failed: {error}"
+                ));
+                return true;
             }
-            slot.route(*cq_id, &mut self.consumed)?;
+            if let Err(error) = slot.route(*cq_id, consumed) {
+                failure = Some(error);
+                return true;
+            }
+            !slot.queue_pairs.is_empty()
+        });
+        match failure {
+            Some(error) => Err(error),
+            None => Ok(()),
         }
-        Ok(())
     }
 }
 
@@ -332,6 +435,27 @@ pub(super) struct Attach<Cq: IbvCompletionQueue> {
     pub(super) reply: OncePortHandle<PollerWake>,
 }
 
+/// Transfers a stopped queue pair and its CQ lease to the poller until every
+/// completion for that queue pair has been consumed.
+#[derive(Debug)]
+pub(super) struct Detach {
+    pub(super) cq_id: CqId,
+    pub(super) qp_num: u32,
+    pub(super) qp: DetachedQueuePair,
+    pub(super) lease: CqLease,
+}
+
+/// Opaque queue-pair resources that the poller retains solely for their drop.
+#[derive(Debug)]
+#[expect(dead_code, reason = "the poller owns this resource only for its drop")]
+pub(super) struct DetachedQueuePair(Box<dyn std::fmt::Debug + Send + Sync>);
+
+impl DetachedQueuePair {
+    pub(super) fn new<Qp: std::fmt::Debug + Send + Sync + 'static>(qp: Qp) -> Self {
+        Self(Box::new(qp))
+    }
+}
+
 #[derive(Debug)]
 enum PollerCommand<Cq> {
     Attach {
@@ -340,6 +464,12 @@ enum PollerCommand<Cq> {
         route: CompletionRoute,
         posted: Arc<AtomicU64>,
         reply: Box<OncePortHandle<PollerWake>>,
+    },
+    Detach {
+        cq_id: CqId,
+        qp_num: u32,
+        qp: DetachedQueuePair,
+        lease: CqLease,
     },
 }
 
@@ -405,11 +535,36 @@ impl<Cq: IbvCompletionQueue> Poller<Cq> {
                         tracing::warn!(qp_num, %error, "failed to deliver Attach reply");
                     }
                 }
+                Ok(PollerCommand::Detach {
+                    cq_id,
+                    qp_num,
+                    qp,
+                    lease,
+                }) => self.state.detach(cq_id, qp_num, qp, lease)?,
                 Err(std_mpsc::TryRecvError::Empty) => return Ok(()),
                 Err(std_mpsc::TryRecvError::Disconnected) => {
                     return Err(anyhow::anyhow!("CQ poller control channel disconnected"));
                 }
             }
+        }
+    }
+}
+
+impl<Cq> Drop for Poller<Cq> {
+    fn drop(&mut self) {
+        let attached = self
+            .state
+            .completion_queues
+            .values()
+            .flat_map(|slot| slot.queue_pairs.values())
+            .filter(|qp| qp.route.is_some())
+            .count();
+        if attached > 0 {
+            tracing::warn!(
+                attached,
+                completion_queues = self.state.completion_queues.len(),
+                "a CQ poller is going away with queue pairs attached to it",
+            );
         }
     }
 }
@@ -548,6 +703,24 @@ impl<Cq: IbvCompletionQueue> Handler<Attach<Cq>> for CompletionQueueActor<Cq> {
 }
 
 #[async_trait]
+impl<Cq: IbvCompletionQueue> Handler<Detach> for CompletionQueueActor<Cq> {
+    async fn handle(&mut self, _cx: &Context<Self>, message: Detach) -> anyhow::Result<()> {
+        let Detach {
+            cq_id,
+            qp_num,
+            qp,
+            lease,
+        } = message;
+        self.send_command(PollerCommand::Detach {
+            cq_id,
+            qp_num,
+            qp,
+            lease,
+        })
+    }
+}
+
+#[async_trait]
 impl<Cq: IbvCompletionQueue> Handler<PollerFailed> for CompletionQueueActor<Cq> {
     async fn handle(&mut self, _cx: &Context<Self>, message: PollerFailed) -> anyhow::Result<()> {
         Err(anyhow::anyhow!(
@@ -618,6 +791,14 @@ mod tests {
         fn polls(&self) -> usize {
             self.inner.lock().expect("mock CQ lock poisoned").polls
         }
+
+        fn queued(&self) -> usize {
+            self.inner
+                .lock()
+                .expect("mock CQ lock poisoned")
+                .queued
+                .len()
+        }
     }
 
     impl IbvCompletionQueue for MockCq {
@@ -635,6 +816,38 @@ mod tests {
             out.extend(inner.queued.drain(..consumed));
             Ok(())
         }
+    }
+
+    #[derive(Debug)]
+    struct TestQp {
+        destroyed: Arc<AtomicBool>,
+        leases: Arc<std::sync::atomic::AtomicU32>,
+        leases_at_destroy: Arc<std::sync::atomic::AtomicU32>,
+    }
+
+    impl Drop for TestQp {
+        fn drop(&mut self) {
+            self.leases_at_destroy
+                .store(self.leases.load(Ordering::SeqCst), Ordering::SeqCst);
+            self.destroyed.store(true, Ordering::SeqCst);
+        }
+    }
+
+    fn test_qp(
+        leases: &Arc<std::sync::atomic::AtomicU32>,
+    ) -> (
+        DetachedQueuePair,
+        Arc<AtomicBool>,
+        Arc<std::sync::atomic::AtomicU32>,
+    ) {
+        let destroyed = Arc::new(AtomicBool::new(false));
+        let leases_at_destroy = Arc::new(std::sync::atomic::AtomicU32::new(u32::MAX));
+        let qp = DetachedQueuePair::new(TestQp {
+            destroyed: Arc::clone(&destroyed),
+            leases: Arc::clone(leases),
+            leases_at_destroy: Arc::clone(&leases_at_destroy),
+        });
+        (qp, destroyed, leases_at_destroy)
     }
 
     #[derive(Debug)]
@@ -675,6 +888,16 @@ mod tests {
         inbox: CompletionInbox,
         posted: Arc<AtomicU64>,
         wake: PollerWake,
+        leases: Arc<std::sync::atomic::AtomicU32>,
+        lease: Option<CqLease>,
+    }
+
+    impl TestRoute {
+        fn lease(&mut self) -> CqLease {
+            self.lease
+                .take()
+                .expect("the queue pair still holds its CQ lease")
+        }
     }
 
     struct CqaHarness {
@@ -712,6 +935,8 @@ mod tests {
         ) -> Result<TestRoute> {
             let (inbox, route) = CompletionInbox::new();
             let posted = Arc::new(AtomicU64::new(0));
+            let leases = Arc::new(std::sync::atomic::AtomicU32::new(0));
+            let lease = CqLease::for_test_counted(Arc::clone(&leases));
             let (reply, receiver) = self.client.mailbox().open_once_port();
             poller.try_post(
                 &self.client,
@@ -728,12 +953,38 @@ mod tests {
                 inbox,
                 posted,
                 wake,
+                leases,
+                lease: Some(lease),
             })
         }
 
         fn post(route: &TestRoute, count: u64) -> Result<()> {
             route.posted.fetch_add(count, Ordering::Relaxed);
             route.wake.notify()
+        }
+
+        fn post_without_wake(route: &TestRoute, count: u64) {
+            route.posted.fetch_add(count, Ordering::Relaxed);
+        }
+
+        fn detach(
+            &self,
+            poller: &ActorHandle<CompletionQueueActor<MockCq>>,
+            cq_id: CqId,
+            qp_num: u32,
+            qp: DetachedQueuePair,
+            lease: CqLease,
+        ) -> Result<()> {
+            poller.try_post(
+                &self.client,
+                Detach {
+                    cq_id,
+                    qp_num,
+                    qp,
+                    lease,
+                },
+            )?;
+            Ok(())
         }
 
         async fn next_supervision_failure(
@@ -755,6 +1006,29 @@ mod tests {
                 self.supervision_rx.recv().await.is_none(),
                 "unexpected supervision event during teardown",
             );
+        }
+    }
+
+    async fn await_flag(flag: &AtomicBool, name: &str) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !flag.load(Ordering::SeqCst) {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for {name}",
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    async fn await_leases(leases: &std::sync::atomic::AtomicU32, expected: u32) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while leases.load(Ordering::Relaxed) != expected {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "leases settled at {} rather than {expected}",
+                leases.load(Ordering::Relaxed),
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
 
@@ -850,6 +1124,128 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn poller_routes_multiple_completion_queues_by_queue_pair() {
+        let first_cq = MockCq::new(1, CQES_PER_POLL);
+        let second_cq = MockCq::new(2, CQES_PER_POLL);
+        let (mut first_cq_first_inbox, first_cq_first_route) = CompletionInbox::new();
+        let (mut first_cq_second_inbox, first_cq_second_route) = CompletionInbox::new();
+        let (mut second_cq_first_inbox, second_cq_first_route) = CompletionInbox::new();
+        let (mut second_cq_second_inbox, second_cq_second_route) = CompletionInbox::new();
+        let mut poller = PollerState::new();
+        poller
+            .attach(
+                Arc::clone(&first_cq),
+                7,
+                first_cq_first_route,
+                Arc::new(AtomicU64::new(2)),
+            )
+            .expect("first queue pair on first CQ should attach");
+        poller
+            .attach(
+                Arc::clone(&first_cq),
+                8,
+                first_cq_second_route,
+                Arc::new(AtomicU64::new(2)),
+            )
+            .expect("second queue pair on first CQ should attach");
+        poller
+            .attach(
+                Arc::clone(&second_cq),
+                9,
+                second_cq_first_route,
+                Arc::new(AtomicU64::new(2)),
+            )
+            .expect("first queue pair on second CQ should attach");
+        poller
+            .attach(
+                Arc::clone(&second_cq),
+                10,
+                second_cq_second_route,
+                Arc::new(AtomicU64::new(2)),
+            )
+            .expect("second queue pair on second CQ should attach");
+        first_cq.queue_completion(8, 200);
+        first_cq.queue_completion(7, 100);
+        first_cq.queue_completion(8, 201);
+        first_cq.queue_completion(7, 101);
+        second_cq.queue_completion(10, 400);
+        second_cq.queue_completion(9, 300);
+        second_cq.queue_completion(10, 401);
+        second_cq.queue_completion(9, 301);
+
+        poller.poll_round().expect("polling should succeed");
+
+        for (inbox, expected) in [
+            (&mut first_cq_first_inbox, [100, 101]),
+            (&mut first_cq_second_inbox, [200, 201]),
+            (&mut second_cq_first_inbox, [300, 301]),
+            (&mut second_cq_second_inbox, [400, 401]),
+        ] {
+            for expected_wr_id in expected {
+                assert_eq!(
+                    inbox
+                        .try_recv()
+                        .expect("routed completion")
+                        .expect("successful completion")
+                        .wr_id(),
+                    expected_wr_id,
+                );
+            }
+            assert!(
+                matches!(inbox.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+                "queue pair must receive only its own completions",
+            );
+        }
+    }
+
+    #[test]
+    fn poller_removes_completion_queue_after_final_queue_pair_detaches() {
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let (_first_inbox, first_route) = CompletionInbox::new();
+        let (_second_inbox, second_route) = CompletionInbox::new();
+        let mut poller = PollerState::new();
+        poller
+            .attach(Arc::clone(&cq), 7, first_route, Arc::new(AtomicU64::new(0)))
+            .expect("first queue pair should attach");
+        poller
+            .attach(
+                Arc::clone(&cq),
+                8,
+                second_route,
+                Arc::new(AtomicU64::new(0)),
+            )
+            .expect("second queue pair should attach");
+
+        poller
+            .detach(
+                cq.cq_id(),
+                7,
+                DetachedQueuePair::new(()),
+                CqLease::for_test_counted(Arc::new(std::sync::atomic::AtomicU32::new(0))),
+            )
+            .expect("first queue pair should detach");
+        let slot = poller
+            .completion_queues
+            .get(&cq.cq_id())
+            .expect("the CQ must remain while one queue pair is attached");
+        assert_eq!(slot.queue_pairs.len(), 1);
+        assert!(slot.queue_pairs.contains_key(&8));
+
+        poller
+            .detach(
+                cq.cq_id(),
+                8,
+                DetachedQueuePair::new(()),
+                CqLease::for_test_counted(Arc::new(std::sync::atomic::AtomicU32::new(0))),
+            )
+            .expect("final queue pair should detach");
+        assert!(
+            !poller.completion_queues.contains_key(&cq.cq_id()),
+            "the final queue-pair removal must remove its CQ",
+        );
+    }
+
     #[test]
     fn poller_leaves_idle_completion_queues_alone() {
         let cq = MockCq::new(1, CQES_PER_POLL);
@@ -866,30 +1262,22 @@ mod tests {
     }
 
     #[test]
-    fn poller_retries_after_a_poll_error() {
+    fn poller_fails_on_a_poll_error() {
         let cq = MockCq::new(1, CQES_PER_POLL);
-        let (mut inbox, route) = CompletionInbox::new();
+        let (_inbox, route) = CompletionInbox::new();
         let posted = Arc::new(AtomicU64::new(1));
         let mut poller = PollerState::new();
         poller
             .attach(Arc::clone(&cq), 7, route, posted)
             .expect("queue pair should attach");
-        cq.queue_poll_error("temporary failure");
-        cq.queue_completion(7, 100);
+        cq.queue_poll_error("poll failure");
 
-        poller.poll_round().expect("a CQ poll error is recoverable");
+        let error = poller
+            .poll_round()
+            .expect_err("a CQ poll error should fail the poller");
         assert!(
-            matches!(inbox.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
-            "a failed poll must not fabricate a completion",
-        );
-        poller.poll_round().expect("the next poll should succeed");
-        assert_eq!(
-            inbox
-                .try_recv()
-                .expect("completion after retry")
-                .expect("successful completion")
-                .wr_id(),
-            100,
+            error.to_string().contains("poll failure"),
+            "unexpected poll error: {error}",
         );
     }
 
@@ -959,6 +1347,77 @@ mod tests {
             report.contains("unattached queue pair 8"),
             "unexpected failure report: {report}",
         );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn detached_queue_pair_lives_until_its_completions_drain() -> Result<()> {
+        let harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut route = harness.attach(&poller, &cq, 7).await?;
+        CqaHarness::post(&route, 2)?;
+        let (qp, destroyed, leases_at_destroy) = test_qp(&route.leases);
+
+        harness.detach(&poller, cq.cq_id(), 7, qp, route.lease())?;
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(
+            !destroyed.load(Ordering::SeqCst),
+            "a queue pair with outstanding completions must remain alive",
+        );
+
+        cq.queue_completion(7, 100);
+        cq.queue_completion(7, 101);
+        route.wake.notify()?;
+        await_flag(&destroyed, "detached queue pair destruction").await;
+        await_leases(&route.leases, 0).await;
+        assert_eq!(
+            leases_at_destroy.load(Ordering::SeqCst),
+            1,
+            "the CQ lease must outlive the queue pair",
+        );
+        assert!(
+            route.inbox.try_recv().is_err(),
+            "detached CQEs are discarded"
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn drained_queue_pair_is_destroyed_on_detach() -> Result<()> {
+        let harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut route = harness.attach(&poller, &cq, 7).await?;
+        let (qp, destroyed, _) = test_qp(&route.leases);
+
+        harness.detach(&poller, cq.cq_id(), 7, qp, route.lease())?;
+        await_flag(&destroyed, "drained queue pair destruction").await;
+        await_leases(&route.leases, 0).await;
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn detach_wakes_the_poller_for_unannounced_work() -> Result<()> {
+        let harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut route = harness.attach(&poller, &cq, 7).await?;
+        tokio::time::sleep(BUSY_POLL_WINDOW + Duration::from_millis(25)).await;
+        CqaHarness::post_without_wake(&route, 1);
+        let (qp, destroyed, _) = test_qp(&route.leases);
+
+        harness.detach(&poller, cq.cq_id(), 7, qp, route.lease())?;
+        assert!(
+            !destroyed.load(Ordering::SeqCst),
+            "the outstanding completion must keep the queue pair alive",
+        );
+        cq.queue_completion(7, 100);
+        await_flag(&destroyed, "detached queue pair destruction").await;
+        assert_eq!(cq.queued(), 0, "detach must wake the poller");
         harness.teardown().await;
         Ok(())
     }

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -14,6 +14,11 @@
 // Nothing outside the tests below uses this module.
 #![allow(dead_code)]
 
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
 use tokio::sync::mpsc;
 
 use super::primitives::IbvCq;
@@ -25,7 +30,7 @@ use super::queue_pair::WorkRequestError;
 const CQES_PER_POLL: usize = 64;
 
 /// Identifies one CQ, distinct from every other live one.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) struct CqId(usize);
 
 /// One completion a poll consumed: the queue pair it completed on, and either the
@@ -140,13 +145,198 @@ impl CompletionRoute {
     }
 }
 
+/// One queue pair reporting on a CQ.
+#[derive(Debug)]
+struct QpSlot {
+    route: CompletionRoute,
+    /// Number of WRs the queue pair has posted. The queue pair increments this
+    /// before waking the poller.
+    posted: Arc<AtomicU64>,
+    /// Number of CQEs the poller has consumed for this queue pair.
+    consumed: u64,
+}
+
+impl QpSlot {
+    fn expects_completions(&self) -> bool {
+        // This count only decides whether polling is useful. A relaxed load is
+        // sufficient because the producer calls `unpark` after incrementing its
+        // posted count. A subsequent wake from `park` on the consumer is then
+        // guaranteed to see the most recent value.
+        self.posted.load(Ordering::Relaxed) > self.consumed
+    }
+}
+
+/// One CQ and the routes for queue pairs that report completions on it.
+#[derive(Debug)]
+struct CqSlot<Cq> {
+    cq: Arc<Cq>,
+    queue_pairs: HashMap<u32, QpSlot>,
+}
+
+impl<Cq: IbvCompletionQueue> CqSlot<Cq> {
+    fn expects_completions(&self) -> bool {
+        self.queue_pairs.values().any(QpSlot::expects_completions)
+    }
+
+    fn route(&mut self, cq_id: CqId, consumed: &mut Vec<Completion>) -> anyhow::Result<()> {
+        for Completion { qp_num, result } in consumed.drain(..) {
+            let qp = self.queue_pairs.get_mut(&qp_num).ok_or_else(|| {
+                anyhow::anyhow!("CQ {cq_id:?} completed for unattached queue pair {qp_num}")
+            })?;
+            // Increment unconditionally, even if the delivery ultimately fails.
+            // Delivery can fail only if the QP actor is stopped or dead, so it
+            // shouldn't be possible to hang the QP actor.
+            qp.consumed += 1;
+            qp.route.deliver(qp_num, cq_id, result);
+        }
+        Ok(())
+    }
+}
+
+/// Completion queues and per-QP routes owned by one poller.
+#[derive(Debug)]
+struct PollerState<Cq> {
+    completion_queues: HashMap<CqId, CqSlot<Cq>>,
+    consumed: Vec<Completion>,
+}
+
+impl<Cq: IbvCompletionQueue> PollerState<Cq> {
+    fn new() -> Self {
+        Self {
+            completion_queues: HashMap::new(),
+            consumed: Vec::with_capacity(CQES_PER_POLL),
+        }
+    }
+
+    fn attach(
+        &mut self,
+        cq: Arc<Cq>,
+        qp_num: u32,
+        route: CompletionRoute,
+        posted: Arc<AtomicU64>,
+    ) -> anyhow::Result<()> {
+        let cq_id = cq.cq_id();
+        let slot = self
+            .completion_queues
+            .entry(cq_id)
+            .or_insert_with(|| CqSlot {
+                cq,
+                queue_pairs: HashMap::new(),
+            });
+        if slot.queue_pairs.contains_key(&qp_num) {
+            return Err(anyhow::anyhow!(
+                "queue pair {qp_num} is already attached to CQ {cq_id:?}"
+            ));
+        }
+        slot.queue_pairs.insert(
+            qp_num,
+            QpSlot {
+                route,
+                posted,
+                consumed: 0,
+            },
+        );
+        Ok(())
+    }
+
+    fn expects_completions(&self) -> bool {
+        self.completion_queues
+            .values()
+            .any(CqSlot::expects_completions)
+    }
+
+    fn poll_round(&mut self) -> anyhow::Result<()> {
+        for (cq_id, slot) in &mut self.completion_queues {
+            if !slot.expects_completions() {
+                continue;
+            }
+            self.consumed.clear();
+            // SAFETY: the poller exclusively owns every CQ in
+            // `completion_queues`; each `Arc<Cq>` keeps its CQ live.
+            if let Err(error) = unsafe { slot.cq.poll(&mut self.consumed) } {
+                tracing::warn!(?cq_id, %error, "consuming from a CQ failed");
+                continue;
+            }
+            slot.route(*cq_id, &mut self.consumed)?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
     use super::*;
     use crate::backend::ibverbs::device::IbvDevice;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
     use crate::backend::ibverbs::primitives::IbvDeviceInfo;
+
+    #[derive(Debug)]
+    struct MockCq {
+        cq_id: CqId,
+        batch: usize,
+        inner: Mutex<MockCqInner>,
+    }
+
+    #[derive(Debug, Default)]
+    struct MockCqInner {
+        queued: VecDeque<Completion>,
+        poll_errors: VecDeque<PollCompletionError>,
+        polls: usize,
+    }
+
+    impl MockCq {
+        fn new(cq_id: usize, batch: usize) -> Arc<Self> {
+            Arc::new(Self {
+                cq_id: CqId(cq_id),
+                batch,
+                inner: Mutex::new(MockCqInner::default()),
+            })
+        }
+
+        fn queue_completion(&self, qp_num: u32, wr_id: u64) {
+            self.inner
+                .lock()
+                .expect("mock CQ lock poisoned")
+                .queued
+                .push_back(Completion {
+                    qp_num,
+                    result: Ok(IbvWc::for_test(wr_id, true)),
+                });
+        }
+
+        fn queue_poll_error(&self, message: &str) {
+            self.inner
+                .lock()
+                .expect("mock CQ lock poisoned")
+                .poll_errors
+                .push_back(PollCompletionError::new(message.to_owned()));
+        }
+
+        fn polls(&self) -> usize {
+            self.inner.lock().expect("mock CQ lock poisoned").polls
+        }
+    }
+
+    impl IbvCompletionQueue for MockCq {
+        fn cq_id(&self) -> CqId {
+            self.cq_id
+        }
+
+        unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError> {
+            let mut inner = self.inner.lock().expect("mock CQ lock poisoned");
+            inner.polls += 1;
+            if let Some(error) = inner.poll_errors.pop_front() {
+                return Err(error);
+            }
+            let consumed = inner.queued.len().min(self.batch);
+            out.extend(inner.queued.drain(..consumed));
+            Ok(())
+        }
+    }
 
     /// Polling a real, empty CQ consumes nothing, and distinct CQs have distinct ids.
     #[test]
@@ -200,6 +390,86 @@ mod tests {
         assert!(
             inbox.recv().await.is_none(),
             "dropping the producer must close the completion channel",
+        );
+    }
+
+    #[tokio::test]
+    async fn poller_routes_a_shared_cq_by_queue_pair() {
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let (mut first_inbox, first_route) = CompletionInbox::new();
+        let (mut second_inbox, second_route) = CompletionInbox::new();
+        let first_posted = Arc::new(AtomicU64::new(1));
+        let second_posted = Arc::new(AtomicU64::new(1));
+        let mut poller = PollerState::new();
+        poller
+            .attach(Arc::clone(&cq), 7, first_route, first_posted)
+            .expect("first queue pair should attach");
+        poller
+            .attach(Arc::clone(&cq), 8, second_route, second_posted)
+            .expect("second queue pair should attach");
+        cq.queue_completion(8, 200);
+        cq.queue_completion(7, 100);
+
+        poller.poll_round().expect("polling should succeed");
+
+        assert_eq!(
+            first_inbox
+                .try_recv()
+                .expect("first completion")
+                .expect("successful completion")
+                .wr_id(),
+            100,
+        );
+        assert_eq!(
+            second_inbox
+                .try_recv()
+                .expect("second completion")
+                .expect("successful completion")
+                .wr_id(),
+            200,
+        );
+    }
+
+    #[test]
+    fn poller_leaves_idle_completion_queues_alone() {
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let (_inbox, route) = CompletionInbox::new();
+        let mut poller = PollerState::new();
+        poller
+            .attach(Arc::clone(&cq), 7, route, Arc::new(AtomicU64::new(0)))
+            .expect("queue pair should attach");
+        cq.queue_completion(7, 100);
+
+        poller.poll_round().expect("polling should succeed");
+
+        assert_eq!(cq.polls(), 0, "an idle queue pair must not trigger a poll");
+    }
+
+    #[test]
+    fn poller_retries_after_a_poll_error() {
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let (mut inbox, route) = CompletionInbox::new();
+        let posted = Arc::new(AtomicU64::new(1));
+        let mut poller = PollerState::new();
+        poller
+            .attach(Arc::clone(&cq), 7, route, posted)
+            .expect("queue pair should attach");
+        cq.queue_poll_error("temporary failure");
+        cq.queue_completion(7, 100);
+
+        poller.poll_round().expect("a CQ poll error is recoverable");
+        assert!(
+            matches!(inbox.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+            "a failed poll must not fabricate a completion",
+        );
+        poller.poll_round().expect("the next poll should succeed");
+        assert_eq!(
+            inbox
+                .try_recv()
+                .expect("completion after retry")
+                .expect("successful completion")
+                .wr_id(),
+            100,
         );
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/cq_pool.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_pool.rs
@@ -107,9 +107,17 @@ impl CqLease {
     /// a device.
     #[cfg(test)]
     pub(super) fn for_test() -> Self {
+        Self::for_test_counted(Arc::new(AtomicU32::new(0)))
+    }
+
+    /// A lease on no completion queue that counts against `leases`, for tests
+    /// that observe when it is released.
+    #[cfg(test)]
+    pub(super) fn for_test_counted(leases: Arc<AtomicU32>) -> Self {
+        leases.fetch_add(1, Ordering::Relaxed);
         Self {
             cq: Arc::new(IbvCq::null()),
-            leases: Arc::new(AtomicU32::new(1)),
+            leases,
         }
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -33,11 +33,11 @@ use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
 use hyperactor::OncePortRef;
-use hyperactor::PortHandle;
 use hyperactor::actor::Referable;
 use rand::seq::IteratorRandom;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::mpsc;
 use typeuri::Named;
 
 use super::IbvOp;
@@ -108,7 +108,7 @@ wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<EfaDevice>>);
 /// [`OpResult`] values.
 pub(super) struct SubmitOps<I: IbvDeviceImpl> {
     pub(super) ops: Vec<IbvOp<IbvManagerActor<I>>>,
-    pub(super) reply: PortHandle<OpResult>,
+    pub(super) reply: mpsc::UnboundedSender<OpResult>,
 }
 
 /// Local-only message: create a fresh, unconnected legacy
@@ -543,26 +543,20 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
             let local_mrs = match self.resolve_local_mrs(&op.local_memory) {
                 Ok(mrs) => mrs,
                 Err(e) => {
-                    reply.try_post(
-                        cx,
-                        OpResult {
-                            op_idx: i,
-                            result: Err(e.to_string()),
-                        },
-                    )?;
+                    let _ = reply.send(OpResult {
+                        op_idx: i,
+                        result: Err(e.to_string()),
+                    });
                     continue;
                 }
             };
             let (local, remote) = match self.pick_peer_pair(&local_mrs, &op.remote_buffers) {
                 Ok((local, remote)) => (local.clone(), remote.clone()),
                 Err(e) => {
-                    reply.try_post(
-                        cx,
-                        OpResult {
-                            op_idx: i,
-                            result: Err(e.to_string()),
-                        },
-                    )?;
+                    let _ = reply.send(OpResult {
+                        op_idx: i,
+                        result: Err(e.to_string()),
+                    });
                     continue;
                 }
             };
@@ -574,13 +568,10 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
             let handle = match self.ensure_qp_actor(cx, &qp_key, op.remote_manager) {
                 Ok(h) => h,
                 Err(e) => {
-                    reply.try_post(
-                        cx,
-                        OpResult {
-                            op_idx: i,
-                            result: Err(e.to_string()),
-                        },
-                    )?;
+                    let _ = reply.send(OpResult {
+                        op_idx: i,
+                        result: Err(e.to_string()),
+                    });
                     continue;
                 }
             };
@@ -826,7 +817,7 @@ where
         }
         let n = ibv_ops.len();
 
-        let (reply, mut reply_rx) = cx.mailbox().open_port::<OpResult>();
+        let (reply, mut reply_rx) = mpsc::unbounded_channel();
 
         self.0.try_post(
             cx,
@@ -851,14 +842,15 @@ where
                 }
                 recv = reply_rx.recv() => {
                     match recv {
-                        Ok(OpResult { result: Ok(()), .. }) => received += 1,
-                        Ok(OpResult { op_idx, result: Err(e) }) => {
+                        Some(OpResult { result: Ok(()), .. }) => received += 1,
+                        Some(OpResult { op_idx, result: Err(e) }) => {
                             received += 1;
                             failures.push((op_idx, e));
                         }
-                        Err(e) => {
+                        None => {
                             terminal = Some(format!(
-                                "SubmitOps reply port closed after {received}/{n} replies with {} failures: {e}",
+                                "operation result channel closed after {received}/{n} replies with {} failures: \
+                                some built-in RDMA actor likely stopped or failed, see logs for more details",
                                 failures.len()
                             ));
                             break;

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -35,12 +35,12 @@ use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::PortHandle;
 use hyperactor::actor::Referable;
 use hyperactor::actor::RemoteHandles;
 use hyperactor::context::Mailbox;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::mpsc;
 use typeuri::Named;
 
 use super::cq_pool::CqLease;
@@ -846,13 +846,7 @@ pub(super) trait Manager:
 
 impl<T> Manager for T where T: Actor + Referable + RemoteHandles<CreatePeerQueuePair<T>> {}
 
-/// Per-op completion reply emitted by [`QueuePairActor`] back to the
-/// manager via [`ProcessOps::reply`]. A named newtype (rather than a
-/// raw `(usize, Result<…>)` tuple) so the manager can identify
-/// undeliverable `OpResult`s by type name in
-/// `handle_undeliverable_message` and absorb them when the original
-/// caller has gone away (typical at test teardown).
-#[allow(dead_code)] // not yet referenced by IbvManagerActor
+/// Per-op completion result sent from a queue-pair actor to the submitter.
 #[derive(Debug)]
 pub(super) struct OpResult {
     pub(super) op_idx: usize,
@@ -881,7 +875,7 @@ pub(super) struct QueuePairOp {
 #[derive(Debug)]
 pub(super) struct ProcessOps {
     pub(super) items: Vec<QueuePairOp>,
-    pub(super) reply: PortHandle<OpResult>,
+    pub(super) reply: mpsc::UnboundedSender<OpResult>,
 }
 
 /// Local-only self-message that drives one round of the scheduler.
@@ -892,7 +886,7 @@ struct Tick;
 #[derive(Debug)]
 struct PendingOp {
     op: QueuePairOp,
-    reply: PortHandle<OpResult>,
+    reply: mpsc::UnboundedSender<OpResult>,
     /// WR count this op will issue when posted, computed once at
     /// construction so retries from a credit head-block don't redo
     /// the work.
@@ -909,7 +903,7 @@ struct PostedOpEntry {
     /// Kept alive so the memory *registration* outlives every in-flight
     /// WR touching it.
     _local_mrv: IbvMemoryRegionView,
-    reply: PortHandle<OpResult>,
+    reply: mpsc::UnboundedSender<OpResult>,
     /// First per-WR error observed for this op. The op's final reply is
     /// held back until `pending_wrs.is_empty()`, so the two fields above
     /// outlive every WR still in flight.
@@ -1021,7 +1015,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
     /// * `Err(_)` — `qp.put`/`qp.get` failed (e.g. the QP is in
     ///   error state). Fatal: the actor's handler returns this,
     ///   which raises a supervision event.
-    fn try_post_head(&mut self, cx: &Instance<Self>) -> Result<bool, anyhow::Error> {
+    fn try_post_head(&mut self) -> Result<bool, anyhow::Error> {
         let pending = self.queue.pop_front().expect("non-empty queue");
         let PendingOp { op, reply, wrs } = pending;
         let op_idx = op.op_idx;
@@ -1032,13 +1026,10 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 "op too large for this QP [op_idx={}, qp_key={:?}, op_type={:?}, wrs={}, max_send_wr={}, local: {:?}, remote: {:?}]",
                 op_idx, self.qp_key, op.op_type, wrs, self.max_send_wr, op.local_memory, op.remote,
             );
-            reply.try_post(
-                cx,
-                OpResult {
-                    op_idx,
-                    result: Err(err),
-                },
-            )?;
+            let _ = reply.send(OpResult {
+                op_idx,
+                result: Err(err),
+            });
             return Ok(true);
         }
 
@@ -1103,7 +1094,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         // 1. Post from the queue head until either it's empty or
         //    the head is credit-blocked.
         while !self.queue.is_empty() {
-            if !self.try_post_head(cx)? {
+            if !self.try_post_head()? {
                 break;
             }
         }
@@ -1151,13 +1142,10 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                     Some(err) => Err(err),
                     None => Ok(()),
                 };
-                entry.reply.try_post(
-                    cx,
-                    OpResult {
-                        op_idx: entry.op_idx,
-                        result,
-                    },
-                )?;
+                let _ = entry.reply.send(OpResult {
+                    op_idx: entry.op_idx,
+                    result,
+                });
             }
         }
         if progressed {
@@ -2189,14 +2177,14 @@ mod tests {
         }
     }
 
-    /// Open a multi-shot port and send a `ProcessOps` batch. Returns
+    /// Open a result channel and send a `ProcessOps` batch. Returns
     /// the receiver so the caller can await per-op results.
     fn submit_ops(
         harness: &QpaHarness,
         actor: &ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
         items: Vec<QueuePairOp>,
-    ) -> Result<hyperactor::mailbox::PortReceiver<OpResult>> {
-        let (reply, rx) = harness.client.mailbox().open_port::<OpResult>();
+    ) -> Result<mpsc::UnboundedReceiver<OpResult>> {
+        let (reply, rx) = mpsc::unbounded_channel();
         actor.try_post(&harness.client, ProcessOps { items, reply })?;
         Ok(rx)
     }
@@ -2204,7 +2192,7 @@ mod tests {
     /// Collect exactly `n` replies with a per-recv timeout, sorted
     /// by op_idx for deterministic comparison.
     async fn collect_replies(
-        rx: &mut hyperactor::mailbox::PortReceiver<OpResult>,
+        rx: &mut mpsc::UnboundedReceiver<OpResult>,
         n: usize,
     ) -> Vec<(usize, Result<(), String>)> {
         let mut out = Vec::with_capacity(n);
@@ -2212,7 +2200,7 @@ mod tests {
             let m = tokio::time::timeout(Duration::from_secs(5), rx.recv())
                 .await
                 .expect("timed out waiting for ProcessOps reply")
-                .expect("ProcessOps reply port closed");
+                .expect("ProcessOps result channel closed");
             out.push((m.op_idx, m.result));
         }
         out.sort_by_key(|(i, _)| *i);
@@ -2222,12 +2210,12 @@ mod tests {
     /// Try to recv with a short timeout, returning `None` on timeout
     /// so callers can assert "no reply yet".
     async fn try_recv(
-        rx: &mut hyperactor::mailbox::PortReceiver<OpResult>,
+        rx: &mut mpsc::UnboundedReceiver<OpResult>,
         wait: Duration,
     ) -> Option<(usize, Result<(), String>)> {
         match tokio::time::timeout(wait, rx.recv()).await {
-            Ok(Ok(m)) => Some((m.op_idx, m.result)),
-            Ok(Err(e)) => panic!("ProcessOps reply port closed: {e}"),
+            Ok(Some(m)) => Some((m.op_idx, m.result)),
+            Ok(None) => panic!("ProcessOps result channel closed"),
             Err(_) => None,
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -22,12 +22,8 @@ use std::io::Error;
 use std::result::Result;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
 
 use async_trait::async_trait;
-use backoff::ExponentialBackoff;
-use backoff::ExponentialBackoffBuilder;
-use backoff::backoff::Backoff;
 use hyperactor::Actor;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
@@ -775,68 +771,6 @@ impl IbvQueuePair for RCQueuePair {
     }
 }
 
-/// Adaptive backoff for the scheduler's `Tick` self-message. Use
-/// [`Self::next_interval`] to ask "how long should I wait before the
-/// next poll attempt?"; call [`Self::reset`] whenever the previous
-/// poll observed completions (so the actor stays tight while work
-/// is making progress).
-///
-/// While the elapsed time since the first non-zero interval is below
-/// `yield_window`, the policy returns `Duration::ZERO` so the actor
-/// just re-sends `Tick` to itself with no delay — keeping latency
-/// tight when WRs are about to complete. Past the window, it walks
-/// an exponential backoff (1ms initial, doubling, capped at 10ms)
-/// so a long-running op doesn't keep the runtime spinning. When
-/// `yield_window` is `None` (the default for
-/// `RDMA_CQ_BUSY_POLL_WINDOW`) the policy always returns
-/// `Duration::ZERO`.
-#[derive(Debug)]
-struct PollSleepPolicy {
-    yield_window: Option<Duration>,
-    started_at: Option<Instant>,
-    backoff: Option<ExponentialBackoff>,
-}
-
-impl PollSleepPolicy {
-    fn new() -> Self {
-        let yield_window = hyperactor_config::global::get(crate::config::RDMA_CQ_BUSY_POLL_WINDOW);
-        Self {
-            yield_window,
-            started_at: None,
-            backoff: None,
-        }
-    }
-
-    /// Forget all accumulated backoff state. Called after a poll
-    /// returns completions, so the next idle stretch starts fresh.
-    fn reset(&mut self) {
-        self.started_at = None;
-        self.backoff = None;
-    }
-
-    /// Suggested delay before the next `Tick`. `Duration::ZERO`
-    /// means "send `Tick` immediately".
-    fn next_interval(&mut self) -> Duration {
-        let Some(window) = self.yield_window else {
-            return Duration::ZERO;
-        };
-        let started = *self.started_at.get_or_insert_with(Instant::now);
-        if started.elapsed() < window {
-            return Duration::ZERO;
-        }
-        let backoff = self.backoff.get_or_insert_with(|| {
-            ExponentialBackoffBuilder::new()
-                .with_initial_interval(Duration::from_millis(1))
-                .with_max_interval(Duration::from_millis(10))
-                .with_multiplier(2.0)
-                .with_randomization_factor(0.0)
-                .with_max_elapsed_time(None)
-                .build()
-        });
-        backoff.next_backoff().unwrap_or(Duration::ZERO)
-    }
-}
-
 /// Bundle of trait bounds for an actor type that can serve as the
 /// peer manager — i.e. the recipient of [`CreatePeerQueuePair`].
 pub(super) trait Manager:
@@ -910,29 +844,11 @@ struct PostedOpEntry {
     first_error: Option<String>,
 }
 
-/// Per-peer queue-pair actor.
-///
-/// Generic over the manager actor type `M` (so tests can swap in a
-/// mock) and the queue-pair type `Qp` (so unit tests run without
-/// RDMA hardware). The QP is constructed by the spawning manager
-/// and handed in as a spawn param; the actor owns it for life and
-/// drops it when the actor stops.
+/// Owns one queue pair and the state used to schedule and complete its work.
 #[derive(Debug)]
-pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
+struct QueuePairState<Qp: IbvQueuePair> {
     qp_key: QpKey,
-    /// Filled into [`CreatePeerQueuePair::sender`] so the peer can
-    /// build its own [`QpKey`] from our identity.
-    local_manager: ActorRef<M>,
-    /// Recipient of [`CreatePeerQueuePair`].
-    peer_manager: ActorRef<M>,
     qp: Qp,
-    /// `true` when the peer QP is colocated with this actor's QP —
-    /// i.e. both endpoints live in the same `IbvManagerActor` *and*
-    /// target the same RDMA device. In that case `init` connects
-    /// the QP to its own endpoint and skips the cross-actor
-    /// handshake.
-    is_loopback: bool,
-    init_timeout: Duration,
     /// QP-wide cap on outstanding send-queue WRs (reads + writes).
     max_send_wr: u32,
     /// Single FIFO of ops awaiting their first post attempt. If the head
@@ -941,7 +857,7 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// future work.
     queue: VecDeque<PendingOp>,
     /// op-id → entry, for tracking WR completion. op-ids are local
-    /// to this actor (monotonic counter); they exist so we can
+    /// to this queue pair (monotonic counter); they exist so we can
     /// route per-WR completions to the right `PostedOpEntry`
     /// without making any assumptions about uniqueness of `op_idx`
     /// across batches.
@@ -952,10 +868,33 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// WRs posted to the send queue and not yet reaped:
     /// what `max_send_wr` gates against.
     in_flight: u32,
+}
+
+/// Per-peer queue-pair actor.
+///
+/// Generic over the manager actor type `M` (so tests can swap in a
+/// mock) and the queue-pair type `Qp` (so unit tests run without
+/// RDMA hardware). The QP is constructed by the spawning manager
+/// and handed in as a spawn param; the actor owns it for life and
+/// drops it when the actor stops.
+#[derive(Debug)]
+pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
+    /// Filled into [`CreatePeerQueuePair::sender`] so the peer can
+    /// build its own [`QpKey`] from our identity.
+    local_manager: ActorRef<M>,
+    /// Recipient of [`CreatePeerQueuePair`].
+    peer_manager: ActorRef<M>,
+    state: QueuePairState<Qp>,
+    /// `true` when the peer QP is colocated with this actor's QP —
+    /// i.e. both endpoints live in the same `IbvManagerActor` *and*
+    /// target the same RDMA device. In that case `init` connects
+    /// the QP to its own endpoint and skips the cross-actor
+    /// handshake.
+    is_loopback: bool,
+    init_timeout: Duration,
     /// `true` while a `Tick` self-message is already in flight; the
     /// flag prevents stacking redundant ticks.
     tick_armed: bool,
-    poll_policy: PollSleepPolicy,
     /// This queue pair's lease on the device's completion queue. Never read: it
     /// is held so the lease -- and the completion queue itself -- outlive the
     /// queue pair, which drops with this actor. This placement is temporary and
@@ -978,30 +917,56 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
     ) -> Self {
         let init_timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
         Self {
-            qp_key,
+            state: QueuePairState::new(qp_key, qp, max_send_wr),
             local_manager,
             peer_manager,
-            qp,
             is_loopback,
             init_timeout,
+            tick_armed: false,
+            _cq_lease: cq_lease,
+        }
+    }
+
+    /// One scheduler round: post everything that fits, poll for
+    /// completions, emit replies for finished ops, and re-arm
+    /// `Tick` if work remains. Returns `Err` for fatal QP-level
+    /// failures; the surrounding handler propagates the error so
+    /// supervision tears the actor down.
+    fn advance(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
+        self.state.post_ready()?;
+
+        self.state.poll_completions()?;
+
+        if self.state.has_work() && !self.tick_armed {
+            self.tick_armed = true;
+            cx.handle().try_post(cx, Tick)?;
+        }
+        Ok(())
+    }
+}
+
+impl<Qp: IbvQueuePair> QueuePairState<Qp> {
+    fn new(qp_key: QpKey, qp: Qp, max_send_wr: u32) -> Self {
+        Self {
+            qp_key,
+            qp,
             max_send_wr,
             queue: VecDeque::new(),
             posted: HashMap::new(),
             wr_to_op: HashMap::new(),
             next_op_id: 0,
             in_flight: 0,
-            tick_armed: false,
-            poll_policy: PollSleepPolicy::new(),
-            _cq_lease: cq_lease,
         }
     }
 
-    /// Number of WRs the QP will issue for an op that targets
-    /// `local_size` bytes. The QP splits large transfers into
-    /// [`IbvQueuePair::max_msg_size`]-bound chunks; a zero-byte op still
-    /// consumes one WR.
-    fn wr_count(&self, local_size: usize) -> u32 {
-        local_size.div_ceil(self.qp.max_msg_size()).max(1) as u32
+    fn enqueue(&mut self, message: ProcessOps) {
+        let max_msg_size = self.qp.max_msg_size();
+        self.queue
+            .extend(message.items.into_iter().map(|op| PendingOp {
+                wrs: op.local_memory.size().div_ceil(max_msg_size).max(1) as u32,
+                op,
+                reply: message.reply.clone(),
+            }));
     }
 
     /// Try to post the head of `queue`.
@@ -1085,26 +1050,17 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         Ok(true)
     }
 
-    /// One scheduler round: post everything that fits, poll for
-    /// completions, emit replies for finished ops, and re-arm
-    /// `Tick` if work remains. Returns `Err` for fatal QP-level
-    /// failures; the surrounding handler propagates the error so
-    /// supervision tears the actor down.
-    fn advance(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
-        // 1. Post from the queue head until either it's empty or
-        //    the head is credit-blocked.
+    fn post_ready(&mut self) -> Result<(), anyhow::Error> {
         while !self.queue.is_empty() {
             if !self.try_post_head()? {
                 break;
             }
         }
+        Ok(())
+    }
 
-        // 2. Drain the send CQ. Each completion identifies its WR by
-        //    `wr_id`; we correlate it back to its op and, once every WR
-        //    for an op has reported, emit the op's reply. Polling only
-        //    while WRs are outstanding keeps the loop from spinning on an
-        //    empty queue, and draining to `None` ensures no completion is
-        //    left behind.
+    /// Drain the send CQ and return whether any completion was observed.
+    fn poll_completions(&mut self) -> Result<bool, anyhow::Error> {
         let mut progressed = false;
         while !self.wr_to_op.is_empty() {
             let completion = self
@@ -1148,22 +1104,11 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 });
             }
         }
-        if progressed {
-            self.poll_policy.reset();
-        }
+        Ok(progressed)
+    }
 
-        // 3. Re-arm Tick if any work remains.
-        let pending_work = !self.queue.is_empty() || !self.posted.is_empty();
-        if pending_work && !self.tick_armed {
-            self.tick_armed = true;
-            let interval = self.poll_policy.next_interval();
-            if interval.is_zero() {
-                cx.handle().try_post(cx, Tick)?;
-            } else {
-                cx.post_after(cx, Tick, interval);
-            }
-        }
-        Ok(())
+    fn has_work(&self) -> bool {
+        !self.queue.is_empty() || !self.posted.is_empty()
     }
 }
 
@@ -1171,8 +1116,8 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
 impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         this.set_system();
-        let local_info = self.qp.get_qp_info().map_err(|e| {
-            tracing::error!(qp_key = ?self.qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
+        let local_info = self.state.qp.get_qp_info().map_err(|e| {
+            tracing::error!(qp_key = ?self.state.qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
             anyhow::anyhow!("could not extract local QP info: {e}")
         })?;
 
@@ -1186,8 +1131,8 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 this,
                 CreatePeerQueuePair {
                     sender: self.local_manager.clone(),
-                    sender_device: self.qp_key.self_device.clone(),
-                    receiver_device: self.qp_key.other_device.clone(),
+                    sender_device: self.state.qp_key.self_device.clone(),
+                    receiver_device: self.state.qp_key.other_device.clone(),
                     sender_info: local_info,
                     reply: reply.bind(),
                 },
@@ -1196,7 +1141,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 Ok(Ok(Ok(info))) => info,
                 Ok(Ok(Err(e))) => {
                     tracing::error!(
-                        qp_key = ?self.qp_key,
+                        qp_key = ?self.state.qp_key,
                         peer_manager = ?self.peer_manager,
                         error = %e,
                         "QueuePairActor init: peer manager rejected CreatePeerQueuePair",
@@ -1205,7 +1150,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 }
                 Ok(Err(e)) => {
                     tracing::error!(
-                        qp_key = ?self.qp_key,
+                        qp_key = ?self.state.qp_key,
                         peer_manager = ?self.peer_manager,
                         error = %e,
                         "QueuePairActor init: peer reply port closed",
@@ -1214,7 +1159,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 }
                 Err(_) => {
                     tracing::error!(
-                        qp_key = ?self.qp_key,
+                        qp_key = ?self.state.qp_key,
                         peer_manager = ?self.peer_manager,
                         timeout = ?self.init_timeout,
                         "QueuePairActor init: timed out waiting for peer reply",
@@ -1227,9 +1172,9 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
             }
         };
 
-        self.qp.connect(&peer_info).map_err(|e| {
+        self.state.qp.connect(&peer_info).map_err(|e| {
             tracing::error!(
-                qp_key = ?self.qp_key,
+                qp_key = ?self.state.qp_key,
                 peer_info = ?peer_info,
                 error = %e,
                 "QueuePairActor init: connect failed",
@@ -1254,14 +1199,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
 #[async_trait]
 impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps> for QueuePairActor<M, Qp> {
     async fn handle(&mut self, cx: &Context<Self>, msg: ProcessOps) -> Result<(), anyhow::Error> {
-        for op in msg.items.into_iter() {
-            let wrs = self.wr_count(op.local_memory.size());
-            self.queue.push_back(PendingOp {
-                op,
-                reply: msg.reply.clone(),
-                wrs,
-            });
-        }
+        self.state.enqueue(msg);
         // If a tick is already armed it will pick up the new ops on
         // its next round; advancing here would just duplicate work.
         if !self.tick_armed {

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -57,18 +57,6 @@ declare_attrs! {
     ))
     pub attr RDMA_TCP_FALLBACK_PARALLELISM: usize = 1;
 
-    /// Cooperative-yield window for the ibverbs CQ poll loop. While
-    /// the policy is within this window it calls
-    /// `tokio::task::yield_now` between polls; past it, polls fall
-    /// into an exponential backoff sleep (1ms initial, x2, capped at
-    /// 10ms). `None` (the default) disables the cutoff entirely:
-    /// the loop only ever yields, never sleeps.
-    @meta(CONFIG = ConfigAttr::new(
-        Some("MONARCH_RDMA_CQ_BUSY_POLL_WINDOW".to_string()),
-        Some("rdma_cq_busy_poll_window".to_string()),
-    ))
-    pub attr RDMA_CQ_BUSY_POLL_WINDOW: Option<Duration> = None;
-
     /// Per-side budget for the `QueuePairInitializer` handshake. The
     /// timer arms once when we send `EnsureQueuePair` and is rearmed
     /// after we hit RTS while still waiting for the peer's


### PR DESCRIPTION
Summary:

Add detach handling to the completion poller. A stopping queue pair transfers its resources and CQ lease to the poller, which discards any remaining completions and releases both only after its posted-versus-consumed count reaches zero. The detach command also wakes a parked poller, covering a queue pair that stops after counting work but before sending its normal wake.

Log shutdown with still-attached queue pairs, and permit the null CQ placeholder used by queue-pair unit tests. This commit still does not wire the poller into the production queue-pair path.

Reviewed By: zdevito

Differential Revision: D118533140


