### PR TITLE
Record effective py-spy capture mode (#4822)

### DIFF
--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -217,8 +217,9 @@
 //!   If the first attempt is not found, the fallback attempt is
 //!   required.
 //! - **PS-4 (structured JSON output):** py-spy runs with `--json`;
-//!   output is parsed into `Vec<PySpyStackTrace>`. Parse failure
-//!   maps to `PySpyResult::Failed`.
+//!   output is parsed into `Vec<PySpyStackTrace>`. A successful result's
+//!   `capture_mode` records whether it used `native_all`, `native`, or
+//!   `python_only`. Parse failure maps to `PySpyResult::Failed`.
 //! - **PS-5 (subprocess timeout):** `try_exec` bounds the py-spy
 //!   subprocess inside the worker to `MESH_ADMIN_PYSPY_TIMEOUT`
 //!   (default 10s). The budget is sized for `--native --native-all`
@@ -264,7 +265,7 @@
 //!   the py-spy binary was resolved — PS-3 means the caller cannot
 //!   otherwise tell which one ran. The warning survives failed
 //!   downgraded outer retries and is attached to any eventual
-//!   successful result.
+//!   successful result, whose `capture_mode` is `native`.
 //! - **PS-11d (native-all-failure-passthrough):** If the downgraded
 //!   retry also fails, the failure flows through the normal
 //!   nonblocking retry logic (PS-10) unchanged.
@@ -309,14 +310,13 @@
 //!   does not consume an outer nonblocking retry slot (PS-10) and
 //!   does not incur the 100ms inter-attempt backoff.
 //! - **PS-15c (native-downgrade-warning):** A successful downgraded
-//!   result includes `pyspy::native_downgrade_warning(label)`, so a
-//!   caller can tell a Python-only dump from a full one. It is the
-//!   only signal that native frames are missing, so it names both
-//!   the py-spy that fell short and the remedy: point the
-//!   `PYSPY_BIN` environment variable on the dumped proc at a build
-//!   that can unwind the target. The warning survives failed
-//!   Python-only outer retries and is attached to any eventual
-//!   successful result.
+//!   result has `capture_mode = python_only` and includes
+//!   `pyspy::native_downgrade_warning(label)`. The enum provides a
+//!   queryable capture-mode signal, while the warning names both the
+//!   py-spy that fell short and the remedy: point the `PYSPY_BIN`
+//!   environment variable on the dumped proc at a build that can
+//!   unwind the target. The warning survives failed Python-only outer
+//!   retries and is attached to any eventual successful result.
 //! - **PS-15d (native-sticky-downgrade):** Once native capture has
 //!   failed, `effective_opts.native` and `effective_opts.native_all`
 //!   remain `false` for all subsequent outer retries. Native is not

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -3312,6 +3312,7 @@ mod tests {
     use super::*;
     use crate::host::SERVICE_PROC_NAME;
     use crate::mesh_id::ResourceId;
+    use crate::pyspy::PySpyCaptureMode;
 
     // Integration tests that spawn MeshAdminAgent must pass
     // `Some("[::]:0".parse().unwrap())` as the admin_addr to get an
@@ -3363,6 +3364,7 @@ mod tests {
         let result = PySpyResult::Ok {
             pid: 1234,
             binary: "py-spy".to_string(),
+            capture_mode: PySpyCaptureMode::PythonOnly,
             stack_traces: vec![],
             warnings: vec![],
         };

--- a/hyperactor_mesh/src/mesh_admin_skill.md
+++ b/hyperactor_mesh/src/mesh_admin_skill.md
@@ -119,13 +119,14 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
   target environment and ptrace permissions.
 
   Success returns a `PySpyResult` JSON variant:
-  - `{"Ok": {"pid": N, "binary": "...", "stack_traces": [...], "warnings": [...]}}` — structured stack dump
+  - `{"Ok": {"pid": N, "binary": "...", "capture_mode": "native_all", "stack_traces": [...], "warnings": [...]}}` — structured stack dump
   - `{"BinaryNotFound": {"searched": [...]}}` — py-spy not available
   - `{"Failed": {"pid": N, "binary": "...", "exit_code": N, "stderr": "..."}}` — py-spy error
 
   Native frames are requested server-side and are best-effort: on
-  failure the server retries python-only and still returns `Ok`, so
-  a degraded dump is only distinguishable via `warnings`. See
+  failure the server retries python-only and still returns `Ok`.
+  `capture_mode` records whether the successful attempt used `--native-all`,
+  `--native`, or neither flag. `warnings` explains any fallback. See
   "py-spy: missing native frames".
 
   The endpoint supports worker procs and the service proc. A
@@ -260,9 +261,9 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
   {"sql": "SELECT * FROM pyspy_dumps WHERE dump_id = '550e8400-...'"}
   ```
 
-  `pyspy_dumps.warnings_json` preserves the result's warnings as a JSON
-  string array. Read it before interpreting a stored dump; a native-capture
-  fallback is recorded there.
+  `pyspy_dumps.capture_mode` records the successful py-spy invocation mode as
+  a queryable string. `pyspy_dumps.warnings_json` preserves the result's
+  warnings as a JSON string array with fallback details.
 
   A failed capture returns `pyspy_failed`, and a missing py-spy binary
   returns `service_unavailable`. Neither response includes a `dump_id`.
@@ -277,9 +278,11 @@ Most endpoints are read-only (`GET`). Three endpoints accept `POST`:
 
 ### py-spy: missing native frames
 
-**If every frame in a dump is a `.py` file, read `warnings` before
+**If every frame in a dump is a `.py` file, check `capture_mode` before
 drawing any conclusion about the process.** An all-Python stack is
-ambiguous: it may be the truth, or it may be a degraded capture.
+ambiguous when the successful attempt used a native flag;
+`capture_mode: "python_only"` confirms that it used neither native flag. Read
+`warnings` for the reason.
 
 This matters because a proc blocked in a collective, an allocator, or a
 hyperactor C++ path shows nothing useful in Python-only frames -- one
@@ -288,7 +291,7 @@ opaque call into an extension module, the real state invisible. Reading
 mistake this prevents.
 
 `GET /v1/pyspy` and `POST /v1/pyspy_dump` request native frames
-(`--native --native-all`) server-side, so a healthy dump interleaves
+(`--native --native-all`) server-side, which can make a dump interleave
 interpreter and extension frames with the Python ones:
 
 ```
@@ -301,13 +304,16 @@ task_step_impl       _asyncio.cpython-312-x86_64-linux-gnu.so:0
 
 For stack dumps, native capture is best-effort: on failure the server
 retries python-only rather than erroring, so you get `200`, an `Ok`
-result, and no error anywhere. `warnings` is the only signal:
+result, and no error anywhere. Check `capture_mode` first;
+`python_only` definitively identifies an attempt that used neither native
+flag. `warnings` explains why:
 
 - `native capture failed; fell back to python-only frames. py-spy
   (<resolution>) could not unwind native frames …` — Python-only. Do not
   treat the stack as complete.
 - `--native-all unsupported by py-spy (<resolution>); fell back to
-  --native` — native frames are present; the stack is usable.
+  --native` — the successful attempt used `--native`. Inspect the returned
+  frames to determine whether native frames appeared.
 
 `<resolution>` is how py-spy was found: `PYSPY_BIN=/path` if set, else
 `py-spy on PATH`. A `PYSPY_BIN=…` prefix means the variable is already

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -27,6 +27,27 @@ use crate::config::PYSPY_BIN;
 
 const SUBPROCESS_REAP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
+/// py-spy mode used by the successful stack-dump attempt.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema
+)]
+#[serde(rename_all = "snake_case")]
+pub enum PySpyCaptureMode {
+    /// The successful attempt used neither `--native` nor `--native-all`.
+    PythonOnly,
+    /// The successful attempt used `--native` but not `--native-all`.
+    Native,
+    /// The successful attempt used `--native-all`.
+    NativeAll,
+}
+
 /// Result of a py-spy stack dump request.
 ///
 /// See PS-2, PS-4 in `introspect` module doc.
@@ -46,6 +67,8 @@ pub enum PySpyResult {
         pid: u32,
         /// Path or name of the py-spy binary that produced the dump.
         binary: String,
+        /// Invocation mode used for the successful attempt.
+        capture_mode: PySpyCaptureMode,
         /// Per-thread stack traces from py-spy.
         stack_traces: Vec<PySpyStackTrace>,
         /// Non-fatal warnings from the capture (e.g., flag
@@ -136,6 +159,18 @@ pub struct PySpyOpts {
     /// Use nonblocking mode — py-spy reads without pausing the
     /// target process (`--nonblocking`). Enables retry logic (PS-10).
     pub nonblocking: bool,
+}
+
+impl From<&PySpyOpts> for PySpyCaptureMode {
+    fn from(opts: &PySpyOpts) -> Self {
+        if opts.native_all {
+            Self::NativeAll
+        } else if opts.native {
+            Self::Native
+        } else {
+            Self::PythonOnly
+        }
+    }
 }
 
 /// Public JSON-facing options for a py-spy profile capture.
@@ -737,12 +772,18 @@ async fn kill_and_reap(subprocess: &mut GuardedSubprocess) -> Option<String> {
 /// Map a process::Output to a PySpyResult, parsing the `--json`
 /// output into structured `PySpyStackTrace` values.
 /// See PS-2, PS-4 in `introspect` module doc.
-fn map_output(output: std::process::Output, pid: u32, binary: &str) -> PySpyResult {
+fn map_output(
+    output: std::process::Output,
+    pid: u32,
+    binary: &str,
+    capture_mode: PySpyCaptureMode,
+) -> PySpyResult {
     if output.status.success() {
         match serde_json::from_slice::<Vec<PySpyStackTrace>>(&output.stdout) {
             Ok(stack_traces) => PySpyResult::Ok {
                 pid,
                 binary: binary.to_string(),
+                capture_mode,
                 stack_traces,
                 warnings: vec![],
             },
@@ -788,10 +829,10 @@ fn native_all_downgrade_warning(label: &str) -> String {
 }
 
 /// The warning attached to a result that fell back to Python-only
-/// frames after native capture failed (PS-15c). This is the only
-/// signal an operator gets that native frames are missing, so it
-/// names the candidate that fell short -- by resolution label, so a
-/// `PYSPY_BIN` that is already set is visible -- and the remedy.
+/// frames after native capture failed (PS-15c). The result's
+/// `capture_mode` field identifies the mode; this message names the
+/// candidate that fell short -- by resolution label, so a `PYSPY_BIN`
+/// that is already set is visible -- and the remedy.
 fn native_downgrade_warning(label: &str) -> String {
     format!(
         "native capture failed; fell back to python-only frames. py-spy ({label}) could not \
@@ -806,6 +847,13 @@ enum ExecOnce {
     Result(PySpyResult),
     /// The binary was not found (NotFound from spawn).
     NotFound,
+}
+
+#[derive(Clone, Copy)]
+struct DumpAttempt<'a> {
+    pid: u32,
+    binary: &'a str,
+    capture_mode: PySpyCaptureMode,
 }
 
 /// Spawn the py-spy binary once, collect output, and return the
@@ -840,7 +888,12 @@ async fn exec_once(
             });
         }
     };
-    ExecOnce::Result(collect_with_timeout(subprocess, pid, binary, remaining).await)
+    let attempt = DumpAttempt {
+        pid,
+        binary,
+        capture_mode: PySpyCaptureMode::from(opts),
+    };
+    ExecOnce::Result(collect_with_timeout(subprocess, attempt, remaining).await)
 }
 
 /// Try to execute py-spy with the given binary path. Returns `None`
@@ -948,8 +1001,7 @@ async fn try_exec(
 /// See PS-5 in `introspect` module doc.
 async fn collect_with_timeout(
     mut subprocess: GuardedSubprocess,
-    pid: u32,
-    binary: &str,
+    attempt: DumpAttempt<'_>,
     timeout: std::time::Duration,
 ) -> PySpyResult {
     // `subprocess` already owns its guard before this future is created. If a
@@ -985,13 +1037,13 @@ async fn collect_with_timeout(
                 stdout: stdout_bytes,
                 stderr: stderr_bytes,
             };
-            map_output(output, pid, binary)
+            map_output(output, attempt.pid, attempt.binary, attempt.capture_mode)
         }
         Ok(Err(e)) => {
             let cleanup = kill_and_reap(&mut subprocess).await;
             PySpyResult::Failed {
-                pid,
-                binary: binary.to_string(),
+                pid: attempt.pid,
+                binary: attempt.binary.to_string(),
                 exit_code: None,
                 stderr: match cleanup {
                     Some(cleanup) => format!("failed to wait for child: {e}; {cleanup}"),
@@ -1002,8 +1054,8 @@ async fn collect_with_timeout(
         Err(_) => {
             let cleanup = kill_and_reap(&mut subprocess).await;
             PySpyResult::Failed {
-                pid,
-                binary: binary.to_string(),
+                pid: attempt.pid,
+                binary: attempt.binary.to_string(),
                 exit_code: None,
                 stderr: match cleanup {
                     Some(cleanup) => format!(
@@ -1219,6 +1271,7 @@ mod tests {
         let original = PySpyResult::Ok {
             pid: 42,
             binary: "py-spy".to_string(),
+            capture_mode: PySpyCaptureMode::Native,
             stack_traces: vec![PySpyStackTrace {
                 pid: 42,
                 thread_id: 1,
@@ -1324,16 +1377,18 @@ mod tests {
             stdout: serde_json::to_vec(&json).unwrap(),
             stderr: vec![],
         };
-        let result = map_output(output, 42, "/usr/bin/py-spy");
+        let result = map_output(output, 42, "/usr/bin/py-spy", PySpyCaptureMode::Native);
         match result {
             PySpyResult::Ok {
                 pid,
                 binary,
+                capture_mode,
                 stack_traces,
                 ..
             } => {
                 assert_eq!(pid, 42);
                 assert_eq!(binary, "/usr/bin/py-spy");
+                assert_eq!(capture_mode, PySpyCaptureMode::Native);
                 assert_eq!(stack_traces.len(), 1);
                 assert_eq!(stack_traces[0].thread_id, 1234);
                 assert_eq!(stack_traces[0].thread_name.as_deref(), Some("MainThread"));
@@ -1355,7 +1410,7 @@ mod tests {
             stdout: b"not valid json".to_vec(),
             stderr: vec![],
         };
-        let result = map_output(output, 42, "py-spy");
+        let result = map_output(output, 42, "py-spy", PySpyCaptureMode::PythonOnly);
         match result {
             PySpyResult::Failed { pid, stderr, .. } => {
                 assert_eq!(pid, 42);
@@ -1377,7 +1432,7 @@ mod tests {
             stdout: vec![],
             stderr: b"Permission denied".to_vec(),
         };
-        let result = map_output(output, 99, "py-spy");
+        let result = map_output(output, 99, "py-spy", PySpyCaptureMode::PythonOnly);
         match result {
             PySpyResult::Failed {
                 pid,
@@ -1403,7 +1458,7 @@ mod tests {
             stdout: serde_json::to_vec(&json).unwrap(),
             stderr: vec![],
         };
-        let result = map_output(output, 12345, "bin");
+        let result = map_output(output, 12345, "bin", PySpyCaptureMode::PythonOnly);
         match result {
             PySpyResult::Ok { pid, .. } => assert_eq!(pid, 12345),
             other => panic!("expected Ok, got {:?}", other),
@@ -1417,6 +1472,19 @@ mod tests {
             native_all: false,
             nonblocking: false,
         }
+    }
+
+    #[test]
+    fn capture_mode_matches_effective_options() {
+        let mut opts = default_opts();
+        assert_eq!(PySpyCaptureMode::from(&opts), PySpyCaptureMode::PythonOnly);
+
+        opts.native = true;
+        assert_eq!(PySpyCaptureMode::from(&opts), PySpyCaptureMode::Native);
+
+        opts.native = false;
+        opts.native_all = true;
+        assert_eq!(PySpyCaptureMode::from(&opts), PySpyCaptureMode::NativeAll);
     }
 
     #[tokio::test]
@@ -1477,7 +1545,15 @@ mod tests {
 
         let result = tokio::time::timeout(
             Duration::from_secs(2),
-            collect_with_timeout(child, target_pid, "sh", Duration::from_millis(200)),
+            collect_with_timeout(
+                child,
+                DumpAttempt {
+                    pid: target_pid,
+                    binary: "sh",
+                    capture_mode: PySpyCaptureMode::PythonOnly,
+                },
+                Duration::from_millis(200),
+            ),
         )
         .await
         .expect("timeout cleanup must itself be bounded");
@@ -1522,8 +1598,11 @@ mod tests {
 
         let task = tokio::spawn(collect_with_timeout(
             child,
-            std::process::id(),
-            "sh",
+            DumpAttempt {
+                pid: std::process::id(),
+                binary: "sh",
+                capture_mode: PySpyCaptureMode::PythonOnly,
+            },
             Duration::from_secs(30),
         ));
         task.abort();
@@ -1659,7 +1738,12 @@ exit 0
         // Must succeed with the downgraded result.
         let result = result.expect("expected Some");
         match &result {
-            PySpyResult::Ok { warnings, .. } => {
+            PySpyResult::Ok {
+                capture_mode,
+                warnings,
+                ..
+            } => {
+                assert_eq!(*capture_mode, PySpyCaptureMode::Native);
                 let expected = native_all_downgrade_warning(&label);
                 assert!(
                     warnings.contains(&expected),
@@ -1724,7 +1808,13 @@ exit 0
         )
         .await
         .expect("expected Some");
-        assert!(matches!(result, PySpyResult::Ok { .. }));
+        assert!(matches!(
+            result,
+            PySpyResult::Ok {
+                capture_mode: PySpyCaptureMode::Native,
+                ..
+            }
+        ));
 
         let log = read_log(&script);
         assert_eq!(log.len(), 2, "expected one native-all downgrade");
@@ -1853,13 +1943,20 @@ exit 0
         .expect("expected Some");
 
         match result {
-            PySpyResult::Ok { warnings, .. } => assert_eq!(
+            PySpyResult::Ok {
+                capture_mode,
                 warnings,
-                vec![
-                    native_all_downgrade_warning(&label),
-                    native_downgrade_warning(&label),
-                ]
-            ),
+                ..
+            } => {
+                assert_eq!(capture_mode, PySpyCaptureMode::PythonOnly);
+                assert_eq!(
+                    warnings,
+                    vec![
+                        native_all_downgrade_warning(&label),
+                        native_downgrade_warning(&label),
+                    ]
+                );
+            }
             other => panic!("expected Ok, got: {other:?}"),
         }
 
@@ -1910,7 +2007,12 @@ exit 0
         .await;
         let result = result.expect("expected Some");
         match &result {
-            PySpyResult::Ok { warnings, .. } => {
+            PySpyResult::Ok {
+                capture_mode,
+                warnings,
+                ..
+            } => {
+                assert_eq!(*capture_mode, PySpyCaptureMode::PythonOnly);
                 let expected = native_downgrade_warning(&label);
                 assert!(
                     warnings.contains(&expected),
@@ -2024,7 +2126,12 @@ exit 0
         .await
         .expect("expected Some");
         match result {
-            PySpyResult::Ok { warnings, .. } => {
+            PySpyResult::Ok {
+                capture_mode,
+                warnings,
+                ..
+            } => {
+                assert_eq!(capture_mode, PySpyCaptureMode::PythonOnly);
                 assert_eq!(warnings, vec![native_downgrade_warning(&label)]);
             }
             other => panic!("expected Ok, got: {other:?}"),

--- a/hyperactor_mesh/src/testdata/openapi.json
+++ b/hyperactor_mesh/src/testdata/openapi.json
@@ -656,6 +656,26 @@
         },
         "type": "object"
       },
+      "PySpyCaptureMode": {
+        "description": "py-spy mode used by the successful stack-dump attempt.",
+        "oneOf": [
+          {
+            "const": "python_only",
+            "description": "The successful attempt used neither `--native` nor `--native-all`.",
+            "type": "string"
+          },
+          {
+            "const": "native",
+            "description": "The successful attempt used `--native` but not `--native-all`.",
+            "type": "string"
+          },
+          {
+            "const": "native_all",
+            "description": "The successful attempt used `--native-all`.",
+            "type": "string"
+          }
+        ]
+      },
       "PySpyFrame": {
         "description": "A single frame in a py-spy stack trace.",
         "properties": {
@@ -793,6 +813,10 @@
                     "description": "Path or name of the py-spy binary that produced the dump.",
                     "type": "string"
                   },
+                  "capture_mode": {
+                    "$ref": "#/components/schemas/PySpyCaptureMode",
+                    "description": "Invocation mode used for the successful attempt."
+                  },
                   "pid": {
                     "description": "OS process ID that was dumped.",
                     "format": "uint32",
@@ -817,6 +841,7 @@
                 "required": [
                   "pid",
                   "binary",
+                  "capture_mode",
                   "stack_traces",
                   "warnings"
                 ],

--- a/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/pyspy.rs
@@ -20,6 +20,7 @@ use anyhow::Result;
 use anyhow::bail;
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::mesh_admin::ApiErrorEnvelope;
+use hyperactor_mesh::pyspy::PySpyCaptureMode;
 use hyperactor_mesh::pyspy::PySpyFrame;
 use hyperactor_mesh::pyspy::PySpyProfileOpts;
 use hyperactor_mesh::pyspy::PySpyResult;
@@ -394,7 +395,11 @@ fn truncate_diagnostic(value: String) -> String {
 /// Render a bounded result summary without including the stack payload.
 pub(crate) fn describe_result(result: &PySpyResult) -> String {
     let summary = match result {
-        PySpyResult::Ok { warnings, .. } => format!("Ok(warnings={warnings:?})"),
+        PySpyResult::Ok {
+            capture_mode,
+            warnings,
+            ..
+        } => format!("Ok(capture_mode={capture_mode:?}, warnings={warnings:?})"),
         PySpyResult::BinaryNotFound { searched } => {
             format!("BinaryNotFound(searched: {})", searched.join(", "))
         }
@@ -530,6 +535,7 @@ fn describe_result_omits_stack_payload() {
     let result = PySpyResult::Ok {
         pid: 1,
         binary: "py-spy".to_string(),
+        capture_mode: PySpyCaptureMode::PythonOnly,
         stack_traces: vec![PySpyStackTrace {
             pid: 1,
             thread_id: 2,
@@ -551,7 +557,10 @@ fn describe_result_omits_stack_payload() {
     };
 
     let description = describe_result(&result);
-    assert_eq!(description, "Ok(warnings=[\"python-only\"])");
+    assert_eq!(
+        description,
+        "Ok(capture_mode=PythonOnly, warnings=[\"python-only\"])"
+    );
     assert!(!description.contains("payload-frame"));
 }
 

--- a/hyperactor_mesh/test/mesh_admin_integration/telemetry.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/telemetry.rs
@@ -142,7 +142,7 @@ pub async fn run_pyspy_dump_and_query() {
             "/v1/query",
             &QueryRequest {
                 sql: format!(
-                    "SELECT dump_id, proc_ref, warnings_json FROM pyspy_dumps WHERE dump_id = '{dump_id}'"
+                    "SELECT dump_id, proc_ref, capture_mode, warnings_json FROM pyspy_dumps WHERE dump_id = '{dump_id}'"
                 ),
             },
         )
@@ -157,6 +157,13 @@ pub async fn run_pyspy_dump_and_query() {
         rows[0]["proc_ref"].as_str().unwrap(),
         proc_ref,
         "proc_ref should match the queried proc"
+    );
+    assert!(
+        matches!(
+            rows[0]["capture_mode"].as_str(),
+            Some("python_only" | "native" | "native_all")
+        ),
+        "capture_mode should be directly queryable"
     );
     let warnings_json = rows[0]["warnings_json"]
         .as_str()

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -876,6 +876,13 @@ impl DatabaseScanner {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
+        let capture_mode = ok
+            .get("capture_mode")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| anyhow::anyhow!("missing py-spy capture_mode"))?;
+        if !matches!(capture_mode, "python_only" | "native" | "native_all") {
+            anyhow::bail!("invalid py-spy capture_mode: {capture_mode}");
+        }
         let warnings = ok
             .get("warnings")
             .and_then(|value| value.as_array())
@@ -894,6 +901,7 @@ impl DatabaseScanner {
             pid,
             binary,
             proc_ref: proc_ref.to_string(),
+            capture_mode: capture_mode.to_string(),
             warnings_json,
         });
         Self::push_batch_to_tables(
@@ -1836,6 +1844,7 @@ mod tests {
         let json = r#"{
             "Ok": {
                 "pid": 1234, "binary": "python3",
+                "capture_mode": "native",
                 "stack_traces": [{
                     "pid": 1234, "thread_id": 100,
                     "thread_name": "MainThread", "os_thread_id": 5678,
@@ -1852,7 +1861,7 @@ mod tests {
                          ], "is_entry": true}
                     ]
                 }],
-                "warnings": ["native capture failed; fell back to python-only frames"]
+                "warnings": ["--native-all unsupported; fell back to --native"]
             }
         }"#;
 
@@ -1890,6 +1899,12 @@ mod tests {
             .as_any()
             .downcast_ref::<StringArray>()
             .unwrap();
+        let capture_modes = batch
+            .column_by_name("capture_mode")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         let warnings_json = batch
             .column_by_name("warnings_json")
             .unwrap()
@@ -1900,9 +1915,10 @@ mod tests {
         assert_eq!(pids.value(0), 1234);
         assert_eq!(binaries.value(0), "python3");
         assert_eq!(proc_refs.value(0), "proc[0]");
+        assert_eq!(capture_modes.value(0), "native");
         assert_eq!(
             warnings_json.value(0),
-            r#"["native capture failed; fell back to python-only frames"]"#
+            r#"["--native-all unsupported; fell back to --native"]"#
         );
 
         // Verify pyspy_stack_traces content
@@ -2088,12 +2104,22 @@ mod tests {
     }
 
     #[test]
+    fn test_store_pyspy_dump_invalid_capture_mode_errors() {
+        let scanner = test_scanner(0);
+        let json = r#"{"Ok": {"capture_mode": "unknown"}}"#;
+
+        assert!(scanner.store_pyspy_dump("x", "p", json).is_err());
+        assert_eq!(table_row_count(&scanner, "pyspy_dumps"), 0);
+    }
+
+    #[test]
     fn test_store_pyspy_dump_multiple_threads() {
         let scanner = test_scanner(0);
 
         let json = r#"{
             "Ok": {
                 "pid": 1, "binary": "python3",
+                "capture_mode": "python_only",
                 "stack_traces": [
                     {"pid": 1, "thread_id": 1, "thread_name": "Main", "os_thread_id": 10,
                      "active": true, "owns_gil": true,

--- a/monarch_distributed_telemetry/src/pyspy_table.rs
+++ b/monarch_distributed_telemetry/src/pyspy_table.rs
@@ -29,6 +29,9 @@ pub struct PySpyDump {
     pub pid: i32,
     pub binary: String,
     pub proc_ref: String,
+    /// Successful py-spy invocation mode: `python_only`, `native`, or
+    /// `native_all`.
+    pub capture_mode: String,
     /// JSON array of non-fatal capture warnings. An empty array means the dump
     /// completed without a reported fallback.
     pub warnings_json: String,

--- a/python/benches/telemetry_query_benchmark/pyspy_fixture.py
+++ b/python/benches/telemetry_query_benchmark/pyspy_fixture.py
@@ -49,6 +49,7 @@ def make_dump(shape: DatasetShape) -> str:
     """Build one compact PySpy JSON payload."""
     payload = {
         "Ok": {
+            "capture_mode": "python_only",
             "stack_traces": [
                 _make_trace(shape, thread_index)
                 for thread_index in range(shape.threads_per_dump)

--- a/python/monarch/monarch_dashboard/frontend/src/components/hierarchy/PySpyPanel.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/hierarchy/PySpyPanel.tsx
@@ -29,7 +29,15 @@ interface PySpyThread {
   frames: PySpyFrame[];
 }
 type PySpyResult =
-  | { Ok: { pid: number; binary: string; stack_traces: PySpyThread[]; warnings: string[] } }
+  | {
+      Ok: {
+        pid: number;
+        binary: string;
+        capture_mode: "python_only" | "native" | "native_all";
+        stack_traces: PySpyThread[];
+        warnings: string[];
+      };
+    }
   | { BinaryNotFound: { searched: string[] } }
   | { Failed: { pid: number; binary: string; exit_code?: number | null; stderr: string } };
 

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -207,6 +207,7 @@ def _sample_pyspy_dump_json() -> str:
             "Ok": {
                 "pid": 1234,
                 "binary": "python3",
+                "capture_mode": "native",
                 "stack_traces": [
                     {
                         "pid": 1234,
@@ -2139,6 +2140,7 @@ def test_store_pyspy_dump_and_query() -> None:
                 "Ok": {
                     "pid": 1234,
                     "binary": "python3",
+                    "capture_mode": "python_only",
                     "stack_traces": [
                         {
                             "pid": 1234,
@@ -2195,6 +2197,13 @@ def test_store_pyspy_dump_and_query() -> None:
         )
 
         _store_pyspy_dump(state, "dump-1", "proc[0]", pyspy_json)
+
+        dump = _query(
+            state,
+            "SELECT capture_mode FROM pyspy_dumps "
+            "WHERE dump_id = 'dump-1' AND capture_mode = 'python_only'",
+        )
+        assert dump["capture_mode"] == ["python_only"]
 
         result_dict = _query(
             state,
@@ -2277,6 +2286,7 @@ def test_store_pyspy_dump_with_child_proc_ref() -> None:
                 "Ok": {
                     "pid": 9999,
                     "binary": "python3",
+                    "capture_mode": "native_all",
                     "stack_traces": [
                         {
                             "pid": 9999,
@@ -2345,6 +2355,7 @@ def test_store_pyspy_dump_with_unknown_proc_ref() -> None:
                 "Ok": {
                     "pid": 7777,
                     "binary": "python3",
+                    "capture_mode": "python_only",
                     "stack_traces": [
                         {
                             "pid": 7777,


### PR DESCRIPTION
Summary:

Follow up D118522403 by recording the effective capture mode for successful py-spy dumps. Represent the result as a typed `PySpyCaptureMode` (`python_only`, `native`, or `native_all`) so callers can distinguish native-all downgrades and Python-only fallbacks without decoding warning strings.

Persist the validated mode in `pyspy_dumps`, expose it through the OpenAPI and dashboard types, and update telemetry documentation and fixtures.

Reviewed By: shayne-fletcher

Differential Revision: D118874553


