### PR TITLE
do not return dump IDs when py-spy fails

### DIFF
--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -2055,7 +2055,7 @@ pub fn build_openapi_spec() -> serde_json::Value {
                 "post": {
                     "summary": "Trigger py-spy dump and store in telemetry",
                     "operationId": "pyspyDumpAndStore",
-                    "description": "Runs py-spy against the target process, stores the result in the dashboard's DataFusion pyspy tables, and returns the dump_id.",
+                    "description": "Runs py-spy against the target process, stores a successful result in the dashboard's DataFusion pyspy tables, and returns the dump_id. Failed captures return an error without a dump_id.",
                     "parameters": [{
                         "name": "proc_reference",
                         "in": "path",
@@ -2074,7 +2074,8 @@ pub fn build_openapi_spec() -> serde_json::Value {
                         },
                         "400": error_response("Bad request (malformed proc reference)"),
                         "404": error_response("Proc or dashboard not found"),
-                        "500": error_response("Internal error"),
+                        "500": error_response("Capture, storage, or internal error"),
+                        "503": error_response("py-spy binary unavailable"),
                         "504": error_response("Gateway timeout")
                     }
                 }
@@ -2510,6 +2511,46 @@ pub struct PyspyDumpAndStoreResponse {
     pub dump_id: String,
 }
 
+fn serialize_storable_pyspy_result(pyspy_result: &PySpyResult) -> Result<String, ApiError> {
+    match pyspy_result {
+        PySpyResult::Ok { .. } => serde_json::to_string(pyspy_result).map_err(|e| ApiError {
+            code: "internal_error".to_string(),
+            message: format!("failed to serialize PySpyResult: {}", e),
+            details: None,
+        }),
+        PySpyResult::BinaryNotFound { searched } => Err(ApiError {
+            code: "service_unavailable".to_string(),
+            message: format!(
+                "py-spy not available on target host; searched: {}",
+                searched.join(", ")
+            ),
+            details: None,
+        }),
+        PySpyResult::Failed {
+            pid,
+            binary,
+            exit_code,
+            stderr,
+        } => {
+            let exit_code =
+                exit_code.map_or_else(|| "unknown".to_string(), |code| code.to_string());
+            let stderr = stderr.trim();
+            let message = if stderr.is_empty() {
+                format!("py-spy dump failed for pid {pid} using {binary} (exit code {exit_code})")
+            } else {
+                format!(
+                    "py-spy dump failed for pid {pid} using {binary} (exit code {exit_code}): {stderr}"
+                )
+            };
+            Err(ApiError {
+                code: "pyspy_failed".to_string(),
+                message,
+                details: None,
+            })
+        }
+    }
+}
+
 /// Resolve the telemetry URL from bridge state, returning an
 /// `ApiError` if not configured.
 fn require_telemetry_url(state: &BridgeState) -> Result<&str, ApiError> {
@@ -2581,9 +2622,10 @@ async fn query_proxy(
 ///
 /// 1. Performs a py-spy dump via `do_pyspy_dump` (same as
 ///    `pyspy_bridge`).
-/// 2. POSTs the serialized result to the dashboard's
+/// 2. Rejects unsuccessful captures without generating a dump id.
+/// 3. POSTs the serialized successful result to the dashboard's
 ///    `/api/pyspy_dump` endpoint for persistent storage.
-/// 3. Returns the generated dump id.
+/// 4. Returns the generated dump id.
 async fn pyspy_dump_and_store(
     State(state): State<Arc<BridgeState>>,
     AxumPath(proc_reference): AxumPath<String>,
@@ -2591,12 +2633,8 @@ async fn pyspy_dump_and_store(
     let telemetry_url = require_telemetry_url(&state)?;
     let pyspy_result = do_pyspy_dump(&state, &proc_reference).await?;
 
+    let pyspy_json = serialize_storable_pyspy_result(&pyspy_result)?;
     let dump_id = uuid::Uuid::new_v4().to_string();
-    let pyspy_json = serde_json::to_string(&pyspy_result).map_err(|e| ApiError {
-        code: "internal_error".to_string(),
-        message: format!("failed to serialize PySpyResult: {}", e),
-        details: None,
-    })?;
 
     let store_body = StorePyspyDumpRequest {
         dump_id: dump_id.clone(),
@@ -3280,6 +3318,63 @@ mod tests {
     // ephemeral port. The default (`None`) reads MESH_ADMIN_ADDR
     // config which is `[::]:1729` — a fixed port that causes bind
     // conflicts when tests run concurrently.
+
+    #[test]
+    fn failed_pyspy_dump_is_rejected_before_storage() {
+        let error = serialize_storable_pyspy_result(&PySpyResult::Failed {
+            pid: 1234,
+            binary: "py-spy".to_string(),
+            exit_code: Some(1),
+            stderr: "capture failed".to_string(),
+        })
+        .expect_err("a failed capture must not be sent to storage");
+
+        assert_eq!(error.code, "pyspy_failed");
+        assert_eq!(
+            error.message,
+            "py-spy dump failed for pid 1234 using py-spy (exit code 1): capture failed"
+        );
+        assert_eq!(
+            error.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[test]
+    fn missing_pyspy_binary_is_rejected_before_storage() {
+        let error = serialize_storable_pyspy_result(&PySpyResult::BinaryNotFound {
+            searched: vec!["configured-py-spy".to_string(), "py-spy".to_string()],
+        })
+        .expect_err("a missing binary must not be sent to storage");
+
+        assert_eq!(error.code, "service_unavailable");
+        assert_eq!(
+            error.message,
+            "py-spy not available on target host; searched: configured-py-spy, py-spy"
+        );
+        assert_eq!(
+            error.into_response().status(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+
+    #[test]
+    fn successful_pyspy_dump_is_serialized_for_storage() {
+        let result = PySpyResult::Ok {
+            pid: 1234,
+            binary: "py-spy".to_string(),
+            stack_traces: vec![],
+            warnings: vec![],
+        };
+
+        let serialized = serialize_storable_pyspy_result(&result)
+            .expect("a successful capture should be sent to storage");
+
+        assert_eq!(
+            serde_json::from_str::<PySpyResult>(&serialized).unwrap(),
+            result
+        );
+    }
 
     #[test]
     fn mesh_admin_access_instructions_print_file_tls_paths() {

--- a/hyperactor_mesh/src/mesh_admin_skill.md
+++ b/hyperactor_mesh/src/mesh_admin_skill.md
@@ -33,11 +33,13 @@ first when building against this API.
 Errors return an `ApiErrorEnvelope` JSON body (see error schema).
 The `error.code` field is authoritative for programmatic decisions,
 not the HTTP status code. Stable codes: `not_found`, `bad_request`,
-`gateway_timeout`, `service_unavailable`, `internal_error`.
+`gateway_timeout`, `service_unavailable`, `pyspy_failed`,
+`internal_error`.
 
-`service_unavailable` is transient (server at capacity) — retry
-with backoff. `gateway_timeout` means a downstream host did not
-respond in time; the node may still exist.
+Retry a capacity-related `service_unavailable` with backoff. The same
+code can also mean a required tool is unavailable on the target.
+`gateway_timeout` means a downstream host did not respond in time;
+the node may still exist.
 
 ## Schema-first workflow
 
@@ -245,7 +247,7 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
   The endpoint performs two steps:
   1. Sends a `PySpyDump` message to the target proc's agent
      (same routing as `GET /v1/pyspy/{proc_reference}`).
-  2. Stores the result in DataFusion via the dashboard, keyed
+  2. Stores a successful result in DataFusion via the dashboard, keyed
      by a generated UUID.
 
   Success returns a `PyspyDumpAndStoreResponse`:
@@ -262,9 +264,10 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
   string array. Read it before interpreting a stored dump; a native-capture
   fallback is recorded there.
 
-  Error handling follows the same conventions as
-  `GET /v1/pyspy/{proc_reference}`: `not_found` if the target
-  agent is unreachable, `gateway_timeout` on timeout.
+  A failed capture returns `pyspy_failed`, and a missing py-spy binary
+  returns `service_unavailable`. Neither response includes a `dump_id`.
+  An unreachable target returns `not_found`; a bridge timeout returns
+  `gateway_timeout`.
 
   Runs the same native-frame capture as `GET /v1/pyspy`, with the
   same best-effort fallback. See "py-spy: missing native frames".

--- a/hyperactor_mesh/src/testdata/openapi.json
+++ b/hyperactor_mesh/src/testdata/openapi.json
@@ -1188,7 +1188,7 @@
     },
     "/v1/pyspy_dump/{proc_reference}": {
       "post": {
-        "description": "Runs py-spy against the target process, stores the result in the dashboard's DataFusion pyspy tables, and returns the dump_id.",
+        "description": "Runs py-spy against the target process, stores a successful result in the dashboard's DataFusion pyspy tables, and returns the dump_id. Failed captures return an error without a dump_id.",
         "operationId": "pyspyDumpAndStore",
         "parameters": [
           {
@@ -1240,7 +1240,17 @@
                 }
               }
             },
-            "description": "Internal error"
+            "description": "Capture, storage, or internal error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorEnvelope"
+                }
+              }
+            },
+            "description": "py-spy binary unavailable"
           },
           "504": {
             "content": {

--- a/hyperactor_mesh/test/mesh_admin_integration/telemetry.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/telemetry.rs
@@ -20,7 +20,6 @@ use hyperactor_mesh::mesh_admin::ApiErrorEnvelope;
 use hyperactor_mesh::mesh_admin::PyspyDumpAndStoreResponse;
 use hyperactor_mesh::mesh_admin::QueryRequest;
 use hyperactor_mesh::mesh_admin::QueryResponse;
-use hyperactor_mesh::pyspy::PySpyResult;
 
 use crate::harness;
 use crate::harness::WorkloadFixture;
@@ -131,18 +130,11 @@ pub async fn run_pyspy_dump_and_query() {
     let encoded = urlencoding::encode(&proc_ref);
     let pyspy_path = format!("/v1/pyspy_dump/{encoded}");
 
-    let mut dump_id = String::new();
-    let resp = fixture
-        .post(&pyspy_path, &serde_json::json!(null))
+    let result: PyspyDumpAndStoreResponse = fixture
+        .post_json(&pyspy_path, &serde_json::json!(null))
         .await
-        .expect("transport should succeed");
-    if resp.status().is_success() {
-        let body = resp.text().await.unwrap();
-        let result: PyspyDumpAndStoreResponse =
-            serde_json::from_str(&body).expect("should deserialize as PyspyDumpAndStoreResponse");
-        dump_id = result.dump_id;
-    }
-    assert!(!dump_id.is_empty(), "dump_id should be set");
+        .expect("py-spy dump should succeed and be stored");
+    let dump_id = result.dump_id;
 
     // 3. Verify the dump exists in the pyspy_dumps table via SQL.
     let resp: QueryResponse = fixture
@@ -157,23 +149,10 @@ pub async fn run_pyspy_dump_and_query() {
         .await
         .expect("pyspy_dumps query should succeed");
     let rows = resp.rows.as_array().expect("rows should be an array");
-    if rows.is_empty() {
-        // A missing row means either the dump never reached `Ok`, or
-        // the store/query path is broken: `store_pyspy_dump` writes
-        // rows only for `PySpyResult::Ok`, while `/v1/pyspy_dump`
-        // returns a dump_id either way. Re-dump to tell them apart --
-        // `Failed` indicts py-spy, `Ok` points downstream.
-        let observed = fixture
-            .get_json::<PySpyResult>(&format!("/v1/pyspy/{encoded}"))
-            .await;
-        let diagnostic = match &observed {
-            Ok(result) => crate::pyspy::describe_result(result),
-            Err(error) => format!("transport: {error:#}"),
-        };
-        panic!(
-            "expected dump_id '{dump_id}' in pyspy_dumps table; live py-spy dump for {proc_ref}: {diagnostic}"
-        );
-    }
+    assert!(
+        !rows.is_empty(),
+        "expected dump_id '{dump_id}' in pyspy_dumps table"
+    );
     assert_eq!(
         rows[0]["proc_ref"].as_str().unwrap(),
         proc_ref,


### PR DESCRIPTION
Summary:
bug-fix.

`POST /v1/pyspy_dump/{proc_reference}` returned a `dump_id` even when py-spy reported a failed capture or could not find a binary. telemetry storage ignores those results, so callers received an ID for a dump that was never stored.

this diff rejects unsuccessful captures before generating an ID or calling storage. a failed capture returns `pyspy_failed`; a missing binary returns `service_unavailable`. successful captures continue to be stored and returned as before.

the integration test now reports the original capture failure instead of failing later when it queries an ID that cannot exist. unit tests cover failed captures, missing binaries, and successful serialization.

this changes only the dump-and-store endpoint’s failure behavior. the telemetry schema and live `/v1/pyspy` endpoint are unchanged.

Differential Revision: D118816461


