### PR TITLE
characterize accumulator execution boundaries (#4834)

### DIFF
--- a/python/tests/test_accumulator_characterization.py
+++ b/python/tests/test_accumulator_characterization.py
@@ -1,0 +1,316 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import asyncio
+import operator
+import sys
+import unittest.mock
+
+import pytest
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._src.actor import future as future_mod
+from monarch._src.actor.future import Future
+from monarch.actor import Accumulator
+
+
+class _CombineError(Exception):
+    pass
+
+
+class _StreamError(Exception):
+    pass
+
+
+def _future_of(value):
+    """A real, single-use monarch Future resolving to value."""
+
+    async def _v():
+        return value
+
+    return Future._from_coro(_v())
+
+
+def _stream_endpoint(values):
+    """A fake Endpoint whose .stream() yields one real Future per value."""
+    ep = unittest.mock.MagicMock()
+    ep.stream.return_value = iter([_future_of(v) for v in values])
+    return ep
+
+
+def _recording_stream_endpoint(values, events, *, make_future=_future_of):
+    """A fake Endpoint that records stream calls and iterator advancement."""
+    ep = unittest.mock.MagicMock()
+
+    def stream(*args, **kwargs):
+        events.append(("stream", args, kwargs))
+
+        def iterator():
+            for value in values:
+                events.append(("next", value))
+                yield make_future(value)
+
+        return iterator()
+
+    ep.stream.side_effect = stream
+    return ep
+
+
+async def _await_result(future):
+    return await future
+
+
+async def _capture_error(future, error_type):
+    with pytest.raises(error_type) as caught:
+        await future
+    return caught.value
+
+
+def _failing_combine():
+    def combine(total, value):
+        if value == 2:
+            raise _CombineError("combine failed on 2")
+        return total + value
+
+    return unittest.mock.MagicMock(side_effect=combine)
+
+
+def test_accumulate_folds_with_combine():
+    """accumulate reduces the per-rank stream through combine from identity."""
+    acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
+    assert acc.accumulate().get() == 6
+
+
+def test_accumulate_empty_stream_returns_identity():
+    """With no streamed values, accumulate returns the identity seed."""
+    acc = Accumulator(_stream_endpoint([]), 42, operator.add)
+    assert acc.accumulate().get() == 42
+
+
+def test_accumulate_folds_left_to_right():
+    """combine is applied left-to-right over the stream, seeded by identity."""
+    acc = Accumulator(_stream_endpoint([1, 2, 3]), [], lambda a, r: a + [r])
+    assert acc.accumulate().get() == [1, 2, 3]
+
+
+def test_accumulate_forwards_args_to_stream():
+    """accumulate forwards its args/kwargs to endpoint.stream()."""
+    ep = _stream_endpoint([1])
+    Accumulator(ep, 0, operator.add).accumulate("a", k=1).get()
+    ep.stream.assert_called_once_with("a", k=1)
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_invokes_stream_before_any_observation():
+    events = []
+    endpoint = _recording_stream_endpoint([2], events)
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    accumulator = Accumulator(endpoint, 1, combine)
+
+    unobserved = accumulator.accumulate()
+    # The private state check is intentional: the event assertions alone could
+    # race a producer that started eagerly but has not advanced the iterator yet.
+    assert isinstance(unobserved._status, future_mod._Unawaited)
+    assert events == [("stream", (), {})]
+    combine.assert_not_called()
+    del unobserved
+    assert events == [("stream", (), {})]
+    combine.assert_not_called()
+
+    assert accumulator.accumulate().get() == 3
+    assert events == [
+        ("stream", (), {}),
+        ("stream", (), {}),
+        ("next", 2),
+    ]
+    combine.assert_called_once_with(1, 2)
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_short_circuits_and_propagates_combine_error():
+    events = []
+    combine = _failing_combine()
+    endpoint = _recording_stream_endpoint([1, 2, 3], events)
+    result = Accumulator(endpoint, 0, combine).accumulate()
+
+    with pytest.raises(_CombineError) as caught:
+        result.get()
+
+    assert type(caught.value) is _CombineError
+    assert str(caught.value) == "combine failed on 2"
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+    ]
+    assert events == [
+        ("stream", (), {}),
+        ("next", 1),
+        ("next", 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_short_circuits_and_propagates_stream_error():
+    events = []
+
+    def make_future(value):
+        if value != 2:
+            return _future_of(value)
+
+        async def fail():
+            raise _StreamError("stream failed on 2")
+
+        return Future._from_coro(fail())
+
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    endpoint = _recording_stream_endpoint([1, 2, 3], events, make_future=make_future)
+    result = Accumulator(endpoint, 0, combine).accumulate()
+
+    with pytest.raises(_StreamError) as first:
+        result.get()
+    second = asyncio.run(_capture_error(result, _StreamError))
+
+    assert type(first.value) is _StreamError
+    assert type(second) is _StreamError
+    assert str(first.value) == "stream failed on 2"
+    assert str(second) == "stream failed on 2"
+    assert second is first.value
+    assert combine.call_args_list == [unittest.mock.call(0, 1)]
+    assert events == [
+        ("stream", (), {}),
+        ("next", 1),
+        ("next", 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_get_then_await_does_not_rerun_combine():
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    assert result.get() == 6
+    assert asyncio.run(_await_result(result)) == 6
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+        unittest.mock.call(3, 3),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_await_then_get_does_not_rerun_combine():
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    assert asyncio.run(_await_result(result)) == 6
+    assert result.get() == 6
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+        unittest.mock.call(3, 3),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_replays_combine_error_get_then_await():
+    combine = _failing_combine()
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    with pytest.raises(_CombineError) as first:
+        result.get()
+    second = asyncio.run(_capture_error(result, _CombineError))
+
+    assert type(first.value) is _CombineError
+    assert type(second) is _CombineError
+    assert str(first.value) == "combine failed on 2"
+    assert str(second) == "combine failed on 2"
+    assert second is first.value
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_replays_combine_error_await_then_get():
+    combine = _failing_combine()
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    first = asyncio.run(_capture_error(result, _CombineError))
+    with pytest.raises(_CombineError) as second:
+        result.get()
+
+    assert type(first) is _CombineError
+    assert type(second.value) is _CombineError
+    assert str(first) == "combine failed on 2"
+    assert str(second.value) == "combine failed on 2"
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_post_start_abandonment_completes_fold_once():
+    gate = {"entered": False, "released": False, "completed": False}
+
+    async def gated_value():
+        gate["entered"] = True
+        while not gate["released"]:
+            await PythonTask.sleep(0.005)
+        gate["completed"] = True
+        return 2
+
+    endpoint = unittest.mock.MagicMock()
+    endpoint.stream.return_value = iter([Future._from_coro(gated_value())])
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(endpoint, 1, combine).accumulate()
+
+    async def cancel_after_start():
+        observer = result.as_asyncio()
+
+        async def wait_for_entry():
+            while not gate["entered"]:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(wait_for_entry(), timeout=5)
+        assert not gate["completed"]
+        assert observer.cancel()
+        # asyncio.Future.cancel() changes the state synchronously; callbacks run
+        # on a later loop turn, but cancelled() is true when cancel() returns true.
+        assert observer.cancelled()
+        gate["released"] = True
+        return await asyncio.wait_for(result.as_asyncio(), timeout=5)
+
+    try:
+        observed = asyncio.run(cancel_after_start())
+    finally:
+        original_error = sys.exc_info()[1]
+        gate["released"] = True
+        try:
+            drained = result.get(timeout=5)
+        except Exception as cleanup_error:
+            if original_error is None:
+                raise
+            # BaseException.add_note() is unavailable on the Python 3.10 OSS
+            # test lane. The original failure still takes precedence there.
+            if hasattr(original_error, "add_note"):
+                original_error.add_note(f"cleanup also failed: {cleanup_error!r}")
+
+    assert observed == 3
+    assert drained == 3
+    assert gate["completed"]
+    combine.assert_called_once_with(1, 2)
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_empty_stream_makes_no_combine_call():
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(_stream_endpoint([]), 42, combine).accumulate()
+
+    assert result.get() == 42
+    combine.assert_not_called()

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -241,6 +241,10 @@ class SyncActor(Actor):
     def sync_endpoint(self, a_counter: Counter):
         return a_counter.value.choose().get()
 
+    @endpoint
+    def accumulate_sync_endpoint(self, a_counter: Counter) -> int:
+        return Accumulator(a_counter.value, 0, operator.add).accumulate().get()
+
 
 @pytest.mark.timeout(60)
 async def test_sync_actor():
@@ -250,6 +254,17 @@ async def test_sync_actor():
     r = await a.sync_endpoint.choose(c)
     assert r == 5
     await proc.stop()
+
+
+@pytest.mark.timeout(60)
+async def test_accumulate_get_works_inside_sync_endpoint() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
+    try:
+        actor = proc.spawn("accumulator_sync_actor", SyncActor)
+        counter = proc.spawn("accumulator_counter", Counter, 3)
+        assert await actor.accumulate_sync_endpoint.choose(counter) == 6
+    finally:
+        await proc.stop()
 
 
 @pytest.mark.timeout(60)
@@ -2232,47 +2247,3 @@ async def test_del_runs_on_proc_mesh_stop() -> None:
             f"file {marker_path} should have contents 'finalized' if the finalizers were run"
         )
     os.unlink(marker_path)
-
-
-# ── Accumulator.accumulate characterization tests ──────────────────────────
-
-
-def _future_of(value):
-    """A real, single-use monarch Future resolving to value."""
-
-    async def _v():
-        return value
-
-    return Future._from_coro(_v())
-
-
-def _stream_endpoint(values):
-    """A fake Endpoint whose .stream() yields one real Future per value."""
-    ep = unittest.mock.MagicMock()
-    ep.stream.return_value = iter([_future_of(v) for v in values])
-    return ep
-
-
-def test_accumulate_folds_with_combine():
-    """accumulate reduces the per-rank stream through combine from identity."""
-    acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
-    assert acc.accumulate().get() == 6
-
-
-def test_accumulate_empty_stream_returns_identity():
-    """With no streamed values, accumulate returns the identity seed."""
-    acc = Accumulator(_stream_endpoint([]), 42, operator.add)
-    assert acc.accumulate().get() == 42
-
-
-def test_accumulate_folds_left_to_right():
-    """combine is applied left-to-right over the stream, seeded by identity."""
-    acc = Accumulator(_stream_endpoint([1, 2, 3]), [], lambda a, r: a + [r])
-    assert acc.accumulate().get() == [1, 2, 3]
-
-
-def test_accumulate_forwards_args_to_stream():
-    """accumulate forwards its args/kwargs to endpoint.stream()."""
-    ep = _stream_endpoint([1])
-    Accumulator(ep, 0, operator.add).accumulate("a", k=1).get()
-    ep.stream.assert_called_once_with("a", k=1)

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -356,7 +356,7 @@ shared_reconstruction = 2
 reserve_binding = 1
 py_mesh_reserve = 2
 py_is_tokio_thread = 3
-pytokio_import = 31
+pytokio_import = 32
 pytokio_module_ref = 17
 helper_symbol = 26
 helper_definition = 6
@@ -775,6 +775,7 @@ owns = [
   "im.test_actor_driver_characterization.module",
   "im.test_admin_spawn_characterization.module",
   "im.test_actor_mesh.module",
+  "im.test_accumulator_characterization.module",
   "im.test_client_context_guard.module",
   "im.test_future_characterization.module",
   "im.test_host_mesh.module",
@@ -969,16 +970,30 @@ public_operation = "Accumulator.accumulate(...)"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code"
-driver = "awaited or blocked on by the caller"
-start_point = "the endpoint stream is dispatched when accumulate() is called; combine runs only on observation"
-abandonment = "possible; the stream was already dispatched, so dropping abandons its replies"
-eager_effect = "observes already-running work"
-drop_behavior = "the combine never runs and the dispatched replies are never collected"
-first_side_effect = "endpoint stream dispatch at call time"
-unobserved_error = "silently dropped"
+driver = "after the shared Future refusal and warning checks, a first no-timeout get() drives the fold inline; a successful first await/as_asyncio() observation or first get() with a valid timeout starts a non-aborting Handle producer that continues independently; result() and exception() delegate to get()"
+start_point = "accumulate() calls endpoint.stream() before constructing the returned Future, but iteration, _take_inner(), and combine begin only when that Future is driven. Source-grounded for ActorEndpoint: stream() opens the response port and submits the cast path before returning PyValueStream; AsyncActorMesh queues resolve-and-cast for later, while a bare PythonActorMeshImpl resolves and casts synchronously"
+abandonment = "dropping a never-observed Future abandons the fold before iteration, _take_inner(), or combine, after endpoint.stream() has already run. After asyncio observation starts the non-aborting Handle producer, cancelling that observer does not stop the fold and a later observer receives the shared result"
+eager_effect = "would start the fold when the replacement Handle is created, allowing iterator advancement, streamed-result waits, and combine to begin before any caller observation; today accumulate() stops after endpoint.stream() returns, whether its mesh queued the cast or completed it synchronously"
+drop_behavior = "before observation, dropping the Future does not advance the iterator or run combine; after asyncio observation starts, observer cancellation does not stop the fold. Every streamed Future already reached by the fold is spent by _take_inner()"
+first_side_effect = "calls endpoint.stream() during accumulate(); ActorEndpoint opens a response port and submits the mesh-dependent cast path before returning"
+unobserved_error = "source-grounded: synchronous endpoint.stream() construction or submission errors raise directly from accumulate(), while remote execution and replies may proceed after the call. A never-driven fold cannot materialize or observe a streamed-result error and never invokes combine. Once driven, an ordinary Exception from either a streamed Future or combine short-circuits and later observers receive the same type and message; the get-first BaseException poisoning case is characterized separately by fbcode//monarch/python/tests:test_future_characterization::test_fm_terminal_baseexception_current_poisons_the_future"
 disposition = "require a binding-specific design"
 semantic_class = "already_started_lazy_observer"
-oracle = "Accumulator exact-once and error behavior (6.0c item 5)"
+oracle = [
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_folds_with_combine",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_empty_stream_returns_identity",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_folds_left_to_right",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_invokes_stream_before_any_observation",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_short_circuits_and_propagates_combine_error",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_short_circuits_and_propagates_stream_error",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_get_then_await_does_not_rerun_combine",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_await_then_get_does_not_rerun_combine",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_replays_combine_error_get_then_await",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_replays_combine_error_await_then_get",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_post_start_abandonment_completes_fold_once",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_empty_stream_makes_no_combine_call",
+  "fbcode//monarch/python/tests:test_python_actors::test_accumulate_get_works_inside_sync_endpoint",
+]
 
 [[site]]
 id = "fc.actor_mesh.ActorMesh._name[Future._from_coroself._inner.name]"
@@ -3016,6 +3031,18 @@ scope = "production"
 state = "legacy"
 transition = "6.2"
 members = ["Handle"]
+
+[[site]]
+id = "im.test_accumulator_characterization.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_accumulator_characterization.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
 
 [[site]]
 id = "im.test_actor_mesh.module"


### PR DESCRIPTION
Summary:

an `Accumulator` sends an endpoint request and then folds one reply from each actor into a single value. `accumulate()` asks for the reply stream before returning, but reading replies and calling the combining function remain suspended in the returned `Future` until somebody observes it. Existing tests checked final values without pinning that execution boundary.

this moves the existing fold tests unchanged into a focused target and adds coverage for both sides of the boundary. Dropping a never-observed `Future` does not advance the reply iterator or call the combining function. Once asynchronous observation starts the fold, cancelling that observer does not stop the work; a later observer receives the same result without running the combining function again.

the tests also show that reply and combining-function errors stop the fold before the next item and retain their exact exception, an empty stream never calls the combining function, and blocking for the result works from inside a synchronous actor endpoint.

the census now links this behavior to the exact tests and distinguishes call-time stream setup from observation-time folding. no production behavior changes.

Differential Revision: D119242209


