### PR TITLE
name process meshes for mesh admin

### DIFF
--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -192,7 +192,10 @@ async def async_main(
         print("\nPress Ctrl+C to stop.\n", flush=True)
 
         # Spawn philosopher processes and actors.
-        procs = host.spawn_procs(per_host={"replica": NUM_PHILOSOPHERS})
+        procs = host.spawn_procs(
+            name="philosopher",
+            per_host={"replica": NUM_PHILOSOPHERS},
+        )
 
         # Spawn waiter on its own proc mesh so it appears in the dashboard hierarchy.
         waiter_proc = host.spawn_procs(name="waiter")

--- a/python/examples/execution_demo.py
+++ b/python/examples/execution_demo.py
@@ -135,7 +135,10 @@ async def async_main(args: argparse.Namespace) -> None:
 
         # N philosophers (one per replica) + a single fork manager on its own proc
         # so it is a distinct, easy-to-find node in the TUI tree.
-        phil_procs = host.spawn_procs(per_host={"replica": n})
+        phil_procs = host.spawn_procs(
+            name="philosopher",
+            per_host={"replica": n},
+        )
         fork_proc = host.spawn_procs(name="fork_manager")
 
         fork_manager = fork_proc.spawn("fork_manager", ForkManager, n)

--- a/python/examples/poisoned_mesh.py
+++ b/python/examples/poisoned_mesh.py
@@ -88,7 +88,10 @@ async def async_main(num_procs: int) -> None:
         state = job.state(cached_path=None)
         host = state.hosts
 
-        procs = host.spawn_procs(per_host={"replica": num_procs})
+        procs = host.spawn_procs(
+            name="worker",
+            per_host={"replica": num_procs},
+        )
         workers = procs.spawn("worker", Worker)
 
         # Let every worker do some work first.

--- a/python/examples/pyspy_workload.py
+++ b/python/examples/pyspy_workload.py
@@ -163,9 +163,13 @@ async def async_main() -> None:
             print(f"    --admin-url {admin_url} --mode {args.mode} --samples 10")
         print("\nPress Ctrl+C to stop.\n", flush=True)
 
-        # Spawn worker procs. The actor name pyspy_worker lets the
-        # verifier filter to workload procs by prefix.
-        procs = host.spawn_procs(per_host={"replica": args.concurrency})
+        # Name the proc mesh so mesh admin shows pyspy_worker-N instead of anon-N.
+        procs = host.spawn_procs(
+            name="pyspy_worker",
+            per_host={"replica": args.concurrency},
+        )
+
+        # The verifier locates workload procs by their pyspy_worker actor.
         workers = procs.spawn("pyspy_worker", Worker, args.mode, args.work_ms)
 
         # Start all workers.

--- a/python/examples/rapid_spawn_exit_stress.py
+++ b/python/examples/rapid_spawn_exit_stress.py
@@ -66,7 +66,10 @@ async def main():
     job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(dashboard_port=0))
     try:
         job_state = job.state(cached_path=None)
-        proc_mesh = job_state.hosts.spawn_procs(per_host={"gpus": 1})
+        proc_mesh = job_state.hosts.spawn_procs(
+            name="tensor_engine",
+            per_host={"gpus": 1},
+        )
 
         print("\nPress Ctrl+C to stop.\n", flush=True)
 

--- a/python/examples/sleep_actors.py
+++ b/python/examples/sleep_actors.py
@@ -65,7 +65,10 @@ async def async_main(num_procs: int) -> None:
         print(f"\nSpawning batches of sleepers across {num_procs} procs.")
         print("Press Ctrl+C to stop.\n", flush=True)
 
-        procs = host.spawn_procs(per_host={"replica": num_procs})
+        procs = host.spawn_procs(
+            name="sleeper",
+            per_host={"replica": num_procs},
+        )
 
         batch = 0
         # Keep references alive so actors aren't torn down prematurely.

--- a/python/examples/stop_mesh.py
+++ b/python/examples/stop_mesh.py
@@ -49,7 +49,10 @@ async def async_main(num_procs: int) -> None:
         state = job.state(cached_path=None)
         host = state.hosts
 
-        procs = host.spawn_procs(per_host={"replica": num_procs})
+        procs = host.spawn_procs(
+            name="worker",
+            per_host={"replica": num_procs},
+        )
         workers = procs.spawn("worker", Worker)
 
         # Let each actor announce itself.


### PR DESCRIPTION
Summary:
bug-fix. several Python examples create process meshes without names, so mesh admin displays their processes as `anon-N`. this makes it hard to tell which workload role each process belongs to.

this gives each process mesh a role-specific name, so mesh admin displays labels such as `pyspy_worker-0`, `philosopher-0`, and `worker-0`.

this only changes process labels in example workloads; process placement and production library behavior are unchanged.

Differential Revision: D118661800


