### PR TITLE
do not start disabled dashboards (#4794)

### DIFF
--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -105,7 +105,7 @@ class TelemetryConfig:
 # before the cast.
 class _TelemetryResponse(TypedDict):
     telemetry_url: str
-    dashboard_url: str
+    dashboard_url: str | None
     socket_path: str
 
 
@@ -277,7 +277,9 @@ class _TelemetryHandle:
             raise RuntimeError("telemetry handle is not open")
         api_url = dashboard_info["api_url"]
         url = dashboard_info["url"]
-        if not isinstance(api_url, str) or not isinstance(url, str):
+        if not isinstance(api_url, str) or (
+            url is not None and not isinstance(url, str)
+        ):
             raise RuntimeError(f"invalid dashboard info: {dashboard_info!r}")
         return {
             "telemetry_url": api_url,
@@ -307,6 +309,7 @@ class _TelemetryHandle:
         dashboard_info = start_dashboard(
             adapter=QueryEngineAdapter(query_engine),
             port=config.dashboard_port,
+            include_dashboard=config.include_dashboard,
         )
         # Self-activate the sidecar process's own `UnixSocketSink` against
         # the client socket so telemetry emitted *by* the sidecar (dashboard

--- a/python/monarch/monarch_dashboard/server/app.py
+++ b/python/monarch/monarch_dashboard/server/app.py
@@ -86,10 +86,30 @@ def create_app(adapter: DBAdapter) -> Flask:
     return app
 
 
+def _create_api_server(app: Flask) -> tuple[str, threading.Thread]:
+    server = make_server(
+        "127.0.0.1",
+        0,
+        app,
+        threaded=True,
+        ssl_context=None,
+    )
+    return (
+        f"http://127.0.0.1:{server.server_port}",
+        threading.Thread(
+            target=server.serve_forever,
+            daemon=True,
+            name="monarch-dashboard-api",
+        ),
+    )
+
+
 def start_dashboard(
     adapter: DBAdapter,
     port: int = 8265,
     host: str = "::",
+    *,
+    include_dashboard: bool = True,
 ) -> dict:
     """Start the dashboard server in a daemon thread.
 
@@ -97,9 +117,10 @@ def start_dashboard(
     in-memory as DataFusion MemTables. There is no on-disk database, so
     the dashboard must share the process to access the QueryEngine.
 
-    On devvm / DevGPU / OnDemand hosts with a local TLS cert, the
-    server uses HTTPS and advertises a Nest Dev Proxy URL for direct
-    browser access without port forwarding.
+    The loopback API server is always started. When the dashboard is included,
+    a browser-facing server is started as well. On devvm / DevGPU / OnDemand
+    hosts with a local TLS cert, that server uses HTTPS and advertises a Nest
+    Dev Proxy URL for direct browser access without port forwarding.
 
     Tupperware / MAST hosts are **not supported**: the Nest Dev Proxy
     edge does not route to ``.tw.fbinfra.net`` task pods. On those
@@ -114,16 +135,38 @@ def start_dashboard(
             the Linux kernel default ``IPV6_V6ONLY=0`` for dual-stack;
             IPv4 clients (including ``localhost``) still work via
             v4-mapped addresses.
+        include_dashboard: Whether to start the browser-facing server. The
+            loopback API remains available when this is false.
 
     Returns:
         A dict with keys: ``url`` (external, browser-openable), ``local_url``
         (in-process URL matching the cert SAN), ``api_url`` (loopback
         plaintext URL for internal API clients), ``port``, ``pid`` (always
-        None), ``handle`` (Thread), and ``api_handle`` (Thread).
+        None), ``handle`` (Thread), and ``api_handle`` (Thread). The public
+        URL, port, and handle fields are None when the dashboard is disabled.
 
     Raises:
-        OSError: If the port is already in use.
+        OSError: If a requested server cannot bind its socket.
     """
+    app = create_app(adapter)
+    # Suppress per-request werkzeug logs (they are noisy in production).
+    logging.getLogger("werkzeug").setLevel(logging.WARNING)
+
+    # A free ephemeral port can still receive traffic from systems configured
+    # to probe it. Do not open a public listener unless the dashboard is enabled.
+    if not include_dashboard:
+        api_url, api_thread = _create_api_server(app)
+        api_thread.start()
+        return {
+            "url": None,
+            "local_url": None,
+            "api_url": api_url,
+            "port": None,
+            "pid": None,
+            "handle": None,
+            "api_handle": api_thread,
+        }
+
     ssl_ctx: ssl.SSLContext | None = None
     tls_hostname: str | None = None
     try:
@@ -137,10 +180,6 @@ def start_dashboard(
             ssl_ctx, tls_hostname = result
     except ImportError:
         pass
-
-    app = create_app(adapter)
-    # Suppress per-request werkzeug logs (they are noisy in production).
-    logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
     try:
         server = make_server(
@@ -163,14 +202,7 @@ def start_dashboard(
         url = f"http://localhost:{actual_port}"
         local_url = url
 
-    api_server = make_server(
-        "127.0.0.1",
-        0,
-        app,
-        threaded=True,
-        ssl_context=None,
-    )
-    api_url = f"http://127.0.0.1:{api_server.server_port}"
+    api_url, api_thread = _create_api_server(app)
 
     thread = threading.Thread(
         target=server.serve_forever,
@@ -178,11 +210,7 @@ def start_dashboard(
         name="monarch-dashboard",
     )
     thread.start()
-    api_thread = threading.Thread(
-        target=api_server.serve_forever,
-        daemon=True,
-        name="monarch-dashboard-api",
-    )
+
     api_thread.start()
     logger.info("Monarch Dashboard running at %s", url)
 

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -526,6 +526,9 @@ def test_job_sidecar_hosts_telemetry_query_api() -> None:
     """Launch the real job sidecar process, open telemetry over the command
     socket, and confirm the data socket is bound and the query API answers."""
     apply_id = _new_apply_id()
+    dashboard_port_guard = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    dashboard_port_guard.bind(("127.0.0.1", 0))
+    dashboard_port = dashboard_port_guard.getsockname()[1]
     socket_dir = telemetry_socket_dir(apply_id)
     _remove_socket_dir(apply_id)
     os.makedirs(socket_dir, mode=0o700)
@@ -534,7 +537,7 @@ def test_job_sidecar_hosts_telemetry_query_api() -> None:
             TelemetryConfig(
                 retention_secs=0,
                 include_dashboard=False,
-                dashboard_port=0,
+                dashboard_port=dashboard_port,
             )
         ).ensure_open(
             apply_id,
@@ -542,9 +545,15 @@ def test_job_sidecar_hosts_telemetry_query_api() -> None:
         )
         assert isinstance(response, dict)
         telemetry_url = response["telemetry_url"]
+        assert response["dashboard_url"] is None
         socket_path = response["socket_path"]
         assert isinstance(telemetry_url, str)
         assert socket_path == telemetry_socket_path(apply_id)
+
+        dashboard_port_guard.close()
+        with pytest.raises(ConnectionRefusedError):
+            with socket.create_connection(("127.0.0.1", dashboard_port), timeout=2):
+                pass
 
         client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
@@ -584,5 +593,6 @@ def test_job_sidecar_hosts_telemetry_query_api() -> None:
             )
         assert error.value.code == 400
     finally:
+        dashboard_port_guard.close()
         js.stop_job_sidecar(apply_id)
         _remove_socket_dir(apply_id)


### PR DESCRIPTION
Summary:

bug-fix.

observed while running the py-spy example:

```console
$ buck run fbcode//monarch/python/examples:pyspy_workload --
...

py-spy workload: mode=cpu, work_ms=500, concurrency=3

...

Press Ctrl+C to stop.

2401:db00:143c:6022:face:0:1e6:0 - - [03/Sep/2026 09:44:06] code 400, message Bad request version ('getStatus\x00\x00\x00\x00\x00')
2401:db00:143c:6022:face:0:1e6:0 - - [03/Sep/2026 09:45:06] code 400, message Bad request version ('getStatus\x00\x00\x00\x00\x00')
.
. message Bad request (... 'getStatus'...) every 1m
.

^C
Shutting down...
$
```

`dashboard_port=0` lets the kernel choose a port from the host's ephemeral port range. this run chose `46099`, which fbagent was already monitoring for another service. every minute, fbagent sent that port an fb303 `getStatus` health check. fb303 uses Thrift, not HTTP.

the dashboard was disabled, but telemetry still opened its public HTTP listener. Werkzeug tried to parse fbagent's Thrift request as HTTP and reported it as a malformed request.

this diff passes `include_dashboard` into server startup. when the dashboard is disabled, telemetry starts only the loopback API and reports no dashboard URL.

this diff adds a regression test that reserves the dashboard port while starting the real sidecar with the dashboard disabled. it verifies that startup does not take the reserved port and that query and ingest still work through the loopback API.

this changes only disabled-dashboard startup. callers that enable the dashboard continue through the existing public-server path.

Differential Revision: D118703691


