### PR TITLE
characterize host and process mesh startup (#4825)

### DIFF
--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -17,6 +17,7 @@ import tempfile
 import textwrap
 import threading
 import time
+import weakref
 from contextlib import ExitStack
 from typing import Dict, List, Optional, Set
 from unittest.mock import patch
@@ -24,15 +25,22 @@ from unittest.mock import patch
 import cloudpickle
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import BootstrapCommand
 from monarch._rust_bindings.monarch_hyperactor.proc import ProcId, Uid
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Point, Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, attach, context
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.host_mesh import HostMesh, this_host, this_proc
+from monarch._src.actor.future import Future
+from monarch._src.actor.host_mesh import (
+    default_bootstrap_cmd,
+    HostMesh,
+    this_host,
+    this_proc,
+)
 from monarch._src.actor.pickle import flatten, unflatten
-from monarch._src.actor.proc_mesh import get_or_spawn_controller
+from monarch._src.actor.proc_mesh import _get_bootstrap_args, get_or_spawn_controller
 from monarch._src.job.job import ProcessState
 from monarch._src.job.process import ProcessJob
 from monarch._src.job.service_identity import new_service_proc_id, service_proc_addr
@@ -166,6 +174,63 @@ def is_process_running(pid: int) -> bool:
         return False
 
 
+def _wait_for_marker(path: pathlib.Path) -> None:
+    # Stress runs start several isolated ProcessJobs at once, so reaching the
+    # bootstrap wrapper can take longer than a focused run.
+    deadline = time.monotonic() + 30
+    while not path.exists():
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"timed out waiting for marker {path}")
+        time.sleep(0.01)
+
+
+def _gated_bootstrap_command(
+    directory: pathlib.Path,
+) -> tuple[BootstrapCommand, pathlib.Path, pathlib.Path]:
+    entered = directory / "bootstrap-entered"
+    release = directory / "bootstrap-release"
+    wrapper = directory / "gated-bootstrap.py"
+    wrapper.write_text(
+        textwrap.dedent(
+            """\
+            import os
+            import pathlib
+            import sys
+            import time
+
+            entered, release, program, arg0, *args = sys.argv[1:]
+            pathlib.Path(entered).touch()
+            deadline = time.monotonic() + 30
+            while not pathlib.Path(release).exists():
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("bootstrap release marker was not published")
+                time.sleep(0.01)
+            os.execvpe(program, [arg0, *args], os.environ)
+            """
+        )
+    )
+
+    base = default_bootstrap_cmd()
+    # BootstrapCommand's Rust binding exposes every field, but its stub declares
+    # only env. Read the argv from the helper used by default_bootstrap_cmd so
+    # this fixture follows the real default without widening the production stub.
+    original_program, original_args, _ = _get_bootstrap_args()
+    command = BootstrapCommand(
+        sys.executable,
+        None,
+        [
+            str(wrapper),
+            str(entered),
+            str(release),
+            original_program,
+            original_program,
+            *(original_args or []),
+        ],
+        dict(base.env),
+    )
+    return command, entered, release
+
+
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 def test_shutdown_host_mesh() -> None:
@@ -197,6 +262,122 @@ def test_shutdown_immediately_after_proc_spawn_without_actor() -> None:
             match="HostMesh has already been shut down",
         ):
             hm.spawn_procs()
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+def test_shutdown_waits_for_a_pending_proc_spawn_after_caller_drops_mesh() -> None:
+    with tempfile.TemporaryDirectory(prefix="monarch_spawn_gate_") as directory:
+        command, entered, release = _gated_bootstrap_command(pathlib.Path(directory))
+        with ExitStack() as cleanup:
+            job = ProcessJob({"hosts": 1})
+            cleanup.callback(job.kill)
+            cleanup.callback(release.touch)
+            hm = job.state(cached_path=None).hosts
+            proc_mesh = hm.spawn_procs(
+                name="pending_proc",
+                bootstrap_command=command,
+            )
+            # HostMesh retains the raw native spawn in _pending_spawns and the
+            # ProcMesh retains a second Shared that performs logging and setup.
+            # Keep witnesses for both before discarding the caller's ProcMesh.
+            spawn = hm._pending_spawns[-1]
+            proc_initialization = proc_mesh._proc_mesh
+            retained_proc_mesh = weakref.ref(proc_mesh)
+            del proc_mesh
+            assert retained_proc_mesh() is hm._proc_meshes[-1]
+            _wait_for_marker(entered)
+
+            flush_entered = threading.Event()
+            flush_exited = threading.Event()
+            release_shutdown = threading.Event()
+            cleanup.callback(release_shutdown.set)
+            flush_pending_spawns = hm._flush_pending_spawns
+
+            async def record_flush_entry() -> None:
+                flush_entered.set()
+                await flush_pending_spawns()
+                flush_exited.set()
+                released = await PythonTask.spawn_blocking(
+                    lambda: release_shutdown.wait(timeout=30)
+                )
+                if not released:
+                    raise TimeoutError("native shutdown release was not published")
+
+            with patch.object(hm, "_flush_pending_spawns", record_flush_entry):
+                shutdown = hm.shutdown()
+                shutdown_results: list[None] = []
+                shutdown_errors: list[Exception] = []
+                shutdown_done = threading.Event()
+
+                def drive_shutdown() -> None:
+                    try:
+                        shutdown_results.append(shutdown.get(timeout=45))
+                    except Exception as error:
+                        shutdown_errors.append(error)
+                    finally:
+                        shutdown_done.set()
+
+                shutdown_thread = threading.Thread(
+                    target=drive_shutdown,
+                    daemon=True,
+                    name="drive-host-mesh-shutdown",
+                )
+                shutdown_thread.start()
+                try:
+                    # Start shutdown on another thread so entry into the flush,
+                    # rather than thread scheduling, is the synchronization
+                    # point for proving that the pending spawn blocks it.
+                    assert flush_entered.wait(timeout=10)
+                    assert spawn.poll() is None
+                    assert proc_initialization.poll() is None
+                    assert not flush_exited.is_set()
+                    assert not shutdown_done.is_set()
+
+                    release.touch()
+                    completion_deadline = time.monotonic() + 30
+                    while spawn.poll() is None:
+                        if time.monotonic() >= completion_deadline:
+                            raise AssertionError(
+                                "proc spawn did not complete after bootstrap release"
+                            )
+                        time.sleep(0.01)
+                    assert flush_exited.wait(
+                        timeout=max(0.0, completion_deadline - time.monotonic())
+                    )
+                    proc_initialization_value = proc_initialization.poll()
+                    while proc_initialization_value is None:
+                        if time.monotonic() >= completion_deadline:
+                            raise AssertionError(
+                                "proc initialization did not complete after bootstrap release"
+                            )
+                        time.sleep(0.01)
+                        proc_initialization_value = proc_initialization.poll()
+                    release_shutdown.set()
+                    assert shutdown_done.wait(timeout=15)
+                finally:
+                    release.touch()
+                    release_shutdown.set()
+                    try:
+                        if shutdown_thread.is_alive():
+                            job.kill()
+                    finally:
+                        shutdown_thread.join(timeout=10)
+
+                assert not shutdown_thread.is_alive()
+                assert flush_exited.is_set()
+                assert shutdown_errors == []
+                assert shutdown_results == [None]
+
+            assert spawn.poll() is not None
+            assert proc_initialization_value is not None
+            assert hm._pending_spawns == []
+            assert hm._inner_host_mesh is None
+            with pytest.raises(
+                RuntimeError,
+                match="HostMesh has already been shut down",
+            ):
+                hm.spawn_procs()
 
 
 @pytest.mark.timeout(60)
@@ -303,6 +484,52 @@ def test_attach_to_workers_accepts_future_addresses() -> None:
         for proc in procs:
             proc.kill()
             proc.wait()
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_attach_starts_before_readiness_observation_and_survives_a_dropped_observer() -> (
+    None
+):
+    address_started = threading.Event()
+    release_address = threading.Event()
+
+    async def resolve_address() -> str:
+        address_started.set()
+        released = await PythonTask.spawn_blocking(
+            lambda: release_address.wait(timeout=30)
+        )
+        if not released:
+            raise TimeoutError("worker address release was not published")
+        return addr
+
+    with ExitStack() as cleanup:
+        job = ProcessJob({"hosts": 1})
+        job.apply()
+        cleanup.callback(job.kill)
+        cleanup.callback(release_address.set)
+        addr = job._host_to_pid["hosts_0"].channel
+        address: Future[str] = Future._from_coro(resolve_address())
+
+        hosts = attach_to_workers(
+            ca="trust_all_connections",
+            workers=[address],
+        )
+
+        with pytest.raises(ValueError) as consumed:
+            address.get()
+        assert str(consumed.value) == "Future was consumed."
+        assert address_started.wait(timeout=10)
+
+        discarded = hosts.initialized
+        with pytest.raises(TimeoutError):
+            discarded.get(timeout=0.25)
+        del discarded
+        release_address.set()
+
+        assert hosts.initialized.get(timeout=30) is True
+        assert hosts.initialized.get(timeout=30) is True
+        assert hosts.shutdown().get(timeout=30) is None
 
 
 @pytest.mark.timeout(60)

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -9,9 +9,12 @@
 from __future__ import annotations
 
 import os
+import pathlib
+import tempfile
 import threading
 import time
 from contextlib import ExitStack
+from functools import partial
 from typing import cast
 from unittest.mock import patch
 
@@ -52,6 +55,32 @@ def _successful_bootstrap() -> None:
 
 def _fail_bootstrap() -> None:
     raise RuntimeError(_BOOTSTRAP_FAILURE)
+
+
+def _gated_bootstrap(
+    entered_path: str,
+    release_path: str,
+    failure: str | None,
+) -> None:
+    pathlib.Path(entered_path).touch()
+    release = pathlib.Path(release_path)
+    deadline = time.monotonic() + 30
+    while not release.exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("proc bootstrap release was not published")
+        time.sleep(0.01)
+    if failure is not None:
+        raise RuntimeError(failure)
+
+
+def _wait_for_marker(path: pathlib.Path) -> None:
+    # The full target launches many isolated ProcessJobs concurrently, so
+    # reaching the remote setup callback can take longer than a focused run.
+    deadline = time.monotonic() + 30
+    while not path.exists():
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"timed out waiting for marker {path}")
+        time.sleep(0.01)
 
 
 class _PendingActorProbe:
@@ -130,6 +159,77 @@ async def test_proc_mesh_initialized_fails_when_bootstrap_fails() -> None:
         proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
         with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
             await proc_mesh.initialized
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+def test_proc_mesh_readiness_replays_success_after_discarded_observer() -> None:
+    with tempfile.TemporaryDirectory(prefix="monarch_proc_ready_") as directory:
+        entered = pathlib.Path(directory) / "entered"
+        release = pathlib.Path(directory) / "release"
+        with ExitStack() as cleanup:
+            state = cleanup.enter_context(
+                scoped_state(ProcessJob({"hosts": 1}), cached_path=None)
+            )
+            cleanup.callback(release.touch)
+            proc_mesh = state.hosts.spawn_procs(
+                name="test_proc",
+                bootstrap=partial(
+                    _gated_bootstrap,
+                    str(entered),
+                    str(release),
+                    None,
+                ),
+            )
+            _wait_for_marker(entered)
+
+            discarded = proc_mesh.initialized
+            with pytest.raises(TimeoutError):
+                discarded.get(timeout=0.25)
+            del discarded
+            release.touch()
+
+            assert proc_mesh.initialized.get(timeout=30) is True
+            assert proc_mesh.initialized.get(timeout=30) is True
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+def test_proc_mesh_readiness_replays_failure_after_discarded_observer() -> None:
+    with tempfile.TemporaryDirectory(prefix="monarch_proc_ready_") as directory:
+        entered = pathlib.Path(directory) / "entered"
+        release = pathlib.Path(directory) / "release"
+        with ExitStack() as cleanup:
+            state = cleanup.enter_context(
+                scoped_state(ProcessJob({"hosts": 1}), cached_path=None)
+            )
+            cleanup.callback(release.touch)
+            proc_mesh = state.hosts.spawn_procs(
+                bootstrap=partial(
+                    _gated_bootstrap,
+                    str(entered),
+                    str(release),
+                    _BOOTSTRAP_FAILURE,
+                )
+            )
+            _wait_for_marker(entered)
+
+            discarded = proc_mesh.initialized
+            with pytest.raises(TimeoutError):
+                discarded.get(timeout=0.25)
+            del discarded
+            release.touch()
+
+            errors = []
+            for _ in range(2):
+                with pytest.raises(monarch.actor.ActorError) as excinfo:
+                    proc_mesh.initialized.get(timeout=30)
+                errors.append(excinfo.value)
+
+            assert type(errors[0]) is monarch.actor.ActorError
+            assert type(errors[1]) is monarch.actor.ActorError
+            assert str(errors[0]) == str(errors[1])
+            assert _BOOTSTRAP_FAILURE in str(errors[0])
 
 
 @pytest.mark.timeout(60)

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1555,6 +1555,28 @@ def test_attach_fails_closed_on_unreachable_host():
             )
 
 
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_attach_failure_replays_to_fresh_readiness_observers() -> None:
+    with configured(mesh_attach_config_timeout="500ms"):
+        with TemporaryDirectory() as directory:
+            unreachable = f"ipc://{directory}/never_bound"
+            hosts = attach_to_workers(ca="trust_all_connections", workers=[unreachable])
+
+            errors = []
+            for _ in range(2):
+                with pytest.raises(RuntimeError) as excinfo:
+                    hosts.initialized.get(timeout=10)
+                errors.append(excinfo.value)
+
+            assert type(errors[0]) is RuntimeError
+            assert type(errors[1]) is RuntimeError
+            assert str(errors[0]) == str(errors[1])
+            message = str(errors[0])
+            assert "attach failed: config push failed during attach" in message
+            assert f"{directory}/never_bound" in message
+
+
 @isolate_in_subprocess
 def test_config_propagates_to_host_agent():
     """Verify that configure() overrides reach host agent OS processes

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1332,9 +1332,24 @@ def test_long_endpoint_completes() -> None:
     pm.stop().get()
 
 
+class UndeliverableMessageReceiver(Actor):
+    def __init__(self):
+        self._messages = asyncio.Queue()
+
+    @endpoint
+    async def receive_undeliverable(
+        self, sender: str, dest: str, error_msg: str
+    ) -> None:
+        await self._messages.put((sender, dest, error_msg))
+
+    @concurrent_endpoint
+    async def get_messages(self) -> Tuple[str, str, str]:
+        return await self._messages.get()
+
+
 class UndeliverableMessageSender(Actor):
     @endpoint
-    async def send_undeliverable(self) -> None:
+    def send_undeliverable(self) -> None:
         actor_instance = context().actor_instance
         port_id = PortId(
             actor_id=ActorAddr(addr="local:0", proc_name="bogus", actor_name="bogus"),
@@ -1351,18 +1366,14 @@ class UndeliverableMessageSender(Actor):
 
 
 class UndeliverableMessageSenderWithOverride(UndeliverableMessageSender):
-    def __init__(self):
-        self._messages: asyncio.Queue[Tuple[str, str, str]] = asyncio.Queue()
-
-    @concurrent_endpoint
-    async def get_messages(self) -> Tuple[str, str, str]:
-        return await self._messages.get()
+    def __init__(self, receiver: UndeliverableMessageReceiver):
+        self._receiver = receiver
 
     def _handle_undeliverable_message(
         self, message: UndeliverableMessageEnvelope
     ) -> bool:
-        self._messages.put_nowait(
-            (str(message.sender()), str(message.dest()), message.error_msg())
+        self._receiver.receive_undeliverable.broadcast(
+            str(message.sender()), str(message.dest()), message.error_msg()
         )
         return True
 
@@ -1371,9 +1382,12 @@ class UndeliverableMessageSenderWithOverride(UndeliverableMessageSender):
 @isolate_in_subprocess
 async def test_undeliverable_message_with_override() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 1})
-    sender = pm.spawn("undeliverable_sender", UndeliverableMessageSenderWithOverride)
+    receiver = pm.spawn("undeliverable_receiver", UndeliverableMessageReceiver)
+    sender = pm.spawn(
+        "undeliverable_sender", UndeliverableMessageSenderWithOverride, receiver
+    )
     await sender.send_undeliverable.call()
-    sender, dest, error_msg = await sender.get_messages.call_one()
+    sender, dest, error_msg = await receiver.get_messages.call_one()
     assert sender != ""
     assert "bogus" in dest
     assert error_msg is not None

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -1122,16 +1122,20 @@ public_operation = "HostMesh.initialized"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code and internal readiness gates"
-driver = "awaited or blocked on by the caller"
-start_point = "the storage Shared is already being driven; the coroutine only awaits it"
-abandonment = "possible; initialization continues on the storage Shared"
-eager_effect = "observes already-running work"
-drop_behavior = "abandons this observer only"
+driver = "the caller drives only the per-access observer coroutine; HostMesh._hy_host_mesh retains a non-aborting Shared source that is already running or already resolved"
+start_point = "property access synchronously snapshots _hy_host_mesh, or raises if the mesh was shut down; the retained Shared source was created earlier, and this observer coroutine starts only when driven"
+abandonment = "before drive, dropping the Future starts no observer but can emit Python's ordinary never-awaited-coroutine warning. Source-grounded after a timed get starts the non-aborting observer: dropping the Future discards its receiver but does not stop that observer or HostMesh's retained Shared source"
+eager_effect = "would begin observing the retained running or resolved Shared during property access rather than when the caller drives the Future"
+drop_behavior = "does not affect host initialization; a fresh initialized Future can observe the same True result or the same retained failure"
 first_side_effect = "none; the property access only raises if the mesh is already shut down"
-unobserved_error = "silently dropped"
+unobserved_error = "a pre-drive drop never observes the Shared's terminal error and can emit Python's ordinary never-awaited-coroutine warning. Source-grounded: if a started observer later sees failure after its receiver is dropped, send_result logs the receiverless background error. The retained Shared independently stores the exact failure, and fresh initialized Futures replay its type and message"
 disposition = "preserve timing"
 semantic_class = "already_started_lazy_observer"
-oracle = "host mesh readiness coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_attach_starts_before_readiness_observation_and_survives_a_dropped_observer",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_fails_closed_on_unreachable_host",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_failure_replays_to_fresh_readiness_observers",
+]
 
 [[site]]
 id = "fc.host_mesh.HostMesh.shutdown[Future._from_corotask]"
@@ -1233,16 +1237,19 @@ public_operation = "ProcMesh.initialized"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code and internal readiness gates"
-driver = "awaited or blocked on by the caller"
-start_point = "the storage Shared is already being driven; the coroutine only awaits it"
-abandonment = "possible; initialization continues on the storage Shared"
-eager_effect = "observes already-running work"
-drop_behavior = "abandons this observer only"
+driver = "the caller drives only the per-access observer coroutine; ProcMesh._proc_mesh retains a Shared source that is already running through native spawn, logging initialization, and setup, or is already resolved"
+start_point = "the ProcMesh retained its running or resolved Shared source before property access; this property's observer coroutine begins only when its per-access Future is driven"
+abandonment = "before drive, dropping the Future starts no observer but can emit Python's ordinary never-awaited-coroutine warning. Source-grounded after a timed get starts the non-aborting observer: dropping the Future discards its receiver but does not stop that observer or the retained ProcMesh Shared source"
+eager_effect = "would begin observing the retained running or resolved Shared during property access rather than when the caller drives the Future"
+drop_behavior = "does not affect proc initialization; a fresh initialized Future can observe the same True result or replay the same retained failure"
 first_side_effect = "none"
-unobserved_error = "silently dropped"
+unobserved_error = "a pre-drive drop never observes the Shared's terminal error and can emit Python's ordinary never-awaited-coroutine warning. Source-grounded: if a started observer later sees failure after its receiver is dropped, send_result logs the receiverless background error. The retained Shared independently stores the exact failure, and fresh initialized Futures replay its type and message"
 disposition = "preserve timing"
 semantic_class = "already_started_lazy_observer"
-oracle = "proc mesh readiness coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_mesh_readiness_replays_success_after_discarded_observer",
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_mesh_readiness_replays_failure_after_discarded_observer",
+]
 
 [[site]]
 id = "fc.proc_mesh.ProcMesh.stop[Future._from_coro_stop_nonblockinginstance]"
@@ -2336,16 +2343,20 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from attach_to_workers"
-consumer = "HostMesh construction, through the bootstrap _as_python_task adapter"
-driver = "awaited inside the host mesh setup coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; the adapter's task may be dropped before it is driven"
-eager_effect = "starts a side effect"
-drop_behavior = "no worker attach is performed"
-unobserved_error = "surfaced on observation"
+consumer = "bootstrap.attach_to_workers normally calls spawn() on the returned task and stores the resulting Shared as HostMesh._inner_host_mesh after constructing the HostMesh extent"
+driver = "PythonTask.spawn drives it on the shared Tokio runtime; HostMesh retains the Shared, while HostMesh.initialized creates only per-access observers"
+start_point = "source-grounded: the binding synchronously takes every input worker PythonTask before constructing its own lazy task. With the ordinary list input covered here, the public wrapper constructs the extent and then spawns that task before returning HostMesh"
+abandonment = "source-grounded: direct private-binding callers can drop the raw task. The public wrapper can also drop it if an accepted custom Sequence iterates successfully but raises when len(workers) constructs the extent; the ordinary-list path tested here spawns it immediately, and dropping HostMesh.initialized abandons only that observer"
+eager_effect = "would begin polling worker-address tasks and attaching during the binding call. That changes direct raw-task abandonment and the source-grounded public exceptional path where extent construction fails before spawn; on the tested ordinary-list path, spawn follows extent construction"
+drop_behavior = "source-grounded: dropping an undriven raw binding task, including during exceptional public extent construction, performs no attach. On the tested ordinary-list path, dropping a readiness observer does not cancel attach because HostMesh retains the non-aborting Shared"
+unobserved_error = "the retained Shared stores an attach failure and later HostMesh.initialized observers replay its original type and message. Source-grounded: if every Shared receiver disappears before completion, send_result logs the error"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "bootstrap attach-to-workers coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_attach_starts_before_readiness_observation_and_survives_a_dropped_observer",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_fails_closed_on_unreachable_host",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_failure_replays_to_fresh_readiness_observers",
+]
 
 [[site]]
 id = "np.bootstrap.run_worker_loop_forever"
@@ -2434,16 +2445,19 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyHostMesh::spawn_nonblocking"
-consumer = "HostMesh._spawn_nonblocking"
-driver = "driven by PythonTask.from_coroutine(task()).spawn() on the Python side"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; the storage Shared may be built and never observed"
-eager_effect = "starts a side effect"
-drop_behavior = "no proc mesh is spawned"
-unobserved_error = "send_result logs an unobserved error once spawned"
+consumer = "HostMesh._spawn_nonblocking's already-started outer coroutine constructs and immediately awaits the returned task after the host mesh is ready; HostMesh retains the outer spawn Shared in _pending_spawns"
+driver = "PythonTask.from_coroutine(task()).spawn() drives the retained outer coroutine, which drives this native task inline; HostMesh also retains the resulting ProcMesh"
+start_point = "source-grounded for the direct binding: the raw native task is lazy in isolation. On the tested public path, spawn_procs starts and retains the outer coroutine before returning ProcMesh, and that coroutine constructs and awaits this task after host readiness"
+abandonment = "source-grounded for the direct private binding: its raw task can be dropped undriven. On the tested public route, dropping the returned ProcMesh or an initialized Future does not cancel spawn because HostMesh retains both the spawn Shared and ProcMesh"
+eager_effect = "source-grounded: an eager binding would begin native proc spawning during task construction instead of at the outer coroutine's immediately following await; the public route has no independent drop point between them"
+drop_behavior = "source-grounded for the direct binding: dropping an undriven raw task performs no native spawn. Tested on the public route: dropping the ProcMesh or readiness observer does not prevent spawn, and HostMesh drains its retained spawn before shutdown"
+unobserved_error = "source-grounded: a native-spawn failure remains in the retained Shared and propagates through ProcMesh initialization; HostMesh stop or shutdown catches and suppresses that pending-spawn failure while draining"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "proc mesh setup coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_shutdown_waits_for_a_pending_proc_spawn_after_caller_drops_mesh",
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_mesh_readiness_replays_success_after_discarded_observer",
+]
 
 [[site]]
 id = "np.host_mesh.PyHostMesh.stop"


### PR DESCRIPTION
Summary:

when the public Python API attaches to workers or starts a process mesh, Monarch retains the startup work independently of any `initialized` Future returned to the caller. Each access to `initialized` creates a new observer of that retained result, so discarding one observer does not cancel initialization and later observers can recover the same success or failure.

this adds controlled tests for those ownership boundaries. worker attachment starts before anyone observes readiness and continues after a started observer is discarded. process-mesh initialization likewise survives a discarded observer and replays either `True` or the original error to later observers. a separate shutdown test shows that `HostMesh` retains a pending process spawn after the caller drops its `ProcMesh` and waits for that spawn before shutting down.

the census now distinguishes the tested public behavior from source-grounded private binding paths and links each affected producer to its exact tests. this changes tests and migration metadata only; production behavior does not change.

Differential Revision: D118968115


