### PR TITLE
characterize logging spawn and flush boundaries

### DIFF
--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -577,43 +577,143 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use anyhow::Result;
     use hyperactor::Instance;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::proc::Proc;
     use hyperactor_mesh::ProcMesh;
     use hyperactor_mesh::host_mesh::HostMesh;
+    use hyperactor_mesh::host_mesh::HostMeshShutdownGuard;
+    use hyperactor_mesh::logging::LogMessage;
     use ndslice::Extent;
     use ndslice::View; // .region(), .num_ranks() etc.
+    use tokio::time::timeout;
 
     use super::*;
     use crate::actor::PythonActor;
     use crate::pytokio::AwaitPyExt;
     use crate::pytokio::ensure_python;
 
+    const TEST_DEADLINE: Duration = Duration::from_secs(30);
+
+    /// The guard covers setup failures and panics. This helper gives ordinary
+    /// `Result` exits a bounded explicit shutdown.
+    async fn shutdown_after_test(
+        mut host_mesh: HostMeshShutdownGuard,
+        instance: &Instance<PythonActor>,
+        test_result: Result<()>,
+    ) -> Result<()> {
+        let shutdown_result = match timeout(TEST_DEADLINE, host_mesh.shutdown(instance)).await {
+            Ok(result) => result,
+            Err(_) => Err(anyhow::anyhow!("host shutdown exceeded {TEST_DEADLINE:?}")),
+        };
+
+        match (test_result, shutdown_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(test_error), Ok(())) => Err(test_error),
+            (Ok(()), Err(shutdown_error)) => Err(shutdown_error),
+            (Err(test_error), Err(shutdown_error)) => Err(anyhow::anyhow!(
+                "test failed: {test_error:#}; host shutdown also failed: {shutdown_error:#}"
+            )),
+        }
+    }
+
+    /// Drive a logging-client task without the test-only conversion helper's
+    /// internal `expect`s, so an error remains available to the cleanup path.
+    async fn drive_logging_client(mut task: PyPythonTask) -> Result<Py<LoggingMeshClient>> {
+        let future = task.take_task()?;
+        let value = timeout(TEST_DEADLINE, future)
+            .await
+            .map_err(|_| anyhow::anyhow!("logging client spawn exceeded {TEST_DEADLINE:?}"))??;
+        Ok(monarch_with_gil(GilSite::Test, |py| {
+            value
+                .bind(py)
+                .extract::<Py<LoggingMeshClient>>()
+                .map_err(|error| pyo3::exceptions::PyTypeError::new_err(error.to_string()))
+        })
+        .await?)
+    }
+
+    /// Drive a unit-returning Python task without a panic-bearing conversion.
+    async fn drive_unit_task(mut task: PyPythonTask, operation: &str) -> Result<()> {
+        let future = task.take_task()?;
+        timeout(TEST_DEADLINE, future)
+            .await
+            .map_err(|_| anyhow::anyhow!("{operation} exceeded {TEST_DEADLINE:?}"))??;
+        Ok(())
+    }
+
+    fn log_client_ordinal(label: &str) -> Result<usize> {
+        if label == "log_client" {
+            return Ok(0);
+        }
+        let suffix = label
+            .strip_prefix("log_client_")
+            .ok_or_else(|| anyhow::anyhow!("unexpected logging client label {label:?}"))?;
+        Ok(suffix.parse()?)
+    }
+
+    /// Read the current sync-flush version without leaving a flush in progress.
+    ///
+    /// `StartSyncFlush` increments the version, so this probe changes the value it
+    /// observes. Posting the matching acknowledgement and awaiting the reply closes
+    /// that operation before another probe or production flush begins.
+    async fn completed_sync_flush_probe(
+        instance: &Instance<PythonActor>,
+        client_actor: &ActorHandle<LogClientActor>,
+    ) -> Result<u64> {
+        let (reply_tx, reply_rx) = instance.open_once_port::<()>();
+        let (version_tx, version_rx) = instance.open_once_port::<u64>();
+
+        client_actor.try_post(
+            instance,
+            LogClientMessage::StartSyncFlush {
+                expected_procs: 1,
+                reply: reply_tx.bind(),
+                version: version_tx.bind(),
+            },
+        )?;
+        let version = timeout(TEST_DEADLINE, version_rx.recv())
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!("sync-flush version probe exceeded {TEST_DEADLINE:?}")
+            })??;
+
+        client_actor.try_post(
+            instance,
+            LogMessage::Flush {
+                sync_version: Some(version),
+            },
+        )?;
+        timeout(TEST_DEADLINE, reply_rx.recv())
+            .await
+            .map_err(|_| anyhow::anyhow!("sync-flush reply probe exceeded {TEST_DEADLINE:?}"))??;
+
+        Ok(version)
+    }
+
     /// Bring up a minimal "world" suitable for integration-style
     /// tests.
-    pub async fn test_world() -> Result<(Proc, Instance<PythonActor>, HostMesh, ProcMesh)> {
+    pub async fn test_world()
+    -> Result<(Proc, Instance<PythonActor>, HostMeshShutdownGuard, ProcMesh)> {
         ensure_python();
 
-        let proc = Proc::direct(ChannelTransport::Unix.any(), "root".to_string())
-            .expect("failed to start root Proc");
+        let proc = Proc::direct(ChannelTransport::Unix.any(), "root".to_string())?;
 
-        let ai = proc
-            .actor_instance("client")
-            .expect("failed to create proc Instance");
+        let ai = proc.actor_instance("client")?;
         let instance = ai.instance;
 
         let host_mesh = HostMesh::local_with_bootstrap(
             crate::testresource::get("monarch/monarch_hyperactor/bootstrap").into(),
         )
-        .await
-        .expect("failed to bootstrap HostMesh");
+        .await?
+        .shutdown_guard();
 
         let proc_mesh = host_mesh
             .spawn(&instance, "p0", Extent::unity(), None, None)
-            .await
-            .expect("failed to spawn ProcMesh");
+            .await?;
 
         Ok((proc, instance, host_mesh, proc_mesh))
     }
@@ -700,6 +800,75 @@ mod tests {
         }
 
         host_mesh.shutdown(&instance).await.expect("host shutdown");
+    }
+
+    /// Constructing the raw spawn task validates and captures its inputs but does
+    /// not spawn the local logging actor. The monotonic label counter is durable
+    /// even if a wrongly created actor stops before the assertion can inspect it.
+    #[cfg_attr(not(target_os = "linux"), ignore = "linux-only")]
+    #[tokio::test]
+    async fn discarded_spawn_task_creates_no_log_client_actor() -> Result<()> {
+        let (_proc, instance, host_mesh, proc_mesh) =
+            timeout(TEST_DEADLINE, test_world())
+                .await
+                .map_err(|_| anyhow::anyhow!("test world setup exceeded {TEST_DEADLINE:?}"))??;
+
+        let test_result = async {
+            let py_instance = PyInstance::from(&instance);
+            let py_proc_mesh = PyProcMesh::new_owned(proc_mesh);
+            let lock = hyperactor_config::global::lock();
+            let _guard = lock.override_key(MESH_ENABLE_LOG_FORWARDING, false);
+
+            let baseline_py = drive_logging_client(LoggingMeshClient::spawn(
+                &py_instance,
+                &py_proc_mesh,
+            )?)
+            .await?;
+            let baseline_label = monarch_with_gil(GilSite::Test, |py| {
+                baseline_py
+                    .borrow(py)
+                    .client_actor
+                    .actor_addr()
+                    .id()
+                    .label()
+                    .map(|label| label.as_str().to_owned())
+            })
+            .await
+            .ok_or_else(|| anyhow::anyhow!("baseline logging client has no label"))?;
+            let baseline_ordinal = log_client_ordinal(&baseline_label)?;
+            drop(baseline_py);
+
+            let discarded = LoggingMeshClient::spawn(&py_instance, &py_proc_mesh)?;
+            drop(discarded);
+
+            let control_py = drive_logging_client(LoggingMeshClient::spawn(
+                &py_instance,
+                &py_proc_mesh,
+            )?)
+            .await?;
+            let control_label = monarch_with_gil(GilSite::Test, |py| {
+                control_py
+                    .borrow(py)
+                    .client_actor
+                    .actor_addr()
+                    .id()
+                    .label()
+                    .map(|label| label.as_str().to_owned())
+            })
+            .await
+            .ok_or_else(|| anyhow::anyhow!("control logging client has no label"))?;
+            let control_ordinal = log_client_ordinal(&control_label)?;
+            anyhow::ensure!(
+                control_ordinal == baseline_ordinal + 1,
+                "dropping an undriven spawn task must not consume a LogClientActor id: baseline {baseline_label}, control {control_label}"
+            );
+
+            drop(control_py);
+            Ok(())
+        }
+        .await;
+
+        shutdown_after_test(host_mesh, &instance, test_result).await
     }
 
     #[cfg_attr(not(target_os = "linux"), ignore = "linux-only")]
@@ -893,5 +1062,71 @@ mod tests {
         }
 
         host_mesh.shutdown(&instance).await.expect("host shutdown");
+    }
+
+    /// A raw flush is inert until driven. Each version probe increments the value
+    /// itself, so `+1` after discard means zero production flushes and `+3` after
+    /// the driven control means exactly one production flush across three probes.
+    #[cfg_attr(not(target_os = "linux"), ignore = "linux-only")]
+    #[tokio::test]
+    async fn discarded_flush_task_does_not_advance_sync_flush_version() -> Result<()> {
+        let (_, instance, host_mesh, proc_mesh) = timeout(TEST_DEADLINE, test_world())
+            .await
+            .map_err(|_| anyhow::anyhow!("test world setup exceeded {TEST_DEADLINE:?}"))??;
+
+        let test_result = async {
+            let py_instance = PyInstance::from(&instance);
+            let py_proc_mesh = PyProcMesh::new_owned(proc_mesh);
+            let lock = hyperactor_config::global::lock();
+            let _guard = lock.override_key(MESH_ENABLE_LOG_FORWARDING, true);
+
+            let client_py = drive_logging_client(LoggingMeshClient::spawn(
+                &py_instance,
+                &py_proc_mesh,
+            )?)
+            .await?;
+            let (forwarding_enabled, client_actor) =
+                monarch_with_gil(GilSite::Test, |py| {
+                    let client = client_py.borrow(py);
+                    (client.forwarder_mesh.is_some(), client.client_actor.clone())
+                })
+                .await;
+            anyhow::ensure!(
+                forwarding_enabled,
+                "the flush witness requires a real forwarding mesh"
+            );
+
+            let baseline = completed_sync_flush_probe(&instance, &client_actor).await?;
+
+            let discarded = monarch_with_gil(GilSite::Test, |py| {
+                client_py.borrow(py).flush(&py_instance)
+            })
+            .await?;
+            drop(discarded);
+
+            let after_discard = completed_sync_flush_probe(&instance, &client_actor).await?;
+            anyhow::ensure!(
+                after_discard == baseline + 1,
+                "a discarded raw flush must add no real flush increment: baseline probe {baseline}, next probe {after_discard}"
+            );
+
+            let control = monarch_with_gil(GilSite::Test, |py| {
+                client_py.borrow(py).flush(&py_instance)
+            })
+            .await?;
+            drive_unit_task(control, "logging flush").await?;
+
+            let after_control = completed_sync_flush_probe(&instance, &client_actor).await?;
+            anyhow::ensure!(
+                after_control == baseline + 3,
+                "one driven flush between completed probes must add one real flush increment: baseline probe {baseline}, final probe {after_control}"
+            );
+
+            drop(client_py);
+            Ok(())
+        }
+        .await;
+
+        shutdown_after_test(host_mesh, &instance, test_result).await
     }
 }

--- a/monarch_hyperactor/tests/client_root.rs
+++ b/monarch_hyperactor/tests/client_root.rs
@@ -33,8 +33,15 @@
 //! Requires the real `monarch` Python package via `py_deps` on
 //! `test_monarch_hyperactor`.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::time::Duration;
+
 use anyhow::Result;
 use hyperactor::Proc;
+use hyperactor::actor::ActorStatus;
+use hyperactor::actor::Signal;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::id::ProcId;
 use hyperactor::proc::Instance;
@@ -43,26 +50,48 @@ use hyperactor_mesh::client_root::ClientRootService;
 use hyperactor_mesh::testactor::TestActor;
 use monarch_hyperactor::actor::PythonActor;
 use monarch_hyperactor::context::PyInstance;
+use monarch_hyperactor::host_mesh::PyBootstrapCommand;
+use monarch_hyperactor::host_mesh::python_client_root;
+use monarch_hyperactor::pytokio::PyPythonTask;
 use monarch_hyperactor::runtime::GilSite;
 use monarch_hyperactor::runtime::get_tokio_runtime;
 use monarch_hyperactor::runtime::monarch_with_gil_blocking;
+use monarch_hyperactor::shape::PyExtent;
+use pyo3::PyTypeInfo;
 use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::PyValueError;
 use pyo3::ffi::c_str;
 use pyo3::prelude::*;
+use pyo3::types::PyAny;
 use pyo3::types::PyTuple;
+
+const WAIT: Duration = Duration::from_secs(30);
+const NO_SIGNAL_WAIT: Duration = Duration::from_secs(1);
+
+// Both tests use the embedded Python interpreter and Monarch runtime, while
+// the bootstrap test also owns process-global one-shot lifecycle state.
+// Do not recover a poisoned guard: a panic can leave that external state
+// inconsistent even though the mutex payload itself is only `()`.
+static CLIENT_ROOT_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+type PythonTaskFuture = Pin<Box<dyn Future<Output = PyResult<Py<PyAny>>> + Send + 'static>>;
 
 #[test]
 #[cfg_attr(not(fbcode_build), ignore)]
 fn python_bootstrap_seeds_client_root_on_local_proc_agent() -> Result<()> {
+    let _test_guard = CLIENT_ROOT_TEST_LOCK
+        .lock()
+        .expect("client-root test lock must not be poisoned");
     pyo3::Python::initialize();
 
-    assert_shutdown_without_host_is_runtime_error()?;
-    let test_result = exercise_python_bootstrap_contract();
-    let shutdown_result = shutdown_python_host();
+    let test_result = assert_bootstrap_is_lazy_and_rejects_invalid_via()
+        .and_then(|()| exercise_python_bootstrap_contract());
+    let shutdown_result = shutdown_python_host_if_present();
 
     match (test_result, shutdown_result) {
-        (Ok(()), Ok(())) => Ok(()),
-        (Err(test_error), Ok(())) => Err(test_error),
+        (Ok(()), Ok(true)) => Ok(()),
+        (Ok(()), Ok(false)) => anyhow::bail!("client-root contract completed without a host"),
+        (Err(test_error), Ok(_)) => Err(test_error),
         (Ok(()), Err(shutdown_error)) => Err(shutdown_error),
         (Err(test_error), Err(shutdown_error)) => anyhow::bail!(
             "client-root contract failed: {test_error:#}; host shutdown also failed: {shutdown_error:#}"
@@ -70,21 +99,74 @@ fn python_bootstrap_seeds_client_root_on_local_proc_agent() -> Result<()> {
     }
 }
 
-fn assert_shutdown_without_host_is_runtime_error() -> Result<()> {
-    monarch_with_gil_blocking(GilSite::Test, |py| -> PyResult<()> {
+fn assert_bootstrap_is_lazy_and_rejects_invalid_via() -> Result<()> {
+    anyhow::ensure!(
+        python_client_root()?.is_none(),
+        "the Python client root must be absent before bootstrap",
+    );
+    assert_shutdown_without_host_is_runtime_error()?;
+
+    monarch_with_gil_blocking(GilSite::Test, |py| -> Result<()> {
         py.run(c_str!("import monarch._rust_bindings"), None, None)?;
         let host_mesh_mod = py.import("monarch._rust_bindings.monarch_hyperactor.host_mesh")?;
-        let error = host_mesh_mod
-            .getattr("shutdown_local_host_mesh")?
-            .call0()
-            .expect_err("shutdown without a host must fail");
-        assert!(
-            error.is_instance_of::<PyRuntimeError>(py),
-            "shutdown without a host must raise RuntimeError, got {error}"
+        let host_mesh_src = py.import("monarch._src.actor.host_mesh")?;
+        let cmd = host_mesh_src.getattr("default_bootstrap_cmd")?.call0()?;
+
+        // Constructing and dropping the raw task must not publish the
+        // observable client-root or host-agent registrations.
+        let discarded = host_mesh_mod.getattr("bootstrap_host")?.call1((&cmd,))?;
+        drop(discarded);
+
+        let error = match host_mesh_mod
+            .getattr("bootstrap_host")?
+            .call1((&cmd, "invalid://scheme"))
+        {
+            Ok(_) => anyhow::bail!("an invalid via address returned a task"),
+            Err(error) => error,
+        };
+        anyhow::ensure!(
+            error.get_type(py).is(PyValueError::type_object(py)),
+            "invalid via must raise exactly ValueError, got {error}",
+        );
+        let message = error.value(py).to_string();
+        anyhow::ensure!(
+            message.contains("via address")
+                && message.contains("unsupported ZMQ scheme")
+                && message.contains("invalid"),
+            "invalid via must identify the address, unsupported scheme, and supplied scheme: {message}",
         );
         Ok(())
     })?;
-    Ok(())
+
+    anyhow::ensure!(
+        python_client_root()?.is_none(),
+        "discarded and rejected bootstrap calls must not register a client root",
+    );
+    assert_shutdown_without_host_is_runtime_error()
+}
+
+fn assert_shutdown_without_host_is_runtime_error() -> Result<()> {
+    monarch_with_gil_blocking(GilSite::Test, |py| -> Result<()> {
+        py.run(c_str!("import monarch._rust_bindings"), None, None)?;
+        let host_mesh_mod = py.import("monarch._rust_bindings.monarch_hyperactor.host_mesh")?;
+        let error = match host_mesh_mod.getattr("shutdown_local_host_mesh")?.call0() {
+            Ok(_) => anyhow::bail!("shutdown without a host returned a task"),
+            Err(error) => error,
+        };
+        anyhow::ensure!(
+            is_no_local_host_error(py, &error),
+            "shutdown without a host must raise exactly RuntimeError and identify the missing local host mesh: {error}",
+        );
+        Ok(())
+    })
+}
+
+fn is_no_local_host_error(py: Python<'_>, error: &PyErr) -> bool {
+    if !error.get_type(py).is(PyRuntimeError::type_object(py)) {
+        return false;
+    }
+    let normalized = error.value(py).to_string().to_ascii_lowercase();
+    normalized.contains("no local host mesh") && normalized.contains("shutdown")
 }
 
 fn exercise_python_bootstrap_contract() -> Result<()> {
@@ -92,8 +174,8 @@ fn exercise_python_bootstrap_contract() -> Result<()> {
     // of Python's RootClientActor (the program's singleton root orchestration actor).
     // Read the restricted root ProcAgent reference from that actor's environment
     // and record which proc hosts the actor.
-    let (root_proc_agent_capability, root_actor_proc_id) =
-        monarch_with_gil_blocking(GilSite::Test, |py| -> PyResult<(ClientRootRef, ProcId)> {
+    let (root_proc_agent_capability, root_actor_proc_id, host_mesh, root_actor_instance) =
+        monarch_with_gil_blocking(GilSite::Test, |py| {
             py.run(c_str!("import monarch._rust_bindings"), None, None)?;
 
             let host_mesh_mod = py.import("monarch._rust_bindings.monarch_hyperactor.host_mesh")?;
@@ -108,7 +190,9 @@ fn exercise_python_bootstrap_contract() -> Result<()> {
                 .getattr("bootstrap_host")?
                 .call1((cmd,))?
                 .call_method0("block_on")?;
-            let root_actor_obj = bootstrap_result.cast::<PyTuple>()?.get_item(2)?;
+            let bootstrap_result = bootstrap_result.cast::<PyTuple>()?;
+            let host_mesh = bootstrap_result.get_item(0)?.unbind();
+            let root_actor_obj = bootstrap_result.get_item(2)?;
             let root_actor = root_actor_obj.cast::<PyInstance>()?.borrow();
             let root_actor_instance: &Instance<PythonActor> = &root_actor;
 
@@ -119,33 +203,18 @@ fn exercise_python_bootstrap_contract() -> Result<()> {
             let root_proc_agent_capability = ClientRootRef::from_env(root_actor_environment)
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
             let root_actor_proc_id = root_actor_instance.self_addr().id().proc_id().clone();
-            Ok((root_proc_agent_capability, root_actor_proc_id))
+            Ok::<_, PyErr>((
+                root_proc_agent_capability,
+                root_actor_proc_id,
+                host_mesh,
+                root_actor_instance.clone_for_py(),
+            ))
         })?;
 
-    // Exercise the capability from an unrelated caller context. This
-    // Proc::client is just a mailbox and caller identity; it is not the Python
-    // RootClientActor. Proc::direct registers network I/O, so construct it
-    // inside the runtime that drives the request.
-    let (service, caller_proc_id) = get_tokio_runtime().block_on(async {
-        let test_proc = Proc::direct(ChannelTransport::Unix.any(), "client_root_test".to_string())?;
-        let caller = test_proc.client("caller");
-        let caller_proc_id = caller.self_addr().id().proc_id().clone();
-
-        // `caller` supplies only the mailbox context for the request and reply;
-        // it neither owns nor places the service. The inherited capability
-        // routes the request to the root ProcAgent.
-        //
-        // This is only a local descriptor: a static service name paired with
-        // the TestActor type. Constructing it does not spawn or contact an
-        // actor. `ensure` performs the request, creating or reusing that named
-        // root-owned service and returning its typed actor reference.
-        let service_descriptor =
-            ClientRootService::<TestActor>::declare("client-root-integration-test");
-        let service_ref = service_descriptor
-            .ensure(&caller, &root_proc_agent_capability, ())
-            .await?;
-        Ok::<_, anyhow::Error>((service_ref, caller_proc_id))
-    })?;
+    // Exercise the capability from an unrelated caller context. This caller is
+    // only a mailbox and identity; it neither owns nor places the service.
+    let (service, caller_proc_id) =
+        ensure_root_service_with_timeout(&root_proc_agent_capability, "client_root_test")?;
 
     // The root ProcAgent and RootClientActor live on the same canonical local
     // proc. A service created through this capability must therefore land on
@@ -160,20 +229,274 @@ fn exercise_python_bootstrap_contract() -> Result<()> {
         "root-owned service was incorrectly created on requester proc {caller_proc_id}",
     );
 
+    // The raw shutdown task is lazy. Dropping it must leave the registered
+    // host agent and root service reachable.
+    discard_python_host_shutdown_task()?;
+    assert_host_agent_accepts_probe_before_shutdown(&host_mesh, &root_actor_instance)?;
+    let (service_after_discard, _) =
+        ensure_root_service_with_timeout(&root_proc_agent_capability, "client_root_after_discard")?;
+    anyhow::ensure!(
+        service_after_discard.actor_addr() == service.actor_addr(),
+        "discarding the raw shutdown task replaced or stopped the root-owned service",
+    );
+
     Ok(())
 }
 
-fn shutdown_python_host() -> Result<()> {
-    // Always exercise the public shutdown path after the contract body returns,
-    // including when a lookup, ensure, or ownership check fails.
+async fn ensure_root_service(
+    root_proc_agent_capability: &ClientRootRef,
+    caller_name: &str,
+) -> Result<(hyperactor::ActorRef<TestActor>, ProcId)> {
+    // Proc::direct registers network I/O, so construct it inside the runtime
+    // that drives the request.
+    let test_proc = Proc::direct(ChannelTransport::Unix.any(), format!("{caller_name}_proc"))?;
+    let caller = test_proc.client(caller_name);
+    let caller_proc_id = caller.self_addr().id().proc_id().clone();
+
+    // This is only a local descriptor. `ensure` performs the request, creating
+    // or reusing the named root-owned service.
+    let service_descriptor =
+        ClientRootService::<TestActor>::declare("client-root-integration-test");
+    let service_ref = service_descriptor
+        .ensure(&caller, root_proc_agent_capability, ())
+        .await?;
+    Ok((service_ref, caller_proc_id))
+}
+
+fn ensure_root_service_with_timeout(
+    root_proc_agent_capability: &ClientRootRef,
+    caller_name: &str,
+) -> Result<(hyperactor::ActorRef<TestActor>, ProcId)> {
+    get_tokio_runtime().block_on(async {
+        tokio::time::timeout(
+            WAIT,
+            ensure_root_service(root_proc_agent_capability, caller_name),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out ensuring root service for {caller_name}"))?
+    })
+}
+
+fn discard_python_host_shutdown_task() -> Result<()> {
     monarch_with_gil_blocking(GilSite::Test, |py| -> PyResult<()> {
         let host_mesh_mod = py.import("monarch._rust_bindings.monarch_hyperactor.host_mesh")?;
-        host_mesh_mod
-            .getattr("shutdown_local_host_mesh")?
-            .call0()?
-            .call_method0("block_on")?;
+        let discarded = host_mesh_mod.getattr("shutdown_local_host_mesh")?.call0()?;
+        drop(discarded);
         Ok(())
     })?;
+    Ok(())
+}
+
+fn assert_host_agent_accepts_probe_before_shutdown(
+    host: &Py<PyAny>,
+    instance: &Instance<PythonActor>,
+) -> Result<()> {
+    // Use the exact HostMesh returned by this test's Python bootstrap. A
+    // process-global lookup can prefer an unrelated Rust host initialized by
+    // another test in this binary, which would make the shutdown witness pass
+    // against the wrong HostAgent.
+    let task = monarch_with_gil_blocking(GilSite::Test, |py| -> PyResult<PythonTaskFuture> {
+        let command = Py::new(
+            py,
+            PyBootstrapCommand {
+                program: "/bin/false".to_string(),
+                arg0: None,
+                args: Vec::new(),
+                env: Default::default(),
+            },
+        )?;
+        let extent = Py::new(py, PyExtent::new(vec!["probes".to_string()], vec![1])?)?;
+        let instance = Py::new(py, PyInstance::from(instance))?;
+        let host = host.bind(py).call_method1("with_bootstrap", (command,))?;
+        let task = host.call_method1(
+            "spawn_nonblocking",
+            (instance, "shutdown-laziness-barrier", extent),
+        )?;
+        take_python_task(&task)
+    })?;
+
+    // The probe deliberately launches /bin/false. A live HostAgent accepts
+    // the request and reports that exit; an agent that already handled an
+    // eager ShutdownHost rejects creation before launching the process.
+    // The current PyPythonTask constructor only stores the future; this probe
+    // does not claim to cover an arbitrary future implementation that detaches
+    // work before it posts to the agent.
+    let outcome = get_tokio_runtime()
+        .block_on(async { tokio::time::timeout(WAIT, task).await })
+        .map_err(|_| anyhow::anyhow!("timed out probing the host agent after task drop"))?;
+    let error = match outcome {
+        Ok(_) => anyhow::bail!("the /bin/false probe process unexpectedly succeeded"),
+        Err(error) => error,
+    };
+    monarch_with_gil_blocking(GilSite::Test, |py| -> Result<()> {
+        anyhow::ensure!(
+            error.get_type(py).is(PyValueError::type_object(py)),
+            "the failed probe must raise exactly ValueError, got {error}",
+        );
+        let message = error.value(py).to_string();
+        // This structured status fragment is the available discriminator that
+        // the HostAgent accepted and launched /bin/false rather than rejecting
+        // the request before process creation.
+        anyhow::ensure!(
+            message.contains("exit_code: 1"),
+            "the host agent did not accept and launch the probe process: {message}",
+        );
+        Ok(())
+    })?;
+    Ok(())
+}
+
+fn shutdown_python_host_if_present() -> Result<bool> {
+    // Always exercise the public shutdown path after the contract body returns,
+    // including when a lookup, ensure, or ownership check fails.
+    let task =
+        monarch_with_gil_blocking(GilSite::Test, |py| -> Result<Option<PythonTaskFuture>> {
+            let host_mesh_mod = py.import("monarch._rust_bindings.monarch_hyperactor.host_mesh")?;
+            match host_mesh_mod.getattr("shutdown_local_host_mesh")?.call0() {
+                Ok(task) => Ok(Some(take_python_task(&task)?)),
+                Err(error) => {
+                    if is_no_local_host_error(py, &error) {
+                        Ok(None)
+                    } else {
+                        Err(anyhow::Error::new(error))
+                    }
+                }
+            }
+        })?;
+    let Some(task) = task else {
+        return Ok(false);
+    };
+    let result = get_tokio_runtime()
+        .block_on(async { tokio::time::timeout(WAIT, task).await })
+        .map_err(|_| anyhow::anyhow!("timed out shutting down the Python host"))??;
+    assert_python_unit(&result, "host shutdown")?;
+
+    Ok(true)
+}
+
+fn take_python_task(task: &Bound<'_, PyAny>) -> PyResult<PythonTaskFuture> {
+    let task = task.cast::<PyPythonTask>()?;
+
+    task.borrow_mut().take_task()
+}
+
+fn assert_python_unit(result: &Py<PyAny>, operation: &str) -> Result<()> {
+    monarch_with_gil_blocking(GilSite::Test, |py| -> Result<()> {
+        let result = result.bind(py).cast::<PyTuple>().map_err(|error| {
+            anyhow::anyhow!("Rust unit did not convert to a Python tuple: {error}")
+        })?;
+        anyhow::ensure!(
+            result.is_empty(),
+            "{operation} must resolve to the empty-tuple conversion of Rust unit",
+        );
+        Ok(())
+    })
+}
+
+fn stop_and_wait_task(instance: &Py<PyInstance>, reason: &str) -> PyResult<PythonTaskFuture> {
+    monarch_with_gil_blocking(GilSite::Test, |py| {
+        let task = instance.bind(py).call_method1("stop_and_wait", (reason,))?;
+        take_python_task(&task)
+    })
+}
+
+#[test]
+#[cfg_attr(not(fbcode_build), ignore)]
+fn py_instance_stop_and_wait_is_lazy_and_repeatable() -> Result<()> {
+    let _test_guard = CLIENT_ROOT_TEST_LOCK
+        .lock()
+        .expect("client-root test lock must not be poisoned");
+    pyo3::Python::initialize();
+
+    let runtime = tokio::runtime::Runtime::new()?;
+    let actor_instance = {
+        let _runtime_guard = runtime.enter();
+        Proc::isolated().actor_instance::<PythonActor>("stop_and_wait_test")?
+    };
+    let instance = actor_instance.instance.clone_for_py();
+    let mut signal = actor_instance.signal;
+    let py_instance =
+        monarch_with_gil_blocking(GilSite::Test, |py| Py::new(py, PyInstance::from(&instance)))?;
+
+    {
+        let _runtime_guard = runtime.enter();
+        monarch_with_gil_blocking(GilSite::Test, |py| -> PyResult<()> {
+            let discarded = py_instance
+                .bind(py)
+                .call_method1("stop_and_wait", ("discarded stop",))?;
+            drop(discarded);
+            Ok(())
+        })?;
+    }
+    // PyPythonTask::new currently stores rather than spawns the future, so no
+    // producer remains after this drop. The bounded wait observes that state;
+    // the driven and repeated controls then consume this same channel in order
+    // and require their exact reasons, catching any queued stray signal. This
+    // does not claim to cover a future implementation that detaches work.
+    let absent =
+        runtime.block_on(async { tokio::time::timeout(NO_SIGNAL_WAIT, signal.recv()).await });
+    anyhow::ensure!(
+        absent.is_err(),
+        "dropping an undriven stop_and_wait task must not signal the actor; got {absent:?}",
+    );
+
+    let reason = "driven stop".to_string();
+    let task = {
+        let _runtime_guard = runtime.enter();
+        stop_and_wait_task(&py_instance, &reason)?
+    };
+    let status_instance = instance.clone_for_py();
+    let driver_reason = reason.clone();
+    let signal_driver = runtime.spawn(async move {
+        let observed = tokio::time::timeout(WAIT, signal.recv())
+            .await
+            .map_err(|_| anyhow::anyhow!("stop signal did not arrive before the deadline"))?
+            .ok_or_else(|| anyhow::anyhow!("stop signal channel closed"))?;
+        match observed {
+            Signal::Stop(actual) => anyhow::ensure!(
+                actual == driver_reason,
+                "expected stop reason {driver_reason:?}, got {actual:?}",
+            ),
+            other => anyhow::bail!("expected Stop signal, got {other:?}"),
+        }
+        status_instance.change_status(ActorStatus::Stopped(driver_reason));
+        Ok::<_, anyhow::Error>(signal)
+    });
+
+    let (result, mut signal) = runtime.block_on(async {
+        let result = tokio::time::timeout(WAIT, task)
+            .await
+            .map_err(|_| anyhow::anyhow!("stop_and_wait did not complete before the deadline"))??;
+        let signal = tokio::time::timeout(WAIT, signal_driver)
+            .await
+            .map_err(|_| anyhow::anyhow!("signal driver did not complete before the deadline"))?
+            .map_err(|error| anyhow::anyhow!("signal driver panicked: {error}"))??;
+        Ok::<_, anyhow::Error>((result, signal))
+    })?;
+    assert_python_unit(&result, "stop_and_wait")?;
+
+    let repeated_reason = "repeated stop";
+    let repeated = {
+        let _runtime_guard = runtime.enter();
+        stop_and_wait_task(&py_instance, repeated_reason)?
+    };
+    let (repeated_result, repeated_signal) = runtime.block_on(async {
+        let result = tokio::time::timeout(WAIT, repeated).await.map_err(|_| {
+            anyhow::anyhow!("repeated stop_and_wait did not complete before the deadline")
+        })??;
+        let signal = tokio::time::timeout(WAIT, signal.recv())
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!("repeated stop signal did not arrive before the deadline")
+            })?
+            .ok_or_else(|| anyhow::anyhow!("stop signal channel closed"))?;
+        Ok::<_, anyhow::Error>((result, signal))
+    })?;
+    assert_python_unit(&repeated_result, "repeated stop_and_wait")?;
+    anyhow::ensure!(
+        matches!(repeated_signal, Signal::Stop(reason) if reason == repeated_reason),
+        "repeated stop_and_wait must signal the actor again",
+    );
 
     Ok(())
 }

--- a/python/tests/_monarch/test_logging.py
+++ b/python/tests/_monarch/test_logging.py
@@ -8,9 +8,10 @@
 
 import asyncio
 import logging
+import threading
 from typing import Any, Callable
 from unittest import IsolatedAsyncioTestCase, TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import call, Mock, patch
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
@@ -30,6 +31,32 @@ class _AwaitTracker:
 
     def get(self, *args: object, **kwargs: object) -> None:
         self.get_called = True
+
+
+class _FlushBaseException(BaseException):
+    pass
+
+
+_FLUSH_BASE_EXCEPTION_MESSAGE = "test flush base exception"
+
+
+def _failing_python_task(error: BaseException) -> PythonTask[None]:
+    async def fail() -> None:
+        raise error
+
+    return PythonTask.from_coroutine(fail())
+
+
+class _RecordingTask:
+    """Expose the real Handle returned when a synthetic task is started."""
+
+    def __init__(self, task: PythonTask[None]) -> None:
+        self._task = task
+        self.handle: Any | None = None
+
+    def spawn_handle(self) -> Any:
+        self.handle = self._task.spawn_handle()
+        return self.handle
 
 
 class LoggingManagerTest(TestCase):
@@ -184,6 +211,28 @@ class LoggingManagerTest(TestCase):
         mock_task.spawn_handle.assert_called_once_with()
         mock_handle.get.assert_called_once_with(timeout=3)
 
+    def test_flush_propagates_base_exception(self) -> None:
+        with patch.object(self.logging_manager, "_new_flush_task") as no_client_task:
+            with self.assertRaises(AssertionError) as no_client_error:
+                self.logging_manager.flush()
+        self.assertIs(type(no_client_error.exception), AssertionError)
+        no_client_task.assert_not_called()
+
+        self.logging_manager._logging_mesh_client = Mock()
+        with patch.object(
+            self.logging_manager,
+            "_new_flush_task",
+            return_value=_failing_python_task(
+                _FlushBaseException(_FLUSH_BASE_EXCEPTION_MESSAGE)
+            ),
+        ) as mock_new_flush_task:
+            with self.assertRaises(_FlushBaseException) as raised:
+                self.logging_manager.flush()
+
+        self.assertIs(type(raised.exception), _FlushBaseException)
+        self.assertEqual(str(raised.exception), _FLUSH_BASE_EXCEPTION_MESSAGE)
+        mock_new_flush_task.assert_called_once_with()
+
     def test_flush_from_tokio_awaits_shared_not_handle(self) -> None:
         mock_task = Mock()
         shared = _AwaitTracker(Shared.from_value(None))
@@ -286,6 +335,175 @@ class LoggingManagerAsyncTest(IsolatedAsyncioTestCase):
         mock_task.spawn.assert_not_called()
         self.assertTrue(handle.awaited)
         self.assertFalse(handle.get_called)
+
+    async def test_flush_async_suppresses_ordinary_error(self) -> None:
+        entered: list[str] = []
+
+        async def fail() -> None:
+            entered.append("ordinary error")
+            raise RuntimeError("test flush error")
+
+        self.logging_manager._logging_mesh_client = Mock()
+        with patch.object(
+            self.logging_manager,
+            "_new_flush_task",
+            return_value=PythonTask.from_coroutine(fail()),
+        ) as mock_new_flush_task:
+            result = await asyncio.wait_for(
+                self.logging_manager.flush_async(), timeout=10
+            )
+
+        self.assertIsNone(result)
+        self.assertEqual(entered, ["ordinary error"])
+        mock_new_flush_task.assert_called_once_with()
+
+    async def test_flush_async_propagates_base_exception(self) -> None:
+        with patch.object(self.logging_manager, "_new_flush_task") as no_client_task:
+            result = await asyncio.wait_for(
+                self.logging_manager.flush_async(), timeout=10
+            )
+        self.assertIsNone(result)
+        no_client_task.assert_not_called()
+
+        self.logging_manager._logging_mesh_client = Mock()
+        with patch.object(
+            self.logging_manager,
+            "_new_flush_task",
+            return_value=_failing_python_task(
+                _FlushBaseException(_FLUSH_BASE_EXCEPTION_MESSAGE)
+            ),
+        ) as mock_new_flush_task:
+            with self.assertRaises(_FlushBaseException) as raised:
+                await asyncio.wait_for(self.logging_manager.flush_async(), timeout=10)
+
+        self.assertIs(type(raised.exception), _FlushBaseException)
+        self.assertEqual(str(raised.exception), _FLUSH_BASE_EXCEPTION_MESSAGE)
+        mock_new_flush_task.assert_called_once_with()
+
+    async def test_flush_from_tokio_propagates_base_exception(self) -> None:
+        with patch.object(self.logging_manager, "_new_flush_task") as no_client_task:
+            no_client = PythonTask.from_coroutine(
+                self.logging_manager._flush_from_tokio()
+            )
+            result = await asyncio.wait_for(
+                asyncio.to_thread(no_client.block_on), timeout=10
+            )
+        self.assertIsNone(result)
+        no_client_task.assert_not_called()
+
+        self.logging_manager._logging_mesh_client = Mock()
+        with patch.object(
+            self.logging_manager,
+            "_new_flush_task",
+            return_value=_failing_python_task(
+                _FlushBaseException(_FLUSH_BASE_EXCEPTION_MESSAGE)
+            ),
+        ) as mock_new_flush_task:
+            adapter = PythonTask.from_coroutine(
+                self.logging_manager._flush_from_tokio()
+            )
+            with self.assertRaises(_FlushBaseException) as raised:
+                await asyncio.wait_for(asyncio.to_thread(adapter.block_on), timeout=10)
+
+        self.assertIs(type(raised.exception), _FlushBaseException)
+        self.assertEqual(str(raised.exception), _FLUSH_BASE_EXCEPTION_MESSAGE)
+        mock_new_flush_task.assert_called_once_with()
+
+    async def test_flush_async_cancellation_leaves_producer_reapable(self) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        completed = threading.Event()
+
+        async def gated_flush() -> None:
+            entered.set()
+            released = await PythonTask.spawn_blocking(lambda: release.wait(timeout=10))
+            if not released:
+                raise TimeoutError("flush release was not published")
+            completed.set()
+
+        # Adapter-level seam: this is a controlled PythonTask, not a native
+        # LoggingMeshClient flush. The production method uses the same
+        # non-abortable Handle observation path. Keep no second Handle here:
+        # cancelling flush_async must drop its only observer before release.
+        controlled = PythonTask.from_coroutine(gated_flush())
+        observer: asyncio.Task[None] | None = None
+        completed_after_cancel = False
+        self.logging_manager._logging_mesh_client = Mock()
+        try:
+            with patch.object(
+                self.logging_manager,
+                "_new_flush_task",
+                return_value=controlled,
+            ):
+                observer = asyncio.create_task(self.logging_manager.flush_async())
+                reached = await asyncio.wait_for(
+                    asyncio.to_thread(entered.wait, 10), timeout=10
+                )
+                self.assertTrue(reached, "the controlled flush did not start")
+
+                self.assertTrue(observer.cancel())
+                with self.assertRaises(asyncio.CancelledError):
+                    await observer
+        finally:
+            release.set()
+            try:
+                completed_after_cancel = await asyncio.wait_for(
+                    asyncio.to_thread(completed.wait, 5), timeout=10
+                )
+            finally:
+                if observer is not None:
+                    if not observer.done():
+                        observer.cancel()
+                    try:
+                        await observer
+                    except asyncio.CancelledError:
+                        pass
+
+        self.assertTrue(
+            completed_after_cancel,
+            "cancelling the observer must not cancel the started producer",
+        )
+
+    async def test_two_manager_flushes_create_two_operations(self) -> None:
+        entries = [0, 0]
+
+        # Adapter-level seam: the native client supplies distinct synthetic
+        # producers, while the real manager helper must request, start, and
+        # observe each one independently. This does not claim to exercise two
+        # native sync-flush barriers; those effects are covered natively.
+        def controlled_task(index: int) -> _RecordingTask:
+            async def enter() -> None:
+                entries[index] += 1
+
+            return _RecordingTask(PythonTask.from_coroutine(enter()))
+
+        first = controlled_task(0)
+        second = controlled_task(1)
+        mock_client = Mock()
+        mock_client.flush.side_effect = [first, second]
+        mock_instance = Mock()
+        self.logging_manager._logging_mesh_client = mock_client
+        with patch("monarch._src.actor.logging.context") as mock_context:
+            mock_context.return_value.actor_instance._as_rust.return_value = (
+                mock_instance
+            )
+            first_result = await asyncio.wait_for(
+                self.logging_manager.flush_async(), timeout=10
+            )
+            second_result = await asyncio.wait_for(
+                self.logging_manager.flush_async(), timeout=10
+            )
+
+        self.assertIsNone(first_result)
+        self.assertIsNone(second_result)
+        self.assertEqual(entries, [1, 1])
+        self.assertIsNotNone(first.handle)
+        self.assertIsNotNone(second.handle)
+        self.assertIsNot(first.handle, second.handle)
+        self.assertEqual(
+            mock_client.flush.call_args_list,
+            [call(mock_instance), call(mock_instance)],
+        )
 
     @patch("monarch._src.actor.logging.LoggingMeshClient")
     @patch("monarch._src.actor.logging.context")

--- a/python/tests/test_admin_spawn_characterization.py
+++ b/python/tests/test_admin_spawn_characterization.py
@@ -1,0 +1,210 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Characterization tests for the task boundaries around admin creation.
+
+The public ``_spawn_admin`` function returns a lazy Monarch ``Future``. Once an
+asyncio caller observes that Future, a retained Handle owns the producer while
+the Python asyncio Future is only an observer. These tests pin both boundaries:
+which validation happens during the public call, and what happens when the
+caller cancels an observer after the raw native task has been constructed.
+"""
+
+import asyncio
+import os
+import threading
+from typing import Callable
+from unittest.mock import patch
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import PyMeshAdminRef
+from monarch._rust_bindings.monarch_hyperactor.pytokio import Handle, PythonTask
+from monarch._src.actor import future as future_module, host_mesh as host_mesh_module
+from monarch._src.actor.actor_mesh import shutdown_context
+from monarch._src.actor.future import Future
+from monarch._src.actor.host_mesh import HostMesh, this_host
+
+
+async def _wait_for_threading_event(event: threading.Event, message: str) -> None:
+    reached = await asyncio.wait_for(
+        asyncio.to_thread(event.wait, 30),
+        timeout=35,
+    )
+    assert reached, message
+
+
+async def _wait_for_handle_result(
+    handle: Handle,
+    message: str,
+) -> tuple[str, PyMeshAdminRef]:
+    deadline = asyncio.get_running_loop().time() + 30
+    while (result := handle.poll()) is None:
+        if asyncio.get_running_loop().time() >= deadline:
+            raise TimeoutError(message)
+        await asyncio.sleep(0)
+    return result
+
+
+class _AdminSpawnGate:
+    """Hold a real native admin task after construction but before its first poll.
+
+    Calling the real binding here preserves its synchronous validation. A valid
+    call returns the production task, which this wrapper holds behind a bounded
+    gate and then awaits normally. The construction event therefore says that
+    the outer producer owns a native task, not that the native task has run.
+    """
+
+    def __init__(self, real_spawn: Callable[..., PythonTask]) -> None:
+        self._real_spawn = real_spawn
+        self.release = threading.Event()
+        self.native_constructed = threading.Event()
+        self.attempts: list[str | None] = []
+        self.tasks_constructed = 0
+        self.results: list[tuple[str, PyMeshAdminRef]] = []
+
+    def __call__(
+        self,
+        host_meshes: object,
+        instance: object,
+        admin_addr: str | None,
+        telemetry_url: str | None,
+    ) -> PythonTask:
+        self.attempts.append(admin_addr)
+        native_task = self._real_spawn(
+            host_meshes,
+            instance,
+            admin_addr,
+            telemetry_url,
+        )
+        self.tasks_constructed += 1
+        self.native_constructed.set()
+
+        async def drive_native() -> tuple[str, PyMeshAdminRef]:
+            released = await PythonTask.spawn_blocking(
+                lambda: self.release.wait(timeout=30)
+            )
+            if not released:
+                raise TimeoutError("admin spawn release was not published")
+            result = await native_task
+            self.results.append(result)
+            return result
+
+        return PythonTask.from_coroutine(drive_native())
+
+
+async def _assert_input_errors(
+    host: HostMesh,
+    gate: _AdminSpawnGate,
+) -> None:
+    with pytest.raises(ValueError) as empty_error:
+        host_mesh_module._spawn_admin([])
+    assert type(empty_error.value) is ValueError
+    assert str(empty_error.value) == "_spawn_admin requires at least one HostMesh"
+    assert gate.attempts == []
+    assert "MONARCH_ADMIN_URL" not in os.environ
+
+    invalid = host_mesh_module._spawn_admin([host], admin_addr="not-an-address")
+    assert gate.attempts == []
+    with pytest.raises(Exception) as invalid_error:
+        await asyncio.wait_for(invalid.as_asyncio(), timeout=30)
+    assert type(invalid_error.value) is Exception
+    assert str(invalid_error.value) == (
+        "invalid admin_addr 'not-an-address': invalid socket address syntax"
+    )
+    assert gate.attempts == ["not-an-address"]
+    assert gate.tasks_constructed == 0
+    assert not gate.native_constructed.is_set()
+    assert gate.results == []
+    assert "MONARCH_ADMIN_URL" not in os.environ
+
+
+@pytest.mark.timeout(240)
+@isolate_in_subprocess
+async def test_spawn_admin_is_lazy_and_survives_cancelled_observer() -> None:
+    previous_admin_url = os.environ.pop("MONARCH_ADMIN_URL", None)
+    gate = _AdminSpawnGate(host_mesh_module._hy_spawn_admin)
+    success: Future[tuple[str, PyMeshAdminRef]] | None = None
+    observer: asyncio.Future[tuple[str, PyMeshAdminRef]] | None = None
+    success_started = False
+    admin_ref: PyMeshAdminRef | None = None
+
+    try:
+        host = this_host()
+        assert await asyncio.wait_for(host.initialized.as_asyncio(), timeout=30) is True
+
+        with patch.object(host_mesh_module, "_hy_spawn_admin", gate):
+            await _assert_input_errors(host, gate)
+
+            successful_spawn = host_mesh_module._spawn_admin(
+                [host], admin_addr="[::]:0"
+            )
+            success = successful_spawn
+            # Future construction captures the current Monarch context, but it
+            # must not resolve the host or invoke the native admin binding.
+            assert gate.attempts == ["not-an-address"]
+            assert "MONARCH_ADMIN_URL" not in os.environ
+
+            observer = successful_spawn.as_asyncio()
+            success_started = True
+            status = successful_spawn._status
+            assert isinstance(status, future_module._Handle)
+            producer_handle = status.handle
+            await _wait_for_threading_event(
+                gate.native_constructed,
+                "the outer producer did not construct the native admin task",
+            )
+            assert gate.attempts == ["not-an-address", "[::]:0"]
+            assert gate.tasks_constructed == 1
+            assert gate.results == []
+            assert not observer.done()
+            assert "MONARCH_ADMIN_URL" not in os.environ
+
+            assert observer.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await observer
+
+            gate.release.set()
+            # Handle.poll() neither drives the producer nor retains another
+            # waiter. The cancelled observer's internal completion waiter stays
+            # alive, so require completion before attaching a replacement
+            # Python observer rather than claiming that no waiter exists.
+            cached_url, cached_ref = await _wait_for_handle_result(
+                producer_handle,
+                "admin spawn did not finish after its first observer was cancelled",
+            )
+            assert os.environ["MONARCH_ADMIN_URL"] == cached_url
+            admin_url, admin_ref = await asyncio.wait_for(
+                successful_spawn.as_asyncio(),
+                timeout=30,
+            )
+            assert len(gate.results) == 1
+            native_url, native_ref = gate.results[0]
+            assert admin_url == native_url
+            assert admin_url == cached_url
+            assert admin_ref is native_ref
+            assert admin_ref is cached_ref
+            assert os.environ["MONARCH_ADMIN_URL"] == admin_url
+    finally:
+        if observer is not None and not observer.done():
+            observer.cancel()
+        gate.release.set()
+        try:
+            if success_started and success is not None:
+                await asyncio.wait_for(success.as_asyncio(), timeout=30)
+        finally:
+            try:
+                await asyncio.wait_for(shutdown_context().as_asyncio(), timeout=30)
+            finally:
+                if previous_admin_url is None:
+                    os.environ.pop("MONARCH_ADMIN_URL", None)
+                else:
+                    os.environ["MONARCH_ADMIN_URL"] = previous_admin_url
+
+    # Keep the opaque capability live through local admin shutdown.
+    assert admin_ref is not None

--- a/python/tests/test_client_shutdown.py
+++ b/python/tests/test_client_shutdown.py
@@ -8,8 +8,12 @@
 
 import os
 import time
+from typing import Any, Callable
+from unittest.mock import patch
 
 import pytest
+from monarch._rust_bindings.monarch_hyperactor import host_mesh as host_mesh_binding
+from monarch._src.actor import actor_mesh as actor_mesh_module
 from monarch.actor import Actor, endpoint, shutdown_context, this_host
 
 
@@ -29,24 +33,71 @@ def pid_exists(pid: int) -> bool:
         return True
 
 
+class _ShutdownCallThrough:
+    """Record shutdown state and forward to the real native binding."""
+
+    def __init__(self, real_shutdown: Callable[[], Any]) -> None:
+        self._real_shutdown = real_shutdown
+        self.calls = 0
+        self.shutdown_done_at_call: list[bool] = []
+
+    def __call__(self) -> Any:
+        self.shutdown_done_at_call.append(actor_mesh_module._shutdown_done)
+        self.calls += 1
+        return self._real_shutdown()
+
+
 # This test has to be in its own file so it does not share any process state
 # with other tests. The client cannot be restarted after it has been shutdown.
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(240)
 def test_client_shutdown() -> None:
     procs = this_host().spawn_procs(per_host={"gpus": 2})
     actors = procs.spawn("simple", Simple)
-    pids = actors.get_pid.call().get()
-    pids = [p for _, p in pids]
-    # Now shutdown the client. Delete references to avoid accidental reuse.
-    del procs
-    del actors
-    assert shutdown_context().get() is None
-    # The already-complete shutdown path remains safe and idempotent.
-    assert shutdown_context().get() is None
+    pid_items = list(actors.get_pid.call().get(timeout=30).items())
+    pids = [pid for _, pid in pid_items]
+
+    call_through = _ShutdownCallThrough(host_mesh_binding.shutdown_local_host_mesh)
+    with patch.object(
+        host_mesh_binding,
+        "shutdown_local_host_mesh",
+        call_through,
+    ):
+        discarded = shutdown_context()
+        del discarded
+        assert list(actors.get_pid.call().get(timeout=30).items()) == pid_items
+        assert call_through.calls == 0
+        assert call_through.shutdown_done_at_call == []
+
+        # Both Futures capture the shutdown-sequence branch now. Driving the
+        # first sets _shutdown_done; observing the second then proves that an
+        # already-constructed sequence takes its own early return.
+        first_shutdown = shutdown_context()
+        second_shutdown = shutdown_context()
+        assert first_shutdown.get(timeout=60) is None
+        assert call_through.calls == 1
+        assert call_through.shutdown_done_at_call == [True]
+
+        # This Future captured the shutdown-sequence branch before the first
+        # one ran, but observes _shutdown_done after the first one completes.
+        assert second_shutdown.get(timeout=30) is None
+        assert call_through.calls == 1
+        assert call_through.shutdown_done_at_call == [True]
+
+        # The client cannot be restarted after this one full shutdown: five
+        # Rust registrations are OnceLock, and _client_context keeps the
+        # stopped Context. Never reset _shutdown_done to rehearse it.
+        del procs
+        del actors
+
+        # This Future is constructed after _shutdown_done became true, so it
+        # takes the separate _noop branch and never calls the native binding.
+        assert shutdown_context().get(timeout=30) is None
+        assert call_through.calls == 1
+        assert call_through.shutdown_done_at_call == [True]
+
     # After this, all the resources created by the client should be released,
-    # including this_host and the procs. We check this by seeing if the pids are
-    # still alive after a short wait period (procs are cleaned up with an async
-    # message).
+    # including this_host and the procs. This observes worker-process exit after
+    # explicit shutdown; it does not exercise client-process exit or atexit.
     still_alive = []
     for _ in range(4):
         time.sleep(5)

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import asyncio
 import os
 import pathlib
 import shutil
@@ -19,15 +20,19 @@ import threading
 import time
 import weakref
 from contextlib import ExitStack
-from typing import Dict, List, Optional, Set
+from typing import Any, cast, Dict, Generator, List, Optional, Set
 from unittest.mock import patch
 
 import cloudpickle
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
-from monarch._rust_bindings.monarch_hyperactor.host_mesh import BootstrapCommand
+from monarch._rust_bindings.monarch_hyperactor.context import Instance as HyInstance
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import (
+    BootstrapCommand,
+    HostMesh as HyHostMesh,
+)
 from monarch._rust_bindings.monarch_hyperactor.proc import ProcId, Uid
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Point, Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, attach, context
 from monarch._src.actor.bootstrap import attach_to_workers
@@ -184,6 +189,106 @@ def _wait_for_marker(path: pathlib.Path) -> None:
         time.sleep(0.01)
 
 
+async def _wait_for_event(event: threading.Event, message: str) -> None:
+    reached = await asyncio.wait_for(
+        asyncio.to_thread(event.wait, 30),
+        timeout=35,
+    )
+    assert reached, message
+
+
+class _AwaitRecord:
+    """Record when a synthetic pending spawn is actually awaited."""
+
+    def __init__(self, record: list[str], value: str) -> None:
+        self._record = record
+        self._value = value
+
+    def __await__(self) -> Generator[Any, None, None]:
+        async def record() -> None:
+            self._record.append(self._value)
+
+        return record().__await__()
+
+
+class _PendingActorRecord:
+    """Expose an initializer that records when the real actor queue drives it."""
+
+    def __init__(self, record: list[str]) -> None:
+        self._record = record
+
+    @property
+    def initialized(self) -> Future[bool]:
+        async def record() -> bool:
+            self._record.append("pending_actor")
+            return True
+
+        return Future._from_coro(record())
+
+
+class _HostTeardownCallThrough:
+    """Observe binding calls while forwarding every call to the real mesh.
+
+    The wrapper can count entry into ``PyHostMesh.stop`` and ``shutdown``. It
+    cannot see which ``SharedCell::take`` branch Rust takes, so tests must not
+    use it to claim that an inner domain operation ran.
+    """
+
+    def __init__(
+        self,
+        inner: HyHostMesh,
+        record: list[str] | None = None,
+        release: threading.Event | None = None,
+    ) -> None:
+        self._inner = inner
+        self._record = record
+        self._release = release
+        self.entered = threading.Event()
+        self.calls: list[str] = []
+
+    def _wrap(self, operation: str, task: PythonTask[None]) -> PythonTask[None]:
+        self.calls.append(operation)
+        if self._record is not None:
+            self._record.append(f"native_{operation}")
+        self.entered.set()
+        release = self._release
+        if release is None:
+            return task
+        release_event = cast(threading.Event, release)
+
+        async def gated() -> None:
+            released = await PythonTask.spawn_blocking(
+                lambda: release_event.wait(timeout=30)
+            )
+            if not released:
+                raise TimeoutError("host teardown release was not published")
+            await task
+
+        return PythonTask.from_coroutine(gated())
+
+    def shutdown(self, instance: HyInstance) -> PythonTask[None]:
+        return self._wrap("shutdown", self._inner.shutdown(instance))
+
+    def stop(self, instance: HyInstance) -> PythonTask[None]:
+        return self._wrap("stop", self._inner.stop(instance))
+
+
+def _install_host_teardown_call_through(
+    host: HostMesh,
+    record: list[str] | None = None,
+    release: threading.Event | None = None,
+    inner: HyHostMesh | None = None,
+) -> _HostTeardownCallThrough:
+    if inner is None:
+        inner = host._hy_host_mesh.block_on()
+    call_through = _HostTeardownCallThrough(inner, record, release)
+    # HostMesh reads this value through the Shared interface. The test wrapper
+    # preserves that interface and forwards every teardown call to the exact
+    # native object it replaced.
+    host._inner_host_mesh = Shared.from_value(cast(HyHostMesh, call_through))
+    return call_through
+
+
 def _gated_bootstrap_command(
     directory: pathlib.Path,
 ) -> tuple[BootstrapCommand, pathlib.Path, pathlib.Path]:
@@ -231,15 +336,111 @@ def _gated_bootstrap_command(
     return command, entered, release
 
 
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+async def test_preconstructed_shutdowns_drain_after_observer_cancellation() -> None:
+    job = ProcessJob({"hosts": 1})
+    release = threading.Event()
+    first_shutdown: Future[None] | None = None
+    try:
+        host = job.state(cached_path=None).hosts
+        proc_mesh = host.spawn_procs(name="drain_order")
+        await asyncio.wait_for(proc_mesh.initialized, timeout=30)
+        inner = host._hy_host_mesh.poll()
+        assert inner is not None
+
+        order: list[str] = []
+        # These synthetic completions sit in the real pending-proc and
+        # pending-actor queues. They prove traversal and ordering through those
+        # queues, not the lifecycle of real proc or actor spawns.
+        host._pending_spawns = [cast(Any, _AwaitRecord(order, "pending_proc"))]
+        proc_mesh._pending_actor_spawns = [cast(Any, _PendingActorRecord(order))]
+        flush_logging = proc_mesh._logging_manager._flush_from_tokio
+
+        async def record_logging_flush() -> None:
+            await flush_logging()
+            order.append("logging_flush")
+
+        call_through = _install_host_teardown_call_through(
+            host,
+            order,
+            release,
+            inner,
+        )
+        first_shutdown = host.shutdown()
+        second_shutdown = host.shutdown()
+        assert order == []
+        assert call_through.calls == []
+
+        with patch.object(
+            proc_mesh._logging_manager,
+            "_flush_from_tokio",
+            record_logging_flush,
+        ):
+            observer = first_shutdown.as_asyncio()
+            await _wait_for_event(
+                call_through.entered,
+                "host shutdown did not reach the native binding",
+            )
+            assert order == [
+                "pending_proc",
+                "pending_actor",
+                "logging_flush",
+                "native_shutdown",
+            ]
+            assert call_through.calls == ["shutdown"]
+
+            assert observer.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await observer
+
+            release.set()
+            assert (
+                await asyncio.wait_for(
+                    asyncio.to_thread(first_shutdown.get, 30),
+                    timeout=35,
+                )
+                is None
+            )
+            assert await asyncio.wait_for(first_shutdown, timeout=30) is None
+            assert host._inner_host_mesh is None
+
+            with pytest.raises(RuntimeError) as second_error:
+                await asyncio.wait_for(second_shutdown, timeout=30)
+            assert type(second_error.value) is RuntimeError
+            assert str(second_error.value) == "HostMesh has already been shut down"
+            assert order == [
+                "pending_proc",
+                "pending_actor",
+                "logging_flush",
+                "native_shutdown",
+                "logging_flush",
+            ]
+            assert call_through.calls == ["shutdown"]
+    finally:
+        release.set()
+        try:
+            if first_shutdown is not None:
+                try:
+                    await asyncio.wait_for(first_shutdown, timeout=30)
+                except (Exception, asyncio.CancelledError):
+                    pass
+        finally:
+            job.kill()
+
+
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 def test_shutdown_host_mesh() -> None:
     with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
         hm = state.hosts
+        discarded_stop = hm.stop()
+        discarded_shutdown = hm.shutdown()
+        del discarded_stop, discarded_shutdown
         pm = hm.spawn_procs(per_host={"gpus": 2})
         am = pm.spawn("actor", RankActor)
-        am.get_rank.choose().get()
-        hm.shutdown().get()
+        am.get_rank.choose().get(timeout=30)
+        assert hm.shutdown().get(timeout=30) is None
         assert hm._inner_host_mesh is None
 
 
@@ -553,15 +754,32 @@ async def test_host_mesh_context_manager() -> None:
 def test_shutdown_sliced_host_mesh_throws_exception() -> None:
     with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
         hm = state.hosts
+        assert hm.initialized.get(timeout=30) is True
         hm_sliced = hm.slice(hosts=1)
         sliced_inner = hm_sliced._inner_host_mesh
         assert sliced_inner is not None
+        reference = sliced_inner.poll()
+        assert reference is not None
+        instance = context().actor_instance._as_rust()
 
-        with pytest.raises(
-            RuntimeError,
-            match="cannot shut down `HostMesh` that is a reference instead of owned",
-        ):
-            hm_sliced.shutdown().get()
+        with pytest.raises(RuntimeError) as raw_shutdown_error:
+            reference.shutdown(instance)
+        assert type(raw_shutdown_error.value) is RuntimeError
+        assert str(raw_shutdown_error.value) == (
+            "cannot shut down `HostMesh` that is a reference instead of owned"
+        )
+
+        with pytest.raises(RuntimeError) as raw_stop_error:
+            reference.stop(instance)
+        assert type(raw_stop_error.value) is RuntimeError
+        assert str(raw_stop_error.value) == (
+            "cannot stop `HostMesh` that is a reference instead of owned"
+        )
+
+        with pytest.raises(RuntimeError) as public_shutdown_error:
+            hm_sliced.shutdown().get(timeout=30)
+        assert type(public_shutdown_error.value) is RuntimeError
+        assert str(public_shutdown_error.value) == str(raw_shutdown_error.value)
 
         assert hm_sliced._inner_host_mesh is sliced_inner
 
@@ -584,34 +802,78 @@ def test_stop_and_reconnect() -> None:
     # waiting for undeliverable-message errors to surface.
     with configured(message_delivery_timeout="5s"):
         job = ProcessJob({"hosts": 2})
+        try:
+            # First connection: spawn actors, verify they work.
+            with scoped_state(job, cached_path=None) as state:
+                hm = state.hosts
+                pm = hm.spawn_procs(per_host={"gpus": 1})
+                am = pm.spawn("actor", RankActor)
+                pids = am.get_pid.call().get(timeout=30)
+                assert len(pids) == 2
+                pids = [pid for _, pid in pids.items()]
 
-        # First connection: spawn actors, verify they work.
-        with scoped_state(job, cached_path=None) as state:
-            hm = state.hosts
-            pm = hm.spawn_procs(per_host={"gpus": 1})
-            am = pm.spawn("actor", RankActor)
-            pids = am.get_pid.call().get()
-            assert len(pids) == 2
-            pids = [pid for _, pid in pids.items()]
+                order: list[str] = []
+                call_through = _install_host_teardown_call_through(hm, order)
+                flush_pending_spawns = hm._flush_pending_spawns
 
-            # Stop: terminate user procs but keep workers alive.
-            hm.stop().get()
-            # Ensure that the procs are actually dead.
-            assert all(not is_process_running(pid) for pid in pids)
+                async def record_drain() -> None:
+                    order.append("drain")
+                    await flush_pending_spawns()
 
-            # Sleep past the message delivery timeout to ensure that no errors
-            # surface from undeliverable messages to dead procs/actors.
-            time.sleep(7)
+                with patch.object(hm, "_flush_pending_spawns", record_drain):
+                    # Stop terminates user procs but leaves workers available.
+                    assert hm.stop().get(timeout=30) is None
+                    assert order == ["drain", "native_stop"]
+                    assert call_through.calls == ["stop"]
+                    assert all(not is_process_running(pid) for pid in pids)
 
-            # Second connection: reconnect to the same workers via state().
-            hm2 = job.state(cached_path=None).hosts
-            pm2 = hm2.spawn_procs(per_host={"gpus": 1})
-            am2 = pm2.spawn("actor", RankActor)
-            ranks2 = am2.get_rank.call().get()
-            assert len(ranks2) == 2
+                    # Sleep past the message delivery timeout to ensure that no
+                    # errors surface from undeliverable messages to dead
+                    # procs/actors.
+                    time.sleep(7)
 
-            # Shutdown: fully tear down and exit workers.
-            hm2.shutdown().get()
+                    # Reconnect after stop and use an actor before exercising
+                    # any repeated-teardown behavior. This remains the ordinary
+                    # stop-and-reconnect regression witness.
+                    hm2 = job.state(cached_path=None).hosts
+                    pm2 = hm2.spawn_procs(per_host={"gpus": 1})
+                    am2 = pm2.spawn("actor", RankActor)
+                    ranks2 = list(am2.get_rank.call().get(timeout=30).items())
+                    assert len(ranks2) == 2
+
+                    # The second stop and following shutdown both report
+                    # success after the first stop consumed the native cell.
+                    assert hm.stop().get(timeout=30) is None
+                    assert hm.shutdown().get(timeout=30) is None
+                    assert hm._inner_host_mesh is None
+
+                    assert order == [
+                        "drain",
+                        "native_stop",
+                        "drain",
+                        "native_stop",
+                        "drain",
+                        "native_shutdown",
+                    ]
+                    assert call_through.calls == ["stop", "stop", "shutdown"]
+                    # The call count proves that both stop requests reached the
+                    # binding. Source inspection, not this seam, shows that only
+                    # the first took the cell and ran the domain stop operation.
+                    # It also shows that an overlapping second stop can return
+                    # success while the first domain stop is still running;
+                    # this sequential test does not exercise that overlap.
+
+                    # This second call characterizes current empty-cell false
+                    # success: the reported shutdown left the same workers and
+                    # actor live. Revise this assertion when repeated teardown
+                    # is corrected; the first call above remains the independent
+                    # reconnect-after-stop regression.
+                    assert list(am2.get_rank.call().get(timeout=30).items()) == ranks2
+
+                # Shutdown: fully tear down and exit workers.
+                hm2.shutdown().get(timeout=30)
+        finally:
+            job.kill()
 
 
 @pytest.mark.timeout(120)

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -17,6 +17,7 @@ import tempfile
 import textwrap
 import threading
 import time
+import weakref
 from contextlib import ExitStack
 from typing import Dict, List, Optional, Set
 from unittest.mock import patch
@@ -24,15 +25,22 @@ from unittest.mock import patch
 import cloudpickle
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import BootstrapCommand
 from monarch._rust_bindings.monarch_hyperactor.proc import ProcId, Uid
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Point, Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, attach, context
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.host_mesh import HostMesh, this_host, this_proc
+from monarch._src.actor.future import Future
+from monarch._src.actor.host_mesh import (
+    default_bootstrap_cmd,
+    HostMesh,
+    this_host,
+    this_proc,
+)
 from monarch._src.actor.pickle import flatten, unflatten
-from monarch._src.actor.proc_mesh import get_or_spawn_controller
+from monarch._src.actor.proc_mesh import _get_bootstrap_args, get_or_spawn_controller
 from monarch._src.job.job import ProcessState
 from monarch._src.job.process import ProcessJob
 from monarch._src.job.service_identity import new_service_proc_id, service_proc_addr
@@ -166,6 +174,63 @@ def is_process_running(pid: int) -> bool:
         return False
 
 
+def _wait_for_marker(path: pathlib.Path) -> None:
+    # Stress runs start several isolated ProcessJobs at once, so reaching the
+    # bootstrap wrapper can take longer than a focused run.
+    deadline = time.monotonic() + 30
+    while not path.exists():
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"timed out waiting for marker {path}")
+        time.sleep(0.01)
+
+
+def _gated_bootstrap_command(
+    directory: pathlib.Path,
+) -> tuple[BootstrapCommand, pathlib.Path, pathlib.Path]:
+    entered = directory / "bootstrap-entered"
+    release = directory / "bootstrap-release"
+    wrapper = directory / "gated-bootstrap.py"
+    wrapper.write_text(
+        textwrap.dedent(
+            """\
+            import os
+            import pathlib
+            import sys
+            import time
+
+            entered, release, program, arg0, *args = sys.argv[1:]
+            pathlib.Path(entered).touch()
+            deadline = time.monotonic() + 30
+            while not pathlib.Path(release).exists():
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("bootstrap release marker was not published")
+                time.sleep(0.01)
+            os.execvpe(program, [arg0, *args], os.environ)
+            """
+        )
+    )
+
+    base = default_bootstrap_cmd()
+    # BootstrapCommand's Rust binding exposes every field, but its stub declares
+    # only env. Read the argv from the helper used by default_bootstrap_cmd so
+    # this fixture follows the real default without widening the production stub.
+    original_program, original_args, _ = _get_bootstrap_args()
+    command = BootstrapCommand(
+        sys.executable,
+        None,
+        [
+            str(wrapper),
+            str(entered),
+            str(release),
+            original_program,
+            original_program,
+            *(original_args or []),
+        ],
+        dict(base.env),
+    )
+    return command, entered, release
+
+
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 def test_shutdown_host_mesh() -> None:
@@ -197,6 +262,122 @@ def test_shutdown_immediately_after_proc_spawn_without_actor() -> None:
             match="HostMesh has already been shut down",
         ):
             hm.spawn_procs()
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+def test_shutdown_waits_for_a_pending_proc_spawn_after_caller_drops_mesh() -> None:
+    with tempfile.TemporaryDirectory(prefix="monarch_spawn_gate_") as directory:
+        command, entered, release = _gated_bootstrap_command(pathlib.Path(directory))
+        with ExitStack() as cleanup:
+            job = ProcessJob({"hosts": 1})
+            cleanup.callback(job.kill)
+            cleanup.callback(release.touch)
+            hm = job.state(cached_path=None).hosts
+            proc_mesh = hm.spawn_procs(
+                name="pending_proc",
+                bootstrap_command=command,
+            )
+            # HostMesh retains the raw native spawn in _pending_spawns and the
+            # ProcMesh retains a second Shared that performs logging and setup.
+            # Keep witnesses for both before discarding the caller's ProcMesh.
+            spawn = hm._pending_spawns[-1]
+            proc_initialization = proc_mesh._proc_mesh
+            retained_proc_mesh = weakref.ref(proc_mesh)
+            del proc_mesh
+            assert retained_proc_mesh() is hm._proc_meshes[-1]
+            _wait_for_marker(entered)
+
+            flush_entered = threading.Event()
+            flush_exited = threading.Event()
+            release_shutdown = threading.Event()
+            cleanup.callback(release_shutdown.set)
+            flush_pending_spawns = hm._flush_pending_spawns
+
+            async def record_flush_entry() -> None:
+                flush_entered.set()
+                await flush_pending_spawns()
+                flush_exited.set()
+                released = await PythonTask.spawn_blocking(
+                    lambda: release_shutdown.wait(timeout=30)
+                )
+                if not released:
+                    raise TimeoutError("native shutdown release was not published")
+
+            with patch.object(hm, "_flush_pending_spawns", record_flush_entry):
+                shutdown = hm.shutdown()
+                shutdown_results: list[None] = []
+                shutdown_errors: list[Exception] = []
+                shutdown_done = threading.Event()
+
+                def drive_shutdown() -> None:
+                    try:
+                        shutdown_results.append(shutdown.get(timeout=45))
+                    except Exception as error:
+                        shutdown_errors.append(error)
+                    finally:
+                        shutdown_done.set()
+
+                shutdown_thread = threading.Thread(
+                    target=drive_shutdown,
+                    daemon=True,
+                    name="drive-host-mesh-shutdown",
+                )
+                shutdown_thread.start()
+                try:
+                    # Start shutdown on another thread so entry into the flush,
+                    # rather than thread scheduling, is the synchronization
+                    # point for proving that the pending spawn blocks it.
+                    assert flush_entered.wait(timeout=10)
+                    assert spawn.poll() is None
+                    assert proc_initialization.poll() is None
+                    assert not flush_exited.is_set()
+                    assert not shutdown_done.is_set()
+
+                    release.touch()
+                    completion_deadline = time.monotonic() + 30
+                    while spawn.poll() is None:
+                        if time.monotonic() >= completion_deadline:
+                            raise AssertionError(
+                                "proc spawn did not complete after bootstrap release"
+                            )
+                        time.sleep(0.01)
+                    assert flush_exited.wait(
+                        timeout=max(0.0, completion_deadline - time.monotonic())
+                    )
+                    proc_initialization_value = proc_initialization.poll()
+                    while proc_initialization_value is None:
+                        if time.monotonic() >= completion_deadline:
+                            raise AssertionError(
+                                "proc initialization did not complete after bootstrap release"
+                            )
+                        time.sleep(0.01)
+                        proc_initialization_value = proc_initialization.poll()
+                    release_shutdown.set()
+                    assert shutdown_done.wait(timeout=15)
+                finally:
+                    release.touch()
+                    release_shutdown.set()
+                    try:
+                        if shutdown_thread.is_alive():
+                            job.kill()
+                    finally:
+                        shutdown_thread.join(timeout=10)
+
+                assert not shutdown_thread.is_alive()
+                assert flush_exited.is_set()
+                assert shutdown_errors == []
+                assert shutdown_results == [None]
+
+            assert spawn.poll() is not None
+            assert proc_initialization_value is not None
+            assert hm._pending_spawns == []
+            assert hm._inner_host_mesh is None
+            with pytest.raises(
+                RuntimeError,
+                match="HostMesh has already been shut down",
+            ):
+                hm.spawn_procs()
 
 
 @pytest.mark.timeout(60)
@@ -303,6 +484,52 @@ def test_attach_to_workers_accepts_future_addresses() -> None:
         for proc in procs:
             proc.kill()
             proc.wait()
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_attach_starts_before_readiness_observation_and_survives_a_dropped_observer() -> (
+    None
+):
+    address_started = threading.Event()
+    release_address = threading.Event()
+
+    async def resolve_address() -> str:
+        address_started.set()
+        released = await PythonTask.spawn_blocking(
+            lambda: release_address.wait(timeout=30)
+        )
+        if not released:
+            raise TimeoutError("worker address release was not published")
+        return addr
+
+    with ExitStack() as cleanup:
+        job = ProcessJob({"hosts": 1})
+        job.apply()
+        cleanup.callback(job.kill)
+        cleanup.callback(release_address.set)
+        addr = job._host_to_pid["hosts_0"].channel
+        address: Future[str] = Future._from_coro(resolve_address())
+
+        hosts = attach_to_workers(
+            ca="trust_all_connections",
+            workers=[address],
+        )
+
+        with pytest.raises(ValueError) as consumed:
+            address.get()
+        assert str(consumed.value) == "Future was consumed."
+        assert address_started.wait(timeout=10)
+
+        discarded = hosts.initialized
+        with pytest.raises(TimeoutError):
+            discarded.get(timeout=0.25)
+        del discarded
+        release_address.set()
+
+        assert hosts.initialized.get(timeout=30) is True
+        assert hosts.initialized.get(timeout=30) is True
+        assert hosts.shutdown().get(timeout=30) is None
 
 
 @pytest.mark.timeout(60)

--- a/python/tests/test_logging_initialization_characterization.py
+++ b/python/tests/test_logging_initialization_characterization.py
@@ -1,0 +1,103 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Characterize host draining while proc-mesh logging is still initializing."""
+
+import threading
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._src.actor.logging import LoggingManager
+from monarch._src.job.process import ProcessJob
+from scoped_state import scoped_state
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+def test_flush_pending_spawns_does_not_await_logging_init() -> None:
+    init_entered = threading.Event()
+    release_init = threading.Event()
+    real_init = LoggingManager.init
+
+    async def gated_init(
+        manager: LoggingManager,
+        proc_mesh: Any,
+        stream_to_client: bool,
+    ) -> None:
+        # ProcMesh calls init only after the native proc spawn resolves. Holding
+        # this method therefore exposes the real interval in which the proc
+        # exists but its logging client has not been installed.
+        init_entered.set()
+        released = await PythonTask.spawn_blocking(
+            lambda: release_init.wait(timeout=30)
+        )
+        if not released:
+            raise TimeoutError("logging initialization release was not published")
+        await real_init(manager, proc_mesh, stream_to_client)
+
+    proc_mesh = None
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        try:
+            with patch.object(LoggingManager, "init", gated_init):
+                proc_mesh = host.spawn_procs(name="logging_init_gate")
+                assert init_entered.wait(timeout=30), (
+                    "logging initialization did not reach the gate"
+                )
+
+                native_spawn = host._pending_spawns[-1]
+                assert native_spawn.poll() is not None
+                assert proc_mesh._logging_manager._logging_mesh_client is None
+                assert proc_mesh._proc_mesh.poll() is None
+
+                flush_without_client: list[bool] = []
+                native_flush_constructions = 0
+                flush_from_tokio = proc_mesh._logging_manager._flush_from_tokio
+                new_flush_task = proc_mesh._logging_manager._new_flush_task
+
+                async def record_flush_from_tokio() -> None:
+                    flush_without_client.append(
+                        proc_mesh._logging_manager._logging_mesh_client is None
+                    )
+                    await flush_from_tokio()
+
+                def record_new_flush_task() -> PythonTask[None]:
+                    nonlocal native_flush_constructions
+                    native_flush_constructions += 1
+                    return new_flush_task()
+
+                with (
+                    patch.object(
+                        proc_mesh._logging_manager,
+                        "_flush_from_tokio",
+                        record_flush_from_tokio,
+                    ),
+                    patch.object(
+                        proc_mesh._logging_manager,
+                        "_new_flush_task",
+                        record_new_flush_task,
+                    ),
+                ):
+                    PythonTask.from_coroutine(
+                        host._flush_pending_spawns()
+                    ).with_timeout(10).block_on()
+
+                assert flush_without_client == [True]
+                assert native_flush_constructions == 0
+                assert host._pending_spawns == []
+                assert proc_mesh._proc_mesh.poll() is None
+        finally:
+            release_init.set()
+            if proc_mesh is not None:
+                assert (
+                    proc_mesh._proc_mesh.task().with_timeout(30).block_on() is not None
+                )
+                assert proc_mesh._logging_manager._logging_mesh_client is not None

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -9,9 +9,12 @@
 from __future__ import annotations
 
 import os
+import pathlib
+import tempfile
 import threading
 import time
 from contextlib import ExitStack
+from functools import partial
 from typing import cast
 from unittest.mock import patch
 
@@ -52,6 +55,32 @@ def _successful_bootstrap() -> None:
 
 def _fail_bootstrap() -> None:
     raise RuntimeError(_BOOTSTRAP_FAILURE)
+
+
+def _gated_bootstrap(
+    entered_path: str,
+    release_path: str,
+    failure: str | None,
+) -> None:
+    pathlib.Path(entered_path).touch()
+    release = pathlib.Path(release_path)
+    deadline = time.monotonic() + 30
+    while not release.exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("proc bootstrap release was not published")
+        time.sleep(0.01)
+    if failure is not None:
+        raise RuntimeError(failure)
+
+
+def _wait_for_marker(path: pathlib.Path) -> None:
+    # The full target launches many isolated ProcessJobs concurrently, so
+    # reaching the remote setup callback can take longer than a focused run.
+    deadline = time.monotonic() + 30
+    while not path.exists():
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"timed out waiting for marker {path}")
+        time.sleep(0.01)
 
 
 class _PendingActorProbe:
@@ -130,6 +159,77 @@ async def test_proc_mesh_initialized_fails_when_bootstrap_fails() -> None:
         proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
         with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
             await proc_mesh.initialized
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+def test_proc_mesh_readiness_replays_success_after_discarded_observer() -> None:
+    with tempfile.TemporaryDirectory(prefix="monarch_proc_ready_") as directory:
+        entered = pathlib.Path(directory) / "entered"
+        release = pathlib.Path(directory) / "release"
+        with ExitStack() as cleanup:
+            state = cleanup.enter_context(
+                scoped_state(ProcessJob({"hosts": 1}), cached_path=None)
+            )
+            cleanup.callback(release.touch)
+            proc_mesh = state.hosts.spawn_procs(
+                name="test_proc",
+                bootstrap=partial(
+                    _gated_bootstrap,
+                    str(entered),
+                    str(release),
+                    None,
+                ),
+            )
+            _wait_for_marker(entered)
+
+            discarded = proc_mesh.initialized
+            with pytest.raises(TimeoutError):
+                discarded.get(timeout=0.25)
+            del discarded
+            release.touch()
+
+            assert proc_mesh.initialized.get(timeout=30) is True
+            assert proc_mesh.initialized.get(timeout=30) is True
+
+
+@pytest.mark.timeout(90)
+@isolate_in_subprocess
+def test_proc_mesh_readiness_replays_failure_after_discarded_observer() -> None:
+    with tempfile.TemporaryDirectory(prefix="monarch_proc_ready_") as directory:
+        entered = pathlib.Path(directory) / "entered"
+        release = pathlib.Path(directory) / "release"
+        with ExitStack() as cleanup:
+            state = cleanup.enter_context(
+                scoped_state(ProcessJob({"hosts": 1}), cached_path=None)
+            )
+            cleanup.callback(release.touch)
+            proc_mesh = state.hosts.spawn_procs(
+                bootstrap=partial(
+                    _gated_bootstrap,
+                    str(entered),
+                    str(release),
+                    _BOOTSTRAP_FAILURE,
+                )
+            )
+            _wait_for_marker(entered)
+
+            discarded = proc_mesh.initialized
+            with pytest.raises(TimeoutError):
+                discarded.get(timeout=0.25)
+            del discarded
+            release.touch()
+
+            errors = []
+            for _ in range(2):
+                with pytest.raises(monarch.actor.ActorError) as excinfo:
+                    proc_mesh.initialized.get(timeout=30)
+                errors.append(excinfo.value)
+
+            assert type(errors[0]) is monarch.actor.ActorError
+            assert type(errors[1]) is monarch.actor.ActorError
+            assert str(errors[0]) == str(errors[1])
+            assert _BOOTSTRAP_FAILURE in str(errors[0])
 
 
 @pytest.mark.timeout(60)

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import pathlib
 import tempfile
@@ -22,6 +23,7 @@ import cloudpickle
 import monarch.actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.context import Instance as HyInstance
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
@@ -81,6 +83,43 @@ def _wait_for_marker(path: pathlib.Path) -> None:
         if time.monotonic() >= deadline:
             raise AssertionError(f"timed out waiting for marker {path}")
         time.sleep(0.01)
+
+
+async def _wait_for_event(event: threading.Event, message: str) -> None:
+    reached = await asyncio.wait_for(
+        asyncio.to_thread(event.wait, 30),
+        timeout=35,
+    )
+    assert reached, message
+
+
+class _ProcStopCallThrough:
+    """Gate a real native stop task without replacing its behavior."""
+
+    def __init__(self, inner: HyProcMesh, release: threading.Event) -> None:
+        self._inner = inner
+        self._release = release
+        self.entered = threading.Event()
+        self.calls = 0
+
+    def stop_nonblocking(
+        self,
+        instance: HyInstance,
+        reason: str,
+    ) -> PythonTask[None]:
+        native_task = self._inner.stop_nonblocking(instance, reason)
+        self.calls += 1
+        self.entered.set()
+
+        async def gated() -> None:
+            released = await PythonTask.spawn_blocking(
+                lambda: self._release.wait(timeout=30)
+            )
+            if not released:
+                raise TimeoutError("proc stop release was not published")
+            await native_task
+
+        return PythonTask.from_coroutine(gated())
 
 
 class _PendingActorProbe:
@@ -234,19 +273,95 @@ def test_proc_mesh_readiness_replays_failure_after_discarded_observer() -> None:
 
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
+async def test_proc_stop_is_lazy_and_survives_cancelled_observer() -> None:
+    job = ProcessJob({"hosts": 1})
+    release = threading.Event()
+    stop_future: Future[None] | None = None
+    try:
+        host = job.state(cached_path=None).hosts
+        owner = host.spawn_procs(per_host={"gpus": 1})
+        await asyncio.wait_for(owner.initialized, timeout=30)
+        inner = owner._proc_mesh.poll()
+        assert inner is not None
+
+        discarded = owner.stop()
+        del discarded
+        assert not owner._stopped
+        actor = owner.spawn("after_discarded_stop", TestActor, 41)
+        assert await asyncio.wait_for(actor.get_value.choose(), 30) == 41
+
+        call_through = _ProcStopCallThrough(inner, release)
+        owner._proc_mesh = Shared.from_value(cast(HyProcMesh, call_through))
+        stop_future = owner.stop()
+        assert not owner._stopped
+        assert call_through.calls == 0
+
+        observer = stop_future.as_asyncio()
+        await _wait_for_event(
+            call_through.entered,
+            "proc stop did not reach the native binding",
+        )
+        assert not owner._stopped
+        assert call_through.calls == 1
+
+        assert observer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await observer
+
+        release.set()
+        assert (
+            await asyncio.wait_for(
+                asyncio.to_thread(stop_future.get, 30),
+                timeout=35,
+            )
+            is None
+        )
+        assert await asyncio.wait_for(stop_future, timeout=30) is None
+        assert owner._stopped
+
+        assert await asyncio.wait_for(owner.stop(), timeout=30) is None
+        assert call_through.calls == 2
+        # The two calls prove that both requests reached the binding. Source
+        # inspection, not this seam, shows that only the first took the
+        # SharedCell and reached the domain ProcMesh::stop operation. It also
+        # shows that an overlapping second stop can set _stopped True even if
+        # the first domain stop later fails; this test does not create overlap.
+    finally:
+        release.set()
+        try:
+            if stop_future is not None:
+                try:
+                    await asyncio.wait_for(stop_future, timeout=30)
+                except (Exception, asyncio.CancelledError):
+                    pass
+        finally:
+            job.kill()
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
 async def test_stop_state_tracks_native_stop_result() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         owner = state.hosts.spawn_procs(per_host={"gpus": 2})
-        await owner.initialized
+        assert await asyncio.wait_for(owner.initialized, timeout=30) is True
         logging_manager = owner._logging_manager
         assert logging_manager._logging_mesh_client is not None
         proc_ref = owner.slice(gpus=0)
+        raw_ref = proc_ref._proc_mesh.poll()
+        assert raw_ref is not None
+        instance = context().actor_instance._as_rust()
 
-        with pytest.raises(
-            ValueError,
-            match="ProcMesh is not owned; must be stopped by an owner",
-        ):
-            await proc_ref.stop()
+        with pytest.raises(ValueError) as raw_stop_error:
+            raw_ref.stop_nonblocking(instance, "test reference rejection")
+        assert type(raw_stop_error.value) is ValueError
+        assert str(raw_stop_error.value) == (
+            "ProcMesh is not owned; must be stopped by an owner"
+        )
+
+        with pytest.raises(ValueError) as public_stop_error:
+            await asyncio.wait_for(proc_ref.stop(), timeout=30)
+        assert type(public_stop_error.value) is ValueError
+        assert str(public_stop_error.value) == str(raw_stop_error.value)
 
         assert not proc_ref._stopped
         flush_started = False
@@ -277,7 +392,7 @@ async def test_stop_state_tracks_native_stop_result() -> None:
                 record_flush_from_tokio,
             ),
         ):
-            assert await owner.stop() is None
+            assert await asyncio.wait_for(owner.stop(), timeout=30) is None
 
             assert proc_flush_called
         assert flush_started

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1555,6 +1555,28 @@ def test_attach_fails_closed_on_unreachable_host():
             )
 
 
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_attach_failure_replays_to_fresh_readiness_observers() -> None:
+    with configured(mesh_attach_config_timeout="500ms"):
+        with TemporaryDirectory() as directory:
+            unreachable = f"ipc://{directory}/never_bound"
+            hosts = attach_to_workers(ca="trust_all_connections", workers=[unreachable])
+
+            errors = []
+            for _ in range(2):
+                with pytest.raises(RuntimeError) as excinfo:
+                    hosts.initialized.get(timeout=10)
+                errors.append(excinfo.value)
+
+            assert type(errors[0]) is RuntimeError
+            assert type(errors[1]) is RuntimeError
+            assert str(errors[0]) == str(errors[1])
+            message = str(errors[0])
+            assert "attach failed: config push failed during attach" in message
+            assert f"{directory}/never_bound" in message
+
+
 @isolate_in_subprocess
 def test_config_propagates_to_host_agent():
     """Verify that configure() overrides reach host agent OS processes

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -1074,15 +1074,17 @@ caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code, usually at process exit"
 driver = "awaited or blocked on by the caller"
-start_point = "the wrapped coroutine is an empty no-op; there is nothing to start"
-abandonment = "possible and harmless; shutdown already completed"
-eager_effect = "only wraps a completed no-op"
-drop_behavior = "no effect; _shutdown_done is already True"
-first_side_effect = "none"
+start_point = "source-grounded branch selection: a call while _shutdown_done is True builds the _noop Future. The test constructs this Future after the first shutdown and verifies that it returns None without another native binding call, but that result is indistinguishable from the preconstructed shutdown sequence's early return. The call synchronously asks Future._from_coro to capture context(); source-grounded, context capture can bootstrap a fresh caller, while the tested post-shutdown caller reuses its cached context"
+abandonment = "possible and harmless to teardown; dropping skips the no-op body after construction-time context capture"
+eager_effect = "only completes the no-op body during the call; shutdown already completed"
+drop_behavior = "no teardown effect; _shutdown_done is already True"
+first_side_effect = "none after construction-time context capture"
 unobserved_error = "none"
 disposition = "replace with a direct value"
 semantic_class = "ready_no_op_wrapper"
-oracle = "lifecycle edge behavior (6.0c item 7)"
+oracle = [
+  "fbcode//monarch/python/tests:test_client_shutdown::test_client_shutdown",
+]
 
 [[site]]
 id = "fc.actor_mesh.shutdown_context[Future._from_coro_shutdown_sequence]"
@@ -1099,15 +1101,17 @@ caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code, usually at process exit"
 driver = "awaited or blocked on by the caller"
-start_point = "lazy; no shutdown work runs until the Future is observed"
-abandonment = "possible; dropping leaves _shutdown_done False and shutdown unperformed"
-eager_effect = "starts a side effect"
-drop_behavior = "shutdown never runs"
+start_point = "source-grounded branch selection: a call while _shutdown_done is False builds the shutdown-sequence Future; the test constructs both sequence Futures before driving the first. When the first is driven, the call-through directly records _shutdown_done as True before invoking local-host teardown. The preconstructed second later returns None without another native binding call, but that result is indistinguishable from _noop. The call synchronously asks Future._from_coro to capture context(); source-grounded, context capture can bootstrap a fresh caller"
+abandonment = "tested after client initialization: dropping an unobserved Future leaves _shutdown_done False, the workers usable, and shutdown unperformed"
+eager_effect = "would set _shutdown_done and begin shutdown during the call even if the returned value were discarded"
+drop_behavior = "after construction-time context capture, no shutdown body runs and the live workers remain usable"
 first_side_effect = "setting _shutdown_done = True"
-unobserved_error = "silently dropped"
+unobserved_error = "an unobserved Future reports nothing because its body never runs. Source-grounded: once driven, RuntimeError from local-host shutdown selects the no-host stop_and_wait fallback; other errors surface only to an observer"
 disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "lifecycle edge behavior (6.0c item 7)"
+oracle = [
+  "fbcode//monarch/python/tests:test_client_shutdown::test_client_shutdown",
+]
 
 [[site]]
 id = "fc.host_mesh.HostMesh.initialized[Future._from_corotask]"
@@ -2412,16 +2416,18 @@ state = "legacy"
 transition = "6.3b"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyInstance::stop_and_wait"
-consumer = "shutdown_context's no-host fallback"
-driver = "awaited inside _shutdown_sequence"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; reachable only when the shutdown coroutine itself is abandoned"
-eager_effect = "starts a side effect"
-drop_behavior = "the root client instance is never stopped"
-unobserved_error = "surfaced on observation"
+consumer = "shutdown_context's no-host fallback; the Rust characterization calls the binding directly"
+driver = "awaited inside _shutdown_sequence on the fallback path; the Rust characterization takes and awaits the raw task under a timeout"
+start_point = "the call clones the instance and reason and constructs the PyPythonTask; actor stop, terminal-status wait, and proc flush begin only when the returned task is driven"
+abandonment = "possible through the direct binding and tested on an isolated instance; the production fallback awaits the task immediately once reached"
+eager_effect = "would signal the actor during the binding call instead of waiting for the returned task to be driven"
+drop_behavior = "dropping the raw task undriven sends no stop signal"
+unobserved_error = "PyPythonTask construction can fail synchronously. After construction, source shows that stop and flush failures are warned and suppressed, the status result is discarded, and a successful stop can wait without a deadline for terminal status; the controlled success and repeated-call paths resolve to PyO3's empty-tuple conversion of Rust unit"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "lifecycle edge behavior (6.0c item 7)"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:test_monarch_hyperactor::client_root::py_instance_stop_and_wait_is_lazy_and_repeatable",
+]
 
 [[site]]
 id = "np.host_mesh.PyHostMesh.shutdown"
@@ -2539,16 +2545,18 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from bootstrap_host"
-consumer = "host mesh construction"
-driver = "awaited inside the host mesh setup coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; the setup coroutine may be abandoned"
-eager_effect = "starts a side effect"
-drop_behavior = "no host is bootstrapped"
-unobserved_error = "surfaced on observation"
+consumer = "_init_client_context immediately calls block_on; a direct binding caller can retain or discard the raw task"
+driver = "_init_client_context immediately consumes it with PyPythonTask.block_on; the Rust integration test exercises that same block_on path after discarding the first raw task"
+start_point = "bootstrap-command conversion and via-address parsing happen during the call; host creation and global registration begin only when the returned task is driven"
+abandonment = "tested through the direct binding: dropping a valid raw task leaves the observable client-root and host-agent registrations absent. Production normally block_on drives immediately; source-grounded, a Python main-thread signal can return from block_on while the spawned bootstrap task continues detached"
+eager_effect = "would begin host creation and permanent global registration during the binding call"
+drop_behavior = "dropping a valid raw task undriven performs no observable bootstrap, and a later fresh task can perform the one allowed bootstrap"
+unobserved_error = "an invalid via raises exact PyValueError before a task exists; bootstrap failures after construction surface when driven. Source-grounded, the main-thread signal branch can report an error while already-started bootstrap continues"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "host mesh setup coverage"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:test_monarch_hyperactor::client_root::python_bootstrap_seeds_client_root_on_local_proc_agent",
+]
 
 [[site]]
 id = "np.host_mesh.shutdown_local_host_mesh"
@@ -2562,16 +2570,20 @@ state = "legacy"
 transition = "6.3b"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from shutdown_local_host_mesh"
-consumer = "_shutdown_sequence, as the local-host path"
-driver = "awaited inside _shutdown_sequence"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; reachable only when the shutdown coroutine is abandoned"
-eager_effect = "starts a side effect"
-drop_behavior = "the local host mesh is never shut down and logs are not flushed"
-unobserved_error = "surfaced on observation"
+consumer = "_shutdown_sequence immediately awaits it on the local-host path; direct binding callers can retain or discard the raw task"
+driver = "awaited inside _shutdown_sequence; the Rust integration test takes and awaits a fresh raw task under a timeout"
+start_point = "the call rejects a missing host agent synchronously; with a host it clones the agent and constructs a lazy task. Driving the task posts ShutdownHost, then takes the optional one-shot HostShutdownHandle"
+abandonment = "tested through both boundaries: after dropping a direct raw task, the same HostAgent accepts and launches a deliberately failing probe process and the root service remains usable; dropping an unobserved outer shutdown_context Future never calls the binding. Source-grounded: the current PyPythonTask constructor stores rather than spawns the future"
+eager_effect = "would post ShutdownHost and take the one-shot shutdown handle during the binding call"
+drop_behavior = "dropping a raw task undriven performs no host shutdown before the same-HostAgent process-creation probe and leaves the root service usable"
+unobserved_error = "a missing host raises exact PyRuntimeError before a task exists. A first driven raw task resolves to PyO3's empty-tuple conversion of Rust unit after the full shutdown, while shutdown_context resolves to None; source-grounded, later raw calls post again but cannot retake the shutdown handle and repeat only root stop/flush. Lower-level coverage proves root flush precedes transport join; binding composition is source-grounded"
 disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "global shutdown sequence coverage"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:test_monarch_hyperactor::client_root::python_bootstrap_seeds_client_root_on_local_proc_agent",
+  "fbcode//monarch/python/tests:test_client_shutdown::test_client_shutdown",
+  "fbcode//monarch/hyperactor_mesh:hyperactor_mesh-unittest::bootstrap::tests::test_host_shutdown_flushes_before_joining_frontend",
+]
 
 [[site]]
 id = "np.logging.LoggingMeshClient.flush"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -356,7 +356,7 @@ shared_reconstruction = 2
 reserve_binding = 1
 py_mesh_reserve = 2
 py_is_tokio_thread = 3
-pytokio_import = 29
+pytokio_import = 30
 pytokio_module_ref = 17
 helper_symbol = 26
 helper_definition = 6
@@ -773,6 +773,7 @@ owns = [
   "im.rdma.module",
   "im.supervision.module",
   "im.test_actor_driver_characterization.module",
+  "im.test_admin_spawn_characterization.module",
   "im.test_actor_mesh.module",
   "im.test_client_context_guard.module",
   "im.test_future_characterization.module",
@@ -1200,17 +1201,19 @@ transition = "6.3c"
 public_operation = "host mesh admin spawn"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
-consumer = "internal admin plumbing"
-driver = "awaited or blocked on by the caller"
-start_point = "lazy; nothing runs until the Future is observed"
-abandonment = "possible; dropping leaves MONARCH_ADMIN_URL unset"
-eager_effect = "starts a side effect"
-drop_behavior = "no admin mesh is spawned"
-first_side_effect = "the native admin spawn, which then sets MONARCH_ADMIN_URL"
-unobserved_error = "silently dropped"
+consumer = "MeshAdminComponent.state in production, which calls get() under fake_sync_state, plus direct internal test callers that await or get the Future"
+driver = "the first asyncio observation or timed get spawns a non-aborting Handle producer; a synchronous get without a timeout drives the coroutine inline. The producer resolves the host meshes, constructs and awaits the raw native task, then publishes MONARCH_ADMIN_URL"
+start_point = "for an unchanged nonempty host list, the call checks that the list is nonempty and constructs the Future. Source inspection shows that construction captures the current Monarch context and can bootstrap a missing client; the oracle starts with an initialized client and proves that no native admin call occurs before observation. Observation first resolves the host Shared values and invokes the native binding"
+abandonment = "source shows that dropping the unobserved Future prevents the native binding call, admin spawn, and environment update. The oracle proves that cancelling one asyncio observer after the retained producer constructs the raw native task does not abort that producer: a fresh observer receives the result after the gate opens"
+eager_effect = "an eager replacement for the outer Future would resolve the hosts and begin the native operation during the call, allowing the admin actor and MONARCH_ADMIN_URL to appear even when the caller discards the return value; the inherited disposition does not decide that behavior change"
+drop_behavior = "source shows that dropping before observation constructs no raw _hy_spawn_admin task and produces no admin or environment value. The oracle proves that after Handle-backed observation starts, cancelling one observer does not stop the retained producer, which completes once and publishes MONARCH_ADMIN_URL"
+first_side_effect = "source inspection shows that construction-time context capture can bootstrap a missing client. In the initialized-client path exercised by the oracle, the first admin-domain effect is spawning the local admin actor when the raw task is driven; after its address is available, the outer producer publishes MONARCH_ADMIN_URL"
+unobserved_error = "an empty list raises exact ValueError during the public call. For the unchanged initialized-host shape in the oracle, an invalid admin_addr is not parsed until observation reaches the raw binding; it then raises exact built-in Exception and does not publish the environment variable. The oracle proves successful-result replay after observer cancellation; error replay is source-grounded in the same Handle state machine"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "admin spawn coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_admin_spawn_characterization::test_spawn_admin_is_lazy_and_survives_cancelled_observer",
+]
 
 [[site]]
 id = "fc.proc_mesh.ProcMesh._proc_mesh_for_asyncio_fixme[Future._from_coroself._proc_mesh.task]"
@@ -2494,16 +2497,18 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from _spawn_admin"
-consumer = "the Python _spawn_admin coroutine, which then sets MONARCH_ADMIN_URL"
-driver = "awaited inside the Python _spawn_admin coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; the admin coroutine may be abandoned"
-eager_effect = "starts a side effect"
-drop_behavior = "no admin mesh is spawned and the environment variable is not set"
-unobserved_error = "surfaced on observation"
+consumer = "the Python _spawn_admin coroutine, which immediately awaits the returned raw task and publishes MONARCH_ADMIN_URL only after success"
+driver = "driven inline by the already-running Python _spawn_admin producer; the public cancellation oracle does not introduce an independent raw-task observer"
+start_point = "the raw binding synchronously rejects an empty native mesh list, parses admin_addr, extracts the HostMeshRef values, and constructs the PyPythonTask. Spawning the local admin actor and querying its address are deferred until that task is driven"
+abandonment = "a direct private caller can drop the raw task before driving it, in which case no admin is spawned. On the tested public route, the outer producer retains and immediately awaits the raw task once constructed, so cancelling its asyncio observer does not abandon the native operation"
+eager_effect = "an eager replacement would spawn the local admin during the raw binding call. The public outer Future would still have to be observed before it invokes that binding; the inherited disposition does not decide either boundary"
+drop_behavior = "source shows that dropping a directly obtained raw task before drive prevents the admin spawn. The public oracle instead proves that cancelling an outer observer after raw task construction leaves the retained producer able to drive it once and publish MONARCH_ADMIN_URL"
+unobserved_error = "the native empty-list and invalid-admin-address checks raise built-in Exception before returning a task; the oracle exercises invalid admin_addr through the public deferred call. Spawn and address-query errors occur only when the returned task is driven and are also mapped to built-in Exception"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "admin spawn coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_admin_spawn_characterization::test_spawn_admin_is_lazy_and_survives_cancelled_observer",
+]
 
 [[site]]
 id = "np.host_mesh.bootstrap_host"
@@ -3016,6 +3021,18 @@ scope = "test"
 state = "legacy"
 transition = "6.8"
 members = ["PythonTask"]
+
+[[site]]
+id = "im.test_admin_spawn_characterization.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_admin_spawn_characterization.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["Handle", "PythonTask"]
 
 [[site]]
 id = "im.test_client_context_guard.module"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -356,7 +356,7 @@ shared_reconstruction = 2
 reserve_binding = 1
 py_mesh_reserve = 2
 py_is_tokio_thread = 3
-pytokio_import = 30
+pytokio_import = 31
 pytokio_module_ref = 17
 helper_symbol = 26
 helper_definition = 6
@@ -779,6 +779,7 @@ owns = [
   "im.test_future_characterization.module",
   "im.test_host_mesh.module",
   "im.test_hyperactor.module",
+  "im.test_logging_initialization_characterization.module",
   "im.test_logging.module",
   "im.test_mailbox.module",
   "im.test_proc_mesh.module",
@@ -2597,16 +2598,33 @@ state = "legacy"
 transition = "6.3b"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from LoggingMeshClient::flush"
-consumer = "ProcMesh.stop and the logging manager's tokio flush"
-driver = "awaited during teardown"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; teardown may abandon it"
-eager_effect = "starts a side effect"
-drop_behavior = "the flush never runs and buffered logs are lost"
-unobserved_error = "currently suppressed rather than reported"
+consumer = "LoggingManager._new_flush_task, reached by flush, flush_async and _flush_from_tokio"
+driver = "flush drives a Handle synchronously; flush_async is an asyncio-driven coroutine awaiting a Handle; _flush_from_tokio is advanced by the pytokio driver on Tokio and awaits a Shared. Adapter-level coverage proves that two manager calls request and drive distinct tasks; their mapping to distinct native operations is source-composed from _new_flush_task calling LoggingMeshClient.flush each time"
+start_point = "the binding call captures the client actor and optional forwarder mesh but leaves the task lazy. Once spawn or spawn_handle starts it, a no-forwarder task returns immediately; a forwarding task posts StartSyncFlush and runs the distributed barrier"
+abandonment = "two tested states. Before start, dropping a raw task performs no flush: against a completed baseline probe v, the next completed probe returns v + 1, which is only that probe's own increment. After start, the synthetic flush_async Handle test proves that cancelling its asyncio observer does not abort the controlled producer. Source-grounded composition: native spawn_handle and the Tokio spawn path both use non-abortable spawn_core(false), so their producers likewise continue after observer cancellation"
+eager_effect = "an eager conversion would begin the sync-flush barrier during the binding call; today the effect begins only at spawn or spawn_handle"
+drop_behavior = "dropping an undriven raw task is inert. The synthetic flush_async cancellation test cancels the only observer, releases the producer, and proves completion through an independent bounded event. Source-grounded: real native flush producers use the same non-abortable Handle and Shared scheduling policy"
+unobserved_error = "ordinary Exception is suppressed by all three logging-manager adapters. A sentinel BaseException escapes all three with its exact type and message. Cancelling the synthetic flush_async observer raises asyncio.CancelledError while its controlled producer continues; continuation of a real native flush and the Tokio spawn path is source-grounded through their shared non-abortable spawn_core(false) policy"
 disposition = "preserve timing"
 semantic_class = "deferred_side_effect"
-oracle = "logging flush ordering coverage"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::logging::tests::discarded_flush_task_does_not_advance_sync_flush_version",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::logging::tests::flush_behaviors",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerTest::test_flush_handles_exception_gracefully",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerTest::test_flush_propagates_base_exception",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerTest::test_flush_from_tokio_awaits_shared_not_handle",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerTest::test_flush_from_tokio_suppresses_ordinary_error",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerAsyncTest::test_flush_async_awaits_handle_not_shared",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerAsyncTest::test_flush_async_suppresses_ordinary_error",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerAsyncTest::test_flush_async_propagates_base_exception",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerAsyncTest::test_flush_from_tokio_propagates_base_exception",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerAsyncTest::test_flush_async_cancellation_leaves_producer_reapable",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerAsyncTest::test_two_manager_flushes_create_two_operations",
+  "fbcode//monarch/python/tests:test_logging_initialization_characterization::test_flush_pending_spawns_does_not_await_logging_init",
+  "fbcode//monarch/python/tests:test_host_mesh::test_preconstructed_shutdowns_drain_after_observer_cancellation",
+  "fbcode//monarch/python/tests:test_python_actors::test_flush_async_drives_flush_on_asyncio_loop",
+  "fbcode//monarch/python/tests:test_python_actors::test_multiple_ongoing_flushes_no_deadlock",
+]
 
 [[site]]
 id = "np.logging.LoggingMeshClient.spawn"
@@ -2620,16 +2638,21 @@ state = "legacy"
 transition = "6.3b"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from LoggingMeshClient::spawn"
-consumer = "proc mesh logging initialization"
-driver = "awaited during proc mesh setup"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; this is the known fast-bootstrap gap"
-eager_effect = "starts a side effect"
-drop_behavior = "the logging client is never created and early logs are lost"
-unobserved_error = "currently suppressed rather than reported"
+consumer = "LoggingManager.init, the sole in-tree caller, awaits the returned task directly"
+driver = "awaited inside ProcMesh.from_host_mesh's task, a PythonTask.from_coroutine producer spawned and advanced by the pytokio driver on Tokio"
+start_point = "proc-mesh validation happens during the binding call; a valid call only captures its inputs and builds a lazy task. The local LogClientActor and remote logging meshes begin spawning when that task is driven"
+abandonment = "a direct binding caller can drop the raw task before drive, which creates no LogClientActor; the production LoggingManager.init path awaits it immediately"
+eager_effect = "an eager conversion would begin spawning the local log client and remote logging actors during the binding call; today construction performs no domain work"
+drop_behavior = "dropping an undriven raw task is inert, and a fresh task can still create exactly one local LogClientActor"
+unobserved_error = "source-grounded: LoggingManager.init does not catch a spawn failure; _proc_mesh retains it and a later observer receives it unchanged. If nobody observes _proc_mesh, _flush_pending_spawns does not await it, so host drain does not itself report the failure"
 disposition = "preserve timing"
 semantic_class = "deferred_side_effect"
-oracle = "logging initialization and suppression coverage"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::logging::tests::discarded_spawn_task_creates_no_log_client_actor",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::logging::tests::spawn_respects_forwarding_flag",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerAsyncTest::test_init_with_hyprocmesh_creates_logging_mesh_client",
+  "fbcode//monarch/python/tests/_monarch:test_logging::LoggingManagerAsyncTest::test_init_returns_early_if_already_initialized",
+]
 
 [[site]]
 id = "np.pickle.PendingMessage.py_resolve"
@@ -3101,6 +3124,18 @@ scope = "test"
 state = "legacy"
 transition = "6.8"
 members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.test_logging_initialization_characterization.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_logging_initialization_characterization.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
 
 [[site]]
 id = "im.test_proc_launcher_probe.module"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -1122,16 +1122,20 @@ public_operation = "HostMesh.initialized"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code and internal readiness gates"
-driver = "awaited or blocked on by the caller"
-start_point = "the storage Shared is already being driven; the coroutine only awaits it"
-abandonment = "possible; initialization continues on the storage Shared"
-eager_effect = "observes already-running work"
-drop_behavior = "abandons this observer only"
+driver = "the caller drives only the per-access observer coroutine; HostMesh._hy_host_mesh retains a non-aborting Shared source that is already running or already resolved"
+start_point = "property access synchronously snapshots _hy_host_mesh, or raises if the mesh was shut down; the retained Shared source was created earlier, and this observer coroutine starts only when driven"
+abandonment = "before drive, dropping the Future starts no observer but can emit Python's ordinary never-awaited-coroutine warning. Source-grounded after a timed get starts the non-aborting observer: dropping the Future discards its receiver but does not stop that observer or HostMesh's retained Shared source"
+eager_effect = "would begin observing the retained running or resolved Shared during property access rather than when the caller drives the Future"
+drop_behavior = "does not affect host initialization; a fresh initialized Future can observe the same True result or the same retained failure"
 first_side_effect = "none; the property access only raises if the mesh is already shut down"
-unobserved_error = "silently dropped"
+unobserved_error = "a pre-drive drop never observes the Shared's terminal error and can emit Python's ordinary never-awaited-coroutine warning. Source-grounded: if a started observer later sees failure after its receiver is dropped, send_result logs the receiverless background error. The retained Shared independently stores the exact failure, and fresh initialized Futures replay its type and message"
 disposition = "preserve timing"
 semantic_class = "already_started_lazy_observer"
-oracle = "host mesh readiness coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_attach_starts_before_readiness_observation_and_survives_a_dropped_observer",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_fails_closed_on_unreachable_host",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_failure_replays_to_fresh_readiness_observers",
+]
 
 [[site]]
 id = "fc.host_mesh.HostMesh.shutdown[Future._from_corotask]"
@@ -1233,16 +1237,19 @@ public_operation = "ProcMesh.initialized"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code and internal readiness gates"
-driver = "awaited or blocked on by the caller"
-start_point = "the storage Shared is already being driven; the coroutine only awaits it"
-abandonment = "possible; initialization continues on the storage Shared"
-eager_effect = "observes already-running work"
-drop_behavior = "abandons this observer only"
+driver = "the caller drives only the per-access observer coroutine; ProcMesh._proc_mesh retains a Shared source that is already running through native spawn, logging initialization, and setup, or is already resolved"
+start_point = "the ProcMesh retained its running or resolved Shared source before property access; this property's observer coroutine begins only when its per-access Future is driven"
+abandonment = "before drive, dropping the Future starts no observer but can emit Python's ordinary never-awaited-coroutine warning. Source-grounded after a timed get starts the non-aborting observer: dropping the Future discards its receiver but does not stop that observer or the retained ProcMesh Shared source"
+eager_effect = "would begin observing the retained running or resolved Shared during property access rather than when the caller drives the Future"
+drop_behavior = "does not affect proc initialization; a fresh initialized Future can observe the same True result or replay the same retained failure"
 first_side_effect = "none"
-unobserved_error = "silently dropped"
+unobserved_error = "a pre-drive drop never observes the Shared's terminal error and can emit Python's ordinary never-awaited-coroutine warning. Source-grounded: if a started observer later sees failure after its receiver is dropped, send_result logs the receiverless background error. The retained Shared independently stores the exact failure, and fresh initialized Futures replay its type and message"
 disposition = "preserve timing"
 semantic_class = "already_started_lazy_observer"
-oracle = "proc mesh readiness coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_mesh_readiness_replays_success_after_discarded_observer",
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_mesh_readiness_replays_failure_after_discarded_observer",
+]
 
 [[site]]
 id = "fc.proc_mesh.ProcMesh.stop[Future._from_coro_stop_nonblockinginstance]"
@@ -2336,16 +2343,20 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from attach_to_workers"
-consumer = "HostMesh construction, through the bootstrap _as_python_task adapter"
-driver = "awaited inside the host mesh setup coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; the adapter's task may be dropped before it is driven"
-eager_effect = "starts a side effect"
-drop_behavior = "no worker attach is performed"
-unobserved_error = "surfaced on observation"
+consumer = "bootstrap.attach_to_workers normally calls spawn() on the returned task and stores the resulting Shared as HostMesh._inner_host_mesh after constructing the HostMesh extent"
+driver = "PythonTask.spawn drives it on the shared Tokio runtime; HostMesh retains the Shared, while HostMesh.initialized creates only per-access observers"
+start_point = "source-grounded: the binding synchronously takes every input worker PythonTask before constructing its own lazy task. With the ordinary list input covered here, the public wrapper constructs the extent and then spawns that task before returning HostMesh"
+abandonment = "source-grounded: direct private-binding callers can drop the raw task. The public wrapper can also drop it if an accepted custom Sequence iterates successfully but raises when len(workers) constructs the extent; the ordinary-list path tested here spawns it immediately, and dropping HostMesh.initialized abandons only that observer"
+eager_effect = "would begin polling worker-address tasks and attaching during the binding call. That changes direct raw-task abandonment and the source-grounded public exceptional path where extent construction fails before spawn; on the tested ordinary-list path, spawn follows extent construction"
+drop_behavior = "source-grounded: dropping an undriven raw binding task, including during exceptional public extent construction, performs no attach. On the tested ordinary-list path, dropping a readiness observer does not cancel attach because HostMesh retains the non-aborting Shared"
+unobserved_error = "the retained Shared stores an attach failure and later HostMesh.initialized observers replay its original type and message. Source-grounded: if every Shared receiver disappears before completion, send_result logs the error"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "bootstrap attach-to-workers coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_attach_starts_before_readiness_observation_and_survives_a_dropped_observer",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_fails_closed_on_unreachable_host",
+  "fbcode//monarch/python/tests:test_python_actors::test_attach_failure_replays_to_fresh_readiness_observers",
+]
 
 [[site]]
 id = "np.bootstrap.run_worker_loop_forever"
@@ -2434,16 +2445,19 @@ state = "legacy"
 transition = "6.3c"
 constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyHostMesh::spawn_nonblocking"
-consumer = "HostMesh._spawn_nonblocking"
-driver = "driven by PythonTask.from_coroutine(task()).spawn() on the Python side"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; the storage Shared may be built and never observed"
-eager_effect = "starts a side effect"
-drop_behavior = "no proc mesh is spawned"
-unobserved_error = "send_result logs an unobserved error once spawned"
+consumer = "HostMesh._spawn_nonblocking's already-started outer coroutine constructs and immediately awaits the returned task after the host mesh is ready; HostMesh retains the outer spawn Shared in _pending_spawns"
+driver = "PythonTask.from_coroutine(task()).spawn() drives the retained outer coroutine, which drives this native task inline; HostMesh also retains the resulting ProcMesh"
+start_point = "source-grounded for the direct binding: the raw native task is lazy in isolation. On the tested public path, spawn_procs starts and retains the outer coroutine before returning ProcMesh, and that coroutine constructs and awaits this task after host readiness"
+abandonment = "source-grounded for the direct private binding: its raw task can be dropped undriven. On the tested public route, dropping the returned ProcMesh or an initialized Future does not cancel spawn because HostMesh retains both the spawn Shared and ProcMesh"
+eager_effect = "source-grounded: an eager binding would begin native proc spawning during task construction instead of at the outer coroutine's immediately following await; the public route has no independent drop point between them"
+drop_behavior = "source-grounded for the direct binding: dropping an undriven raw task performs no native spawn. Tested on the public route: dropping the ProcMesh or readiness observer does not prevent spawn, and HostMesh drains its retained spawn before shutdown"
+unobserved_error = "source-grounded: a native-spawn failure remains in the retained Shared and propagates through ProcMesh initialization; HostMesh stop or shutdown catches and suppresses that pending-spawn failure while draining"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "proc mesh setup coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_shutdown_waits_for_a_pending_proc_spawn_after_caller_drops_mesh",
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_mesh_readiness_replays_success_after_discarded_observer",
+]
 
 [[site]]
 id = "np.host_mesh.PyHostMesh.stop"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -1152,16 +1152,20 @@ public_operation = "HostMesh.shutdown()"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code and context-manager exit"
-driver = "awaited or blocked on by the caller"
-start_point = "lazy; nothing runs until the Future is observed"
-abandonment = "possible; dropping leaves the mesh running and _inner_host_mesh set"
-eager_effect = "starts a side effect"
-drop_behavior = "shutdown never runs"
+driver = "the first observation drives a retained Handle producer; synchronous get without a timeout may instead drive inline"
+start_point = "the call synchronously wraps the coroutine and captures context, but pending-spawn drain and shutdown do not begin until the Future is observed"
+abandonment = "dropping an unobserved Future leaves the mesh usable and _inner_host_mesh set; after asyncio observation starts, cancelling that observer does not abort the retained shutdown producer"
+eager_effect = "an eager replacement would begin draining and shutting down during the call even if the returned Future were discarded"
+drop_behavior = "before observation shutdown never runs; after observation the retained producer completes despite observer cancellation"
 first_side_effect = "flushing pending spawns"
-unobserved_error = "silently dropped"
+unobserved_error = "an unobserved Future reports nothing; after observation, the successful result remains available to another observer. Source-grounded: Python pending-spawn and logging-flush failures are silently suppressed, while native drain and acknowledgement failures warn and return success. Tested consumed states differ: a second preconstructed shutdown drains and then raises before another native call, while shutdown after stop reports success and clears the Python field although the workers remain live"
 disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "immediate-shutdown coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_preconstructed_shutdowns_drain_after_observer_cancellation",
+  "fbcode//monarch/python/tests:test_host_mesh::test_shutdown_host_mesh",
+  "fbcode//monarch/python/tests:test_host_mesh::test_stop_and_reconnect",
+]
 
 [[site]]
 id = "fc.host_mesh.HostMesh.stop[Future._from_corotask]"
@@ -1178,15 +1182,18 @@ caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code"
 driver = "awaited or blocked on by the caller"
-start_point = "lazy; nothing runs until the Future is observed"
-abandonment = "possible; dropping leaves the mesh running"
-eager_effect = "starts a side effect"
-drop_behavior = "stop never runs"
+start_point = "the call synchronously wraps the coroutine and captures context, but pending-spawn drain and stop do not begin until the Future is observed"
+abandonment = "dropping an unobserved Future leaves the mesh usable and does not stop its processes"
+eager_effect = "an eager replacement would begin draining and stopping during the call even if the returned Future were discarded"
+drop_behavior = "stop never runs before observation"
 first_side_effect = "flushing pending spawns"
-unobserved_error = "silently dropped"
+unobserved_error = "an unobserved Future reports nothing. Source-grounded: Python pending-spawn and logging-flush failures are silently suppressed, while native drain failures warn and return success. A repeated stop drains and reaches the binding again, then returns None; source inspection shows the empty cell prevents a second domain stop and lets an overlapping second stop return while the first domain stop is still running"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "stop idempotence coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_shutdown_host_mesh",
+  "fbcode//monarch/python/tests:test_host_mesh::test_stop_and_reconnect",
+]
 
 [[site]]
 id = "fc.host_mesh._spawn_admin[Future._from_corotask]"
@@ -1268,16 +1275,19 @@ public_operation = "ProcMesh.stop()"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code and context-manager exit"
-driver = "awaited or blocked on by the caller"
-start_point = "lazy; nothing runs until the Future is observed"
-abandonment = "possible; dropping leaves _stopped False and logs unflushed"
-eager_effect = "starts a side effect"
-drop_behavior = "stop never runs"
+driver = "the first observation drives a retained Handle producer; synchronous get without a timeout may instead drive inline"
+start_point = "the call synchronously captures the current Rust instance and wraps the coroutine; actor drain, logging flush, and native stop begin only when the Future is observed"
+abandonment = "dropping an unobserved Future leaves the proc mesh usable and _stopped False; after asyncio observation starts, cancelling that observer does not abort the retained stop producer"
+eager_effect = "an eager replacement would begin draining actors, flushing logs, and stopping processes during the call even if the returned Future were discarded"
+drop_behavior = "before observation stop never runs; after observation the retained producer completes despite observer cancellation"
 first_side_effect = "flushing pending actor spawns"
-unobserved_error = "silently dropped"
+unobserved_error = "an unobserved Future reports nothing; after observation, the successful result remains available to another observer. Source-grounded: pending-actor and logging-flush failures are silently suppressed. A repeated stop reaches the binding and returns None; source inspection shows the empty cell prevents a second domain stop before the public wrapper sets _stopped True, so an overlapping second stop can mark the mesh stopped even if the first domain stop later fails"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "proc mesh stop idempotence coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_stop_is_lazy_and_survives_cancelled_observer",
+  "fbcode//monarch/python/tests:test_proc_mesh::test_stop_state_tracks_native_stop_result",
+]
 
 [[site]]
 id = "fc.job.exec_command[Future._from_coro_impl]"
@@ -2427,14 +2437,18 @@ constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyHostMesh::shutdown"
 consumer = "HostMesh.shutdown, after flushing pending spawns"
 driver = "awaited inside the HostMesh.shutdown coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; reachable only when the shutdown coroutine is abandoned"
-eager_effect = "starts a side effect"
-drop_behavior = "the host mesh is never shut down"
-unobserved_error = "surfaced on observation"
+start_point = "the Owned call constructs a lazy task; driving it takes a nonempty SharedCell before awaiting domain shutdown, while an empty cell returns success without domain shutdown and a Ref raises RuntimeError before task construction"
+abandonment = "source-grounded for a direct private caller: dropping the raw task before drive leaves the SharedCell intact; on the tested public route the outer coroutine immediately awaits it"
+eager_effect = "an eager replacement would take the SharedCell and start domain shutdown during the binding call"
+drop_behavior = "source-grounded for the direct binding: an undriven raw task performs no shutdown; the public wrapper's own unobserved Future never calls this binding"
+unobserved_error = "a Ref raises synchronously with its exact managed-only message. Source-grounded: a first Owned shutdown warns and returns success on native drain or acknowledgement failure; an empty-cell repeat logs and returns success without domain shutdown. The empty-cell outcome is a current defect to revisit when repeated teardown is corrected, not a target invariant"
 disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "immediate-shutdown and drain coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_preconstructed_shutdowns_drain_after_observer_cancellation",
+  "fbcode//monarch/python/tests:test_host_mesh::test_shutdown_sliced_host_mesh_throws_exception",
+  "fbcode//monarch/python/tests:test_host_mesh::test_stop_and_reconnect",
+]
 
 [[site]]
 id = "np.host_mesh.PyHostMesh.spawn_nonblocking"
@@ -2476,14 +2490,17 @@ constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyHostMesh::stop"
 consumer = "HostMesh.stop, after flushing pending spawns"
 driver = "awaited inside the HostMesh.stop coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; reachable only when the stop coroutine is abandoned"
-eager_effect = "starts a side effect"
-drop_behavior = "the host mesh is never stopped"
-unobserved_error = "surfaced on observation"
+start_point = "the Owned call constructs a lazy task; driving it takes a nonempty SharedCell before awaiting domain stop, while an empty cell returns success without domain stop and a Ref raises RuntimeError before task construction"
+abandonment = "source-grounded for a direct private caller: dropping the raw task before drive leaves the SharedCell intact; on the tested public route the outer coroutine immediately awaits it"
+eager_effect = "an eager replacement would take the SharedCell and start domain stop during the binding call"
+drop_behavior = "source-grounded for the direct binding: an undriven raw task performs no stop; the public wrapper's own unobserved Future never calls this binding"
+unobserved_error = "a Ref raises synchronously with its exact managed-only message. Source-grounded: a first Owned stop warns and returns success on native drain failure; an empty-cell repeat logs and returns success without domain stop. The empty-cell outcome is a current defect to revisit when repeated teardown is corrected, not a target invariant"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "stop idempotence coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_host_mesh::test_shutdown_sliced_host_mesh_throws_exception",
+  "fbcode//monarch/python/tests:test_host_mesh::test_stop_and_reconnect",
+]
 
 [[site]]
 id = "np.host_mesh._spawn_admin"
@@ -2669,14 +2686,17 @@ constructor = "PyPythonTask"
 return_surface = "PyPythonTask returned from PyProcMesh::stop_nonblocking"
 consumer = "ProcMesh.stop, after flushing pending actor spawns and logs"
 driver = "awaited inside the _stop_nonblocking coroutine"
-start_point = "lazy; the boxed future is not polled until the returned task is driven"
-abandonment = "possible; reachable only when the stop coroutine is abandoned"
-eager_effect = "starts a side effect"
-drop_behavior = "the proc mesh is never stopped and _stopped stays False"
-unobserved_error = "surfaced on observation"
+start_point = "the call takes the GIL and rejects a Ref synchronously; for Owned it constructs a lazy task that takes a nonempty SharedCell only when driven, while an empty cell returns success without domain stop"
+abandonment = "source-grounded for a direct private caller: dropping the raw task before drive leaves the SharedCell intact; on the tested public route the outer producer immediately awaits it once reached"
+eager_effect = "an eager replacement would take the SharedCell and start domain stop during the binding call"
+drop_behavior = "source-grounded for the direct binding: an undriven raw task performs no stop; dropping the public outer Future before observation prevents this binding from being called"
+unobserved_error = "a Ref raises PyValueError synchronously with its exact owned-only message. Source-grounded: a first Owned stop failure is reported as PyValueError when the task is observed; an empty-cell repeat logs and returns success without domain stop"
 disposition = "intentionally become eager"
 semantic_class = "deferred_side_effect"
-oracle = "proc mesh stop idempotence coverage"
+oracle = [
+  "fbcode//monarch/python/tests:test_proc_mesh::test_proc_stop_is_lazy_and_survives_cancelled_observer",
+  "fbcode//monarch/python/tests:test_proc_mesh::test_stop_state_tracks_native_stop_result",
+]
 
 [[site]]
 id = "np.lib.PyRdmaAction.submit"
@@ -3068,7 +3088,7 @@ operation = "pytokio_import"
 scope = "test"
 state = "legacy"
 transition = "6.8"
-members = ["PythonTask"]
+members = ["PythonTask", "Shared"]
 
 [[site]]
 id = "im.test_proc_launcher_probe.module"


### PR DESCRIPTION
Summary:
when Monarch starts logging for a group of worker processes, Rust returns a task. running that task creates the client-side log collector, starts a logging-control actor in each worker, and optionally starts per-worker actors that forward stdout and stderr to the collector. flushing logs returns another task that coordinates a distributed flush. merely receiving either task does not start that work.

the normal Python callers start these tasks as soon as they receive them, so there are two different drop boundaries to preserve during the pytokio migration. dropping a task before it starts creates no logging actors and performs no flush. once Python has started a flush, cancelling the caller waiting for it does not cancel the underlying work.

this adds tests for both boundaries. once a logging client exists, ordinary exceptions raised while starting or waiting for a flush are ignored, while BaseException values retain their original type and message. repeated flush calls create separate operations rather than reuse an earlier result.

there is also a shutdown timing case to preserve. Monarch can finish starting a worker before that worker’s logging machinery is ready. if shutdown happens in that interval, the logging flush sees that no logging client exists and returns without starting a flush. the new real-host test pauses setup at exactly that point and verifies the behavior. because it holds a worker behind a gate, it runs in a separate target instead of adding load to the general host-mesh suite.

the census now links both logging operations to their exact tests. this changes tests and migration metadata only; production behavior does not change.

Differential Revision: D119207000


