### PR TITLE
Add benchmarks to be published (#4793)

### DIFF
--- a/python/benches/bootstrap_benchmark.py
+++ b/python/benches/bootstrap_benchmark.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import statistics
+import time
+
+from monarch.job import JobTrait
+from noop_rpc_benchmark import NoopActor
+
+_WARMUP_ITERATIONS = 10
+
+
+def benchmark_bootstrap(
+    job: JobTrait,
+    num_iterations: int,
+    procs_per_host: int = 8,
+    *,
+    host_mesh_name: str = "hosts",
+) -> None:
+    """Measure bootstrap on a job's available host mesh through the first RPC."""
+    if num_iterations <= 0:
+        raise ValueError("num_iterations must be positive")
+    if procs_per_host <= 0:
+        raise ValueError("procs_per_host must be positive")
+
+    host_mesh = getattr(job.state(cached_path=None), host_mesh_name)
+    host_mesh.initialized.get()
+
+    proc_mesh_spawn_times = []
+    actor_mesh_spawn_times = []
+    first_rpc_times = []
+    total_bootstrap_times = []
+
+    for iteration in range(_WARMUP_ITERATIONS + num_iterations):
+        start = time.perf_counter()
+        proc_mesh = host_mesh.spawn_procs(per_host={"procs": procs_per_host})
+        try:
+            proc_mesh.initialized.get()
+            proc_mesh_ready = time.perf_counter()
+
+            actor: NoopActor = proc_mesh.spawn("noop_rpc_benchmark", NoopActor)
+            actor.initialized.get()
+            actor_mesh_ready = time.perf_counter()
+
+            actor.noop.call().get()
+            first_rpc_complete = time.perf_counter()
+
+            if iteration >= _WARMUP_ITERATIONS:
+                proc_mesh_spawn_times.append(proc_mesh_ready - start)
+                actor_mesh_spawn_times.append(actor_mesh_ready - proc_mesh_ready)
+                first_rpc_times.append(first_rpc_complete - actor_mesh_ready)
+                total_bootstrap_times.append(first_rpc_complete - start)
+        finally:
+            proc_mesh.stop().get()
+
+    print(f"warmup iterations: {_WARMUP_ITERATIONS}")
+    print(f"measured iterations: {num_iterations}")
+    for name, timings in (
+        ("proc mesh spawn", proc_mesh_spawn_times),
+        ("actor mesh spawn", actor_mesh_spawn_times),
+        ("first noop RPC", first_rpc_times),
+        ("total bootstrap", total_bootstrap_times),
+    ):
+        print(
+            f"{name}: mean {statistics.fmean(timings):.3f} s, "
+            f"p50 {statistics.median(timings):.3f} s"
+        )

--- a/python/benches/noop_rpc_benchmark.py
+++ b/python/benches/noop_rpc_benchmark.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import statistics
+import time
+
+from monarch.actor import Actor, endpoint
+
+_WARMUP_ITERATIONS = 10
+
+
+class NoopActor(Actor):
+    @endpoint
+    async def noop(self) -> None:
+        return None
+
+
+def benchmark_noop_rpc(
+    actor: NoopActor,
+    num_iterations: int,
+) -> None:
+    """Measure the latency of the requested number of noop calls."""
+    if num_iterations <= 0:
+        raise ValueError("num_iterations must be positive")
+
+    for _ in range(_WARMUP_ITERATIONS):
+        actor.noop.call().get()
+
+    latencies_ms = []
+    for _ in range(num_iterations):
+        start = time.perf_counter()
+        actor.noop.call().get()
+        latencies_ms.append((time.perf_counter() - start) * 1000)
+
+    print(f"warmup iterations: {_WARMUP_ITERATIONS}")
+    print(f"measured iterations: {num_iterations}")
+    print(f"mean noop RPC latency: {statistics.fmean(latencies_ms):.3f} ms")
+    print(f"p50 noop RPC latency: {statistics.median(latencies_ms):.3f} ms")


### PR DESCRIPTION
Summary:

We need benchmark code to point users to when we publish our results.

We run our jobs with MASTJob which is internal, so we've made it so that our benchmarks are just files that take in a host mesh so if users want to reproduce they will need to supply their own host mesh obtained from whatever scheduler they use.

Here we create noop_rpc_benchmark.py which just invokes
```
class NoopActor(Actor):
    endpoint
    async def noop(self) -> None:
        return None
```

and bootstrap_benchmark.py, which takes in a HostMesh, and spawns a proc mesh, actor mesh, and makes 1 rpc call each iteration.

Internally, we add some runnable scripts which create a MASTJob and calls the benchmark function with the MASTJob host mesh

Differential Revision: D118536119


