### PR TITLE
characterize host and process mesh teardown

### DIFF
--- a/python/tests/test_admin_spawn_characterization.py
+++ b/python/tests/test_admin_spawn_characterization.py
@@ -1,0 +1,210 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Characterization tests for the task boundaries around admin creation.
+
+The public ``_spawn_admin`` function returns a lazy Monarch ``Future``. Once an
+asyncio caller observes that Future, a retained Handle owns the producer while
+the Python asyncio Future is only an observer. These tests pin both boundaries:
+which validation happens during the public call, and what happens when the
+caller cancels an observer after the raw native task has been constructed.
+"""
+
+import asyncio
+import os
+import threading
+from typing import Callable
+from unittest.mock import patch
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import PyMeshAdminRef
+from monarch._rust_bindings.monarch_hyperactor.pytokio import Handle, PythonTask
+from monarch._src.actor import future as future_module, host_mesh as host_mesh_module
+from monarch._src.actor.actor_mesh import shutdown_context
+from monarch._src.actor.future import Future
+from monarch._src.actor.host_mesh import HostMesh, this_host
+
+
+async def _wait_for_threading_event(event: threading.Event, message: str) -> None:
+    reached = await asyncio.wait_for(
+        asyncio.to_thread(event.wait, 30),
+        timeout=35,
+    )
+    assert reached, message
+
+
+async def _wait_for_handle_result(
+    handle: Handle,
+    message: str,
+) -> tuple[str, PyMeshAdminRef]:
+    deadline = asyncio.get_running_loop().time() + 30
+    while (result := handle.poll()) is None:
+        if asyncio.get_running_loop().time() >= deadline:
+            raise TimeoutError(message)
+        await asyncio.sleep(0)
+    return result
+
+
+class _AdminSpawnGate:
+    """Hold a real native admin task after construction but before its first poll.
+
+    Calling the real binding here preserves its synchronous validation. A valid
+    call returns the production task, which this wrapper holds behind a bounded
+    gate and then awaits normally. The construction event therefore says that
+    the outer producer owns a native task, not that the native task has run.
+    """
+
+    def __init__(self, real_spawn: Callable[..., PythonTask]) -> None:
+        self._real_spawn = real_spawn
+        self.release = threading.Event()
+        self.native_constructed = threading.Event()
+        self.attempts: list[str | None] = []
+        self.tasks_constructed = 0
+        self.results: list[tuple[str, PyMeshAdminRef]] = []
+
+    def __call__(
+        self,
+        host_meshes: object,
+        instance: object,
+        admin_addr: str | None,
+        telemetry_url: str | None,
+    ) -> PythonTask:
+        self.attempts.append(admin_addr)
+        native_task = self._real_spawn(
+            host_meshes,
+            instance,
+            admin_addr,
+            telemetry_url,
+        )
+        self.tasks_constructed += 1
+        self.native_constructed.set()
+
+        async def drive_native() -> tuple[str, PyMeshAdminRef]:
+            released = await PythonTask.spawn_blocking(
+                lambda: self.release.wait(timeout=30)
+            )
+            if not released:
+                raise TimeoutError("admin spawn release was not published")
+            result = await native_task
+            self.results.append(result)
+            return result
+
+        return PythonTask.from_coroutine(drive_native())
+
+
+async def _assert_input_errors(
+    host: HostMesh,
+    gate: _AdminSpawnGate,
+) -> None:
+    with pytest.raises(ValueError) as empty_error:
+        host_mesh_module._spawn_admin([])
+    assert type(empty_error.value) is ValueError
+    assert str(empty_error.value) == "_spawn_admin requires at least one HostMesh"
+    assert gate.attempts == []
+    assert "MONARCH_ADMIN_URL" not in os.environ
+
+    invalid = host_mesh_module._spawn_admin([host], admin_addr="not-an-address")
+    assert gate.attempts == []
+    with pytest.raises(Exception) as invalid_error:
+        await asyncio.wait_for(invalid.as_asyncio(), timeout=30)
+    assert type(invalid_error.value) is Exception
+    assert str(invalid_error.value) == (
+        "invalid admin_addr 'not-an-address': invalid socket address syntax"
+    )
+    assert gate.attempts == ["not-an-address"]
+    assert gate.tasks_constructed == 0
+    assert not gate.native_constructed.is_set()
+    assert gate.results == []
+    assert "MONARCH_ADMIN_URL" not in os.environ
+
+
+@pytest.mark.timeout(240)
+@isolate_in_subprocess
+async def test_spawn_admin_is_lazy_and_survives_cancelled_observer() -> None:
+    previous_admin_url = os.environ.pop("MONARCH_ADMIN_URL", None)
+    gate = _AdminSpawnGate(host_mesh_module._hy_spawn_admin)
+    success: Future[tuple[str, PyMeshAdminRef]] | None = None
+    observer: asyncio.Future[tuple[str, PyMeshAdminRef]] | None = None
+    success_started = False
+    admin_ref: PyMeshAdminRef | None = None
+
+    try:
+        host = this_host()
+        assert await asyncio.wait_for(host.initialized.as_asyncio(), timeout=30) is True
+
+        with patch.object(host_mesh_module, "_hy_spawn_admin", gate):
+            await _assert_input_errors(host, gate)
+
+            successful_spawn = host_mesh_module._spawn_admin(
+                [host], admin_addr="[::]:0"
+            )
+            success = successful_spawn
+            # Future construction captures the current Monarch context, but it
+            # must not resolve the host or invoke the native admin binding.
+            assert gate.attempts == ["not-an-address"]
+            assert "MONARCH_ADMIN_URL" not in os.environ
+
+            observer = successful_spawn.as_asyncio()
+            success_started = True
+            status = successful_spawn._status
+            assert isinstance(status, future_module._Handle)
+            producer_handle = status.handle
+            await _wait_for_threading_event(
+                gate.native_constructed,
+                "the outer producer did not construct the native admin task",
+            )
+            assert gate.attempts == ["not-an-address", "[::]:0"]
+            assert gate.tasks_constructed == 1
+            assert gate.results == []
+            assert not observer.done()
+            assert "MONARCH_ADMIN_URL" not in os.environ
+
+            assert observer.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await observer
+
+            gate.release.set()
+            # Handle.poll() neither drives the producer nor retains another
+            # waiter. The cancelled observer's internal completion waiter stays
+            # alive, so require completion before attaching a replacement
+            # Python observer rather than claiming that no waiter exists.
+            cached_url, cached_ref = await _wait_for_handle_result(
+                producer_handle,
+                "admin spawn did not finish after its first observer was cancelled",
+            )
+            assert os.environ["MONARCH_ADMIN_URL"] == cached_url
+            admin_url, admin_ref = await asyncio.wait_for(
+                successful_spawn.as_asyncio(),
+                timeout=30,
+            )
+            assert len(gate.results) == 1
+            native_url, native_ref = gate.results[0]
+            assert admin_url == native_url
+            assert admin_url == cached_url
+            assert admin_ref is native_ref
+            assert admin_ref is cached_ref
+            assert os.environ["MONARCH_ADMIN_URL"] == admin_url
+    finally:
+        if observer is not None and not observer.done():
+            observer.cancel()
+        gate.release.set()
+        try:
+            if success_started and success is not None:
+                await asyncio.wait_for(success.as_asyncio(), timeout=30)
+        finally:
+            try:
+                await asyncio.wait_for(shutdown_context().as_asyncio(), timeout=30)
+            finally:
+                if previous_admin_url is None:
+                    os.environ.pop("MONARCH_ADMIN_URL", None)
+                else:
+                    os.environ["MONARCH_ADMIN_URL"] = previous_admin_url
+
+    # Keep the opaque capability live through local admin shutdown.
+    assert admin_ref is not None

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import asyncio
 import os
 import pathlib
 import shutil
@@ -19,15 +20,19 @@ import threading
 import time
 import weakref
 from contextlib import ExitStack
-from typing import Dict, List, Optional, Set
+from typing import Any, cast, Dict, Generator, List, Optional, Set
 from unittest.mock import patch
 
 import cloudpickle
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
-from monarch._rust_bindings.monarch_hyperactor.host_mesh import BootstrapCommand
+from monarch._rust_bindings.monarch_hyperactor.context import Instance as HyInstance
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import (
+    BootstrapCommand,
+    HostMesh as HyHostMesh,
+)
 from monarch._rust_bindings.monarch_hyperactor.proc import ProcId, Uid
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Point, Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, attach, context
 from monarch._src.actor.bootstrap import attach_to_workers
@@ -184,6 +189,106 @@ def _wait_for_marker(path: pathlib.Path) -> None:
         time.sleep(0.01)
 
 
+async def _wait_for_event(event: threading.Event, message: str) -> None:
+    reached = await asyncio.wait_for(
+        asyncio.to_thread(event.wait, 30),
+        timeout=35,
+    )
+    assert reached, message
+
+
+class _AwaitRecord:
+    """Record when a synthetic pending spawn is actually awaited."""
+
+    def __init__(self, record: list[str], value: str) -> None:
+        self._record = record
+        self._value = value
+
+    def __await__(self) -> Generator[Any, None, None]:
+        async def record() -> None:
+            self._record.append(self._value)
+
+        return record().__await__()
+
+
+class _PendingActorRecord:
+    """Expose an initializer that records when the real actor queue drives it."""
+
+    def __init__(self, record: list[str]) -> None:
+        self._record = record
+
+    @property
+    def initialized(self) -> Future[bool]:
+        async def record() -> bool:
+            self._record.append("pending_actor")
+            return True
+
+        return Future._from_coro(record())
+
+
+class _HostTeardownCallThrough:
+    """Observe binding calls while forwarding every call to the real mesh.
+
+    The wrapper can count entry into ``PyHostMesh.stop`` and ``shutdown``. It
+    cannot see which ``SharedCell::take`` branch Rust takes, so tests must not
+    use it to claim that an inner domain operation ran.
+    """
+
+    def __init__(
+        self,
+        inner: HyHostMesh,
+        record: list[str] | None = None,
+        release: threading.Event | None = None,
+    ) -> None:
+        self._inner = inner
+        self._record = record
+        self._release = release
+        self.entered = threading.Event()
+        self.calls: list[str] = []
+
+    def _wrap(self, operation: str, task: PythonTask[None]) -> PythonTask[None]:
+        self.calls.append(operation)
+        if self._record is not None:
+            self._record.append(f"native_{operation}")
+        self.entered.set()
+        release = self._release
+        if release is None:
+            return task
+        release_event = cast(threading.Event, release)
+
+        async def gated() -> None:
+            released = await PythonTask.spawn_blocking(
+                lambda: release_event.wait(timeout=30)
+            )
+            if not released:
+                raise TimeoutError("host teardown release was not published")
+            await task
+
+        return PythonTask.from_coroutine(gated())
+
+    def shutdown(self, instance: HyInstance) -> PythonTask[None]:
+        return self._wrap("shutdown", self._inner.shutdown(instance))
+
+    def stop(self, instance: HyInstance) -> PythonTask[None]:
+        return self._wrap("stop", self._inner.stop(instance))
+
+
+def _install_host_teardown_call_through(
+    host: HostMesh,
+    record: list[str] | None = None,
+    release: threading.Event | None = None,
+    inner: HyHostMesh | None = None,
+) -> _HostTeardownCallThrough:
+    if inner is None:
+        inner = host._hy_host_mesh.block_on()
+    call_through = _HostTeardownCallThrough(inner, record, release)
+    # HostMesh reads this value through the Shared interface. The test wrapper
+    # preserves that interface and forwards every teardown call to the exact
+    # native object it replaced.
+    host._inner_host_mesh = Shared.from_value(cast(HyHostMesh, call_through))
+    return call_through
+
+
 def _gated_bootstrap_command(
     directory: pathlib.Path,
 ) -> tuple[BootstrapCommand, pathlib.Path, pathlib.Path]:
@@ -231,15 +336,111 @@ def _gated_bootstrap_command(
     return command, entered, release
 
 
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+async def test_preconstructed_shutdowns_drain_after_observer_cancellation() -> None:
+    job = ProcessJob({"hosts": 1})
+    release = threading.Event()
+    first_shutdown: Future[None] | None = None
+    try:
+        host = job.state(cached_path=None).hosts
+        proc_mesh = host.spawn_procs(name="drain_order")
+        await asyncio.wait_for(proc_mesh.initialized, timeout=30)
+        inner = host._hy_host_mesh.poll()
+        assert inner is not None
+
+        order: list[str] = []
+        # These synthetic completions sit in the real pending-proc and
+        # pending-actor queues. They prove traversal and ordering through those
+        # queues, not the lifecycle of real proc or actor spawns.
+        host._pending_spawns = [cast(Any, _AwaitRecord(order, "pending_proc"))]
+        proc_mesh._pending_actor_spawns = [cast(Any, _PendingActorRecord(order))]
+        flush_logging = proc_mesh._logging_manager._flush_from_tokio
+
+        async def record_logging_flush() -> None:
+            await flush_logging()
+            order.append("logging_flush")
+
+        call_through = _install_host_teardown_call_through(
+            host,
+            order,
+            release,
+            inner,
+        )
+        first_shutdown = host.shutdown()
+        second_shutdown = host.shutdown()
+        assert order == []
+        assert call_through.calls == []
+
+        with patch.object(
+            proc_mesh._logging_manager,
+            "_flush_from_tokio",
+            record_logging_flush,
+        ):
+            observer = first_shutdown.as_asyncio()
+            await _wait_for_event(
+                call_through.entered,
+                "host shutdown did not reach the native binding",
+            )
+            assert order == [
+                "pending_proc",
+                "pending_actor",
+                "logging_flush",
+                "native_shutdown",
+            ]
+            assert call_through.calls == ["shutdown"]
+
+            assert observer.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await observer
+
+            release.set()
+            assert (
+                await asyncio.wait_for(
+                    asyncio.to_thread(first_shutdown.get, 30),
+                    timeout=35,
+                )
+                is None
+            )
+            assert await asyncio.wait_for(first_shutdown, timeout=30) is None
+            assert host._inner_host_mesh is None
+
+            with pytest.raises(RuntimeError) as second_error:
+                await asyncio.wait_for(second_shutdown, timeout=30)
+            assert type(second_error.value) is RuntimeError
+            assert str(second_error.value) == "HostMesh has already been shut down"
+            assert order == [
+                "pending_proc",
+                "pending_actor",
+                "logging_flush",
+                "native_shutdown",
+                "logging_flush",
+            ]
+            assert call_through.calls == ["shutdown"]
+    finally:
+        release.set()
+        try:
+            if first_shutdown is not None:
+                try:
+                    await asyncio.wait_for(first_shutdown, timeout=30)
+                except (Exception, asyncio.CancelledError):
+                    pass
+        finally:
+            job.kill()
+
+
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 def test_shutdown_host_mesh() -> None:
     with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
         hm = state.hosts
+        discarded_stop = hm.stop()
+        discarded_shutdown = hm.shutdown()
+        del discarded_stop, discarded_shutdown
         pm = hm.spawn_procs(per_host={"gpus": 2})
         am = pm.spawn("actor", RankActor)
-        am.get_rank.choose().get()
-        hm.shutdown().get()
+        am.get_rank.choose().get(timeout=30)
+        assert hm.shutdown().get(timeout=30) is None
         assert hm._inner_host_mesh is None
 
 
@@ -553,15 +754,32 @@ async def test_host_mesh_context_manager() -> None:
 def test_shutdown_sliced_host_mesh_throws_exception() -> None:
     with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
         hm = state.hosts
+        assert hm.initialized.get(timeout=30) is True
         hm_sliced = hm.slice(hosts=1)
         sliced_inner = hm_sliced._inner_host_mesh
         assert sliced_inner is not None
+        reference = sliced_inner.poll()
+        assert reference is not None
+        instance = context().actor_instance._as_rust()
 
-        with pytest.raises(
-            RuntimeError,
-            match="cannot shut down `HostMesh` that is a reference instead of owned",
-        ):
-            hm_sliced.shutdown().get()
+        with pytest.raises(RuntimeError) as raw_shutdown_error:
+            reference.shutdown(instance)
+        assert type(raw_shutdown_error.value) is RuntimeError
+        assert str(raw_shutdown_error.value) == (
+            "cannot shut down `HostMesh` that is a reference instead of owned"
+        )
+
+        with pytest.raises(RuntimeError) as raw_stop_error:
+            reference.stop(instance)
+        assert type(raw_stop_error.value) is RuntimeError
+        assert str(raw_stop_error.value) == (
+            "cannot stop `HostMesh` that is a reference instead of owned"
+        )
+
+        with pytest.raises(RuntimeError) as public_shutdown_error:
+            hm_sliced.shutdown().get(timeout=30)
+        assert type(public_shutdown_error.value) is RuntimeError
+        assert str(public_shutdown_error.value) == str(raw_shutdown_error.value)
 
         assert hm_sliced._inner_host_mesh is sliced_inner
 
@@ -584,34 +802,78 @@ def test_stop_and_reconnect() -> None:
     # waiting for undeliverable-message errors to surface.
     with configured(message_delivery_timeout="5s"):
         job = ProcessJob({"hosts": 2})
+        try:
+            # First connection: spawn actors, verify they work.
+            with scoped_state(job, cached_path=None) as state:
+                hm = state.hosts
+                pm = hm.spawn_procs(per_host={"gpus": 1})
+                am = pm.spawn("actor", RankActor)
+                pids = am.get_pid.call().get(timeout=30)
+                assert len(pids) == 2
+                pids = [pid for _, pid in pids.items()]
 
-        # First connection: spawn actors, verify they work.
-        with scoped_state(job, cached_path=None) as state:
-            hm = state.hosts
-            pm = hm.spawn_procs(per_host={"gpus": 1})
-            am = pm.spawn("actor", RankActor)
-            pids = am.get_pid.call().get()
-            assert len(pids) == 2
-            pids = [pid for _, pid in pids.items()]
+                order: list[str] = []
+                call_through = _install_host_teardown_call_through(hm, order)
+                flush_pending_spawns = hm._flush_pending_spawns
 
-            # Stop: terminate user procs but keep workers alive.
-            hm.stop().get()
-            # Ensure that the procs are actually dead.
-            assert all(not is_process_running(pid) for pid in pids)
+                async def record_drain() -> None:
+                    order.append("drain")
+                    await flush_pending_spawns()
 
-            # Sleep past the message delivery timeout to ensure that no errors
-            # surface from undeliverable messages to dead procs/actors.
-            time.sleep(7)
+                with patch.object(hm, "_flush_pending_spawns", record_drain):
+                    # Stop terminates user procs but leaves workers available.
+                    assert hm.stop().get(timeout=30) is None
+                    assert order == ["drain", "native_stop"]
+                    assert call_through.calls == ["stop"]
+                    assert all(not is_process_running(pid) for pid in pids)
 
-            # Second connection: reconnect to the same workers via state().
-            hm2 = job.state(cached_path=None).hosts
-            pm2 = hm2.spawn_procs(per_host={"gpus": 1})
-            am2 = pm2.spawn("actor", RankActor)
-            ranks2 = am2.get_rank.call().get()
-            assert len(ranks2) == 2
+                    # Sleep past the message delivery timeout to ensure that no
+                    # errors surface from undeliverable messages to dead
+                    # procs/actors.
+                    time.sleep(7)
 
-            # Shutdown: fully tear down and exit workers.
-            hm2.shutdown().get()
+                    # Reconnect after stop and use an actor before exercising
+                    # any repeated-teardown behavior. This remains the ordinary
+                    # stop-and-reconnect regression witness.
+                    hm2 = job.state(cached_path=None).hosts
+                    pm2 = hm2.spawn_procs(per_host={"gpus": 1})
+                    am2 = pm2.spawn("actor", RankActor)
+                    ranks2 = list(am2.get_rank.call().get(timeout=30).items())
+                    assert len(ranks2) == 2
+
+                    # The second stop and following shutdown both report
+                    # success after the first stop consumed the native cell.
+                    assert hm.stop().get(timeout=30) is None
+                    assert hm.shutdown().get(timeout=30) is None
+                    assert hm._inner_host_mesh is None
+
+                    assert order == [
+                        "drain",
+                        "native_stop",
+                        "drain",
+                        "native_stop",
+                        "drain",
+                        "native_shutdown",
+                    ]
+                    assert call_through.calls == ["stop", "stop", "shutdown"]
+                    # The call count proves that both stop requests reached the
+                    # binding. Source inspection, not this seam, shows that only
+                    # the first took the cell and ran the domain stop operation.
+                    # It also shows that an overlapping second stop can return
+                    # success while the first domain stop is still running;
+                    # this sequential test does not exercise that overlap.
+
+                    # This second call characterizes current empty-cell false
+                    # success: the reported shutdown left the same workers and
+                    # actor live. Revise this assertion when repeated teardown
+                    # is corrected; the first call above remains the independent
+                    # reconnect-after-stop regression.
+                    assert list(am2.get_rank.call().get(timeout=30).items()) == ranks2
+
+                # Shutdown: fully tear down and exit workers.
+                hm2.shutdown().get(timeout=30)
+        finally:
+            job.kill()
 
 
 @pytest.mark.timeout(120)

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -17,6 +17,7 @@ import tempfile
 import textwrap
 import threading
 import time
+import weakref
 from contextlib import ExitStack
 from typing import Dict, List, Optional, Set
 from unittest.mock import patch
@@ -24,15 +25,22 @@ from unittest.mock import patch
 import cloudpickle
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import BootstrapCommand
 from monarch._rust_bindings.monarch_hyperactor.proc import ProcId, Uid
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Point, Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, attach, context
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.host_mesh import HostMesh, this_host, this_proc
+from monarch._src.actor.future import Future
+from monarch._src.actor.host_mesh import (
+    default_bootstrap_cmd,
+    HostMesh,
+    this_host,
+    this_proc,
+)
 from monarch._src.actor.pickle import flatten, unflatten
-from monarch._src.actor.proc_mesh import get_or_spawn_controller
+from monarch._src.actor.proc_mesh import _get_bootstrap_args, get_or_spawn_controller
 from monarch._src.job.job import ProcessState
 from monarch._src.job.process import ProcessJob
 from monarch._src.job.service_identity import new_service_proc_id, service_proc_addr
@@ -166,6 +174,63 @@ def is_process_running(pid: int) -> bool:
         return False
 
 
+def _wait_for_marker(path: pathlib.Path) -> None:
+    # Stress runs start several isolated ProcessJobs at once, so reaching the
+    # bootstrap wrapper can take longer than a focused run.
+    deadline = time.monotonic() + 30
+    while not path.exists():
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"timed out waiting for marker {path}")
+        time.sleep(0.01)
+
+
+def _gated_bootstrap_command(
+    directory: pathlib.Path,
+) -> tuple[BootstrapCommand, pathlib.Path, pathlib.Path]:
+    entered = directory / "bootstrap-entered"
+    release = directory / "bootstrap-release"
+    wrapper = directory / "gated-bootstrap.py"
+    wrapper.write_text(
+        textwrap.dedent(
+            """\
+            import os
+            import pathlib
+            import sys
+            import time
+
+            entered, release, program, arg0, *args = sys.argv[1:]
+            pathlib.Path(entered).touch()
+            deadline = time.monotonic() + 30
+            while not pathlib.Path(release).exists():
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("bootstrap release marker was not published")
+                time.sleep(0.01)
+            os.execvpe(program, [arg0, *args], os.environ)
+            """
+        )
+    )
+
+    base = default_bootstrap_cmd()
+    # BootstrapCommand's Rust binding exposes every field, but its stub declares
+    # only env. Read the argv from the helper used by default_bootstrap_cmd so
+    # this fixture follows the real default without widening the production stub.
+    original_program, original_args, _ = _get_bootstrap_args()
+    command = BootstrapCommand(
+        sys.executable,
+        None,
+        [
+            str(wrapper),
+            str(entered),
+            str(release),
+            original_program,
+            original_program,
+            *(original_args or []),
+        ],
+        dict(base.env),
+    )
+    return command, entered, release
+
+
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 def test_shutdown_host_mesh() -> None:
@@ -197,6 +262,122 @@ def test_shutdown_immediately_after_proc_spawn_without_actor() -> None:
             match="HostMesh has already been shut down",
         ):
             hm.spawn_procs()
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+def test_shutdown_waits_for_a_pending_proc_spawn_after_caller_drops_mesh() -> None:
+    with tempfile.TemporaryDirectory(prefix="monarch_spawn_gate_") as directory:
+        command, entered, release = _gated_bootstrap_command(pathlib.Path(directory))
+        with ExitStack() as cleanup:
+            job = ProcessJob({"hosts": 1})
+            cleanup.callback(job.kill)
+            cleanup.callback(release.touch)
+            hm = job.state(cached_path=None).hosts
+            proc_mesh = hm.spawn_procs(
+                name="pending_proc",
+                bootstrap_command=command,
+            )
+            # HostMesh retains the raw native spawn in _pending_spawns and the
+            # ProcMesh retains a second Shared that performs logging and setup.
+            # Keep witnesses for both before discarding the caller's ProcMesh.
+            spawn = hm._pending_spawns[-1]
+            proc_initialization = proc_mesh._proc_mesh
+            retained_proc_mesh = weakref.ref(proc_mesh)
+            del proc_mesh
+            assert retained_proc_mesh() is hm._proc_meshes[-1]
+            _wait_for_marker(entered)
+
+            flush_entered = threading.Event()
+            flush_exited = threading.Event()
+            release_shutdown = threading.Event()
+            cleanup.callback(release_shutdown.set)
+            flush_pending_spawns = hm._flush_pending_spawns
+
+            async def record_flush_entry() -> None:
+                flush_entered.set()
+                await flush_pending_spawns()
+                flush_exited.set()
+                released = await PythonTask.spawn_blocking(
+                    lambda: release_shutdown.wait(timeout=30)
+                )
+                if not released:
+                    raise TimeoutError("native shutdown release was not published")
+
+            with patch.object(hm, "_flush_pending_spawns", record_flush_entry):
+                shutdown = hm.shutdown()
+                shutdown_results: list[None] = []
+                shutdown_errors: list[Exception] = []
+                shutdown_done = threading.Event()
+
+                def drive_shutdown() -> None:
+                    try:
+                        shutdown_results.append(shutdown.get(timeout=45))
+                    except Exception as error:
+                        shutdown_errors.append(error)
+                    finally:
+                        shutdown_done.set()
+
+                shutdown_thread = threading.Thread(
+                    target=drive_shutdown,
+                    daemon=True,
+                    name="drive-host-mesh-shutdown",
+                )
+                shutdown_thread.start()
+                try:
+                    # Start shutdown on another thread so entry into the flush,
+                    # rather than thread scheduling, is the synchronization
+                    # point for proving that the pending spawn blocks it.
+                    assert flush_entered.wait(timeout=10)
+                    assert spawn.poll() is None
+                    assert proc_initialization.poll() is None
+                    assert not flush_exited.is_set()
+                    assert not shutdown_done.is_set()
+
+                    release.touch()
+                    completion_deadline = time.monotonic() + 30
+                    while spawn.poll() is None:
+                        if time.monotonic() >= completion_deadline:
+                            raise AssertionError(
+                                "proc spawn did not complete after bootstrap release"
+                            )
+                        time.sleep(0.01)
+                    assert flush_exited.wait(
+                        timeout=max(0.0, completion_deadline - time.monotonic())
+                    )
+                    proc_initialization_value = proc_initialization.poll()
+                    while proc_initialization_value is None:
+                        if time.monotonic() >= completion_deadline:
+                            raise AssertionError(
+                                "proc initialization did not complete after bootstrap release"
+                            )
+                        time.sleep(0.01)
+                        proc_initialization_value = proc_initialization.poll()
+                    release_shutdown.set()
+                    assert shutdown_done.wait(timeout=15)
+                finally:
+                    release.touch()
+                    release_shutdown.set()
+                    try:
+                        if shutdown_thread.is_alive():
+                            job.kill()
+                    finally:
+                        shutdown_thread.join(timeout=10)
+
+                assert not shutdown_thread.is_alive()
+                assert flush_exited.is_set()
+                assert shutdown_errors == []
+                assert shutdown_results == [None]
+
+            assert spawn.poll() is not None
+            assert proc_initialization_value is not None
+            assert hm._pending_spawns == []
+            assert hm._inner_host_mesh is None
+            with pytest.raises(
+                RuntimeError,
+                match="HostMesh has already been shut down",
+            ):
+                hm.spawn_procs()
 
 
 @pytest.mark.timeout(60)
@@ -303,6 +484,52 @@ def test_attach_to_workers_accepts_future_addresses() -> None:
         for proc in procs:
             proc.kill()
             proc.wait()
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_attach_starts_before_readiness_observation_and_survives_a_dropped_observer() -> (
+    None
+):
+    address_started = threading.Event()
+    release_address = threading.Event()
+
+    async def resolve_address() -> str:
+        address_started.set()
+        released = await PythonTask.spawn_blocking(
+            lambda: release_address.wait(timeout=30)
+        )
+        if not released:
+            raise TimeoutError("worker address release was not published")
+        return addr
+
+    with ExitStack() as cleanup:
+        job = ProcessJob({"hosts": 1})
+        job.apply()
+        cleanup.callback(job.kill)
+        cleanup.callback(release_address.set)
+        addr = job._host_to_pid["hosts_0"].channel
+        address: Future[str] = Future._from_coro(resolve_address())
+
+        hosts = attach_to_workers(
+            ca="trust_all_connections",
+            workers=[address],
+        )
+
+        with pytest.raises(ValueError) as consumed:
+            address.get()
+        assert str(consumed.value) == "Future was consumed."
+        assert address_started.wait(timeout=10)
+
+        discarded = hosts.initialized
+        with pytest.raises(TimeoutError):
+            discarded.get(timeout=0.25)
+        del discarded
+        release_address.set()
+
+        assert hosts.initialized.get(timeout=30) is True
+        assert hosts.initialized.get(timeout=30) is True
+        assert hosts.shutdown().get(timeout=30) is None
 
 
 @pytest.mark.timeout(60)

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -9,9 +9,12 @@
 from __future__ import annotations
 
 import os
+import pathlib
+import tempfile
 import threading
 import time
 from contextlib import ExitStack
+from functools import partial
 from typing import cast
 from unittest.mock import patch
 
@@ -52,6 +55,32 @@ def _successful_bootstrap() -> None:
 
 def _fail_bootstrap() -> None:
     raise RuntimeError(_BOOTSTRAP_FAILURE)
+
+
+def _gated_bootstrap(
+    entered_path: str,
+    release_path: str,
+    failure: str | None,
+) -> None:
+    pathlib.Path(entered_path).touch()
+    release = pathlib.Path(release_path)
+    deadline = time.monotonic() + 30
+    while not release.exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("proc bootstrap release was not published")
+        time.sleep(0.01)
+    if failure is not None:
+        raise RuntimeError(failure)
+
+
+def _wait_for_marker(path: pathlib.Path) -> None:
+    # The full target launches many isolated ProcessJobs concurrently, so
+    # reaching the remote setup callback can take longer than a focused run.
+    deadline = time.monotonic() + 30
+    while not path.exists():
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"timed out waiting for marker {path}")
+        time.sleep(0.01)
 
 
 class _PendingActorProbe:
@@ -130,6 +159,77 @@ async def test_proc_mesh_initialized_fails_when_bootstrap_fails() -> None:
         proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
         with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
             await proc_mesh.initialized
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+def test_proc_mesh_readiness_replays_success_after_discarded_observer() -> None:
+    with tempfile.TemporaryDirectory(prefix="monarch_proc_ready_") as directory:
+        entered = pathlib.Path(directory) / "entered"
+        release = pathlib.Path(directory) / "release"
+        with ExitStack() as cleanup:
+            state = cleanup.enter_context(
+                scoped_state(ProcessJob({"hosts": 1}), cached_path=None)
+            )
+            cleanup.callback(release.touch)
+            proc_mesh = state.hosts.spawn_procs(
+                name="test_proc",
+                bootstrap=partial(
+                    _gated_bootstrap,
+                    str(entered),
+                    str(release),
+                    None,
+                ),
+            )
+            _wait_for_marker(entered)
+
+            discarded = proc_mesh.initialized
+            with pytest.raises(TimeoutError):
+                discarded.get(timeout=0.25)
+            del discarded
+            release.touch()
+
+            assert proc_mesh.initialized.get(timeout=30) is True
+            assert proc_mesh.initialized.get(timeout=30) is True
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+def test_proc_mesh_readiness_replays_failure_after_discarded_observer() -> None:
+    with tempfile.TemporaryDirectory(prefix="monarch_proc_ready_") as directory:
+        entered = pathlib.Path(directory) / "entered"
+        release = pathlib.Path(directory) / "release"
+        with ExitStack() as cleanup:
+            state = cleanup.enter_context(
+                scoped_state(ProcessJob({"hosts": 1}), cached_path=None)
+            )
+            cleanup.callback(release.touch)
+            proc_mesh = state.hosts.spawn_procs(
+                bootstrap=partial(
+                    _gated_bootstrap,
+                    str(entered),
+                    str(release),
+                    _BOOTSTRAP_FAILURE,
+                )
+            )
+            _wait_for_marker(entered)
+
+            discarded = proc_mesh.initialized
+            with pytest.raises(TimeoutError):
+                discarded.get(timeout=0.25)
+            del discarded
+            release.touch()
+
+            errors = []
+            for _ in range(2):
+                with pytest.raises(monarch.actor.ActorError) as excinfo:
+                    proc_mesh.initialized.get(timeout=30)
+                errors.append(excinfo.value)
+
+            assert type(errors[0]) is monarch.actor.ActorError
+            assert type(errors[1]) is monarch.actor.ActorError
+            assert str(errors[0]) == str(errors[1])
+            assert _BOOTSTRAP_FAILURE in str(errors[0])
 
 
 @pytest.mark.timeout(60)

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import pathlib
 import tempfile
@@ -22,6 +23,7 @@ import cloudpickle
 import monarch.actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.context import Instance as HyInstance
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
@@ -81,6 +83,43 @@ def _wait_for_marker(path: pathlib.Path) -> None:
         if time.monotonic() >= deadline:
             raise AssertionError(f"timed out waiting for marker {path}")
         time.sleep(0.01)
+
+
+async def _wait_for_event(event: threading.Event, message: str) -> None:
+    reached = await asyncio.wait_for(
+        asyncio.to_thread(event.wait, 30),
+        timeout=35,
+    )
+    assert reached, message
+
+
+class _ProcStopCallThrough:
+    """Gate a real native stop task without replacing its behavior."""
+
+    def __init__(self, inner: HyProcMesh, release: threading.Event) -> None:
+        self._inner = inner
+        self._release = release
+        self.entered = threading.Event()
+        self.calls = 0
+
+    def stop_nonblocking(
+        self,
+        instance: HyInstance,
+        reason: str,
+    ) -> PythonTask[None]:
+        native_task = self._inner.stop_nonblocking(instance, reason)
+        self.calls += 1
+        self.entered.set()
+
+        async def gated() -> None:
+            released = await PythonTask.spawn_blocking(
+                lambda: self._release.wait(timeout=30)
+            )
+            if not released:
+                raise TimeoutError("proc stop release was not published")
+            await native_task
+
+        return PythonTask.from_coroutine(gated())
 
 
 class _PendingActorProbe:
@@ -234,19 +273,95 @@ def test_proc_mesh_readiness_replays_failure_after_discarded_observer() -> None:
 
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
+async def test_proc_stop_is_lazy_and_survives_cancelled_observer() -> None:
+    job = ProcessJob({"hosts": 1})
+    release = threading.Event()
+    stop_future: Future[None] | None = None
+    try:
+        host = job.state(cached_path=None).hosts
+        owner = host.spawn_procs(per_host={"gpus": 1})
+        await asyncio.wait_for(owner.initialized, timeout=30)
+        inner = owner._proc_mesh.poll()
+        assert inner is not None
+
+        discarded = owner.stop()
+        del discarded
+        assert not owner._stopped
+        actor = owner.spawn("after_discarded_stop", TestActor, 41)
+        assert await asyncio.wait_for(actor.get_value.choose(), 30) == 41
+
+        call_through = _ProcStopCallThrough(inner, release)
+        owner._proc_mesh = Shared.from_value(cast(HyProcMesh, call_through))
+        stop_future = owner.stop()
+        assert not owner._stopped
+        assert call_through.calls == 0
+
+        observer = stop_future.as_asyncio()
+        await _wait_for_event(
+            call_through.entered,
+            "proc stop did not reach the native binding",
+        )
+        assert not owner._stopped
+        assert call_through.calls == 1
+
+        assert observer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await observer
+
+        release.set()
+        assert (
+            await asyncio.wait_for(
+                asyncio.to_thread(stop_future.get, 30),
+                timeout=35,
+            )
+            is None
+        )
+        assert await asyncio.wait_for(stop_future, timeout=30) is None
+        assert owner._stopped
+
+        assert await asyncio.wait_for(owner.stop(), timeout=30) is None
+        assert call_through.calls == 2
+        # The two calls prove that both requests reached the binding. Source
+        # inspection, not this seam, shows that only the first took the
+        # SharedCell and reached the domain ProcMesh::stop operation. It also
+        # shows that an overlapping second stop can set _stopped True even if
+        # the first domain stop later fails; this test does not create overlap.
+    finally:
+        release.set()
+        try:
+            if stop_future is not None:
+                try:
+                    await asyncio.wait_for(stop_future, timeout=30)
+                except (Exception, asyncio.CancelledError):
+                    pass
+        finally:
+            job.kill()
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
 async def test_stop_state_tracks_native_stop_result() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         owner = state.hosts.spawn_procs(per_host={"gpus": 2})
-        await owner.initialized
+        assert await asyncio.wait_for(owner.initialized, timeout=30) is True
         logging_manager = owner._logging_manager
         assert logging_manager._logging_mesh_client is not None
         proc_ref = owner.slice(gpus=0)
+        raw_ref = proc_ref._proc_mesh.poll()
+        assert raw_ref is not None
+        instance = context().actor_instance._as_rust()
 
-        with pytest.raises(
-            ValueError,
-            match="ProcMesh is not owned; must be stopped by an owner",
-        ):
-            await proc_ref.stop()
+        with pytest.raises(ValueError) as raw_stop_error:
+            raw_ref.stop_nonblocking(instance, "test reference rejection")
+        assert type(raw_stop_error.value) is ValueError
+        assert str(raw_stop_error.value) == (
+            "ProcMesh is not owned; must be stopped by an owner"
+        )
+
+        with pytest.raises(ValueError) as public_stop_error:
+            await asyncio.wait_for(proc_ref.stop(), timeout=30)
+        assert type(public_stop_error.value) is ValueError
+        assert str(public_stop_error.value) == str(raw_stop_error.value)
 
         assert not proc_ref._stopped
         flush_started = False
@@ -277,7 +392,7 @@ async def test_stop_state_tracks_native_stop_result() -> None:
                 record_flush_from_tokio,
             ),
         ):
-            assert await owner.stop() is None
+            assert await asyncio.wait_for(owner.stop(), timeout=30) is None
 
             assert proc_flush_called
         assert flush_started

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1555,6 +1555,28 @@ def test_attach_fails_closed_on_unreachable_host():
             )
 
 
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_attach_failure_replays_to_fresh_readiness_observers() -> None:
+    with configured(mesh_attach_config_timeout="500ms"):
+        with TemporaryDirectory() as directory:
+            unreachable = f"ipc://{directory}/never_bound"
+            hosts = attach_to_workers(ca="trust_all_connections", workers=[unreachable])
+
+            errors = []
+            for _ in range(2):
+                with pytest.raises(RuntimeError) as excinfo:
+                    hosts.initialized.get(timeout=10)
+                errors.append(excinfo.value)
+
+            assert type(errors[0]) is RuntimeError
+            assert type(errors[1]) is RuntimeError
+            assert str(errors[0]) == str(errors[1])
+            message = str(errors[0])
+            assert "attach failed: config push failed during attach" in message
+            assert f"{directory}/never_bound" in message
+
+
 @isolate_in_subprocess
 def test_config_propagates_to_host_agent():
     """Verify that configure() overrides reach host agent OS processes

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -356,7 +356,7 @@ shared_reconstruction = 2
 reserve_binding = 1
 py_mesh_reserve = 2
 py_is_tokio_thread = 3
-pytokio_import = 29
+pytokio_import = 30
 pytokio_module_ref = 17
 helper_symbol = 26
 helper_definition = 6
@@ -773,6 +773,7 @@ owns = [
   "im.rdma.module",
   "im.supervision.module",
   "im.test_actor_driver_characterization.module",
+  "im.test_admin_spawn_characterization.module",
   "im.test_actor_mesh.module",
   "im.test_client_context_guard.module",
   "im.test_future_characterization.module",
@@ -1200,17 +1201,19 @@ transition = "6.3c"
 public_operation = "host mesh admin spawn"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
-consumer = "internal admin plumbing"
-driver = "awaited or blocked on by the caller"
-start_point = "lazy; nothing runs until the Future is observed"
-abandonment = "possible; dropping leaves MONARCH_ADMIN_URL unset"
-eager_effect = "starts a side effect"
-drop_behavior = "no admin mesh is spawned"
-first_side_effect = "the native admin spawn, which then sets MONARCH_ADMIN_URL"
-unobserved_error = "silently dropped"
+consumer = "MeshAdminComponent.state in production, which calls get() under fake_sync_state, plus direct internal test callers that await or get the Future"
+driver = "the first asyncio observation or timed get spawns a non-aborting Handle producer; a synchronous get without a timeout drives the coroutine inline. The producer resolves the host meshes, constructs and awaits the raw native task, then publishes MONARCH_ADMIN_URL"
+start_point = "for an unchanged nonempty host list, the call checks that the list is nonempty and constructs the Future. Source inspection shows that construction captures the current Monarch context and can bootstrap a missing client; the oracle starts with an initialized client and proves that no native admin call occurs before observation. Observation first resolves the host Shared values and invokes the native binding"
+abandonment = "source shows that dropping the unobserved Future prevents the native binding call, admin spawn, and environment update. The oracle proves that cancelling one asyncio observer after the retained producer constructs the raw native task does not abort that producer: a fresh observer receives the result after the gate opens"
+eager_effect = "an eager replacement for the outer Future would resolve the hosts and begin the native operation during the call, allowing the admin actor and MONARCH_ADMIN_URL to appear even when the caller discards the return value; the inherited disposition does not decide that behavior change"
+drop_behavior = "source shows that dropping before observation constructs no raw _hy_spawn_admin task and produces no admin or environment value. The oracle proves that after Handle-backed observation starts, cancelling one observer does not stop the retained producer, which completes once and publishes MONARCH_ADMIN_URL"
+first_side_effect = "source inspection shows that construction-time context capture can bootstrap a missing client. In the initialized-client path exercised by the oracle, the first admin-domain effect is spawning the local admin actor when the raw task is driven; after its address is available, the outer producer publishes MONARCH_ADMIN_URL"
+unobserved_error = "an empty list raises exact ValueError during the public call. For the unchanged initialized-host shape in the oracle, an invalid admin_addr is not parsed until observation reaches the raw binding; it then raises exact built-in Exception and does not publish the environment variable. The oracle proves successful-result replay after observer cancellation; error replay is source-grounded in the same Handle state machine"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "admin spawn coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_admin_spawn_characterization::test_spawn_admin_is_lazy_and_survives_cancelled_observer",
+]
 
 [[site]]
 id = "fc.proc_mesh.ProcMesh._proc_mesh_for_asyncio_fixme[Future._from_coroself._proc_mesh.task]"
@@ -2494,16 +2497,18 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from _spawn_admin"
-consumer = "the Python _spawn_admin coroutine, which then sets MONARCH_ADMIN_URL"
-driver = "awaited inside the Python _spawn_admin coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; the admin coroutine may be abandoned"
-eager_effect = "starts a side effect"
-drop_behavior = "no admin mesh is spawned and the environment variable is not set"
-unobserved_error = "surfaced on observation"
+consumer = "the Python _spawn_admin coroutine, which immediately awaits the returned raw task and publishes MONARCH_ADMIN_URL only after success"
+driver = "driven inline by the already-running Python _spawn_admin producer; the public cancellation oracle does not introduce an independent raw-task observer"
+start_point = "the raw binding synchronously rejects an empty native mesh list, parses admin_addr, extracts the HostMeshRef values, and constructs the PyPythonTask. Spawning the local admin actor and querying its address are deferred until that task is driven"
+abandonment = "a direct private caller can drop the raw task before driving it, in which case no admin is spawned. On the tested public route, the outer producer retains and immediately awaits the raw task once constructed, so cancelling its asyncio observer does not abandon the native operation"
+eager_effect = "an eager replacement would spawn the local admin during the raw binding call. The public outer Future would still have to be observed before it invokes that binding; the inherited disposition does not decide either boundary"
+drop_behavior = "source shows that dropping a directly obtained raw task before drive prevents the admin spawn. The public oracle instead proves that cancelling an outer observer after raw task construction leaves the retained producer able to drive it once and publish MONARCH_ADMIN_URL"
+unobserved_error = "the native empty-list and invalid-admin-address checks raise built-in Exception before returning a task; the oracle exercises invalid admin_addr through the public deferred call. Spawn and address-query errors occur only when the returned task is driven and are also mapped to built-in Exception"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "admin spawn coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_admin_spawn_characterization::test_spawn_admin_is_lazy_and_survives_cancelled_observer",
+]
 
 [[site]]
 id = "np.host_mesh.bootstrap_host"
@@ -3016,6 +3021,18 @@ scope = "test"
 state = "legacy"
 transition = "6.8"
 members = ["PythonTask"]
+
+[[site]]
+id = "im.test_admin_spawn_characterization.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_admin_spawn_characterization.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["Handle", "PythonTask"]
 
 [[site]]
 id = "im.test_client_context_guard.module"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -1122,16 +1122,20 @@ public_operation = "HostMesh.initialized"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code and internal readiness gates"
-driver = "awaited or blocked on by the caller"
-start_point = "the storage Shared is already being driven; the coroutine only awaits it"
-abandonment = "possible; initialization continues on the storage Shared"
-eager_effect = "observes already-running work"
-drop_behavior = "abandons this observer only"
+driver = "the caller drives only the per-access observer coroutine; HostMesh._hy_host_mesh retains a non-aborting Shared source that is already running or already resolved"
+start_point = "property access synchronously snapshots _hy_host_mesh, or raises if the mesh was shut down; the retained Shared source was created earlier, and this observer coroutine starts only when driven"
+abandonment = "before drive, dropping the Future starts no observer but can emit Python's ordinary never-awaited-coroutine warning. Source-grounded after a timed get starts the non-aborting observer: dropping the Future discards its receiver but does not stop that observer or HostMesh's retained Shared source"
+eager_effect = "would begin observing the retained running or resolved Shared during property access rather than when the caller drives the Future"
+drop_behavior = "does not affect host initialization; a fresh initialized Future can observe the same True result or the same retained failure"
 first_side_effect = "none; the property access only raises if the mesh is already shut down"
-unobserved_error = "silently dropped"
+unobserved_error = "a pre-drive drop never observes the Shared's terminal error and can emit Python's ordinary never-awaited-coroutine warning. Source-grounded: if a started observer later sees failure after its receiver is dropped, send_result logs the receiverless background error. The retained Shared independently stores the exact failure, and fresh initialized Futures replay its type and message"
 disposition = "preserve timing"
 semantic_class = "already_started_lazy_observer"
-oracle = "host mesh readiness coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_attach_starts_before_readiness_observation_and_survives_a_dropped_observer",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_fails_closed_on_unreachable_host",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_failure_replays_to_fresh_readiness_observers",
+]
 
 [[site]]
 id = "fc.host_mesh.HostMesh.shutdown[Future._from_corotask]"
@@ -1233,16 +1237,19 @@ public_operation = "ProcMesh.initialized"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code and internal readiness gates"
-driver = "awaited or blocked on by the caller"
-start_point = "the storage Shared is already being driven; the coroutine only awaits it"
-abandonment = "possible; initialization continues on the storage Shared"
-eager_effect = "observes already-running work"
-drop_behavior = "abandons this observer only"
+driver = "the caller drives only the per-access observer coroutine; ProcMesh._proc_mesh retains a Shared source that is already running through native spawn, logging initialization, and setup, or is already resolved"
+start_point = "the ProcMesh retained its running or resolved Shared source before property access; this property's observer coroutine begins only when its per-access Future is driven"
+abandonment = "before drive, dropping the Future starts no observer but can emit Python's ordinary never-awaited-coroutine warning. Source-grounded after a timed get starts the non-aborting observer: dropping the Future discards its receiver but does not stop that observer or the retained ProcMesh Shared source"
+eager_effect = "would begin observing the retained running or resolved Shared during property access rather than when the caller drives the Future"
+drop_behavior = "does not affect proc initialization; a fresh initialized Future can observe the same True result or replay the same retained failure"
 first_side_effect = "none"
-unobserved_error = "silently dropped"
+unobserved_error = "a pre-drive drop never observes the Shared's terminal error and can emit Python's ordinary never-awaited-coroutine warning. Source-grounded: if a started observer later sees failure after its receiver is dropped, send_result logs the receiverless background error. The retained Shared independently stores the exact failure, and fresh initialized Futures replay its type and message"
 disposition = "preserve timing"
 semantic_class = "already_started_lazy_observer"
-oracle = "proc mesh readiness coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_mesh_readiness_replays_success_after_discarded_observer",
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_mesh_readiness_replays_failure_after_discarded_observer",
+]
 
 [[site]]
 id = "fc.proc_mesh.ProcMesh.stop[Future._from_coro_stop_nonblockinginstance]"
@@ -2336,16 +2343,20 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from attach_to_workers"
-consumer = "HostMesh construction, through the bootstrap _as_python_task adapter"
-driver = "awaited inside the host mesh setup coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; the adapter's task may be dropped before it is driven"
-eager_effect = "starts a side effect"
-drop_behavior = "no worker attach is performed"
-unobserved_error = "surfaced on observation"
+consumer = "bootstrap.attach_to_workers normally calls spawn() on the returned task and stores the resulting Shared as HostMesh._inner_host_mesh after constructing the HostMesh extent"
+driver = "PythonTask.spawn drives it on the shared Tokio runtime; HostMesh retains the Shared, while HostMesh.initialized creates only per-access observers"
+start_point = "source-grounded: the binding synchronously takes every input worker PythonTask before constructing its own lazy task. With the ordinary list input covered here, the public wrapper constructs the extent and then spawns that task before returning HostMesh"
+abandonment = "source-grounded: direct private-binding callers can drop the raw task. The public wrapper can also drop it if an accepted custom Sequence iterates successfully but raises when len(workers) constructs the extent; the ordinary-list path tested here spawns it immediately, and dropping HostMesh.initialized abandons only that observer"
+eager_effect = "would begin polling worker-address tasks and attaching during the binding call. That changes direct raw-task abandonment and the source-grounded public exceptional path where extent construction fails before spawn; on the tested ordinary-list path, spawn follows extent construction"
+drop_behavior = "source-grounded: dropping an undriven raw binding task, including during exceptional public extent construction, performs no attach. On the tested ordinary-list path, dropping a readiness observer does not cancel attach because HostMesh retains the non-aborting Shared"
+unobserved_error = "the retained Shared stores an attach failure and later HostMesh.initialized observers replay its original type and message. Source-grounded: if every Shared receiver disappears before completion, send_result logs the error"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "bootstrap attach-to-workers coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_attach_starts_before_readiness_observation_and_survives_a_dropped_observer",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_fails_closed_on_unreachable_host",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_failure_replays_to_fresh_readiness_observers",
+]
 
 [[site]]
 id = "np.bootstrap.run_worker_loop_forever"
@@ -2434,16 +2445,19 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyHostMesh::spawn_nonblocking"
-consumer = "HostMesh._spawn_nonblocking"
-driver = "driven by PythonTask.from_coroutine(task()).spawn() on the Python side"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; the storage Shared may be built and never observed"
-eager_effect = "starts a side effect"
-drop_behavior = "no proc mesh is spawned"
-unobserved_error = "send_result logs an unobserved error once spawned"
+consumer = "HostMesh._spawn_nonblocking's already-started outer coroutine constructs and immediately awaits the returned task after the host mesh is ready; HostMesh retains the outer spawn Shared in _pending_spawns"
+driver = "PythonTask.from_coroutine(task()).spawn() drives the retained outer coroutine, which drives this native task inline; HostMesh also retains the resulting ProcMesh"
+start_point = "source-grounded for the direct binding: the raw native task is lazy in isolation. On the tested public path, spawn_procs starts and retains the outer coroutine before returning ProcMesh, and that coroutine constructs and awaits this task after host readiness"
+abandonment = "source-grounded for the direct private binding: its raw task can be dropped undriven. On the tested public route, dropping the returned ProcMesh or an initialized Future does not cancel spawn because HostMesh retains both the spawn Shared and ProcMesh"
+eager_effect = "source-grounded: an eager binding would begin native proc spawning during task construction instead of at the outer coroutine's immediately following await; the public route has no independent drop point between them"
+drop_behavior = "source-grounded for the direct binding: dropping an undriven raw task performs no native spawn. Tested on the public route: dropping the ProcMesh or readiness observer does not prevent spawn, and HostMesh drains its retained spawn before shutdown"
+unobserved_error = "source-grounded: a native-spawn failure remains in the retained Shared and propagates through ProcMesh initialization; HostMesh stop or shutdown catches and suppresses that pending-spawn failure while draining"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "proc mesh setup coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_shutdown_waits_for_a_pending_proc_spawn_after_caller_drops_mesh",
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_mesh_readiness_replays_success_after_discarded_observer",
+]
 
 [[site]]
 id = "np.host_mesh.PyHostMesh.stop"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -1152,16 +1152,20 @@ public_operation = "HostMesh.shutdown()"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code and context-manager exit"
-driver = "awaited or blocked on by the caller"
-start_point = "lazy; nothing runs until the Future is observed"
-abandonment = "possible; dropping leaves the mesh running and _inner_host_mesh set"
-eager_effect = "starts a side effect"
-drop_behavior = "shutdown never runs"
+driver = "the first observation drives a retained Handle producer; synchronous get without a timeout may instead drive inline"
+start_point = "the call synchronously wraps the coroutine and captures context, but pending-spawn drain and shutdown do not begin until the Future is observed"
+abandonment = "dropping an unobserved Future leaves the mesh usable and _inner_host_mesh set; after asyncio observation starts, cancelling that observer does not abort the retained shutdown producer"
+eager_effect = "an eager replacement would begin draining and shutting down during the call even if the returned Future were discarded"
+drop_behavior = "before observation shutdown never runs; after observation the retained producer completes despite observer cancellation"
 first_side_effect = "flushing pending spawns"
-unobserved_error = "silently dropped"
+unobserved_error = "an unobserved Future reports nothing; after observation, the successful result remains available to another observer. Source-grounded: Python pending-spawn and logging-flush failures are silently suppressed, while native drain and acknowledgement failures warn and return success. Tested consumed states differ: a second preconstructed shutdown drains and then raises before another native call, while shutdown after stop reports success and clears the Python field although the workers remain live"
 disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "immediate-shutdown coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_preconstructed_shutdowns_drain_after_observer_cancellation",
+  "fbcode//monarch/python/tests:test_host_mesh::test_shutdown_host_mesh",
+  "fbcode//monarch/python/tests:test_host_mesh::test_stop_and_reconnect",
+]
 
 [[site]]
 id = "fc.host_mesh.HostMesh.stop[Future._from_corotask]"
@@ -1178,15 +1182,18 @@ caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code"
 driver = "awaited or blocked on by the caller"
-start_point = "lazy; nothing runs until the Future is observed"
-abandonment = "possible; dropping leaves the mesh running"
-eager_effect = "starts a side effect"
-drop_behavior = "stop never runs"
+start_point = "the call synchronously wraps the coroutine and captures context, but pending-spawn drain and stop do not begin until the Future is observed"
+abandonment = "dropping an unobserved Future leaves the mesh usable and does not stop its processes"
+eager_effect = "an eager replacement would begin draining and stopping during the call even if the returned Future were discarded"
+drop_behavior = "stop never runs before observation"
 first_side_effect = "flushing pending spawns"
-unobserved_error = "silently dropped"
+unobserved_error = "an unobserved Future reports nothing. Source-grounded: Python pending-spawn and logging-flush failures are silently suppressed, while native drain failures warn and return success. A repeated stop drains and reaches the binding again, then returns None; source inspection shows the empty cell prevents a second domain stop and lets an overlapping second stop return while the first domain stop is still running"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "stop idempotence coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_shutdown_host_mesh",
+  "fbcode//monarch/python/tests:test_host_mesh::test_stop_and_reconnect",
+]
 
 [[site]]
 id = "fc.host_mesh._spawn_admin[Future._from_corotask]"
@@ -1268,16 +1275,19 @@ public_operation = "ProcMesh.stop()"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code and context-manager exit"
-driver = "awaited or blocked on by the caller"
-start_point = "lazy; nothing runs until the Future is observed"
-abandonment = "possible; dropping leaves _stopped False and logs unflushed"
-eager_effect = "starts a side effect"
-drop_behavior = "stop never runs"
+driver = "the first observation drives a retained Handle producer; synchronous get without a timeout may instead drive inline"
+start_point = "the call synchronously captures the current Rust instance and wraps the coroutine; actor drain, logging flush, and native stop begin only when the Future is observed"
+abandonment = "dropping an unobserved Future leaves the proc mesh usable and _stopped False; after asyncio observation starts, cancelling that observer does not abort the retained stop producer"
+eager_effect = "an eager replacement would begin draining actors, flushing logs, and stopping processes during the call even if the returned Future were discarded"
+drop_behavior = "before observation stop never runs; after observation the retained producer completes despite observer cancellation"
 first_side_effect = "flushing pending actor spawns"
-unobserved_error = "silently dropped"
+unobserved_error = "an unobserved Future reports nothing; after observation, the successful result remains available to another observer. Source-grounded: pending-actor and logging-flush failures are silently suppressed. A repeated stop reaches the binding and returns None; source inspection shows the empty cell prevents a second domain stop before the public wrapper sets _stopped True, so an overlapping second stop can mark the mesh stopped even if the first domain stop later fails"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "proc mesh stop idempotence coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_stop_is_lazy_and_survives_cancelled_observer",
+  "fbcode//monarch/python/tests:test_proc_mesh::test_stop_state_tracks_native_stop_result",
+]
 
 [[site]]
 id = "fc.job.exec_command[Future._from_coro_impl]"
@@ -2427,14 +2437,18 @@ constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyHostMesh::shutdown"
 consumer = "HostMesh.shutdown, after flushing pending spawns"
 driver = "awaited inside the HostMesh.shutdown coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; reachable only when the shutdown coroutine is abandoned"
-eager_effect = "starts a side effect"
-drop_behavior = "the host mesh is never shut down"
-unobserved_error = "surfaced on observation"
+start_point = "the Owned call constructs a lazy task; driving it takes a nonempty SharedCell before awaiting domain shutdown, while an empty cell returns success without domain shutdown and a Ref raises RuntimeError before task construction"
+abandonment = "source-grounded for a direct private caller: dropping the raw task before drive leaves the SharedCell intact; on the tested public route the outer coroutine immediately awaits it"
+eager_effect = "an eager replacement would take the SharedCell and start domain shutdown during the binding call"
+drop_behavior = "source-grounded for the direct binding: an undriven raw task performs no shutdown; the public wrapper's own unobserved Future never calls this binding"
+unobserved_error = "a Ref raises synchronously with its exact managed-only message. Source-grounded: a first Owned shutdown warns and returns success on native drain or acknowledgement failure; an empty-cell repeat logs and returns success without domain shutdown. The empty-cell outcome is a current defect to revisit when repeated teardown is corrected, not a target invariant"
 disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "immediate-shutdown and drain coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_preconstructed_shutdowns_drain_after_observer_cancellation",
+  "fbcode//monarch/python/tests:test_host_mesh::test_shutdown_sliced_host_mesh_throws_exception",
+  "fbcode//monarch/python/tests:test_host_mesh::test_stop_and_reconnect",
+]
 
 [[site]]
 id = "np.host_mesh.PyHostMesh.spawn_nonblocking"
@@ -2476,14 +2490,17 @@ constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyHostMesh::stop"
 consumer = "HostMesh.stop, after flushing pending spawns"
 driver = "awaited inside the HostMesh.stop coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; reachable only when the stop coroutine is abandoned"
-eager_effect = "starts a side effect"
-drop_behavior = "the host mesh is never stopped"
-unobserved_error = "surfaced on observation"
+start_point = "the Owned call constructs a lazy task; driving it takes a nonempty SharedCell before awaiting domain stop, while an empty cell returns success without domain stop and a Ref raises RuntimeError before task construction"
+abandonment = "source-grounded for a direct private caller: dropping the raw task before drive leaves the SharedCell intact; on the tested public route the outer coroutine immediately awaits it"
+eager_effect = "an eager replacement would take the SharedCell and start domain stop during the binding call"
+drop_behavior = "source-grounded for the direct binding: an undriven raw task performs no stop; the public wrapper's own unobserved Future never calls this binding"
+unobserved_error = "a Ref raises synchronously with its exact managed-only message. Source-grounded: a first Owned stop warns and returns success on native drain failure; an empty-cell repeat logs and returns success without domain stop. The empty-cell outcome is a current defect to revisit when repeated teardown is corrected, not a target invariant"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "stop idempotence coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_shutdown_sliced_host_mesh_throws_exception",
+  "fbcode//monarch/python/tests:test_host_mesh::test_stop_and_reconnect",
+]
 
 [[site]]
 id = "np.host_mesh._spawn_admin"
@@ -2669,14 +2686,17 @@ constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyProcMesh::stop_nonblocking"
 consumer = "ProcMesh.stop, after flushing pending actor spawns and logs"
 driver = "awaited inside the _stop_nonblocking coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; reachable only when the stop coroutine is abandoned"
-eager_effect = "starts a side effect"
-drop_behavior = "the proc mesh is never stopped and _stopped stays False"
-unobserved_error = "surfaced on observation"
+start_point = "the call takes the GIL and rejects a Ref synchronously; for Owned it constructs a lazy task that takes a nonempty SharedCell only when driven, while an empty cell returns success without domain stop"
+abandonment = "source-grounded for a direct private caller: dropping the raw task before drive leaves the SharedCell intact; on the tested public route the outer producer immediately awaits it once reached"
+eager_effect = "an eager replacement would take the SharedCell and start domain stop during the binding call"
+drop_behavior = "source-grounded for the direct binding: an undriven raw task performs no stop; dropping the public outer Future before observation prevents this binding from being called"
+unobserved_error = "a Ref raises PyValueError synchronously with its exact owned-only message. Source-grounded: a first Owned stop failure is reported as PyValueError when the task is observed; an empty-cell repeat logs and returns success without domain stop"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "proc mesh stop idempotence coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_stop_is_lazy_and_survives_cancelled_observer",
+  "fbcode//monarch/python/tests:test_proc_mesh::test_stop_state_tracks_native_stop_result",
+]
 
 [[site]]
 id = "np.lib.PyRdmaAction.submit"
@@ -3068,7 +3088,7 @@ operation = "pytokio_import"
 scope = "test"
 state = "legacy"
 transition = "6.8"
-members = ["PythonTask"]
+members = ["PythonTask", "Shared"]
 
 [[site]]
 id = "im.test_proc_launcher_probe.module"


### PR DESCRIPTION
Summary:
stopping a process mesh, or stopping or shutting down a host mesh, returns a `Future`. creating and discarding that `Future` does not begin teardown. once a caller starts waiting on it, Monarch retains the work independently: cancelling that asyncio observer does not abort teardown, and another observation of the same `Future` can still receive the completed result.

this adds bounded tests against real native meshes. they show that discarded teardown Futures leave their meshes usable, started teardown continues after observer cancellation, and host shutdown drains queued process work, actor work, and logging before entering native shutdown. they also pin when a process mesh becomes stopped and the exact synchronous errors returned for mesh references that do not own the underlying resources.

the tests expose a current repeated-teardown defect. the first driven teardown consumes the native mesh ownership cell, but later stop or shutdown calls can report success without performing the requested operation. after stop and shutdown both report success, the same actor remains alive. this is recorded as a defect to correct during the migration, not behavior to preserve.

where an existing process-backed test already creates the required mesh, the new assertions extend that fixture instead of starting another worker job solely for the same state. some assertions inspect private wrapper state because that is where this lifetime boundary is visible; this is migration scaffolding rather than a new public testing interface.

the census links the six affected producers to their exact tests and distinguishes tested behavior from source-grounded internal branches. this changes tests and migration metadata only; production behavior does not change.

Differential Revision: D119010649


