### PR TITLE
Add experimental ThreadTimeout (#4795)

### DIFF
--- a/python/monarch/experimental/README.md
+++ b/python/monarch/experimental/README.md
@@ -1,0 +1,8 @@
+# Experimental Python utilities
+
+This directory contains standalone utilities that may be useful with Monarch
+but are not part of Monarch's supported API. Monarch must not depend on these
+utilities. They may change or be removed without a compatibility period.
+
+Each utility is self-contained so that users can copy it into their own
+repository before removal.

--- a/python/monarch/experimental/__init__.py
+++ b/python/monarch/experimental/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Experimental utilities that are not part of Monarch's supported API."""

--- a/python/monarch/experimental/tests/test_thread_timeout.py
+++ b/python/monarch/experimental/tests/test_thread_timeout.py
@@ -1,0 +1,139 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+import unittest
+
+from monarch.actor import Actor, endpoint, this_proc
+from monarch.experimental.thread_timeout import ThreadTimeout, ThreadTimeoutError
+
+
+def _busy_wait(seconds: float = 2) -> None:
+    """Run Python code for a bounded time so a regression cannot hang CI."""
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        pass
+
+
+class _ThreadTimeoutActor(Actor):
+    @endpoint
+    async def time_out(self) -> bool:
+        """Return whether the timeout interrupted this endpoint."""
+        try:
+            with ThreadTimeout(0.01):
+                _busy_wait()
+        except ThreadTimeoutError:
+            return True
+        return False
+
+    @endpoint
+    async def ping(self) -> int:
+        """Return a value that confirms the endpoint loop is still healthy."""
+        return 42
+
+
+class ThreadTimeoutTest(unittest.TestCase):
+    """Tests the public thread-timeout behavior."""
+
+    def test_completes_before_deadline(self) -> None:
+        with ThreadTimeout(1):
+            result = 42
+
+        self.assertEqual(42, result)
+
+    def test_propagates_unrelated_exception(self) -> None:
+        with self.assertRaisesRegex(ValueError, "failure"):
+            with ThreadTimeout(1):
+                raise ValueError("failure")
+
+    def test_preserves_exception_raised_after_timeout(self) -> None:
+        with self.assertRaisesRegex(ValueError, "after timeout"):
+            with ThreadTimeout(0.01):
+                try:
+                    _busy_wait()
+                except ThreadTimeoutError:
+                    raise ValueError("after timeout")
+
+    def test_timeout_bypasses_exception_handlers(self) -> None:
+        caught = False
+        deadline = time.monotonic() + 2
+
+        with self.assertRaises(ThreadTimeoutError):
+            with ThreadTimeout(0.01):
+                while time.monotonic() < deadline:
+                    try:
+                        for _ in range(100):
+                            pass
+                    except Exception:
+                        caught = True
+
+        self.assertFalse(caught)
+
+    def test_base_exception_handler_cannot_suppress_timeout(self) -> None:
+        caught: BaseException | None = None
+
+        with self.assertRaises(ThreadTimeoutError):
+            with ThreadTimeout(0.01):
+                try:
+                    _busy_wait()
+                except BaseException as error:  # noqa: B036
+                    caught = error
+
+        # The context raises again after the handler catches the injection.
+        self.assertIsInstance(caught, ThreadTimeoutError)
+
+    def test_rejects_nonpositive_deadline(self) -> None:
+        with self.assertRaises(ValueError):
+            ThreadTimeout(0)
+
+    def test_instance_is_single_use(self) -> None:
+        timeout = ThreadTimeout(1)
+        with timeout:
+            pass
+
+        with self.assertRaises(RuntimeError):
+            with timeout:
+                pass
+
+    def test_rejects_nested_contexts(self) -> None:
+        with ThreadTimeout(1):
+            with self.assertRaisesRegex(RuntimeError, "cannot be nested"):
+                with ThreadTimeout(1):
+                    pass
+
+        with ThreadTimeout(1):
+            pass
+
+    def test_works_inside_monarch_endpoint(self) -> None:
+        actor = this_proc().spawn("thread_timeout_test", _ThreadTimeoutActor)
+        try:
+            self.assertTrue(actor.time_out.call_one().get(timeout=5))
+            self.assertEqual(42, actor.ping.call_one().get(timeout=5))
+        finally:
+            actor.stop().get(timeout=5)
+
+
+class ThreadTimeoutAsyncTest(unittest.IsolatedAsyncioTestCase):
+    """Tests thread timeouts used from asyncio."""
+
+    async def test_works_with_to_thread(self) -> None:
+        worker_thread_id: int | None = None
+
+        def work() -> None:
+            nonlocal worker_thread_id
+            worker_thread_id = threading.get_ident()
+            with ThreadTimeout(0.01):
+                _busy_wait()
+
+        with self.assertRaises(ThreadTimeoutError):
+            await asyncio.to_thread(work)
+
+        self.assertIsNotNone(worker_thread_id)
+        self.assertNotEqual(threading.get_ident(), worker_thread_id)

--- a/python/monarch/experimental/thread_timeout.py
+++ b/python/monarch/experimental/thread_timeout.py
@@ -1,0 +1,209 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Best-effort timeouts for synchronous Python running on CPython threads.
+
+Unlike ``signal.SIGALRM``, this module can interrupt a non-main thread. It uses
+CPython's ``PyThreadState_SetAsyncExc`` to schedule an exception in the thread
+at its next interpreter evaluation point. It cannot interrupt a native call;
+the exception is delivered only after the native call returns to the interpreter.
+
+Monarch provides this experimental utility because actor endpoints run on
+non-main threads. Python delivers signals on the main thread, so the common
+``SIGALRM`` timeout pattern cannot protect synchronous work inside an endpoint.
+``ThreadTimeout`` provides a thread-targeted alternative for that use case.
+
+Asynchronous exceptions can interrupt code between bytecode instructions, so
+use context managers or ``finally`` blocks for cleanup.
+
+Basic use::
+
+    try:
+        with ThreadTimeout(5):
+            result = expensive_python_work()
+    except ThreadTimeoutError:
+        handle_timeout()
+
+Here, ``expensive_python_work`` is a synchronous function.
+
+You can also put the synchronous work and its timeout in a function passed to
+asyncio.to_thread::
+
+    def timed_expensive_python_work():
+        with ThreadTimeout(5):
+            return expensive_python_work()
+
+    async def run_async_work():
+        try:
+            return await asyncio.to_thread(timed_expensive_python_work)
+        except ThreadTimeoutError:
+            handle_timeout()
+
+Do not let the context span an ``await``::
+
+    async def run_async_work():
+        with ThreadTimeout(5):
+            return await async_work()
+
+The timeout targets a thread rather than an asyncio task, so it could interrupt
+unrelated event-loop work while the original coroutine is suspended.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import functools
+import logging
+import sys
+import threading
+from collections.abc import Callable
+from types import TracebackType
+
+__all__ = [
+    "ThreadTimeout",
+    "ThreadTimeoutError",
+]
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class ThreadTimeoutError(BaseException):
+    """The exception injected when a thread exceeds its deadline.
+
+    This inherits from ``BaseException`` so broad ``except Exception`` handlers
+    inside the protected code do not suppress the timeout. Catch
+    ``ThreadTimeoutError`` explicitly outside the ``ThreadTimeout`` context.
+    """
+
+
+class _ThreadTimeoutState(threading.local):
+    """Track an active timeout so ``__enter__`` can reject nested contexts.
+
+    CPython provides one pending asynchronous-exception slot per thread, so
+    nested contexts could overwrite or clear each other's exception.
+    """
+
+    active: bool = False
+
+
+@functools.cache
+def _get_thread_timeout_state() -> _ThreadTimeoutState:
+    return _ThreadTimeoutState()
+
+
+@functools.cache
+def _get_set_async_exception() -> Callable[..., int]:
+    """Configure the shared ctypes binding once, on first use.
+
+    ``ctypes.pythonapi`` reuses function objects, so setting the prototype on
+    every injection would repeatedly mutate shared state. Caching also keeps
+    this setup out of module import and makes later calls cheaper.
+    """
+    set_async_exception = ctypes.pythonapi.PyThreadState_SetAsyncExc
+    set_async_exception.argtypes = (ctypes.c_ulong, ctypes.py_object)
+    set_async_exception.restype = ctypes.c_int
+    return set_async_exception
+
+
+def _set_async_exception(thread_id: int) -> bool:
+    modified = _get_set_async_exception()(
+        ctypes.c_ulong(thread_id), ctypes.py_object(ThreadTimeoutError)
+    )
+    if modified == 0:
+        return False
+    if modified > 1:
+        _clear_async_exception(thread_id)
+        logger.warning(
+            "async exception injection modified multiple threads",
+            extra={"thread_id": thread_id, "modified": modified},
+        )
+        return False
+    return True
+
+
+def _clear_async_exception(thread_id: int) -> None:
+    _get_set_async_exception()(ctypes.c_ulong(thread_id), ctypes.py_object())
+
+
+class ThreadTimeout:
+    """Bound the wall-clock time of a synchronous block on a CPython thread.
+
+    The timeout targets the thread that enters the context. Instances are
+    single-use. Once the watchdog fires, ``ThreadTimeoutError`` propagates from
+    the context even if the protected code catches the injected exception.
+    """
+
+    def __init__(
+        self,
+        seconds: float,
+    ) -> None:
+        if sys.implementation.name != "cpython":
+            raise RuntimeError("ThreadTimeout requires CPython")
+        if seconds <= 0:
+            raise ValueError(f"seconds must be positive, got {seconds!r}")
+        self._seconds = seconds
+        self._fired = False
+        self._target_thread_id: int | None = None
+        self._finished = threading.Event()
+        self._lock = threading.Lock()
+        self._watchdog: threading.Thread | None = None
+
+    def __enter__(self) -> ThreadTimeout:
+        if self._target_thread_id is not None:
+            raise RuntimeError("ThreadTimeout instances are single-use")
+
+        thread_state = _get_thread_timeout_state()
+        if thread_state.active:
+            raise RuntimeError("ThreadTimeout contexts cannot be nested")
+        thread_state.active = True
+
+        target_thread_id = threading.get_ident()
+        self._target_thread_id = target_thread_id
+        self._watchdog = threading.Thread(
+            target=self._run_watchdog,
+            args=(target_thread_id,),
+            name=f"thread-timeout-{target_thread_id}",
+            daemon=True,
+        )
+        try:
+            self._watchdog.start()
+            return self
+        except BaseException:
+            thread_state.active = False
+            raise
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exception, traceback
+        try:
+            fired = self._finish()
+        finally:
+            _get_thread_timeout_state().active = False
+        if fired and exception_type is None:
+            raise ThreadTimeoutError
+
+    def _finish(self) -> bool:
+        with self._lock:
+            self._finished.set()
+            fired = self._fired
+        if fired and self._target_thread_id is not None:
+            _clear_async_exception(self._target_thread_id)
+        return fired
+
+    def _run_watchdog(self, target_thread_id: int) -> None:
+        if self._finished.wait(self._seconds):
+            return
+
+        with self._lock:
+            if self._finished.is_set():
+                return
+            if not _set_async_exception(target_thread_id):
+                return
+            self._fired = True

--- a/scripts/common-setup-macos.sh
+++ b/scripts/common-setup-macos.sh
@@ -42,7 +42,8 @@ run_test_groups() {
         pkill -9 python || true
         pkill -9 pytest || true
         sleep 2
-        LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
+        LC_ALL=C pytest python/tests/ python/monarch/experimental/tests/ \
+            -s -v -m "not oss_skip" \
             --ignore-glob="**/meta/**" \
             --dist=no \
             --group="$GROUP" \

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -344,7 +344,8 @@ run_test_groups() {
   export LD_PRELOAD="${CONDA_LIBSTDCPP}${LD_PRELOAD:+:$LD_PRELOAD}"
   export RUST_BACKTRACE=1
   mkdir -p "$test_results_dir"
-  LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
+  LC_ALL=C pytest python/tests/ python/monarch/experimental/tests/ \
+      -s -v -m "not oss_skip" \
       --ignore-glob="**/meta/**" \
       --crash-recovery \
       --max-crashes=10 \


### PR DESCRIPTION
Summary:

I run into this case when working with TorchtitanRL:

* TorchtitanRL uses [`math_verify`](https://github.com/huggingface/blog/blob/main/math_verify_leaderboard.md) in their rollout path.
* math_verify uses [SIGALRM to raise timeout error](https://github.com/huggingface/Math-Verify/blob/ba3d3aaff23b3f4cac7a14672b4f6e293d97c98b/src/math_verify/utils.py#L66). 
* Python restricts signal handling to the main thread.
* Monarch actor runs on a worker thread.

As a result, `math_verify` cannot run on monarch actor's thread with its timeout setting.

The user could put the `math_verify` logic in a subprocess, but that defeats their purpose of making `Rollouter` a monarch actor. They want to use the monarch actor as a process pool (i.e. `proc_mesh = this_host().spawn`).

`math_verify` allows you to set timeout to None in its API, so the user can implement their own timeout handling logic. This diff adds an experimental `ThreadTimeout` utility, which provides that timeout handling logic.

The reason I want to offer `ThreadTimeout` as a monarch's experimental utility is because I think other Monarch users could run into the same problem. It is beneficial for the monarch community to make this widely avaiable.

Differential Revision: D118714219


