### PR TITLE
move QP data path to tokio tasks (#4836)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4895,7 +4895,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "backoff",
  "bytes",
  "dashmap",
  "erased-serde",

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -10,7 +10,6 @@ license = "BSD-3-Clause"
 [dependencies]
 anyhow = "1.0.104"
 async-trait = "0.1.92"
-backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = { version = "1.12.1", features = ["serde"] }
 dashmap = { version = "6.2.1", features = ["rayon", "serde"] }
 erased-serde = "0.4.10"

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -15,10 +15,26 @@
 #![allow(dead_code)]
 
 use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::sync::mpsc as std_mpsc;
+use std::thread::JoinHandle;
+use std::thread::Thread;
+use std::time::Duration;
+use std::time::Instant;
 
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::Context;
+use hyperactor::Handler;
+use hyperactor::Instance;
+use hyperactor::OncePortHandle;
+use hyperactor::PortHandle;
+use hyperactor::actor::ActorError;
 use tokio::sync::mpsc;
 
 use super::primitives::IbvCq;
@@ -28,6 +44,7 @@ use super::queue_pair::WorkRequestError;
 
 /// The number of CQEs requested in each `ibv_poll_cq` call.
 const CQES_PER_POLL: usize = 64;
+const BUSY_POLL_WINDOW: Duration = Duration::from_millis(100);
 
 /// Identifies one CQ, distinct from every other live one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -263,10 +280,292 @@ impl<Cq: IbvCompletionQueue> PollerState<Cq> {
     }
 }
 
+#[derive(Debug, Default)]
+struct PollerSignal {
+    cancelled: AtomicBool,
+    thread: OnceLock<Thread>,
+}
+
+impl PollerSignal {
+    fn notify(&self) -> anyhow::Result<()> {
+        self.thread
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("CQ polling thread has not started"))?
+            .unpark();
+        Ok(())
+    }
+
+    fn cancel(&self) {
+        // Release publishes cancellation to the poller's acquire checks.
+        self.cancelled.store(true, Ordering::Release);
+        if let Some(thread) = self.thread.get() {
+            thread.unpark();
+        }
+    }
+
+    fn install_thread(&self, thread: Thread) {
+        self.thread
+            .set(thread)
+            .expect("the CQ polling thread is installed only once");
+    }
+}
+
+/// A cheap wake-up handle for notifying the dedicated CQ polling thread.
+#[derive(Clone, Debug)]
+pub(super) struct PollerWake {
+    signal: Arc<PollerSignal>,
+}
+
+impl PollerWake {
+    pub(super) fn notify(&self) -> anyhow::Result<()> {
+        self.signal.notify()
+    }
+}
+
+/// Installs the route for completions `qp_num` produces on `cq`.
+#[derive(Debug)]
+pub(super) struct Attach<Cq: IbvCompletionQueue> {
+    pub(super) cq: Arc<Cq>,
+    pub(super) qp_num: u32,
+    pub(super) route: CompletionRoute,
+    pub(super) posted: Arc<AtomicU64>,
+    pub(super) reply: OncePortHandle<PollerWake>,
+}
+
+#[derive(Debug)]
+enum PollerCommand<Cq> {
+    Attach {
+        cq: Arc<Cq>,
+        qp_num: u32,
+        route: CompletionRoute,
+        posted: Arc<AtomicU64>,
+        reply: Box<OncePortHandle<PollerWake>>,
+    },
+}
+
+#[derive(Debug)]
+struct Poller<Cq> {
+    state: PollerState<Cq>,
+    commands: std_mpsc::Receiver<PollerCommand<Cq>>,
+    signal: Arc<PollerSignal>,
+}
+
+impl<Cq: IbvCompletionQueue> Poller<Cq> {
+    fn new(commands: std_mpsc::Receiver<PollerCommand<Cq>>, signal: Arc<PollerSignal>) -> Self {
+        Self {
+            state: PollerState::new(),
+            commands,
+            signal,
+        }
+    }
+
+    fn run(mut self) -> anyhow::Result<()> {
+        let mut last_work = Instant::now();
+        loop {
+            // Acquire pairs with `cancel`'s release store so the poller sees
+            // everything that happened before cancellation.
+            if self.signal.cancelled.load(Ordering::Acquire) {
+                return Ok(());
+            }
+            self.process_commands()?;
+            if self.state.expects_completions() {
+                self.state.poll_round()?;
+                last_work = Instant::now();
+                continue;
+            }
+            if last_work.elapsed() < BUSY_POLL_WINDOW {
+                std::hint::spin_loop();
+                continue;
+            }
+            // `unpark` leaves a one-bit permit when it runs before `park`, so a
+            // producer cannot miss this transition into sleep. Its release
+            // synchronizes with `park`'s acquire return; spurious returns are
+            // harmless because the loop checks all work again.
+            std::thread::park();
+        }
+    }
+
+    fn process_commands(&mut self) -> anyhow::Result<()> {
+        loop {
+            match self.commands.try_recv() {
+                Ok(PollerCommand::Attach {
+                    cq,
+                    qp_num,
+                    route,
+                    posted,
+                    reply,
+                }) => {
+                    self.state.attach(cq, qp_num, route, posted)?;
+                    if let Err(error) = reply.try_post(
+                        Instance::<CompletionQueueActor<Cq>>::self_client(),
+                        PollerWake {
+                            signal: Arc::clone(&self.signal),
+                        },
+                    ) {
+                        tracing::warn!(qp_num, %error, "failed to deliver Attach reply");
+                    }
+                }
+                Err(std_mpsc::TryRecvError::Empty) => return Ok(()),
+                Err(std_mpsc::TryRecvError::Disconnected) => {
+                    return Err(anyhow::anyhow!("CQ poller control channel disconnected"));
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PollerFailed {
+    error: String,
+}
+
+/// Owns and supervises a native thread that polls a set of completion queues.
+#[derive(Debug)]
+pub(super) struct CompletionQueueActor<Cq> {
+    commands: std_mpsc::Sender<PollerCommand<Cq>>,
+    command_rx: Option<std_mpsc::Receiver<PollerCommand<Cq>>>,
+    wake: PollerWake,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl<Cq: IbvCompletionQueue> CompletionQueueActor<Cq> {
+    pub(super) fn new() -> Self {
+        let (commands, command_rx) = std_mpsc::channel();
+        let signal = Arc::new(PollerSignal::default());
+        Self {
+            commands,
+            command_rx: Some(command_rx),
+            wake: PollerWake { signal },
+            thread: None,
+        }
+    }
+
+    fn send_command(&self, command: PollerCommand<Cq>) -> anyhow::Result<()> {
+        self.commands
+            .send(command)
+            .map_err(|_| anyhow::anyhow!("CQ polling thread stopped"))?;
+        self.wake.notify()
+    }
+
+    fn cancel(&self) {
+        self.wake.signal.cancel();
+    }
+}
+
+impl<Cq> Drop for CompletionQueueActor<Cq> {
+    fn drop(&mut self) {
+        self.wake.signal.cancel();
+        // In theory, joining the thread here could block the tokio runtime,
+        // but in practice, it should be safe. The polling loop should break
+        // and return quickly after cancellation.
+        if let Some(thread) = self.thread.take()
+            && thread.join().is_err()
+        {
+            tracing::error!("joining CQ polling thread during actor drop failed");
+        }
+    }
+}
+
+fn run_poller<Cq: IbvCompletionQueue>(poller: Poller<Cq>, failed: PortHandle<PollerFailed>) {
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| poller.run()));
+    let error = match result {
+        Ok(Ok(())) => return,
+        Ok(Err(error)) => error.to_string(),
+        Err(_) => "CQ polling thread panicked".to_owned(),
+    };
+    let error_for_log = error.clone();
+    if let Err(post_error) = failed.try_post(
+        Instance::<CompletionQueueActor<Cq>>::self_client(),
+        PollerFailed { error },
+    ) {
+        tracing::error!(
+            error = %error_for_log,
+            %post_error,
+            "reporting CQ polling thread failure failed",
+        );
+    }
+}
+
+#[async_trait]
+impl<Cq: IbvCompletionQueue> Actor for CompletionQueueActor<Cq> {
+    async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
+        let commands = self
+            .command_rx
+            .take()
+            .expect("the CQ polling thread has not been started");
+        let poller = Poller::new(commands, Arc::clone(&self.wake.signal));
+        let failed = this.handle().port::<PollerFailed>();
+        let thread = std::thread::Builder::new()
+            .name("monarch-rdma-cq".to_owned())
+            .spawn(move || run_poller(poller, failed))?;
+        self.wake.signal.install_thread(thread.thread().clone());
+        self.thread = Some(thread);
+        Ok(())
+    }
+
+    async fn cleanup(
+        &mut self,
+        _this: &Instance<Self>,
+        _err: Option<&ActorError>,
+    ) -> anyhow::Result<()> {
+        self.cancel();
+        let Some(thread) = self.thread.take() else {
+            return Ok(());
+        };
+        tokio::task::spawn_blocking(move || thread.join())
+            .await
+            .map_err(|error| anyhow::anyhow!("joining CQ polling thread failed: {error}"))?
+            .map_err(|_| anyhow::anyhow!("CQ polling thread panicked"))
+    }
+
+    fn spawn_server_task<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        crate::rdma_runtime::spawn_on_rdma_runtime(future)
+    }
+}
+
+#[async_trait]
+impl<Cq: IbvCompletionQueue> Handler<Attach<Cq>> for CompletionQueueActor<Cq> {
+    async fn handle(&mut self, _cx: &Context<Self>, message: Attach<Cq>) -> anyhow::Result<()> {
+        let Attach {
+            cq,
+            qp_num,
+            route,
+            posted,
+            reply,
+        } = message;
+        self.send_command(PollerCommand::Attach {
+            cq,
+            qp_num,
+            route,
+            posted,
+            reply: Box::new(reply),
+        })
+    }
+}
+
+#[async_trait]
+impl<Cq: IbvCompletionQueue> Handler<PollerFailed> for CompletionQueueActor<Cq> {
+    async fn handle(&mut self, _cx: &Context<Self>, message: PollerFailed) -> anyhow::Result<()> {
+        Err(anyhow::anyhow!(
+            "CQ polling thread failed: {}",
+            message.error
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
     use std::sync::Mutex;
+
+    use anyhow::Result;
+    use hyperactor::ActorHandle;
+    use hyperactor::context::Mailbox;
+    use hyperactor::proc::Proc;
 
     use super::*;
     use crate::backend::ibverbs::device::IbvDevice;
@@ -335,6 +634,127 @@ mod tests {
             let consumed = inner.queued.len().min(self.batch);
             out.extend(inner.queued.drain(..consumed));
             Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockParent {
+        supervision_tx: mpsc::UnboundedSender<hyperactor::supervision::ActorSupervisionEvent>,
+    }
+
+    #[async_trait]
+    impl Actor for MockParent {
+        async fn handle_supervision_event(
+            &mut self,
+            _this: &Instance<Self>,
+            event: &hyperactor::supervision::ActorSupervisionEvent,
+        ) -> Result<bool> {
+            self.supervision_tx
+                .send(event.clone())
+                .map_err(|error| anyhow::anyhow!("sending supervision event failed: {error}"))?;
+            Ok(true)
+        }
+    }
+
+    #[derive(Debug)]
+    struct SpawnPoller {
+        reply: OncePortHandle<ActorHandle<CompletionQueueActor<MockCq>>>,
+    }
+
+    #[async_trait]
+    impl Handler<SpawnPoller> for MockParent {
+        async fn handle(&mut self, cx: &Context<Self>, message: SpawnPoller) -> Result<()> {
+            message
+                .reply
+                .try_post(cx, cx.spawn(CompletionQueueActor::<MockCq>::new()))?;
+            Ok(())
+        }
+    }
+
+    struct TestRoute {
+        inbox: CompletionInbox,
+        posted: Arc<AtomicU64>,
+        wake: PollerWake,
+    }
+
+    struct CqaHarness {
+        proc: Proc,
+        parent: ActorHandle<MockParent>,
+        client: hyperactor::Client,
+        supervision_rx: mpsc::UnboundedReceiver<hyperactor::supervision::ActorSupervisionEvent>,
+    }
+
+    impl CqaHarness {
+        fn new() -> Self {
+            let proc = Proc::anonymous();
+            let (supervision_tx, supervision_rx) = mpsc::unbounded_channel();
+            let parent = proc.spawn_with_label("parent", MockParent { supervision_tx });
+            let client = proc.client("client");
+            Self {
+                proc,
+                parent,
+                client,
+                supervision_rx,
+            }
+        }
+
+        async fn spawn_poller(&self) -> Result<ActorHandle<CompletionQueueActor<MockCq>>> {
+            let (reply, receiver) = self.client.mailbox().open_once_port();
+            self.parent.try_post(&self.client, SpawnPoller { reply })?;
+            Ok(receiver.recv().await?)
+        }
+
+        async fn attach(
+            &self,
+            poller: &ActorHandle<CompletionQueueActor<MockCq>>,
+            cq: &Arc<MockCq>,
+            qp_num: u32,
+        ) -> Result<TestRoute> {
+            let (inbox, route) = CompletionInbox::new();
+            let posted = Arc::new(AtomicU64::new(0));
+            let (reply, receiver) = self.client.mailbox().open_once_port();
+            poller.try_post(
+                &self.client,
+                Attach {
+                    cq: Arc::clone(cq),
+                    qp_num,
+                    route,
+                    posted: Arc::clone(&posted),
+                    reply,
+                },
+            )?;
+            let wake = receiver.recv().await?;
+            Ok(TestRoute {
+                inbox,
+                posted,
+                wake,
+            })
+        }
+
+        fn post(route: &TestRoute, count: u64) -> Result<()> {
+            route.posted.fetch_add(count, Ordering::Relaxed);
+            route.wake.notify()
+        }
+
+        async fn next_supervision_failure(
+            &mut self,
+        ) -> hyperactor::supervision::ActorSupervisionEvent {
+            tokio::time::timeout(Duration::from_secs(5), self.supervision_rx.recv())
+                .await
+                .expect("timed out waiting for child failure event")
+                .expect("supervision channel closed")
+        }
+
+        async fn teardown(mut self) {
+            self.proc
+                .destroy_and_wait(Duration::from_secs(30), "test teardown")
+                .await
+                .expect("destroy_and_wait failed");
+            self.supervision_rx.close();
+            assert!(
+                self.supervision_rx.recv().await.is_none(),
+                "unexpected supervision event during teardown",
+            );
         }
     }
 
@@ -471,5 +891,75 @@ mod tests {
                 .wr_id(),
             100,
         );
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn native_poller_wakes_for_new_work() -> Result<()> {
+        let harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut route = harness.attach(&poller, &cq, 7).await?;
+
+        tokio::time::sleep(BUSY_POLL_WINDOW + Duration::from_millis(25)).await;
+        let polls_before_post = cq.polls();
+        cq.queue_completion(7, 100);
+        CqaHarness::post(&route, 1)?;
+
+        let completion = tokio::time::timeout(Duration::from_secs(5), route.inbox.recv())
+            .await
+            .expect("timed out waiting for completion")
+            .expect("completion channel closed")
+            .expect("completion should succeed");
+        assert_eq!(completion.wr_id(), 100);
+        assert!(
+            cq.polls() > polls_before_post,
+            "posting work must wake the native poller",
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn native_poller_drains_more_than_one_poll_batch() -> Result<()> {
+        let harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut route = harness.attach(&poller, &cq, 7).await?;
+        let count = CQES_PER_POLL as u64 + 1;
+        for wr_id in 0..count {
+            cq.queue_completion(7, wr_id);
+        }
+        CqaHarness::post(&route, count)?;
+
+        for expected in 0..count {
+            let completion = tokio::time::timeout(Duration::from_secs(5), route.inbox.recv())
+                .await
+                .expect("timed out waiting for completion")
+                .expect("completion channel closed")
+                .expect("completion should succeed");
+            assert_eq!(completion.wr_id(), expected);
+        }
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn native_poller_failure_reaches_supervisor() -> Result<()> {
+        let mut harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let route = harness.attach(&poller, &cq, 7).await?;
+        cq.queue_completion(8, 100);
+        CqaHarness::post(&route, 1)?;
+
+        let event = harness.next_supervision_failure().await;
+        assert_eq!(&event.actor_id, poller.actor_addr());
+        let report = event.failure_report().expect("event should be a failure");
+        assert!(
+            report.contains("unattached queue pair 8"),
+            "unexpected failure report: {report}",
+        );
+        harness.teardown().await;
+        Ok(())
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -14,6 +14,8 @@
 // Nothing outside the tests below uses this module.
 #![allow(dead_code)]
 
+use tokio::sync::mpsc;
+
 use super::primitives::IbvCq;
 use super::primitives::IbvWc;
 use super::queue_pair::PollCompletionError;
@@ -95,6 +97,49 @@ impl IbvCompletionQueue for IbvCq {
     }
 }
 
+pub(super) type CompletionResult = Result<IbvWc, WorkRequestError>;
+
+/// Producer-side route used by a CQ poller to deliver one queue pair's
+/// completions directly to its data-plane task.
+#[derive(Clone, Debug)]
+pub(super) struct CompletionRoute {
+    sender: mpsc::UnboundedSender<CompletionResult>,
+}
+
+/// Consumer-side queue owned by a queue pair's data-plane task.
+#[derive(Debug)]
+pub(super) struct CompletionInbox {
+    receiver: mpsc::UnboundedReceiver<CompletionResult>,
+}
+
+impl CompletionInbox {
+    pub(super) fn new() -> (Self, CompletionRoute) {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        (Self { receiver }, CompletionRoute { sender })
+    }
+
+    pub(super) async fn recv(&mut self) -> Option<CompletionResult> {
+        self.receiver.recv().await
+    }
+
+    pub(super) fn try_recv(&mut self) -> Result<CompletionResult, mpsc::error::TryRecvError> {
+        self.receiver.try_recv()
+    }
+}
+
+impl CompletionRoute {
+    #[cfg(test)]
+    pub(super) fn sender_for_test(&self) -> mpsc::UnboundedSender<CompletionResult> {
+        self.sender.clone()
+    }
+
+    fn deliver(&self, qp_num: u32, cq_id: CqId, result: CompletionResult) {
+        if let Err(error) = self.sender.send(result) {
+            tracing::error!(qp_num, ?cq_id, %error, "queueing a completion for a queue pair failed");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +166,40 @@ mod tests {
         // handed and so nothing else polls.
         unsafe { cq.poll(&mut consumed) }.expect("polling an empty CQ should succeed");
         assert!(consumed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn completion_inbox_preserves_order() {
+        let (mut inbox, route) = CompletionInbox::new();
+        route.deliver(7, CqId(1), Ok(IbvWc::for_test(100, true)));
+        route.deliver(7, CqId(1), Ok(IbvWc::for_test(200, true)));
+        assert_eq!(
+            inbox
+                .recv()
+                .await
+                .expect("first completion")
+                .expect("successful completion")
+                .wr_id(),
+            100,
+        );
+        assert_eq!(
+            inbox
+                .recv()
+                .await
+                .expect("second completion")
+                .expect("successful completion")
+                .wr_id(),
+            200,
+        );
+    }
+
+    #[tokio::test]
+    async fn completion_inbox_closes_when_its_route_is_dropped() {
+        let (mut inbox, route) = CompletionInbox::new();
+        drop(route);
+        assert!(
+            inbox.recv().await.is_none(),
+            "dropping the producer must close the completion channel",
+        );
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -6,10 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Consuming completions from a completion queue (CQ).
+//! Polling and routing completions from shared completion queues (CQs).
 //!
-//! [`IbvCompletionQueue`] is what a CQ offers a consumer: one call hands back a
-//! bounded batch, each completion naming the queue pair it completed on.
+//! Each queue pair attaches a direct completion route. A dedicated native
+//! thread polls the CQs and dispatches each completion to the queue pair that
+//! produced it. Detached queue-pair resources remain alive until their final
+//! CQEs have been consumed.
 
 // Nothing outside the tests below uses this module.
 #![allow(dead_code)]
@@ -37,6 +39,7 @@ use hyperactor::PortHandle;
 use hyperactor::actor::ActorError;
 use tokio::sync::mpsc;
 
+use super::cq_pool::CqLease;
 use super::primitives::IbvCq;
 use super::primitives::IbvWc;
 use super::queue_pair::PollCompletionError;
@@ -69,8 +72,7 @@ pub(super) trait IbvCompletionQueue: std::fmt::Debug + Send + Sync + 'static {
     ///
     /// # Safety
     ///
-    /// The CQ must be live -- a null `ibv_cq` does not qualify -- and no other
-    /// thread may poll it for the duration.
+    /// The CQ must be live and no other thread may poll it for the duration.
     unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError>;
 }
 
@@ -79,11 +81,29 @@ impl IbvCompletionQueue for IbvCq {
         CqId(self.as_ptr().addr())
     }
 
+    /// A null CQ is rejected in production and treated as an empty placeholder
+    /// in unit tests.
     unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError> {
         let cq = self.as_ptr();
-        // SAFETY: `cq` is a live `ibv_cq` (caller contract), which holds its device
-        // context alive; we invoke that context's `poll_cq` verb through the ops
-        // table.
+
+        #[cfg(test)]
+        {
+            // Test-only placeholder CQs cannot produce completions.
+            if cq.is_null() {
+                return Ok(());
+            }
+        }
+
+        #[cfg(not(test))]
+        {
+            if cq.is_null() {
+                return Err(PollCompletionError::new("cannot poll null CQ".into()));
+            }
+        }
+
+        // SAFETY: `cq` is non-null and therefore a live `ibv_cq` (caller
+        // contract), which holds its device context alive; invoke that context's
+        // `poll_cq` verb through the ops table.
         let poll_cq = unsafe {
             (*(*cq).context)
                 .ops
@@ -165,21 +185,39 @@ impl CompletionRoute {
 /// One queue pair reporting on a CQ.
 #[derive(Debug)]
 struct QpSlot {
-    route: CompletionRoute,
+    /// Where completions go, or `None` after the queue pair detaches.
+    route: Option<CompletionRoute>,
     /// Number of WRs the queue pair has posted. The queue pair increments this
     /// before waking the poller.
     posted: Arc<AtomicU64>,
     /// Number of CQEs the poller has consumed for this queue pair.
     consumed: u64,
+    /// Resources transferred by `Detach` and retained until all CQEs drain.
+    qp: Option<DetachedQueuePair>,
+    _lease: Option<CqLease>,
 }
 
 impl QpSlot {
-    fn expects_completions(&self) -> bool {
-        // This count only decides whether polling is useful. A relaxed load is
-        // sufficient because the producer calls `unpark` after incrementing its
-        // posted count. A subsequent wake from `park` on the consumer is then
-        // guaranteed to see the most recent value.
-        self.posted.load(Ordering::Relaxed) > self.consumed
+    fn outstanding(&self) -> u64 {
+        // This count is used for two purposes:
+        // (1) To decide whether polling is useful. A relaxed load is sufficient
+        //  because the producer calls `unpark` after incrementing its posted
+        //  count. A subsequent wake from `park` on the consumer is then guaranteed
+        //  to see the most recent value.
+        // (2) To decide whether it is safe to drop the QP because no more work
+        //  is left. We have to ensure that it isn't possible for the poller to
+        //  observe that `posted` increased after it received the detach signal
+        //  from the QP. Once the QP sends the detach signal over the actor port,
+        //  it never posts again; when the poller receives the message, it
+        //  synchronizes-with the QP's thread and so is guaranteed to see the final
+        //  value for `posted`, even with this relaxed load.
+        self.posted
+            .load(Ordering::Relaxed)
+            .saturating_sub(self.consumed)
+    }
+
+    fn is_live(&self) -> bool {
+        self.route.is_some() || self.outstanding() > 0
     }
 }
 
@@ -192,19 +230,38 @@ struct CqSlot<Cq> {
 
 impl<Cq: IbvCompletionQueue> CqSlot<Cq> {
     fn expects_completions(&self) -> bool {
-        self.queue_pairs.values().any(QpSlot::expects_completions)
+        self.queue_pairs.values().any(|qp| qp.outstanding() > 0)
     }
 
     fn route(&mut self, cq_id: CqId, consumed: &mut Vec<Completion>) -> anyhow::Result<()> {
         for Completion { qp_num, result } in consumed.drain(..) {
-            let qp = self.queue_pairs.get_mut(&qp_num).ok_or_else(|| {
-                anyhow::anyhow!("CQ {cq_id:?} completed for unattached queue pair {qp_num}")
-            })?;
-            // Increment unconditionally, even if the delivery ultimately fails.
-            // Delivery can fail only if the QP actor is stopped or dead, so it
-            // shouldn't be possible to hang the QP actor.
-            qp.consumed += 1;
-            qp.route.deliver(qp_num, cq_id, result);
+            let remove = {
+                // It is impossible to observe a CQE for a QP that is untracked, since
+                // we hold detached QPs until `consumed == posted`, and by the time
+                // the poller receives a detached QP, `posted` has necessarily settled
+                // at its true value.
+                let qp = self.queue_pairs.get_mut(&qp_num).ok_or_else(|| {
+                    anyhow::anyhow!("CQ {cq_id:?} completed for unattached queue pair {qp_num}")
+                })?;
+                // Increment unconditionally, even if the delivery ultimately fails.
+                // Delivery can fail only if the QP actor is stopped or dead, so it
+                // shouldn't be possible to hang the QP actor.
+                qp.consumed += 1;
+                if let Some(route) = &qp.route {
+                    route.deliver(qp_num, cq_id, result);
+                } else {
+                    tracing::warn!(
+                        qp_num,
+                        ?cq_id,
+                        ?result,
+                        "received work completion after detach"
+                    );
+                }
+                !qp.is_live()
+            };
+            if remove {
+                self.queue_pairs.remove(&qp_num);
+            }
         }
         Ok(())
     }
@@ -240,6 +297,8 @@ impl<Cq: IbvCompletionQueue> PollerState<Cq> {
                 cq,
                 queue_pairs: HashMap::new(),
             });
+        // Fail even if the queue pair is detached. A detached queue pair
+        // may still produce CQEs, leaving the poller unable to disambiguate.
         if slot.queue_pairs.contains_key(&qp_num) {
             return Err(anyhow::anyhow!(
                 "queue pair {qp_num} is already attached to CQ {cq_id:?}"
@@ -248,11 +307,40 @@ impl<Cq: IbvCompletionQueue> PollerState<Cq> {
         slot.queue_pairs.insert(
             qp_num,
             QpSlot {
-                route,
+                route: Some(route),
                 posted,
                 consumed: 0,
+                qp: None,
+                _lease: None,
             },
         );
+        Ok(())
+    }
+
+    fn detach(
+        &mut self,
+        cq_id: CqId,
+        qp_num: u32,
+        qp: DetachedQueuePair,
+        lease: CqLease,
+    ) -> anyhow::Result<()> {
+        let slot = self.completion_queues.get_mut(&cq_id).ok_or_else(|| {
+            anyhow::anyhow!(
+                "detach for queue pair {qp_num} on CQ {cq_id:?}, which this poller does not hold"
+            )
+        })?;
+        let qp_slot = slot.queue_pairs.get_mut(&qp_num).ok_or_else(|| {
+            anyhow::anyhow!("detach for queue pair {qp_num}, which is not attached to CQ {cq_id:?}")
+        })?;
+        qp_slot.route = None;
+        qp_slot.qp = Some(qp);
+        qp_slot._lease = Some(lease);
+        if !qp_slot.is_live() {
+            slot.queue_pairs.remove(&qp_num);
+        }
+        if slot.queue_pairs.is_empty() {
+            self.completion_queues.remove(&cq_id);
+        }
         Ok(())
     }
 
@@ -263,20 +351,35 @@ impl<Cq: IbvCompletionQueue> PollerState<Cq> {
     }
 
     fn poll_round(&mut self) -> anyhow::Result<()> {
-        for (cq_id, slot) in &mut self.completion_queues {
-            if !slot.expects_completions() {
-                continue;
+        let mut failure = None;
+        let Self {
+            completion_queues,
+            consumed,
+        } = self;
+        completion_queues.retain(|cq_id, slot| {
+            if failure.is_some() || !slot.expects_completions() {
+                return true;
             }
-            self.consumed.clear();
-            // SAFETY: the poller exclusively owns every CQ in
-            // `completion_queues`; each `Arc<Cq>` keeps its CQ live.
-            if let Err(error) = unsafe { slot.cq.poll(&mut self.consumed) } {
-                tracing::warn!(?cq_id, %error, "consuming from a CQ failed");
-                continue;
+            consumed.clear();
+            // SAFETY: the poller exclusively polls every CQ in
+            // `completion_queues`; each `Arc<Cq>` keeps its CQ live until the
+            // final detached queue pair drains.
+            if let Err(error) = unsafe { slot.cq.poll(consumed) } {
+                failure = Some(anyhow::anyhow!(
+                    "consuming from CQ {cq_id:?} failed: {error}"
+                ));
+                return true;
             }
-            slot.route(*cq_id, &mut self.consumed)?;
+            if let Err(error) = slot.route(*cq_id, consumed) {
+                failure = Some(error);
+                return true;
+            }
+            !slot.queue_pairs.is_empty()
+        });
+        match failure {
+            Some(error) => Err(error),
+            None => Ok(()),
         }
-        Ok(())
     }
 }
 
@@ -332,6 +435,27 @@ pub(super) struct Attach<Cq: IbvCompletionQueue> {
     pub(super) reply: OncePortHandle<PollerWake>,
 }
 
+/// Transfers a stopped queue pair and its CQ lease to the poller until every
+/// completion for that queue pair has been consumed.
+#[derive(Debug)]
+pub(super) struct Detach {
+    pub(super) cq_id: CqId,
+    pub(super) qp_num: u32,
+    pub(super) qp: DetachedQueuePair,
+    pub(super) lease: CqLease,
+}
+
+/// Opaque queue-pair resources that the poller retains solely for their drop.
+#[derive(Debug)]
+#[expect(dead_code, reason = "the poller owns this resource only for its drop")]
+pub(super) struct DetachedQueuePair(Box<dyn std::fmt::Debug + Send + Sync>);
+
+impl DetachedQueuePair {
+    pub(super) fn new<Qp: std::fmt::Debug + Send + Sync + 'static>(qp: Qp) -> Self {
+        Self(Box::new(qp))
+    }
+}
+
 #[derive(Debug)]
 enum PollerCommand<Cq> {
     Attach {
@@ -340,6 +464,12 @@ enum PollerCommand<Cq> {
         route: CompletionRoute,
         posted: Arc<AtomicU64>,
         reply: Box<OncePortHandle<PollerWake>>,
+    },
+    Detach {
+        cq_id: CqId,
+        qp_num: u32,
+        qp: DetachedQueuePair,
+        lease: CqLease,
     },
 }
 
@@ -405,11 +535,36 @@ impl<Cq: IbvCompletionQueue> Poller<Cq> {
                         tracing::warn!(qp_num, %error, "failed to deliver Attach reply");
                     }
                 }
+                Ok(PollerCommand::Detach {
+                    cq_id,
+                    qp_num,
+                    qp,
+                    lease,
+                }) => self.state.detach(cq_id, qp_num, qp, lease)?,
                 Err(std_mpsc::TryRecvError::Empty) => return Ok(()),
                 Err(std_mpsc::TryRecvError::Disconnected) => {
                     return Err(anyhow::anyhow!("CQ poller control channel disconnected"));
                 }
             }
+        }
+    }
+}
+
+impl<Cq> Drop for Poller<Cq> {
+    fn drop(&mut self) {
+        let attached = self
+            .state
+            .completion_queues
+            .values()
+            .flat_map(|slot| slot.queue_pairs.values())
+            .filter(|qp| qp.route.is_some())
+            .count();
+        if attached > 0 {
+            tracing::warn!(
+                attached,
+                completion_queues = self.state.completion_queues.len(),
+                "a CQ poller is going away with queue pairs attached to it",
+            );
         }
     }
 }
@@ -548,6 +703,24 @@ impl<Cq: IbvCompletionQueue> Handler<Attach<Cq>> for CompletionQueueActor<Cq> {
 }
 
 #[async_trait]
+impl<Cq: IbvCompletionQueue> Handler<Detach> for CompletionQueueActor<Cq> {
+    async fn handle(&mut self, _cx: &Context<Self>, message: Detach) -> anyhow::Result<()> {
+        let Detach {
+            cq_id,
+            qp_num,
+            qp,
+            lease,
+        } = message;
+        self.send_command(PollerCommand::Detach {
+            cq_id,
+            qp_num,
+            qp,
+            lease,
+        })
+    }
+}
+
+#[async_trait]
 impl<Cq: IbvCompletionQueue> Handler<PollerFailed> for CompletionQueueActor<Cq> {
     async fn handle(&mut self, _cx: &Context<Self>, message: PollerFailed) -> anyhow::Result<()> {
         Err(anyhow::anyhow!(
@@ -618,6 +791,14 @@ mod tests {
         fn polls(&self) -> usize {
             self.inner.lock().expect("mock CQ lock poisoned").polls
         }
+
+        fn queued(&self) -> usize {
+            self.inner
+                .lock()
+                .expect("mock CQ lock poisoned")
+                .queued
+                .len()
+        }
     }
 
     impl IbvCompletionQueue for MockCq {
@@ -635,6 +816,38 @@ mod tests {
             out.extend(inner.queued.drain(..consumed));
             Ok(())
         }
+    }
+
+    #[derive(Debug)]
+    struct TestQp {
+        destroyed: Arc<AtomicBool>,
+        leases: Arc<std::sync::atomic::AtomicU32>,
+        leases_at_destroy: Arc<std::sync::atomic::AtomicU32>,
+    }
+
+    impl Drop for TestQp {
+        fn drop(&mut self) {
+            self.leases_at_destroy
+                .store(self.leases.load(Ordering::SeqCst), Ordering::SeqCst);
+            self.destroyed.store(true, Ordering::SeqCst);
+        }
+    }
+
+    fn test_qp(
+        leases: &Arc<std::sync::atomic::AtomicU32>,
+    ) -> (
+        DetachedQueuePair,
+        Arc<AtomicBool>,
+        Arc<std::sync::atomic::AtomicU32>,
+    ) {
+        let destroyed = Arc::new(AtomicBool::new(false));
+        let leases_at_destroy = Arc::new(std::sync::atomic::AtomicU32::new(u32::MAX));
+        let qp = DetachedQueuePair::new(TestQp {
+            destroyed: Arc::clone(&destroyed),
+            leases: Arc::clone(leases),
+            leases_at_destroy: Arc::clone(&leases_at_destroy),
+        });
+        (qp, destroyed, leases_at_destroy)
     }
 
     #[derive(Debug)]
@@ -675,6 +888,16 @@ mod tests {
         inbox: CompletionInbox,
         posted: Arc<AtomicU64>,
         wake: PollerWake,
+        leases: Arc<std::sync::atomic::AtomicU32>,
+        lease: Option<CqLease>,
+    }
+
+    impl TestRoute {
+        fn lease(&mut self) -> CqLease {
+            self.lease
+                .take()
+                .expect("the queue pair still holds its CQ lease")
+        }
     }
 
     struct CqaHarness {
@@ -712,6 +935,8 @@ mod tests {
         ) -> Result<TestRoute> {
             let (inbox, route) = CompletionInbox::new();
             let posted = Arc::new(AtomicU64::new(0));
+            let leases = Arc::new(std::sync::atomic::AtomicU32::new(0));
+            let lease = CqLease::for_test_counted(Arc::clone(&leases));
             let (reply, receiver) = self.client.mailbox().open_once_port();
             poller.try_post(
                 &self.client,
@@ -728,12 +953,38 @@ mod tests {
                 inbox,
                 posted,
                 wake,
+                leases,
+                lease: Some(lease),
             })
         }
 
         fn post(route: &TestRoute, count: u64) -> Result<()> {
             route.posted.fetch_add(count, Ordering::Relaxed);
             route.wake.notify()
+        }
+
+        fn post_without_wake(route: &TestRoute, count: u64) {
+            route.posted.fetch_add(count, Ordering::Relaxed);
+        }
+
+        fn detach(
+            &self,
+            poller: &ActorHandle<CompletionQueueActor<MockCq>>,
+            cq_id: CqId,
+            qp_num: u32,
+            qp: DetachedQueuePair,
+            lease: CqLease,
+        ) -> Result<()> {
+            poller.try_post(
+                &self.client,
+                Detach {
+                    cq_id,
+                    qp_num,
+                    qp,
+                    lease,
+                },
+            )?;
+            Ok(())
         }
 
         async fn next_supervision_failure(
@@ -755,6 +1006,29 @@ mod tests {
                 self.supervision_rx.recv().await.is_none(),
                 "unexpected supervision event during teardown",
             );
+        }
+    }
+
+    async fn await_flag(flag: &AtomicBool, name: &str) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !flag.load(Ordering::SeqCst) {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for {name}",
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    async fn await_leases(leases: &std::sync::atomic::AtomicU32, expected: u32) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while leases.load(Ordering::Relaxed) != expected {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "leases settled at {} rather than {expected}",
+                leases.load(Ordering::Relaxed),
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
 
@@ -850,6 +1124,128 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn poller_routes_multiple_completion_queues_by_queue_pair() {
+        let first_cq = MockCq::new(1, CQES_PER_POLL);
+        let second_cq = MockCq::new(2, CQES_PER_POLL);
+        let (mut first_cq_first_inbox, first_cq_first_route) = CompletionInbox::new();
+        let (mut first_cq_second_inbox, first_cq_second_route) = CompletionInbox::new();
+        let (mut second_cq_first_inbox, second_cq_first_route) = CompletionInbox::new();
+        let (mut second_cq_second_inbox, second_cq_second_route) = CompletionInbox::new();
+        let mut poller = PollerState::new();
+        poller
+            .attach(
+                Arc::clone(&first_cq),
+                7,
+                first_cq_first_route,
+                Arc::new(AtomicU64::new(2)),
+            )
+            .expect("first queue pair on first CQ should attach");
+        poller
+            .attach(
+                Arc::clone(&first_cq),
+                8,
+                first_cq_second_route,
+                Arc::new(AtomicU64::new(2)),
+            )
+            .expect("second queue pair on first CQ should attach");
+        poller
+            .attach(
+                Arc::clone(&second_cq),
+                9,
+                second_cq_first_route,
+                Arc::new(AtomicU64::new(2)),
+            )
+            .expect("first queue pair on second CQ should attach");
+        poller
+            .attach(
+                Arc::clone(&second_cq),
+                10,
+                second_cq_second_route,
+                Arc::new(AtomicU64::new(2)),
+            )
+            .expect("second queue pair on second CQ should attach");
+        first_cq.queue_completion(8, 200);
+        first_cq.queue_completion(7, 100);
+        first_cq.queue_completion(8, 201);
+        first_cq.queue_completion(7, 101);
+        second_cq.queue_completion(10, 400);
+        second_cq.queue_completion(9, 300);
+        second_cq.queue_completion(10, 401);
+        second_cq.queue_completion(9, 301);
+
+        poller.poll_round().expect("polling should succeed");
+
+        for (inbox, expected) in [
+            (&mut first_cq_first_inbox, [100, 101]),
+            (&mut first_cq_second_inbox, [200, 201]),
+            (&mut second_cq_first_inbox, [300, 301]),
+            (&mut second_cq_second_inbox, [400, 401]),
+        ] {
+            for expected_wr_id in expected {
+                assert_eq!(
+                    inbox
+                        .try_recv()
+                        .expect("routed completion")
+                        .expect("successful completion")
+                        .wr_id(),
+                    expected_wr_id,
+                );
+            }
+            assert!(
+                matches!(inbox.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+                "queue pair must receive only its own completions",
+            );
+        }
+    }
+
+    #[test]
+    fn poller_removes_completion_queue_after_final_queue_pair_detaches() {
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let (_first_inbox, first_route) = CompletionInbox::new();
+        let (_second_inbox, second_route) = CompletionInbox::new();
+        let mut poller = PollerState::new();
+        poller
+            .attach(Arc::clone(&cq), 7, first_route, Arc::new(AtomicU64::new(0)))
+            .expect("first queue pair should attach");
+        poller
+            .attach(
+                Arc::clone(&cq),
+                8,
+                second_route,
+                Arc::new(AtomicU64::new(0)),
+            )
+            .expect("second queue pair should attach");
+
+        poller
+            .detach(
+                cq.cq_id(),
+                7,
+                DetachedQueuePair::new(()),
+                CqLease::for_test_counted(Arc::new(std::sync::atomic::AtomicU32::new(0))),
+            )
+            .expect("first queue pair should detach");
+        let slot = poller
+            .completion_queues
+            .get(&cq.cq_id())
+            .expect("the CQ must remain while one queue pair is attached");
+        assert_eq!(slot.queue_pairs.len(), 1);
+        assert!(slot.queue_pairs.contains_key(&8));
+
+        poller
+            .detach(
+                cq.cq_id(),
+                8,
+                DetachedQueuePair::new(()),
+                CqLease::for_test_counted(Arc::new(std::sync::atomic::AtomicU32::new(0))),
+            )
+            .expect("final queue pair should detach");
+        assert!(
+            !poller.completion_queues.contains_key(&cq.cq_id()),
+            "the final queue-pair removal must remove its CQ",
+        );
+    }
+
     #[test]
     fn poller_leaves_idle_completion_queues_alone() {
         let cq = MockCq::new(1, CQES_PER_POLL);
@@ -866,30 +1262,22 @@ mod tests {
     }
 
     #[test]
-    fn poller_retries_after_a_poll_error() {
+    fn poller_fails_on_a_poll_error() {
         let cq = MockCq::new(1, CQES_PER_POLL);
-        let (mut inbox, route) = CompletionInbox::new();
+        let (_inbox, route) = CompletionInbox::new();
         let posted = Arc::new(AtomicU64::new(1));
         let mut poller = PollerState::new();
         poller
             .attach(Arc::clone(&cq), 7, route, posted)
             .expect("queue pair should attach");
-        cq.queue_poll_error("temporary failure");
-        cq.queue_completion(7, 100);
+        cq.queue_poll_error("poll failure");
 
-        poller.poll_round().expect("a CQ poll error is recoverable");
+        let error = poller
+            .poll_round()
+            .expect_err("a CQ poll error should fail the poller");
         assert!(
-            matches!(inbox.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
-            "a failed poll must not fabricate a completion",
-        );
-        poller.poll_round().expect("the next poll should succeed");
-        assert_eq!(
-            inbox
-                .try_recv()
-                .expect("completion after retry")
-                .expect("successful completion")
-                .wr_id(),
-            100,
+            error.to_string().contains("poll failure"),
+            "unexpected poll error: {error}",
         );
     }
 
@@ -959,6 +1347,77 @@ mod tests {
             report.contains("unattached queue pair 8"),
             "unexpected failure report: {report}",
         );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn detached_queue_pair_lives_until_its_completions_drain() -> Result<()> {
+        let harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut route = harness.attach(&poller, &cq, 7).await?;
+        CqaHarness::post(&route, 2)?;
+        let (qp, destroyed, leases_at_destroy) = test_qp(&route.leases);
+
+        harness.detach(&poller, cq.cq_id(), 7, qp, route.lease())?;
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(
+            !destroyed.load(Ordering::SeqCst),
+            "a queue pair with outstanding completions must remain alive",
+        );
+
+        cq.queue_completion(7, 100);
+        cq.queue_completion(7, 101);
+        route.wake.notify()?;
+        await_flag(&destroyed, "detached queue pair destruction").await;
+        await_leases(&route.leases, 0).await;
+        assert_eq!(
+            leases_at_destroy.load(Ordering::SeqCst),
+            1,
+            "the CQ lease must outlive the queue pair",
+        );
+        assert!(
+            route.inbox.try_recv().is_err(),
+            "detached CQEs are discarded"
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn drained_queue_pair_is_destroyed_on_detach() -> Result<()> {
+        let harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut route = harness.attach(&poller, &cq, 7).await?;
+        let (qp, destroyed, _) = test_qp(&route.leases);
+
+        harness.detach(&poller, cq.cq_id(), 7, qp, route.lease())?;
+        await_flag(&destroyed, "drained queue pair destruction").await;
+        await_leases(&route.leases, 0).await;
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn detach_wakes_the_poller_for_unannounced_work() -> Result<()> {
+        let harness = CqaHarness::new();
+        let poller = harness.spawn_poller().await?;
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let mut route = harness.attach(&poller, &cq, 7).await?;
+        tokio::time::sleep(BUSY_POLL_WINDOW + Duration::from_millis(25)).await;
+        CqaHarness::post_without_wake(&route, 1);
+        let (qp, destroyed, _) = test_qp(&route.leases);
+
+        harness.detach(&poller, cq.cq_id(), 7, qp, route.lease())?;
+        assert!(
+            !destroyed.load(Ordering::SeqCst),
+            "the outstanding completion must keep the queue pair alive",
+        );
+        cq.queue_completion(7, 100);
+        await_flag(&destroyed, "detached queue pair destruction").await;
+        assert_eq!(cq.queued(), 0, "detach must wake the poller");
         harness.teardown().await;
         Ok(())
     }

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -14,6 +14,11 @@
 // Nothing outside the tests below uses this module.
 #![allow(dead_code)]
 
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
 use tokio::sync::mpsc;
 
 use super::primitives::IbvCq;
@@ -25,7 +30,7 @@ use super::queue_pair::WorkRequestError;
 const CQES_PER_POLL: usize = 64;
 
 /// Identifies one CQ, distinct from every other live one.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) struct CqId(usize);
 
 /// One completion a poll consumed: the queue pair it completed on, and either the
@@ -140,13 +145,198 @@ impl CompletionRoute {
     }
 }
 
+/// One queue pair reporting on a CQ.
+#[derive(Debug)]
+struct QpSlot {
+    route: CompletionRoute,
+    /// Number of WRs the queue pair has posted. The queue pair increments this
+    /// before waking the poller.
+    posted: Arc<AtomicU64>,
+    /// Number of CQEs the poller has consumed for this queue pair.
+    consumed: u64,
+}
+
+impl QpSlot {
+    fn expects_completions(&self) -> bool {
+        // This count only decides whether polling is useful. A relaxed load is
+        // sufficient because the producer calls `unpark` after incrementing its
+        // posted count. A subsequent wake from `park` on the consumer is then
+        // guaranteed to see the most recent value.
+        self.posted.load(Ordering::Relaxed) > self.consumed
+    }
+}
+
+/// One CQ and the routes for queue pairs that report completions on it.
+#[derive(Debug)]
+struct CqSlot<Cq> {
+    cq: Arc<Cq>,
+    queue_pairs: HashMap<u32, QpSlot>,
+}
+
+impl<Cq: IbvCompletionQueue> CqSlot<Cq> {
+    fn expects_completions(&self) -> bool {
+        self.queue_pairs.values().any(QpSlot::expects_completions)
+    }
+
+    fn route(&mut self, cq_id: CqId, consumed: &mut Vec<Completion>) -> anyhow::Result<()> {
+        for Completion { qp_num, result } in consumed.drain(..) {
+            let qp = self.queue_pairs.get_mut(&qp_num).ok_or_else(|| {
+                anyhow::anyhow!("CQ {cq_id:?} completed for unattached queue pair {qp_num}")
+            })?;
+            // Increment unconditionally, even if the delivery ultimately fails.
+            // Delivery can fail only if the QP actor is stopped or dead, so it
+            // shouldn't be possible to hang the QP actor.
+            qp.consumed += 1;
+            qp.route.deliver(qp_num, cq_id, result);
+        }
+        Ok(())
+    }
+}
+
+/// Completion queues and per-QP routes owned by one poller.
+#[derive(Debug)]
+struct PollerState<Cq> {
+    completion_queues: HashMap<CqId, CqSlot<Cq>>,
+    consumed: Vec<Completion>,
+}
+
+impl<Cq: IbvCompletionQueue> PollerState<Cq> {
+    fn new() -> Self {
+        Self {
+            completion_queues: HashMap::new(),
+            consumed: Vec::with_capacity(CQES_PER_POLL),
+        }
+    }
+
+    fn attach(
+        &mut self,
+        cq: Arc<Cq>,
+        qp_num: u32,
+        route: CompletionRoute,
+        posted: Arc<AtomicU64>,
+    ) -> anyhow::Result<()> {
+        let cq_id = cq.cq_id();
+        let slot = self
+            .completion_queues
+            .entry(cq_id)
+            .or_insert_with(|| CqSlot {
+                cq,
+                queue_pairs: HashMap::new(),
+            });
+        if slot.queue_pairs.contains_key(&qp_num) {
+            return Err(anyhow::anyhow!(
+                "queue pair {qp_num} is already attached to CQ {cq_id:?}"
+            ));
+        }
+        slot.queue_pairs.insert(
+            qp_num,
+            QpSlot {
+                route,
+                posted,
+                consumed: 0,
+            },
+        );
+        Ok(())
+    }
+
+    fn expects_completions(&self) -> bool {
+        self.completion_queues
+            .values()
+            .any(CqSlot::expects_completions)
+    }
+
+    fn poll_round(&mut self) -> anyhow::Result<()> {
+        for (cq_id, slot) in &mut self.completion_queues {
+            if !slot.expects_completions() {
+                continue;
+            }
+            self.consumed.clear();
+            // SAFETY: the poller exclusively owns every CQ in
+            // `completion_queues`; each `Arc<Cq>` keeps its CQ live.
+            if let Err(error) = unsafe { slot.cq.poll(&mut self.consumed) } {
+                tracing::warn!(?cq_id, %error, "consuming from a CQ failed");
+                continue;
+            }
+            slot.route(*cq_id, &mut self.consumed)?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
     use super::*;
     use crate::backend::ibverbs::device::IbvDevice;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
     use crate::backend::ibverbs::primitives::IbvDeviceInfo;
+
+    #[derive(Debug)]
+    struct MockCq {
+        cq_id: CqId,
+        batch: usize,
+        inner: Mutex<MockCqInner>,
+    }
+
+    #[derive(Debug, Default)]
+    struct MockCqInner {
+        queued: VecDeque<Completion>,
+        poll_errors: VecDeque<PollCompletionError>,
+        polls: usize,
+    }
+
+    impl MockCq {
+        fn new(cq_id: usize, batch: usize) -> Arc<Self> {
+            Arc::new(Self {
+                cq_id: CqId(cq_id),
+                batch,
+                inner: Mutex::new(MockCqInner::default()),
+            })
+        }
+
+        fn queue_completion(&self, qp_num: u32, wr_id: u64) {
+            self.inner
+                .lock()
+                .expect("mock CQ lock poisoned")
+                .queued
+                .push_back(Completion {
+                    qp_num,
+                    result: Ok(IbvWc::for_test(wr_id, true)),
+                });
+        }
+
+        fn queue_poll_error(&self, message: &str) {
+            self.inner
+                .lock()
+                .expect("mock CQ lock poisoned")
+                .poll_errors
+                .push_back(PollCompletionError::new(message.to_owned()));
+        }
+
+        fn polls(&self) -> usize {
+            self.inner.lock().expect("mock CQ lock poisoned").polls
+        }
+    }
+
+    impl IbvCompletionQueue for MockCq {
+        fn cq_id(&self) -> CqId {
+            self.cq_id
+        }
+
+        unsafe fn poll(&self, out: &mut Vec<Completion>) -> Result<(), PollCompletionError> {
+            let mut inner = self.inner.lock().expect("mock CQ lock poisoned");
+            inner.polls += 1;
+            if let Some(error) = inner.poll_errors.pop_front() {
+                return Err(error);
+            }
+            let consumed = inner.queued.len().min(self.batch);
+            out.extend(inner.queued.drain(..consumed));
+            Ok(())
+        }
+    }
 
     /// Polling a real, empty CQ consumes nothing, and distinct CQs have distinct ids.
     #[test]
@@ -200,6 +390,86 @@ mod tests {
         assert!(
             inbox.recv().await.is_none(),
             "dropping the producer must close the completion channel",
+        );
+    }
+
+    #[tokio::test]
+    async fn poller_routes_a_shared_cq_by_queue_pair() {
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let (mut first_inbox, first_route) = CompletionInbox::new();
+        let (mut second_inbox, second_route) = CompletionInbox::new();
+        let first_posted = Arc::new(AtomicU64::new(1));
+        let second_posted = Arc::new(AtomicU64::new(1));
+        let mut poller = PollerState::new();
+        poller
+            .attach(Arc::clone(&cq), 7, first_route, first_posted)
+            .expect("first queue pair should attach");
+        poller
+            .attach(Arc::clone(&cq), 8, second_route, second_posted)
+            .expect("second queue pair should attach");
+        cq.queue_completion(8, 200);
+        cq.queue_completion(7, 100);
+
+        poller.poll_round().expect("polling should succeed");
+
+        assert_eq!(
+            first_inbox
+                .try_recv()
+                .expect("first completion")
+                .expect("successful completion")
+                .wr_id(),
+            100,
+        );
+        assert_eq!(
+            second_inbox
+                .try_recv()
+                .expect("second completion")
+                .expect("successful completion")
+                .wr_id(),
+            200,
+        );
+    }
+
+    #[test]
+    fn poller_leaves_idle_completion_queues_alone() {
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let (_inbox, route) = CompletionInbox::new();
+        let mut poller = PollerState::new();
+        poller
+            .attach(Arc::clone(&cq), 7, route, Arc::new(AtomicU64::new(0)))
+            .expect("queue pair should attach");
+        cq.queue_completion(7, 100);
+
+        poller.poll_round().expect("polling should succeed");
+
+        assert_eq!(cq.polls(), 0, "an idle queue pair must not trigger a poll");
+    }
+
+    #[test]
+    fn poller_retries_after_a_poll_error() {
+        let cq = MockCq::new(1, CQES_PER_POLL);
+        let (mut inbox, route) = CompletionInbox::new();
+        let posted = Arc::new(AtomicU64::new(1));
+        let mut poller = PollerState::new();
+        poller
+            .attach(Arc::clone(&cq), 7, route, posted)
+            .expect("queue pair should attach");
+        cq.queue_poll_error("temporary failure");
+        cq.queue_completion(7, 100);
+
+        poller.poll_round().expect("a CQ poll error is recoverable");
+        assert!(
+            matches!(inbox.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+            "a failed poll must not fabricate a completion",
+        );
+        poller.poll_round().expect("the next poll should succeed");
+        assert_eq!(
+            inbox
+                .try_recv()
+                .expect("completion after retry")
+                .expect("successful completion")
+                .wr_id(),
+            100,
         );
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -13,9 +13,6 @@
 //! produced it. Detached queue-pair resources remain alive until their final
 //! CQEs have been consumed.
 
-// Nothing outside the tests below uses this module.
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
@@ -160,6 +157,7 @@ impl CompletionInbox {
         (Self { receiver }, CompletionRoute { sender })
     }
 
+    #[cfg(test)]
     pub(super) async fn recv(&mut self) -> Option<CompletionResult> {
         self.receiver.recv().await
     }
@@ -211,6 +209,8 @@ impl QpSlot {
         //  it never posts again; when the poller receives the message, it
         //  synchronizes-with the QP's thread and so is guaranteed to see the final
         //  value for `posted`, even with this relaxed load.
+        // A CQE may briefly make `consumed` exceed `posted` between hardware
+        // posting and the counter increment; saturating at zero is safe then.
         self.posted
             .load(Ordering::Relaxed)
             .saturating_sub(self.consumed)

--- a/monarch_rdma/src/backend/ibverbs/cq_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_actor.rs
@@ -31,10 +31,10 @@ use hyperactor::Actor;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::OncePortHandle;
 use hyperactor::PortHandle;
 use hyperactor::actor::ActorError;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 
 use super::cq_pool::CqLease;
 use super::primitives::IbvCq;
@@ -157,11 +157,11 @@ impl CompletionInbox {
         (Self { receiver }, CompletionRoute { sender })
     }
 
-    #[cfg(test)]
     pub(super) async fn recv(&mut self) -> Option<CompletionResult> {
         self.receiver.recv().await
     }
 
+    #[cfg(test)]
     pub(super) fn try_recv(&mut self) -> Result<CompletionResult, mpsc::error::TryRecvError> {
         self.receiver.try_recv()
     }
@@ -432,7 +432,7 @@ pub(super) struct Attach<Cq: IbvCompletionQueue> {
     pub(super) qp_num: u32,
     pub(super) route: CompletionRoute,
     pub(super) posted: Arc<AtomicU64>,
-    pub(super) reply: OncePortHandle<PollerWake>,
+    pub(super) reply: oneshot::Sender<PollerWake>,
 }
 
 /// Transfers a stopped queue pair and its CQ lease to the poller until every
@@ -463,7 +463,7 @@ enum PollerCommand<Cq> {
         qp_num: u32,
         route: CompletionRoute,
         posted: Arc<AtomicU64>,
-        reply: Box<OncePortHandle<PollerWake>>,
+        reply: oneshot::Sender<PollerWake>,
     },
     Detach {
         cq_id: CqId,
@@ -526,13 +526,13 @@ impl<Cq: IbvCompletionQueue> Poller<Cq> {
                     reply,
                 }) => {
                     self.state.attach(cq, qp_num, route, posted)?;
-                    if let Err(error) = reply.try_post(
-                        Instance::<CompletionQueueActor<Cq>>::self_client(),
-                        PollerWake {
+                    if reply
+                        .send(PollerWake {
                             signal: Arc::clone(&self.signal),
-                        },
-                    ) {
-                        tracing::warn!(qp_num, %error, "failed to deliver Attach reply");
+                        })
+                        .is_err()
+                    {
+                        tracing::warn!(qp_num, "failed to deliver Attach reply");
                     }
                 }
                 Ok(PollerCommand::Detach {
@@ -697,7 +697,7 @@ impl<Cq: IbvCompletionQueue> Handler<Attach<Cq>> for CompletionQueueActor<Cq> {
             qp_num,
             route,
             posted,
-            reply: Box::new(reply),
+            reply,
         })
     }
 }
@@ -737,6 +737,7 @@ mod tests {
 
     use anyhow::Result;
     use hyperactor::ActorHandle;
+    use hyperactor::OncePortHandle;
     use hyperactor::context::Mailbox;
     use hyperactor::proc::Proc;
 
@@ -937,7 +938,7 @@ mod tests {
             let posted = Arc::new(AtomicU64::new(0));
             let leases = Arc::new(std::sync::atomic::AtomicU32::new(0));
             let lease = CqLease::for_test_counted(Arc::clone(&leases));
-            let (reply, receiver) = self.client.mailbox().open_once_port();
+            let (reply, receiver) = oneshot::channel();
             poller.try_post(
                 &self.client,
                 Attach {
@@ -948,7 +949,7 @@ mod tests {
                     reply,
                 },
             )?;
-            let wake = receiver.recv().await?;
+            let wake = receiver.await?;
             Ok(TestRoute {
                 inbox,
                 posted,

--- a/monarch_rdma/src/backend/ibverbs/cq_pool.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_pool.rs
@@ -107,9 +107,17 @@ impl CqLease {
     /// a device.
     #[cfg(test)]
     pub(super) fn for_test() -> Self {
+        Self::for_test_counted(Arc::new(AtomicU32::new(0)))
+    }
+
+    /// A lease on no completion queue that counts against `leases`, for tests
+    /// that observe when it is released.
+    #[cfg(test)]
+    pub(super) fn for_test_counted(leases: Arc<AtomicU32>) -> Self {
+        leases.fetch_add(1, Ordering::Relaxed);
         Self {
             cq: Arc::new(IbvCq::null()),
-            leases: Arc::new(AtomicU32::new(1)),
+            leases,
         }
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/cq_pool.rs
+++ b/monarch_rdma/src/backend/ibverbs/cq_pool.rs
@@ -86,11 +86,10 @@ struct CqEntry {
 /// One queue pair's lease on a completion queue.
 ///
 /// Holding a lease is what entitles a queue pair to post: the completion queue
-/// has room for its full `max_send_wr` of work requests, and -- while
-/// `rdma_qps_per_cq` is 1 -- the leaseholder is the only queue pair polling it.
-/// Dropping the lease returns that room to the pool, so a lease must outlive
-/// every completion its queue pair can still produce -- including the flush
-/// entries a teardown generates.
+/// has room for its full `max_send_wr` of work requests. Dropping the lease
+/// returns that room to the pool, so a lease must outlive every completion its
+/// queue pair can still produce -- including the flush entries a teardown
+/// generates.
 #[derive(Debug)]
 pub(crate) struct CqLease {
     cq: Arc<IbvCq>,
@@ -156,15 +155,6 @@ impl CqPool {
     ) -> anyhow::Result<Self> {
         let configured: usize =
             hyperactor_config::global::get(crate::config::RDMA_QPS_PER_CQ).into();
-        // Each queue pair polls its own completion queue, so two of them sharing
-        // one would give it two pollers, splitting its completions between them.
-        // The cap is temporary while each queue pair is responsible for polling
-        // its CQ.
-        anyhow::ensure!(
-            configured == 1,
-            "rdma_qps_per_cq is {configured}, but only 1 queue pair per completion \
-             queue is supported: each polls its own",
-        );
         let queue_pairs_per_cq = u32::try_from(configured)
             .map_err(|_| anyhow::anyhow!("rdma_qps_per_cq {configured} does not fit a u32"))?;
         let cq_entries = cq_entries_for(queue_pairs_per_cq, max_send_wr, device_info.max_cqe())?;
@@ -177,8 +167,7 @@ impl CqPool {
     }
 
     /// A pool that admits `queue_pairs_per_cq` leases per completion queue,
-    /// bypassing the config. Lets the sharing and reuse logic be exercised while
-    /// the configured value is held at 1.
+    /// bypassing the config.
     #[cfg(test)]
     pub(super) fn for_test(
         context: Arc<IbvContext>,
@@ -240,8 +229,7 @@ impl CqPool {
     /// Such a queue pair still needs a completion queue to be created against,
     /// but produces no entries, so it consumes no capacity and takes no lease:
     /// it shares whichever queue is already there rather than pinning one of its
-    /// own. It must not poll that queue either, which is what leaves the
-    /// leaseholder as the only poller.
+    /// own.
     pub(super) fn cq_without_lease(&mut self) -> anyhow::Result<Arc<IbvCq>> {
         if let Some(entry) = self.completion_queues.first() {
             return Ok(Arc::clone(&entry.cq));
@@ -323,10 +311,8 @@ mod tests {
         assert_eq!(leases.load(Ordering::Relaxed), 0);
     }
 
-    /// The configured value is held at 1 while each queue pair polls its own
-    /// completion queue.
     #[test]
-    fn pool_refuses_a_configured_value_above_one() {
+    fn pool_accepts_multiple_configured_queue_pairs_per_cq() {
         let info =
             IbvDeviceInfo::first_available().expect("test runs on machines with RDMA devices");
         let lock = hyperactor_config::global::lock();
@@ -336,12 +322,11 @@ mod tests {
                 .expect("2 is non-zero")
                 .into(),
         );
-        let err = CqPool::new(Arc::new(IbvContext::null()), &info, 512)
-            .expect_err("two queue pairs per completion queue is not supported");
-        assert!(
-            err.to_string().contains("rdma_qps_per_cq"),
-            "the error should name the knob: {err}",
-        );
+
+        let pool = CqPool::new(Arc::new(IbvContext::null()), &info, 512)
+            .expect("two queue pairs per completion queue should be supported");
+
+        assert_eq!(pool.queue_pairs_per_cq, 2);
     }
 
     /// Queue pairs share a completion queue up to `queue_pairs_per_cq`, the next

--- a/monarch_rdma/src/backend/ibverbs/efa_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_queue_pair.rs
@@ -23,11 +23,7 @@ use super::primitives::IbvConfig;
 use super::primitives::IbvCq;
 use super::primitives::IbvQp;
 use super::primitives::IbvQpInfo;
-use super::primitives::IbvWc;
 use super::queue_pair::IbvQueuePair;
-use super::queue_pair::PollCompletionError;
-use super::queue_pair::PollTarget;
-use super::queue_pair::WorkRequestError;
 
 /// Queue key for EFA SRD traffic. Both peers must present the same value or the
 /// responder drops the traffic silently; [`IbvQpInfo`] carries no queue key, so
@@ -655,18 +651,6 @@ impl IbvQueuePair for EfaQueuePair {
             remote_src.rkey,
             remote_src.size,
         )
-    }
-
-    fn poll_completion(
-        &mut self,
-        target: PollTarget,
-    ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-        // SAFETY: `self.qp` owns the live queue pair built in `new`, along with
-        // its completion queues and device context, all non-null and alive for
-        // `self`'s lifetime. `&mut self` excludes another poll through this queue
-        // pair, and its lease leaves it the only queue pair polling that
-        // completion queue, so no other thread is polling it.
-        unsafe { super::queue_pair::poll_one(&self.qp, target) }
     }
 }
 

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -33,11 +33,11 @@ use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
 use hyperactor::OncePortRef;
-use hyperactor::PortHandle;
 use hyperactor::actor::Referable;
 use rand::seq::IteratorRandom;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::mpsc;
 use typeuri::Named;
 
 use super::IbvOp;
@@ -108,7 +108,7 @@ wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<EfaDevice>>);
 /// [`OpResult`] values.
 pub(super) struct SubmitOps<I: IbvDeviceImpl> {
     pub(super) ops: Vec<IbvOp<IbvManagerActor<I>>>,
-    pub(super) reply: PortHandle<OpResult>,
+    pub(super) reply: mpsc::UnboundedSender<OpResult>,
 }
 
 /// Local-only message: create a fresh, unconnected legacy
@@ -543,26 +543,20 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
             let local_mrs = match self.resolve_local_mrs(&op.local_memory) {
                 Ok(mrs) => mrs,
                 Err(e) => {
-                    reply.try_post(
-                        cx,
-                        OpResult {
-                            op_idx: i,
-                            result: Err(e.to_string()),
-                        },
-                    )?;
+                    let _ = reply.send(OpResult {
+                        op_idx: i,
+                        result: Err(e.to_string()),
+                    });
                     continue;
                 }
             };
             let (local, remote) = match self.pick_peer_pair(&local_mrs, &op.remote_buffers) {
                 Ok((local, remote)) => (local.clone(), remote.clone()),
                 Err(e) => {
-                    reply.try_post(
-                        cx,
-                        OpResult {
-                            op_idx: i,
-                            result: Err(e.to_string()),
-                        },
-                    )?;
+                    let _ = reply.send(OpResult {
+                        op_idx: i,
+                        result: Err(e.to_string()),
+                    });
                     continue;
                 }
             };
@@ -574,13 +568,10 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
             let handle = match self.ensure_qp_actor(cx, &qp_key, op.remote_manager) {
                 Ok(h) => h,
                 Err(e) => {
-                    reply.try_post(
-                        cx,
-                        OpResult {
-                            op_idx: i,
-                            result: Err(e.to_string()),
-                        },
-                    )?;
+                    let _ = reply.send(OpResult {
+                        op_idx: i,
+                        result: Err(e.to_string()),
+                    });
                     continue;
                 }
             };
@@ -826,7 +817,7 @@ where
         }
         let n = ibv_ops.len();
 
-        let (reply, mut reply_rx) = cx.mailbox().open_port::<OpResult>();
+        let (reply, mut reply_rx) = mpsc::unbounded_channel();
 
         self.0.try_post(
             cx,
@@ -851,14 +842,15 @@ where
                 }
                 recv = reply_rx.recv() => {
                     match recv {
-                        Ok(OpResult { result: Ok(()), .. }) => received += 1,
-                        Ok(OpResult { op_idx, result: Err(e) }) => {
+                        Some(OpResult { result: Ok(()), .. }) => received += 1,
+                        Some(OpResult { op_idx, result: Err(e) }) => {
                             received += 1;
                             failures.push((op_idx, e));
                         }
-                        Err(e) => {
+                        None => {
                             terminal = Some(format!(
-                                "SubmitOps reply port closed after {received}/{n} replies with {} failures: {e}",
+                                "operation result channel closed after {received}/{n} replies with {} failures: \
+                                some built-in RDMA actor likely stopped or failed, see logs for more details",
                                 failures.len()
                             ));
                             break;

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -41,6 +41,7 @@ use tokio::sync::mpsc;
 use typeuri::Named;
 
 use super::IbvOp;
+use super::cq_actor::CompletionQueueActor;
 use super::device::IbvDevice;
 use super::device::IbvDeviceImpl;
 use super::device_selection::PeerDeviceAffinityPolicy;
@@ -54,6 +55,7 @@ use super::memory_region::IbvMemoryRegionView;
 use super::memory_region::IbvRemoteMemoryRegionView;
 use super::mlx_device::MlxDevice;
 use super::primitives::IbvConfig;
+use super::primitives::IbvCq;
 use super::primitives::IbvQpInfo;
 use super::primitives::ibverbs_supported;
 use super::queue_pair::IbvQueuePair;
@@ -188,6 +190,10 @@ pub struct IbvManagerActor<I: IbvDeviceImpl> {
     /// Read once, when the manager starts.
     peer_device_affinity: PeerDeviceAffinityPolicy,
 
+    /// Completion pollers, keyed by device name when each device gets its own
+    /// poller and by the empty string when all devices share one.
+    cq_pollers: HashMap<String, ActorHandle<CompletionQueueActor<IbvCq>>>,
+
     config: IbvConfig,
 }
 
@@ -226,6 +232,10 @@ impl<I: IbvDeviceImpl> Drop for IbvManagerActor<I> {
         // own `Drop`.
         for (_key, handle) in self.qp_handles.drain() {
             let _ = handle.drain_and_stop("IbvManagerActor dropped");
+        }
+
+        for (_key, poller) in self.cq_pollers.drain() {
+            let _ = poller.drain_and_stop("IbvManagerActor dropped");
         }
 
         // The remaining fields (`peer_created_qps`, `devices`) free their FFI
@@ -282,6 +292,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             peer_created_qps: HashMap::new(),
             devices: HashMap::new(),
             peer_device_affinity: configured_peer_device_affinity()?,
+            cq_pollers: HashMap::new(),
             config,
         };
 
@@ -491,6 +502,23 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         Ok(local_info)
     }
 
+    /// Returns the poller for `device`, spawning it on first use.
+    fn ensure_cq_poller(
+        &mut self,
+        cx: &Context<'_, Self>,
+        device: &str,
+    ) -> ActorHandle<CompletionQueueActor<IbvCq>> {
+        let key = if hyperactor_config::global::get(crate::config::RDMA_CQ_POLLER_PER_DEVICE) {
+            device.to_owned()
+        } else {
+            String::new()
+        };
+        self.cq_pollers
+            .entry(key)
+            .or_insert_with(|| cx.spawn(CompletionQueueActor::new()))
+            .clone()
+    }
+
     /// Lazy active-side QP actor: if `qp_key` is absent from
     /// [`Self::qp_handles`], create an [`IbvQueuePair`] on the
     /// requested device and spawn a [`QueuePairActor`] to drive its
@@ -509,6 +537,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         }
         let self_device = qp_key.self_device.clone();
         let config = self.config.clone();
+        let cq_poller = self.ensure_cq_poller(cx, &self_device);
         let (qp, cq_lease) = self
             .get_or_create_device(&self_device)?
             .create_queue_pair(DEFAULT_DOMAIN, &config)
@@ -521,6 +550,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             local_manager,
             peer_manager,
             qp,
+            cq_poller,
             cq_lease,
             is_loopback,
             config.max_send_wr,
@@ -538,7 +568,7 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
         // Interleave MR resolution with QP dispatch: as soon as op `i`'s
         // local MRs are resolved and its QP actor is in place, ship a
         // one-item `ProcessOps` to that QP. The QP can then post and
-        // poll op `i` while we run `resolve_local_mrs` for op `i+1`.
+        // retire op `i` while we run `resolve_local_mrs` for op `i+1`.
         for (i, op) in ops.into_iter().enumerate() {
             let local_mrs = match self.resolve_local_mrs(&op.local_memory) {
                 Ok(mrs) => mrs,

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -63,6 +63,7 @@ use super::queue_pair::OpResult;
 use super::queue_pair::ProcessOps;
 use super::queue_pair::QpKey;
 use super::queue_pair::QueuePairActor;
+use super::queue_pair::QueuePairHandle;
 use super::queue_pair::QueuePairOp;
 use super::queue_pair::legacy;
 use crate::RdmaOp;
@@ -164,13 +165,13 @@ const DEFAULT_DOMAIN: &str = "default";
 pub struct IbvManagerActor<I: IbvDeviceImpl> {
     owner: OnceLock<ActorHandle<RdmaManagerActor>>,
 
-    /// Active-side [`QueuePairActor`] children, keyed from this
-    /// manager's perspective. Lazily populated on the first
+    /// Active-side queue-pair workers and their supervising actor, keyed
+    /// from this manager's perspective. Lazily populated on the first
     /// [`SubmitOps`] that targets a new `(self_device, peer,
     /// other_device)` triple.
     qp_handles: HashMap<
         QpKey,
-        ActorHandle<QueuePairActor<IbvManagerActor<I>, <I::Domain as IbvDomainImpl>::QueuePair>>,
+        QueuePairHandle<IbvManagerActor<I>, <I::Domain as IbvDomainImpl>::QueuePair>,
     >,
 
     /// Passive-side mirror QPs, created in response to a peer's
@@ -226,10 +227,8 @@ impl<I: IbvDeviceImpl> Actor for IbvManagerActor<I> {
 
 impl<I: IbvDeviceImpl> Drop for IbvManagerActor<I> {
     fn drop(&mut self) {
-        // Drain active-side QP actors. Each child owns its
-        // `IbvQueuePair`; `drain_and_stop` schedules the actor to
-        // finish in-flight ops and exit, dropping the QP via its
-        // own `Drop`.
+        // Stop each supervising QP actor; its cleanup cancels and joins the
+        // data-plane worker that owns the QP.
         for (_key, handle) in self.qp_handles.drain() {
             let _ = handle.drain_and_stop("IbvManagerActor dropped");
         }
@@ -519,19 +518,16 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             .clone()
     }
 
-    /// Lazy active-side QP actor: if `qp_key` is absent from
+    /// Lazy active-side QP worker: if `qp_key` is absent from
     /// [`Self::qp_handles`], create an [`IbvQueuePair`] on the
-    /// requested device and spawn a [`QueuePairActor`] to drive its
-    /// handshake + data path. Returns a clone of the actor handle.
+    /// requested device and spawn a [`QueuePairActor`] to drive its handshake
+    /// and supervise its data-plane task. Returns a handle to the QP actor.
     fn ensure_qp_actor(
         &mut self,
         cx: &Context<'_, Self>,
         qp_key: &QpKey,
         peer_manager: ActorRef<Self>,
-    ) -> Result<
-        ActorHandle<QueuePairActor<Self, <I::Domain as IbvDomainImpl>::QueuePair>>,
-        anyhow::Error,
-    > {
+    ) -> Result<QueuePairHandle<Self, <I::Domain as IbvDomainImpl>::QueuePair>, anyhow::Error> {
         if let Some(h) = self.qp_handles.get(qp_key) {
             return Ok(h.clone());
         }
@@ -545,7 +541,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         let local_manager: ActorRef<Self> = cx.bind();
         let is_loopback = local_manager.actor_addr() == peer_manager.actor_addr()
             && qp_key.self_device == qp_key.other_device;
-        let actor = cx.spawn(QueuePairActor::new(
+        let (actor, sender) = QueuePairActor::new(
             qp_key.clone(),
             local_manager,
             peer_manager,
@@ -554,9 +550,10 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             cq_lease,
             is_loopback,
             config.max_send_wr,
-        ));
-        self.qp_handles.insert(qp_key.clone(), actor.clone());
-        Ok(actor)
+        );
+        let handle = QueuePairHandle::new(cx.spawn(actor), sender);
+        self.qp_handles.insert(qp_key.clone(), handle.clone());
+        Ok(handle)
     }
 }
 
@@ -605,19 +602,16 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
                     continue;
                 }
             };
-            handle.try_post(
-                cx,
-                ProcessOps {
-                    items: vec![QueuePairOp {
-                        op_idx: i,
-                        op_type: op.op_type,
-                        local_memory: op.local_memory,
-                        local,
-                        remote,
-                    }],
-                    reply: reply.clone(),
-                },
-            )?;
+            handle.send(ProcessOps {
+                items: vec![QueuePairOp {
+                    op_idx: i,
+                    op_type: op.op_type,
+                    local_memory: op.local_memory,
+                    local,
+                    remote,
+                }],
+                reply: reply.clone(),
+            })?;
         }
         Ok(())
     }

--- a/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
@@ -22,12 +22,8 @@ use super::primitives::IbvConfig;
 use super::primitives::IbvCq;
 use super::primitives::IbvQp;
 use super::primitives::IbvQpInfo;
-use super::primitives::IbvWc;
 use super::queue_pair::IbvQueuePair;
-use super::queue_pair::PollCompletionError;
-use super::queue_pair::PollTarget;
 use super::queue_pair::RCQueuePair;
-use super::queue_pair::WorkRequestError;
 
 /// An mlx5 RC queue pair created through `mlx5dv_create_qp`, so it carries the
 /// mlx5dv send-ops flags that arm a direct-WQE/doorbell data path.
@@ -162,12 +158,5 @@ impl IbvQueuePair for MlxQueuePair {
         remote_src: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         self.0.get(local_dst, remote_src)
-    }
-
-    fn poll_completion(
-        &mut self,
-        target: PollTarget,
-    ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-        self.0.poll_completion(target)
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -1261,8 +1261,8 @@ impl Drop for IbvCq {
 #[derive(Debug)]
 pub(super) struct IbvQp {
     qp: *mut rdmaxcel_sys::ibv_qp,
-    send_cq: Arc<IbvCq>,
-    recv_cq: Arc<IbvCq>,
+    _send_cq: Arc<IbvCq>,
+    _recv_cq: Arc<IbvCq>,
     /// Keeps the PD alive for the QP's lifetime and is the source of the QP's
     /// device context (via [`IbvPd::context`]).
     pd: Arc<IbvPd>,
@@ -1294,8 +1294,8 @@ impl IbvQp {
     ) -> Self {
         Self {
             qp,
-            send_cq,
-            recv_cq,
+            _send_cq: send_cq,
+            _recv_cq: recv_cq,
             pd,
         }
     }
@@ -1303,16 +1303,6 @@ impl IbvQp {
     /// The raw `ibv_qp`; null for a placeholder that holds no queue pair.
     pub(super) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_qp {
         self.qp
-    }
-
-    /// The send completion queue.
-    pub(super) fn send_cq(&self) -> &IbvCq {
-        &self.send_cq
-    }
-
-    /// The receive completion queue.
-    pub(super) fn recv_cq(&self) -> &IbvCq {
-        &self.recv_cq
     }
 
     /// The protection domain this QP was created against, shareable as a
@@ -1332,8 +1322,8 @@ impl IbvQp {
     pub(super) fn null() -> Self {
         Self {
             qp: std::ptr::null_mut(),
-            send_cq: Arc::new(IbvCq::null()),
-            recv_cq: Arc::new(IbvCq::null()),
+            _send_cq: Arc::new(IbvCq::null()),
+            _recv_cq: Arc::new(IbvCq::null()),
             pd: Arc::new(IbvPd::null()),
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -35,12 +35,12 @@ use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::PortHandle;
 use hyperactor::actor::Referable;
 use hyperactor::actor::RemoteHandles;
 use hyperactor::context::Mailbox;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::mpsc;
 use typeuri::Named;
 
 use super::cq_pool::CqLease;
@@ -846,13 +846,7 @@ pub(super) trait Manager:
 
 impl<T> Manager for T where T: Actor + Referable + RemoteHandles<CreatePeerQueuePair<T>> {}
 
-/// Per-op completion reply emitted by [`QueuePairActor`] back to the
-/// manager via [`ProcessOps::reply`]. A named newtype (rather than a
-/// raw `(usize, Result<…>)` tuple) so the manager can identify
-/// undeliverable `OpResult`s by type name in
-/// `handle_undeliverable_message` and absorb them when the original
-/// caller has gone away (typical at test teardown).
-#[allow(dead_code)] // not yet referenced by IbvManagerActor
+/// Per-op completion result sent from a queue-pair actor to the submitter.
 #[derive(Debug)]
 pub(super) struct OpResult {
     pub(super) op_idx: usize,
@@ -881,7 +875,7 @@ pub(super) struct QueuePairOp {
 #[derive(Debug)]
 pub(super) struct ProcessOps {
     pub(super) items: Vec<QueuePairOp>,
-    pub(super) reply: PortHandle<OpResult>,
+    pub(super) reply: mpsc::UnboundedSender<OpResult>,
 }
 
 /// Local-only self-message that drives one round of the scheduler.
@@ -892,7 +886,7 @@ struct Tick;
 #[derive(Debug)]
 struct PendingOp {
     op: QueuePairOp,
-    reply: PortHandle<OpResult>,
+    reply: mpsc::UnboundedSender<OpResult>,
     /// WR count this op will issue when posted, computed once at
     /// construction so retries from a credit head-block don't redo
     /// the work.
@@ -909,7 +903,7 @@ struct PostedOpEntry {
     /// Kept alive so the memory *registration* outlives every in-flight
     /// WR touching it.
     _local_mrv: IbvMemoryRegionView,
-    reply: PortHandle<OpResult>,
+    reply: mpsc::UnboundedSender<OpResult>,
     /// First per-WR error observed for this op. The op's final reply is
     /// held back until `pending_wrs.is_empty()`, so the two fields above
     /// outlive every WR still in flight.
@@ -1021,7 +1015,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
     /// * `Err(_)` — `qp.put`/`qp.get` failed (e.g. the QP is in
     ///   error state). Fatal: the actor's handler returns this,
     ///   which raises a supervision event.
-    fn try_post_head(&mut self, cx: &Instance<Self>) -> Result<bool, anyhow::Error> {
+    fn try_post_head(&mut self) -> Result<bool, anyhow::Error> {
         let pending = self.queue.pop_front().expect("non-empty queue");
         let PendingOp { op, reply, wrs } = pending;
         let op_idx = op.op_idx;
@@ -1032,13 +1026,10 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 "op too large for this QP [op_idx={}, qp_key={:?}, op_type={:?}, wrs={}, max_send_wr={}, local: {:?}, remote: {:?}]",
                 op_idx, self.qp_key, op.op_type, wrs, self.max_send_wr, op.local_memory, op.remote,
             );
-            reply.try_post(
-                cx,
-                OpResult {
-                    op_idx,
-                    result: Err(err),
-                },
-            )?;
+            let _ = reply.send(OpResult {
+                op_idx,
+                result: Err(err),
+            });
             return Ok(true);
         }
 
@@ -1103,7 +1094,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         // 1. Post from the queue head until either it's empty or
         //    the head is credit-blocked.
         while !self.queue.is_empty() {
-            if !self.try_post_head(cx)? {
+            if !self.try_post_head()? {
                 break;
             }
         }
@@ -1151,13 +1142,10 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                     Some(err) => Err(err),
                     None => Ok(()),
                 };
-                entry.reply.try_post(
-                    cx,
-                    OpResult {
-                        op_idx: entry.op_idx,
-                        result,
-                    },
-                )?;
+                let _ = entry.reply.send(OpResult {
+                    op_idx: entry.op_idx,
+                    result,
+                });
             }
         }
         if progressed {
@@ -2189,14 +2177,14 @@ mod tests {
         }
     }
 
-    /// Open a multi-shot port and send a `ProcessOps` batch. Returns
+    /// Open a result channel and send a `ProcessOps` batch. Returns
     /// the receiver so the caller can await per-op results.
     fn submit_ops(
         harness: &QpaHarness,
         actor: &ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
         items: Vec<QueuePairOp>,
-    ) -> Result<hyperactor::mailbox::PortReceiver<OpResult>> {
-        let (reply, rx) = harness.client.mailbox().open_port::<OpResult>();
+    ) -> Result<mpsc::UnboundedReceiver<OpResult>> {
+        let (reply, rx) = mpsc::unbounded_channel();
         actor.try_post(&harness.client, ProcessOps { items, reply })?;
         Ok(rx)
     }
@@ -2204,7 +2192,7 @@ mod tests {
     /// Collect exactly `n` replies with a per-recv timeout, sorted
     /// by op_idx for deterministic comparison.
     async fn collect_replies(
-        rx: &mut hyperactor::mailbox::PortReceiver<OpResult>,
+        rx: &mut mpsc::UnboundedReceiver<OpResult>,
         n: usize,
     ) -> Vec<(usize, Result<(), String>)> {
         let mut out = Vec::with_capacity(n);
@@ -2212,7 +2200,7 @@ mod tests {
             let m = tokio::time::timeout(Duration::from_secs(5), rx.recv())
                 .await
                 .expect("timed out waiting for ProcessOps reply")
-                .expect("ProcessOps reply port closed");
+                .expect("ProcessOps result channel closed");
             out.push((m.op_idx, m.result));
         }
         out.sort_by_key(|(i, _)| *i);
@@ -2222,12 +2210,12 @@ mod tests {
     /// Try to recv with a short timeout, returning `None` on timeout
     /// so callers can assert "no reply yet".
     async fn try_recv(
-        rx: &mut hyperactor::mailbox::PortReceiver<OpResult>,
+        rx: &mut mpsc::UnboundedReceiver<OpResult>,
         wait: Duration,
     ) -> Option<(usize, Result<(), String>)> {
         match tokio::time::timeout(wait, rx.recv()).await {
-            Ok(Ok(m)) => Some((m.op_idx, m.result)),
-            Ok(Err(e)) => panic!("ProcessOps reply port closed: {e}"),
+            Ok(Some(m)) => Some((m.op_idx, m.result)),
+            Ok(None) => panic!("ProcessOps result channel closed"),
             Err(_) => None,
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -22,12 +22,8 @@ use std::io::Error;
 use std::result::Result;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
 
 use async_trait::async_trait;
-use backoff::ExponentialBackoff;
-use backoff::ExponentialBackoffBuilder;
-use backoff::backoff::Backoff;
 use hyperactor::Actor;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
@@ -775,68 +771,6 @@ impl IbvQueuePair for RCQueuePair {
     }
 }
 
-/// Adaptive backoff for the scheduler's `Tick` self-message. Use
-/// [`Self::next_interval`] to ask "how long should I wait before the
-/// next poll attempt?"; call [`Self::reset`] whenever the previous
-/// poll observed completions (so the actor stays tight while work
-/// is making progress).
-///
-/// While the elapsed time since the first non-zero interval is below
-/// `yield_window`, the policy returns `Duration::ZERO` so the actor
-/// just re-sends `Tick` to itself with no delay — keeping latency
-/// tight when WRs are about to complete. Past the window, it walks
-/// an exponential backoff (1ms initial, doubling, capped at 10ms)
-/// so a long-running op doesn't keep the runtime spinning. When
-/// `yield_window` is `None` (the default for
-/// `RDMA_CQ_BUSY_POLL_WINDOW`) the policy always returns
-/// `Duration::ZERO`.
-#[derive(Debug)]
-struct PollSleepPolicy {
-    yield_window: Option<Duration>,
-    started_at: Option<Instant>,
-    backoff: Option<ExponentialBackoff>,
-}
-
-impl PollSleepPolicy {
-    fn new() -> Self {
-        let yield_window = hyperactor_config::global::get(crate::config::RDMA_CQ_BUSY_POLL_WINDOW);
-        Self {
-            yield_window,
-            started_at: None,
-            backoff: None,
-        }
-    }
-
-    /// Forget all accumulated backoff state. Called after a poll
-    /// returns completions, so the next idle stretch starts fresh.
-    fn reset(&mut self) {
-        self.started_at = None;
-        self.backoff = None;
-    }
-
-    /// Suggested delay before the next `Tick`. `Duration::ZERO`
-    /// means "send `Tick` immediately".
-    fn next_interval(&mut self) -> Duration {
-        let Some(window) = self.yield_window else {
-            return Duration::ZERO;
-        };
-        let started = *self.started_at.get_or_insert_with(Instant::now);
-        if started.elapsed() < window {
-            return Duration::ZERO;
-        }
-        let backoff = self.backoff.get_or_insert_with(|| {
-            ExponentialBackoffBuilder::new()
-                .with_initial_interval(Duration::from_millis(1))
-                .with_max_interval(Duration::from_millis(10))
-                .with_multiplier(2.0)
-                .with_randomization_factor(0.0)
-                .with_max_elapsed_time(None)
-                .build()
-        });
-        backoff.next_backoff().unwrap_or(Duration::ZERO)
-    }
-}
-
 /// Bundle of trait bounds for an actor type that can serve as the
 /// peer manager — i.e. the recipient of [`CreatePeerQueuePair`].
 pub(super) trait Manager:
@@ -910,29 +844,11 @@ struct PostedOpEntry {
     first_error: Option<String>,
 }
 
-/// Per-peer queue-pair actor.
-///
-/// Generic over the manager actor type `M` (so tests can swap in a
-/// mock) and the queue-pair type `Qp` (so unit tests run without
-/// RDMA hardware). The QP is constructed by the spawning manager
-/// and handed in as a spawn param; the actor owns it for life and
-/// drops it when the actor stops.
+/// Owns one queue pair and the state used to schedule and complete its work.
 #[derive(Debug)]
-pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
+struct QueuePairState<Qp: IbvQueuePair> {
     qp_key: QpKey,
-    /// Filled into [`CreatePeerQueuePair::sender`] so the peer can
-    /// build its own [`QpKey`] from our identity.
-    local_manager: ActorRef<M>,
-    /// Recipient of [`CreatePeerQueuePair`].
-    peer_manager: ActorRef<M>,
     qp: Qp,
-    /// `true` when the peer QP is colocated with this actor's QP —
-    /// i.e. both endpoints live in the same `IbvManagerActor` *and*
-    /// target the same RDMA device. In that case `init` connects
-    /// the QP to its own endpoint and skips the cross-actor
-    /// handshake.
-    is_loopback: bool,
-    init_timeout: Duration,
     /// QP-wide cap on outstanding send-queue WRs (reads + writes).
     max_send_wr: u32,
     /// Single FIFO of ops awaiting their first post attempt. If the head
@@ -941,7 +857,7 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// future work.
     queue: VecDeque<PendingOp>,
     /// op-id → entry, for tracking WR completion. op-ids are local
-    /// to this actor (monotonic counter); they exist so we can
+    /// to this queue pair (monotonic counter); they exist so we can
     /// route per-WR completions to the right `PostedOpEntry`
     /// without making any assumptions about uniqueness of `op_idx`
     /// across batches.
@@ -952,10 +868,33 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// WRs posted to the send queue and not yet reaped:
     /// what `max_send_wr` gates against.
     in_flight: u32,
+}
+
+/// Per-peer queue-pair actor.
+///
+/// Generic over the manager actor type `M` (so tests can swap in a
+/// mock) and the queue-pair type `Qp` (so unit tests run without
+/// RDMA hardware). The QP is constructed by the spawning manager
+/// and handed in as a spawn param; the actor owns it for life and
+/// drops it when the actor stops.
+#[derive(Debug)]
+pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
+    /// Filled into [`CreatePeerQueuePair::sender`] so the peer can
+    /// build its own [`QpKey`] from our identity.
+    local_manager: ActorRef<M>,
+    /// Recipient of [`CreatePeerQueuePair`].
+    peer_manager: ActorRef<M>,
+    state: QueuePairState<Qp>,
+    /// `true` when the peer QP is colocated with this actor's QP —
+    /// i.e. both endpoints live in the same `IbvManagerActor` *and*
+    /// target the same RDMA device. In that case `init` connects
+    /// the QP to its own endpoint and skips the cross-actor
+    /// handshake.
+    is_loopback: bool,
+    init_timeout: Duration,
     /// `true` while a `Tick` self-message is already in flight; the
     /// flag prevents stacking redundant ticks.
     tick_armed: bool,
-    poll_policy: PollSleepPolicy,
     /// This queue pair's lease on the device's completion queue. Never read: it
     /// is held so the lease -- and the completion queue itself -- outlive the
     /// queue pair, which drops with this actor. This placement is temporary and
@@ -978,30 +917,56 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
     ) -> Self {
         let init_timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
         Self {
-            qp_key,
+            state: QueuePairState::new(qp_key, qp, max_send_wr),
             local_manager,
             peer_manager,
-            qp,
             is_loopback,
             init_timeout,
+            tick_armed: false,
+            _cq_lease: cq_lease,
+        }
+    }
+
+    /// One scheduler round: post everything that fits, poll for
+    /// completions, emit replies for finished ops, and re-arm
+    /// `Tick` if work remains. Returns `Err` for fatal QP-level
+    /// failures; the surrounding handler propagates the error so
+    /// supervision tears the actor down.
+    fn advance(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
+        self.state.post_ready()?;
+
+        self.state.poll_completions()?;
+
+        if self.state.has_work() && !self.tick_armed {
+            self.tick_armed = true;
+            cx.handle().try_post(cx, Tick)?;
+        }
+        Ok(())
+    }
+}
+
+impl<Qp: IbvQueuePair> QueuePairState<Qp> {
+    fn new(qp_key: QpKey, qp: Qp, max_send_wr: u32) -> Self {
+        Self {
+            qp_key,
+            qp,
             max_send_wr,
             queue: VecDeque::new(),
             posted: HashMap::new(),
             wr_to_op: HashMap::new(),
             next_op_id: 0,
             in_flight: 0,
-            tick_armed: false,
-            poll_policy: PollSleepPolicy::new(),
-            _cq_lease: cq_lease,
         }
     }
 
-    /// Number of WRs the QP will issue for an op that targets
-    /// `local_size` bytes. The QP splits large transfers into
-    /// [`IbvQueuePair::max_msg_size`]-bound chunks; a zero-byte op still
-    /// consumes one WR.
-    fn wr_count(&self, local_size: usize) -> u32 {
-        local_size.div_ceil(self.qp.max_msg_size()).max(1) as u32
+    fn enqueue(&mut self, message: ProcessOps) {
+        let max_msg_size = self.qp.max_msg_size();
+        self.queue
+            .extend(message.items.into_iter().map(|op| PendingOp {
+                wrs: op.local_memory.size().div_ceil(max_msg_size).max(1) as u32,
+                op,
+                reply: message.reply.clone(),
+            }));
     }
 
     /// Try to post the head of `queue`.
@@ -1085,26 +1050,17 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         Ok(true)
     }
 
-    /// One scheduler round: post everything that fits, poll for
-    /// completions, emit replies for finished ops, and re-arm
-    /// `Tick` if work remains. Returns `Err` for fatal QP-level
-    /// failures; the surrounding handler propagates the error so
-    /// supervision tears the actor down.
-    fn advance(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
-        // 1. Post from the queue head until either it's empty or
-        //    the head is credit-blocked.
+    fn post_ready(&mut self) -> Result<(), anyhow::Error> {
         while !self.queue.is_empty() {
             if !self.try_post_head()? {
                 break;
             }
         }
+        Ok(())
+    }
 
-        // 2. Drain the send CQ. Each completion identifies its WR by
-        //    `wr_id`; we correlate it back to its op and, once every WR
-        //    for an op has reported, emit the op's reply. Polling only
-        //    while WRs are outstanding keeps the loop from spinning on an
-        //    empty queue, and draining to `None` ensures no completion is
-        //    left behind.
+    /// Drain the send CQ and return whether any completion was observed.
+    fn poll_completions(&mut self) -> Result<bool, anyhow::Error> {
         let mut progressed = false;
         while !self.wr_to_op.is_empty() {
             let completion = self
@@ -1148,22 +1104,11 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 });
             }
         }
-        if progressed {
-            self.poll_policy.reset();
-        }
+        Ok(progressed)
+    }
 
-        // 3. Re-arm Tick if any work remains.
-        let pending_work = !self.queue.is_empty() || !self.posted.is_empty();
-        if pending_work && !self.tick_armed {
-            self.tick_armed = true;
-            let interval = self.poll_policy.next_interval();
-            if interval.is_zero() {
-                cx.handle().try_post(cx, Tick)?;
-            } else {
-                cx.post_after(cx, Tick, interval);
-            }
-        }
-        Ok(())
+    fn has_work(&self) -> bool {
+        !self.queue.is_empty() || !self.posted.is_empty()
     }
 }
 
@@ -1171,8 +1116,8 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
 impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         this.set_system();
-        let local_info = self.qp.get_qp_info().map_err(|e| {
-            tracing::error!(qp_key = ?self.qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
+        let local_info = self.state.qp.get_qp_info().map_err(|e| {
+            tracing::error!(qp_key = ?self.state.qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
             anyhow::anyhow!("could not extract local QP info: {e}")
         })?;
 
@@ -1186,8 +1131,8 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 this,
                 CreatePeerQueuePair {
                     sender: self.local_manager.clone(),
-                    sender_device: self.qp_key.self_device.clone(),
-                    receiver_device: self.qp_key.other_device.clone(),
+                    sender_device: self.state.qp_key.self_device.clone(),
+                    receiver_device: self.state.qp_key.other_device.clone(),
                     sender_info: local_info,
                     reply: reply.bind(),
                 },
@@ -1196,7 +1141,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 Ok(Ok(Ok(info))) => info,
                 Ok(Ok(Err(e))) => {
                     tracing::error!(
-                        qp_key = ?self.qp_key,
+                        qp_key = ?self.state.qp_key,
                         peer_manager = ?self.peer_manager,
                         error = %e,
                         "QueuePairActor init: peer manager rejected CreatePeerQueuePair",
@@ -1205,7 +1150,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 }
                 Ok(Err(e)) => {
                     tracing::error!(
-                        qp_key = ?self.qp_key,
+                        qp_key = ?self.state.qp_key,
                         peer_manager = ?self.peer_manager,
                         error = %e,
                         "QueuePairActor init: peer reply port closed",
@@ -1214,7 +1159,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 }
                 Err(_) => {
                     tracing::error!(
-                        qp_key = ?self.qp_key,
+                        qp_key = ?self.state.qp_key,
                         peer_manager = ?self.peer_manager,
                         timeout = ?self.init_timeout,
                         "QueuePairActor init: timed out waiting for peer reply",
@@ -1227,9 +1172,9 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
             }
         };
 
-        self.qp.connect(&peer_info).map_err(|e| {
+        self.state.qp.connect(&peer_info).map_err(|e| {
             tracing::error!(
-                qp_key = ?self.qp_key,
+                qp_key = ?self.state.qp_key,
                 peer_info = ?peer_info,
                 error = %e,
                 "QueuePairActor init: connect failed",
@@ -1254,14 +1199,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
 #[async_trait]
 impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps> for QueuePairActor<M, Qp> {
     async fn handle(&mut self, cx: &Context<Self>, msg: ProcessOps) -> Result<(), anyhow::Error> {
-        for op in msg.items.into_iter() {
-            let wrs = self.wr_count(op.local_memory.size());
-            self.queue.push_back(PendingOp {
-                op,
-                reply: msg.reply.clone(),
-                wrs,
-            });
-        }
+        self.state.enqueue(msg);
         // If a tick is already armed it will pick up the new ops on
         // its next round; advancing here would just duplicate work.
         if !self.tick_armed {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -21,10 +21,13 @@ use std::collections::VecDeque;
 use std::io::Error;
 use std::result::Result;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
+use hyperactor::ActorHandle;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Context;
@@ -39,6 +42,16 @@ use serde::Serialize;
 use tokio::sync::mpsc;
 use typeuri::Named;
 
+use super::cq_actor::Attach;
+use super::cq_actor::CompletionInbox;
+use super::cq_actor::CompletionQueueActor;
+use super::cq_actor::CompletionResult;
+use super::cq_actor::CompletionRoute;
+use super::cq_actor::CqId;
+use super::cq_actor::Detach;
+use super::cq_actor::DetachedQueuePair;
+use super::cq_actor::IbvCompletionQueue as _;
+use super::cq_actor::PollerWake;
 use super::cq_pool::CqLease;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
@@ -53,6 +66,7 @@ use super::primitives::IbvCq;
 use super::primitives::IbvOperation;
 use super::primitives::IbvQp;
 use super::primitives::IbvQpInfo;
+#[cfg(test)]
 use super::primitives::IbvWc;
 use super::primitives::resolve_qp_type;
 use crate::RdmaOpType;
@@ -117,7 +131,6 @@ impl WorkRequestError {
 
 /// A CQ-level poll failure: `ibv_poll_cq` itself failed, naming no work request.
 /// The entry that caused it, if any, has been consumed.
-/// [`IbvQueuePair::poll_completion`] treats it as poisoning its queue pair.
 #[derive(Debug)]
 pub struct PollCompletionError {
     message: String,
@@ -247,21 +260,6 @@ pub trait IbvQueuePair: std::fmt::Debug + Send + Sync + 'static + Sized {
         local_dst: IbvMemoryRegionView,
         remote_src: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error>;
-
-    /// Poll `target`'s completion queue for a single work completion.
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(None)` — the CQ is currently empty.
-    /// * `Ok(Some(Ok(wc)))` — a completion landed with success status.
-    /// * `Ok(Some(Err(_)))` — a completion landed with a non-success
-    ///   status; the [`WorkRequestError`] names the failed request.
-    /// * `Err(_)` — `ibv_poll_cq` itself failed; the QP should be treated
-    ///   as poisoned.
-    fn poll_completion(
-        &mut self,
-        target: PollTarget,
-    ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError>;
 }
 
 /// Queries the local endpoint info for `qp`, whose device `context` and the QP
@@ -432,70 +430,6 @@ pub(super) unsafe fn connect(
         ));
     }
     Ok(())
-}
-
-/// Polls `target`'s completion queue on `qp` for a single work completion,
-/// through the device context's `poll_cq` verb. Shared by every queue-pair
-/// implementation built on an [`IbvQp`]; see
-/// [`IbvQueuePair::poll_completion`] for the meaning of the return value.
-///
-/// # Safety
-///
-/// `qp` must hold a non-null, live `ibv_qp` whose send and receive completion
-/// queues and device context are likewise non-null and live: this invokes the
-/// `poll_cq` verb through them without re-checking. A placeholder [`IbvQp`]
-/// built from null handles does not qualify.
-///
-/// No other thread may be polling `target`'s completion queue for the duration.
-pub(super) unsafe fn poll_one(
-    qp: &IbvQp,
-    target: PollTarget,
-) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-    let (cq, cq_type) = match target {
-        PollTarget::Send => (qp.send_cq().as_ptr(), "send"),
-        PollTarget::Recv => (qp.recv_cq().as_ptr(), "recv"),
-    };
-    let context = qp.context().as_ptr();
-    // SAFETY: `context` is `qp`'s live device context (caller contract); we
-    // invoke its `poll_cq` verb through the ops table.
-    let poll_cq = unsafe {
-        (*context)
-            .ops
-            .poll_cq
-            .expect("poll_cq verb missing from ibv_context ops")
-    };
-    let mut wc = rdmaxcel_sys::ibv_wc::default();
-    // SAFETY: `cq` is a live `ibv_cq` belonging to `qp` (caller contract);
-    // `&mut wc` has room for the single entry requested, and `poll_cq`
-    // overwrites it whenever it returns a completion (`ret >= 1`).
-    let ret = unsafe { poll_cq(cq, 1, &mut wc) };
-
-    if ret < 0 {
-        return Err(PollCompletionError {
-            message: format!("{} CQ poll failed (ibv_poll_cq returned {})", cq_type, ret),
-        });
-    }
-    if ret == 0 {
-        return Ok(None);
-    }
-
-    // `ret >= 1`: a single entry was requested, so `wc` holds one completion.
-    // `error()` is `Some` exactly when the status is not `IBV_WC_SUCCESS`.
-    if let Some((status, vendor_err)) = wc.error() {
-        return Ok(Some(Err(WorkRequestError {
-            wr_id: wc.wr_id(),
-            status,
-            vendor_err,
-            message: format!(
-                "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
-                cq_type,
-                wc.wr_id(),
-                status,
-                vendor_err,
-            ),
-        })));
-    }
-    Ok(Some(Ok(IbvWc::from(wc))))
 }
 
 /// An RDMA reliable-connected (RC) queue pair built on plain ibverbs
@@ -757,18 +691,6 @@ impl IbvQueuePair for RCQueuePair {
             remote_src.size,
         )
     }
-
-    fn poll_completion(
-        &mut self,
-        target: PollTarget,
-    ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-        // SAFETY: `self.qp` wraps a live, fully non-null `ibv_qp` — everything
-        // reached through it included — per `from_qp`'s contract, and it stays
-        // alive for `self`'s lifetime. `&mut self` excludes another poll through
-        // this queue pair, and its lease leaves it the only queue pair polling
-        // that completion queue, so no other thread is polling it.
-        unsafe { poll_one(&self.qp, target) }
-    }
 }
 
 /// Bundle of trait bounds for an actor type that can serve as the
@@ -868,6 +790,17 @@ struct QueuePairState<Qp: IbvQueuePair> {
     /// WRs posted to the send queue and not yet reaped:
     /// what `max_send_wr` gates against.
     in_flight: u32,
+    /// Work requests posted by this queue pair. The completion poller compares
+    /// this with its consumed count to decide when polling is useful.
+    posted_wrs: Arc<AtomicU64>,
+    completions: CompletionInbox,
+    poller_wake: Option<PollerWake>,
+}
+
+#[derive(Debug)]
+struct DetachedQueuePairResources<Qp> {
+    _qp: Qp,
+    _posted: HashMap<u64, PostedOpEntry>,
 }
 
 /// Per-peer queue-pair actor.
@@ -875,8 +808,8 @@ struct QueuePairState<Qp: IbvQueuePair> {
 /// Generic over the manager actor type `M` (so tests can swap in a
 /// mock) and the queue-pair type `Qp` (so unit tests run without
 /// RDMA hardware). The QP is constructed by the spawning manager
-/// and handed in as a spawn param; the actor owns it for life and
-/// drops it when the actor stops.
+/// and handed in as a spawn param. On teardown, the actor transfers the QP to
+/// its completion poller, which drops it after its final CQE has been consumed.
 #[derive(Debug)]
 pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// Filled into [`CreatePeerQueuePair::sender`] so the peer can
@@ -884,7 +817,10 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     local_manager: ActorRef<M>,
     /// Recipient of [`CreatePeerQueuePair`].
     peer_manager: ActorRef<M>,
-    state: QueuePairState<Qp>,
+    state: Option<QueuePairState<Qp>>,
+    cq_poller: ActorHandle<CompletionQueueActor<IbvCq>>,
+    completion_route: Option<CompletionRoute>,
+    detach_target: Option<(CqId, u32)>,
     /// `true` when the peer QP is colocated with this actor's QP —
     /// i.e. both endpoints live in the same `IbvManagerActor` *and*
     /// target the same RDMA device. In that case `init` connects
@@ -895,14 +831,10 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// `true` while a `Tick` self-message is already in flight; the
     /// flag prevents stacking redundant ticks.
     tick_armed: bool,
-    /// This queue pair's lease on the device's completion queue. Never read: it
-    /// is held so the lease -- and the completion queue itself -- outlive the
-    /// queue pair, which drops with this actor. This placement is temporary and
-    /// works now only because each queue pair still gets its own unique CQ. Once
-    /// multiple QPs share a CQ (and polling is handled elsewhere), the CQ's poller
-    /// will own the lease, ensuring it isn't dropped until all of a QP's pending
-    /// work requests have been drained.
-    _cq_lease: CqLease,
+    /// Transferred to the completion poller with the queue pair during teardown.
+    cq_lease: Option<CqLease>,
+    #[cfg(test)]
+    completion_sender: mpsc::UnboundedSender<CompletionResult>,
 }
 
 impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
@@ -911,33 +843,64 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         local_manager: ActorRef<M>,
         peer_manager: ActorRef<M>,
         qp: Qp,
+        cq_poller: ActorHandle<CompletionQueueActor<IbvCq>>,
         cq_lease: CqLease,
         is_loopback: bool,
         max_send_wr: u32,
     ) -> Self {
         let init_timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
+        let posted_wrs = Arc::new(AtomicU64::new(0));
+        let (completions, completion_route) = CompletionInbox::new();
+        #[cfg(test)]
+        let completion_sender = completion_route.sender_for_test();
         Self {
-            state: QueuePairState::new(qp_key, qp, max_send_wr),
+            state: Some(QueuePairState::new(
+                qp_key,
+                qp,
+                max_send_wr,
+                posted_wrs,
+                completions,
+            )),
             local_manager,
             peer_manager,
+            cq_poller,
+            completion_route: Some(completion_route),
+            detach_target: None,
             is_loopback,
             init_timeout,
             tick_armed: false,
-            _cq_lease: cq_lease,
+            cq_lease: Some(cq_lease),
+            #[cfg(test)]
+            completion_sender,
         }
     }
 
-    /// One scheduler round: post everything that fits, poll for
+    fn state(&self) -> &QueuePairState<Qp> {
+        self.state
+            .as_ref()
+            .expect("the queue pair has not been detached")
+    }
+
+    fn state_mut(&mut self) -> &mut QueuePairState<Qp> {
+        self.state
+            .as_mut()
+            .expect("the queue pair has not been detached")
+    }
+
+    /// One scheduler round: post everything that fits, consume routed
     /// completions, emit replies for finished ops, and re-arm
     /// `Tick` if work remains. Returns `Err` for fatal QP-level
     /// failures; the surrounding handler propagates the error so
     /// supervision tears the actor down.
     fn advance(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
-        self.state.post_ready()?;
+        let has_work = {
+            let state = self.state_mut();
+            state.post_ready()?;
+            state.drain_completions()?;
+            state.has_work()
+        };
 
-        self.state.poll_completions()?;
-
-        if self.state.has_work() && !self.tick_armed {
+        if has_work && !self.tick_armed {
             self.tick_armed = true;
             cx.handle().try_post(cx, Tick)?;
         }
@@ -946,7 +909,13 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
 }
 
 impl<Qp: IbvQueuePair> QueuePairState<Qp> {
-    fn new(qp_key: QpKey, qp: Qp, max_send_wr: u32) -> Self {
+    fn new(
+        qp_key: QpKey,
+        qp: Qp,
+        max_send_wr: u32,
+        posted_wrs: Arc<AtomicU64>,
+        completions: CompletionInbox,
+    ) -> Self {
         Self {
             qp_key,
             qp,
@@ -956,6 +925,9 @@ impl<Qp: IbvQueuePair> QueuePairState<Qp> {
             wr_to_op: HashMap::new(),
             next_op_id: 0,
             in_flight: 0,
+            posted_wrs,
+            completions,
+            poller_wake: None,
         }
     }
 
@@ -1047,6 +1019,20 @@ impl<Qp: IbvQueuePair> QueuePairState<Qp> {
                 first_error: None,
             },
         );
+        // This state is the counter's only writer. The following `unpark`
+        // publishes the increment before a parked poller checks the count.
+        self.posted_wrs
+            .fetch_add(wr_ids.len() as u64, Ordering::Relaxed);
+        self.poller_wake
+            .as_ref()
+            .expect("the queue pair attached before posting work")
+            .notify()
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "could not wake the completion queue poller [qp_key={:?}]: {error}",
+                    self.qp_key,
+                )
+            })?;
         Ok(true)
     }
 
@@ -1059,56 +1045,98 @@ impl<Qp: IbvQueuePair> QueuePairState<Qp> {
         Ok(())
     }
 
-    /// Drain the send CQ and return whether any completion was observed.
-    fn poll_completions(&mut self) -> Result<bool, anyhow::Error> {
-        let mut progressed = false;
-        while !self.wr_to_op.is_empty() {
-            let completion = self
-                .qp
-                .poll_completion(PollTarget::Send)
-                .map_err(|e| anyhow::anyhow!("CQ poll failed for qp_key={:?}: {e}", self.qp_key))?;
-            let Some(wc_result) = completion else {
-                break;
-            };
-            progressed = true;
-
-            let (wr_id, wr_error) = match wc_result {
-                Ok(wc) => (wc.wr_id(), None),
-                Err(per_wr) => (per_wr.wr_id, Some(per_wr.to_string())),
-            };
-
-            let op_id = self
-                .wr_to_op
-                .remove(&wr_id)
-                .expect("completed wr_id missing from wr_to_op");
-            let entry = self
-                .posted
-                .get_mut(&op_id)
-                .expect("op_id missing from posted");
-            entry.pending_wrs.remove(&wr_id);
-            self.in_flight -= 1;
-            if let Some(err) = wr_error
-                && entry.first_error.is_none()
-            {
-                entry.first_error = Some(err);
-            }
-            if entry.pending_wrs.is_empty() {
-                let entry = self.posted.remove(&op_id).expect("just verified");
-                let result = match entry.first_error {
-                    Some(err) => Err(err),
-                    None => Ok(()),
-                };
-                let _ = entry.reply.send(OpResult {
-                    op_idx: entry.op_idx,
-                    result,
-                });
+    fn drain_completions(&mut self) -> Result<(), anyhow::Error> {
+        loop {
+            match self.completions.try_recv() {
+                Ok(completion) => self.complete_wr(completion)?,
+                Err(mpsc::error::TryRecvError::Empty) => return Ok(()),
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    return Err(anyhow::anyhow!("completion queue poller stopped"));
+                }
             }
         }
-        Ok(progressed)
+    }
+
+    fn complete_wr(&mut self, completion: CompletionResult) -> Result<(), anyhow::Error> {
+        let (wr_id, wr_error) = match completion {
+            Ok(wc) => (wc.wr_id(), None),
+            Err(per_wr) => (per_wr.wr_id, Some(per_wr.to_string())),
+        };
+        let op_id = self
+            .wr_to_op
+            .remove(&wr_id)
+            .expect("completed wr_id missing from wr_to_op");
+        let entry = self
+            .posted
+            .get_mut(&op_id)
+            .expect("op_id missing from posted");
+        entry.pending_wrs.remove(&wr_id);
+        self.in_flight -= 1;
+        if let Some(err) = wr_error
+            && entry.first_error.is_none()
+        {
+            entry.first_error = Some(err);
+        }
+        if entry.pending_wrs.is_empty() {
+            let entry = self.posted.remove(&op_id).expect("just verified");
+            let result = match entry.first_error {
+                Some(err) => Err(err),
+                None => Ok(()),
+            };
+            let _ = entry.reply.send(OpResult {
+                op_idx: entry.op_idx,
+                result,
+            });
+        }
+        Ok(())
     }
 
     fn has_work(&self) -> bool {
         !self.queue.is_empty() || !self.posted.is_empty()
+    }
+
+    fn into_detached(self) -> DetachedQueuePair {
+        DetachedQueuePair::new(DetachedQueuePairResources {
+            _qp: self.qp,
+            // If we dropped these now, the user would get an error immediately
+            // even though the operations are still being processed and it isn't
+            // safe for them to access the relevant memory yet.
+            _posted: self.posted,
+        })
+    }
+}
+
+impl<M: Manager, Qp: IbvQueuePair> Drop for QueuePairActor<M, Qp> {
+    fn drop(&mut self) {
+        let Some((cq_id, qp_num)) = self.detach_target else {
+            return;
+        };
+        let state = self
+            .state
+            .take()
+            .expect("a queue pair with a detach target has state");
+        let lease = self
+            .cq_lease
+            .take()
+            .expect("a queue pair with a detach target has a CQ lease");
+        let qp_key = state.qp_key.clone();
+        if let Err(error) = self.cq_poller.try_post(
+            Instance::<Self>::self_client(),
+            Detach {
+                cq_id,
+                qp_num,
+                qp: state.into_detached(),
+                lease,
+            },
+        ) {
+            tracing::warn!(
+                ?qp_key,
+                qp_num,
+                ?cq_id,
+                %error,
+                "handing the queue pair to its poller failed",
+            );
+        }
     }
 }
 
@@ -1116,10 +1144,41 @@ impl<Qp: IbvQueuePair> QueuePairState<Qp> {
 impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         this.set_system();
-        let local_info = self.state.qp.get_qp_info().map_err(|e| {
-            tracing::error!(qp_key = ?self.state.qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
+        let qp_key = self.state().qp_key.clone();
+        let local_info = self.state_mut().qp.get_qp_info().map_err(|e| {
+            tracing::error!(?qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
             anyhow::anyhow!("could not extract local QP info: {e}")
         })?;
+
+        let qp_num = local_info.qp_num;
+        let cq = Arc::clone(
+            self.cq_lease
+                .as_ref()
+                .expect("the queue pair was constructed with a CQ lease")
+                .cq(),
+        );
+        let cq_id = cq.cq_id();
+        let (reply, installed) = this.mailbox().open_once_port();
+        self.cq_poller
+            .try_post(
+                Instance::<Self>::self_client(),
+                Attach {
+                    cq,
+                    qp_num,
+                    route: self
+                        .completion_route
+                        .take()
+                        .expect("the completion route has not been attached"),
+                    posted: Arc::clone(&self.state().posted_wrs),
+                    reply,
+                },
+            )
+            .map_err(|error| anyhow::anyhow!("could not reach the CQ poller: {error}"))?;
+        self.detach_target = Some((cq_id, qp_num));
+        self.state_mut().poller_wake =
+            Some(installed.recv().await.map_err(|error| {
+                anyhow::anyhow!("CQ poller did not attach queue pair: {error}")
+            })?);
 
         let peer_info = if self.is_loopback {
             // The "peer" is ourselves; skip the round-trip and
@@ -1131,8 +1190,8 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 this,
                 CreatePeerQueuePair {
                     sender: self.local_manager.clone(),
-                    sender_device: self.state.qp_key.self_device.clone(),
-                    receiver_device: self.state.qp_key.other_device.clone(),
+                    sender_device: qp_key.self_device.clone(),
+                    receiver_device: qp_key.other_device.clone(),
                     sender_info: local_info,
                     reply: reply.bind(),
                 },
@@ -1141,7 +1200,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 Ok(Ok(Ok(info))) => info,
                 Ok(Ok(Err(e))) => {
                     tracing::error!(
-                        qp_key = ?self.state.qp_key,
+                        ?qp_key,
                         peer_manager = ?self.peer_manager,
                         error = %e,
                         "QueuePairActor init: peer manager rejected CreatePeerQueuePair",
@@ -1150,7 +1209,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 }
                 Ok(Err(e)) => {
                     tracing::error!(
-                        qp_key = ?self.state.qp_key,
+                        ?qp_key,
                         peer_manager = ?self.peer_manager,
                         error = %e,
                         "QueuePairActor init: peer reply port closed",
@@ -1159,7 +1218,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                 }
                 Err(_) => {
                     tracing::error!(
-                        qp_key = ?self.state.qp_key,
+                        ?qp_key,
                         peer_manager = ?self.peer_manager,
                         timeout = ?self.init_timeout,
                         "QueuePairActor init: timed out waiting for peer reply",
@@ -1172,9 +1231,9 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
             }
         };
 
-        self.state.qp.connect(&peer_info).map_err(|e| {
+        self.state_mut().qp.connect(&peer_info).map_err(|e| {
             tracing::error!(
-                qp_key = ?self.state.qp_key,
+                ?qp_key,
                 peer_info = ?peer_info,
                 error = %e,
                 "QueuePairActor init: connect failed",
@@ -1199,7 +1258,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
 #[async_trait]
 impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps> for QueuePairActor<M, Qp> {
     async fn handle(&mut self, cx: &Context<Self>, msg: ProcessOps) -> Result<(), anyhow::Error> {
-        self.state.enqueue(msg);
+        self.state_mut().enqueue(msg);
         // If a tick is already armed it will pick up the new ops on
         // its next round; advancing here would just duplicate work.
         if !self.tick_armed {
@@ -1410,15 +1469,19 @@ mod tests {
     impl Handler<SpawnQpaChild> for QpaMockManager {
         async fn handle(&mut self, cx: &Context<Self>, msg: SpawnQpaChild) -> Result<()> {
             let local_manager = cx.bind::<QpaMockManager>();
+            let cq_poller = cx.spawn(CompletionQueueActor::<IbvCq>::new());
+            let test_qp = msg.qp.clone();
             let actor = QueuePairActor::new(
                 msg.qp_key,
                 local_manager,
                 msg.peer_manager,
                 msg.qp,
+                cq_poller,
                 CqLease::for_test(),
                 msg.is_loopback,
                 msg.max_send_wr,
             );
+            test_qp.set_completion_sender(actor.completion_sender.clone());
             let handle = cx.spawn(actor);
             msg.reply.try_post(cx, handle)?;
             Ok(())
@@ -1448,12 +1511,7 @@ mod tests {
         /// Every `put`/`get` call is forwarded here in order, so the
         /// test body can `await` rather than poll.
         posted_tx: tokio::sync::mpsc::UnboundedSender<PostedOp>,
-        /// FIFO of completions the next `poll_completion` calls hand
-        /// back, one per call. Each entry is either `Ok(IbvWc)`
-        /// (success) or `Err(...)` (per-WR completion failure).
-        pending_completions: VecDeque<std::result::Result<IbvWc, WorkRequestError>>,
-        /// One-shot CQ-level error; cleared after the next poll consumes it.
-        poll_error: Option<PollCompletionError>,
+        completion_sender: Option<mpsc::UnboundedSender<CompletionResult>>,
         /// One-shot error for the next `put` or `get` call.
         post_error: Option<String>,
     }
@@ -1484,8 +1542,7 @@ mod tests {
                     connect_calls: Vec::new(),
                     next_wr_id: 0,
                     posted_tx,
-                    pending_completions: VecDeque::new(),
-                    poll_error: None,
+                    completion_sender: None,
                     post_error: None,
                 })),
             };
@@ -1496,31 +1553,27 @@ mod tests {
             self.inner.lock().unwrap().connect_calls.clone()
         }
 
-        /// Queue a successful WC for `wr_id`. A subsequent
-        /// `poll_completion` call returns it in FIFO order.
+        fn set_completion_sender(&self, sender: mpsc::UnboundedSender<CompletionResult>) {
+            self.inner.lock().unwrap().completion_sender = Some(sender);
+        }
+
         fn queue_completion(&self, wr_id: u64) {
-            self.inner
-                .lock()
-                .unwrap()
-                .pending_completions
-                .push_back(Ok(IbvWc::for_test(wr_id, true)));
+            self.queue_completion_result(Ok(IbvWc::for_test(wr_id, true)));
         }
 
-        /// Queue a per-WR completion failure for `wr_id` — the actor
-        /// receives it as the inner `Err` from `poll_completion` and
-        /// should fail just that op (not poison the QP).
         fn queue_per_wr_error(&self, wr_id: u64, message: &str) {
+            self.queue_completion_result(Err(WorkRequestError::for_test(wr_id, message)));
+        }
+
+        fn queue_completion_result(&self, result: CompletionResult) {
             self.inner
                 .lock()
                 .unwrap()
-                .pending_completions
-                .push_back(Err(WorkRequestError::for_test(wr_id, message)));
-        }
-
-        /// Queue a CQ-level poll error (one-shot). The next poll
-        /// returns this as the outer `Err`, simulating a poisoned QP.
-        fn queue_poll_error(&self, err: PollCompletionError) {
-            self.inner.lock().unwrap().poll_error = Some(err);
+                .completion_sender
+                .as_ref()
+                .expect("the mock queue pair is attached")
+                .send(result)
+                .expect("the completion inbox should remain open");
         }
 
         /// Make the next `put`/`get` return this error (one-shot).
@@ -1598,20 +1651,6 @@ mod tests {
                 wr_ids: wr_ids.clone(),
             });
             Ok(wr_ids)
-        }
-
-        fn poll_completion(
-            &mut self,
-            _target: PollTarget,
-        ) -> std::result::Result<
-            Option<std::result::Result<IbvWc, WorkRequestError>>,
-            PollCompletionError,
-        > {
-            let mut inner = self.inner.lock().unwrap();
-            if let Some(err) = inner.poll_error.take() {
-                return Err(err);
-            }
-            Ok(inner.pending_completions.pop_front())
         }
     }
 
@@ -2186,6 +2225,32 @@ mod tests {
     }
 
     #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_survives_a_dropped_operation_result_receiver() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(1).await?;
+        let abandoned = submit_ops(
+            &harness,
+            &actor,
+            vec![make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 4096)],
+        )?;
+        drop(abandoned);
+        let (_, _, first_wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        qp.queue_completion(first_wrs[0]);
+
+        let mut reply = submit_ops(
+            &harness,
+            &actor,
+            vec![make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096)],
+        )?;
+        let (_, _, second_wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        qp.queue_completion(second_wrs[0]);
+
+        assert_eq!(collect_replies(&mut reply, 1).await, vec![(1, Ok(()))]);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn qpa_posted_op_pins_local_memory() -> Result<()> {
         let harness = QpaHarness::build()?;
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
@@ -2584,32 +2649,6 @@ mod tests {
             .expect_err("op_idx 0 should fail as too large");
         assert!(err.contains("too large"), "expected too-large error: {err}");
         assert_eq!(replies[1], (1usize, Ok(())));
-        harness.teardown().await;
-        Ok(())
-    }
-
-    #[timed_test::async_timed_test(timeout_secs = 60)]
-    async fn qpa_poll_error_kills_actor_via_supervision() -> Result<()> {
-        let mut harness = QpaHarness::build()?;
-        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
-
-        // Post one op so the next poll has something to look at.
-        let items = vec![make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
-        let _rx = submit_ops(&harness, &actor, items)?;
-        let _ = recv_posted(&mut posted_rx).await;
-        qp.queue_poll_error(PollCompletionError::new("simulated CQ poison".to_string()));
-
-        let event = harness.next_supervision_failure().await;
-        assert_eq!(&event.actor_id, actor.actor_addr());
-        let report = event.failure_report().expect("event should be a failure");
-        assert!(
-            report.contains("CQ poll failed") && report.contains("simulated CQ poison"),
-            "supervision report should name the poll failure: {report}",
-        );
-        await_status(&actor, |s| {
-            matches!(s, hyperactor::actor::ActorStatus::Failed(_))
-        })
-        .await;
         harness.teardown().await;
         Ok(())
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::io::Error;
+use std::panic::AssertUnwindSafe;
 use std::result::Result;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
@@ -26,6 +27,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures::FutureExt as _;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorId;
@@ -34,12 +36,15 @@ use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::PortHandle;
+use hyperactor::actor::ActorError;
 use hyperactor::actor::Referable;
 use hyperactor::actor::RemoteHandles;
 use hyperactor::context::Mailbox;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use typeuri::Named;
 
 use super::cq_actor::Attach;
@@ -702,7 +707,7 @@ pub(super) trait Manager:
 
 impl<T> Manager for T where T: Actor + Referable + RemoteHandles<CreatePeerQueuePair<T>> {}
 
-/// Per-op completion result sent from a queue-pair actor to the submitter.
+/// Per-op completion result sent from a queue-pair worker to the submitter.
 #[derive(Debug)]
 pub(super) struct OpResult {
     pub(super) op_idx: usize,
@@ -723,8 +728,8 @@ pub(super) struct QueuePairOp {
     pub(super) remote: IbvRemoteMemoryRegionView,
 }
 
-/// Local-only message: enqueue a batch of ops on this QP. As each op resolves
-/// the actor sends one [`OpResult`] on `reply`. Its inner `Result` is `Ok(())`
+/// Local-only request: enqueue a batch of ops on this QP. As each op resolves
+/// the worker sends one [`OpResult`] on `reply`. Its inner `Result` is `Ok(())`
 /// if every WR for the op completed successfully, otherwise `Err` carrying the
 /// first per-WR error observed (held back until the op's other WRs also report,
 /// so the memory handle and MR registration outlive the data path).
@@ -734,11 +739,7 @@ pub(super) struct ProcessOps {
     pub(super) reply: mpsc::UnboundedSender<OpResult>,
 }
 
-/// Local-only self-message that drives one round of the scheduler.
-#[derive(Debug)]
-struct Tick;
-
-/// An op accepted by the actor but not yet posted to the QP.
+/// An op accepted by the worker but not yet posted to the QP.
 #[derive(Debug)]
 struct PendingOp {
     op: QueuePairOp,
@@ -793,7 +794,6 @@ struct QueuePairState<Qp: IbvQueuePair> {
     /// Work requests posted by this queue pair. The completion poller compares
     /// this with its consumed count to decide when polling is useful.
     posted_wrs: Arc<AtomicU64>,
-    completions: CompletionInbox,
     poller_wake: Option<PollerWake>,
 }
 
@@ -803,13 +803,70 @@ struct DetachedQueuePairResources<Qp> {
     _posted: HashMap<u64, PostedOpEntry>,
 }
 
-/// Per-peer queue-pair actor.
+#[derive(Debug)]
+struct QueuePairWorkerFailed {
+    error: String,
+}
+
+/// Local data-plane handle for submitting work to a queue pair while retaining
+/// its actor handle for lifecycle management.
+#[derive(Debug)]
+pub(super) struct QueuePairHandle<M: Manager, Qp: IbvQueuePair> {
+    actor: ActorHandle<QueuePairActor<M, Qp>>,
+    sender: mpsc::UnboundedSender<ProcessOps>,
+}
+
+impl<M: Manager, Qp: IbvQueuePair> Clone for QueuePairHandle<M, Qp> {
+    fn clone(&self) -> Self {
+        Self {
+            actor: self.actor.clone(),
+            sender: self.sender.clone(),
+        }
+    }
+}
+
+impl<M: Manager, Qp: IbvQueuePair> QueuePairHandle<M, Qp> {
+    pub(super) fn new(
+        actor: ActorHandle<QueuePairActor<M, Qp>>,
+        sender: mpsc::UnboundedSender<ProcessOps>,
+    ) -> Self {
+        Self { actor, sender }
+    }
+
+    pub(super) fn send(&self, message: ProcessOps) -> Result<(), anyhow::Error> {
+        self.sender
+            .send(message)
+            .map_err(|_| anyhow::anyhow!("queue pair worker stopped"))
+    }
+
+    pub(super) fn drain_and_stop(&self, reason: &str) -> Result<(), ActorError> {
+        self.actor.drain_and_stop(reason)
+    }
+
+    #[cfg(test)]
+    fn actor(&self) -> &ActorHandle<QueuePairActor<M, Qp>> {
+        &self.actor
+    }
+}
+
+#[derive(Debug)]
+struct QueuePairWorker<Qp: IbvQueuePair> {
+    state: Option<QueuePairState<Qp>>,
+    completions: CompletionInbox,
+    completion_route: Option<CompletionRoute>,
+    process_ops: mpsc::UnboundedReceiver<ProcessOps>,
+    _submission_sender: mpsc::UnboundedSender<ProcessOps>,
+    cq_poller: ActorHandle<CompletionQueueActor<IbvCq>>,
+    detach_target: Option<(CqId, u32)>,
+    cq_lease: Option<CqLease>,
+}
+
+/// Supervises one per-peer queue pair's data-plane task.
 ///
-/// Generic over the manager actor type `M` (so tests can swap in a
-/// mock) and the queue-pair type `Qp` (so unit tests run without
-/// RDMA hardware). The QP is constructed by the spawning manager
-/// and handed in as a spawn param. On teardown, the actor transfers the QP to
-/// its completion poller, which drops it after its final CQE has been consumed.
+/// The actor performs the connection handshake and integrates the worker with
+/// the supervision tree. After initialization, [`QueuePairWorker`] exclusively
+/// owns the QP and its mutable bookkeeping and receives submissions and
+/// completions through separate local channels.
 #[derive(Debug)]
 pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// Filled into [`CreatePeerQueuePair::sender`] so the peer can
@@ -817,10 +874,7 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     local_manager: ActorRef<M>,
     /// Recipient of [`CreatePeerQueuePair`].
     peer_manager: ActorRef<M>,
-    state: Option<QueuePairState<Qp>>,
-    cq_poller: ActorHandle<CompletionQueueActor<IbvCq>>,
-    completion_route: Option<CompletionRoute>,
-    detach_target: Option<(CqId, u32)>,
+    worker: Option<QueuePairWorker<Qp>>,
     /// `true` when the peer QP is colocated with this actor's QP —
     /// i.e. both endpoints live in the same `IbvManagerActor` *and*
     /// target the same RDMA device. In that case `init` connects
@@ -828,16 +882,19 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// handshake.
     is_loopback: bool,
     init_timeout: Duration,
-    /// `true` while a `Tick` self-message is already in flight; the
-    /// flag prevents stacking redundant ticks.
-    tick_armed: bool,
-    /// Transferred to the completion poller with the queue pair during teardown.
-    cq_lease: Option<CqLease>,
+    cancellation: CancellationToken,
+    task: Option<tokio::task::JoinHandle<()>>,
     #[cfg(test)]
     completion_sender: mpsc::UnboundedSender<CompletionResult>,
 }
 
 impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
+    fn worker_mut(&mut self) -> &mut QueuePairWorker<Qp> {
+        self.worker
+            .as_mut()
+            .expect("the queue pair worker has not started")
+    }
+
     pub(super) fn new(
         qp_key: QpKey,
         local_manager: ActorRef<M>,
@@ -847,75 +904,48 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         cq_lease: CqLease,
         is_loopback: bool,
         max_send_wr: u32,
-    ) -> Self {
+    ) -> (Self, mpsc::UnboundedSender<ProcessOps>) {
         let init_timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
         let posted_wrs = Arc::new(AtomicU64::new(0));
         let (completions, completion_route) = CompletionInbox::new();
+        let (sender, process_ops) = mpsc::unbounded_channel();
         #[cfg(test)]
         let completion_sender = completion_route.sender_for_test();
-        Self {
-            state: Some(QueuePairState::new(
-                qp_key,
-                qp,
-                max_send_wr,
-                posted_wrs,
-                completions,
-            )),
-            local_manager,
-            peer_manager,
-            cq_poller,
-            completion_route: Some(completion_route),
-            detach_target: None,
-            is_loopback,
-            init_timeout,
-            tick_armed: false,
-            cq_lease: Some(cq_lease),
-            #[cfg(test)]
-            completion_sender,
-        }
+        let state = QueuePairState::new(qp_key, qp, max_send_wr, posted_wrs);
+        (
+            Self {
+                worker: Some(QueuePairWorker {
+                    state: Some(state),
+                    completions,
+                    completion_route: Some(completion_route),
+                    process_ops,
+                    _submission_sender: sender.clone(),
+                    cq_poller,
+                    detach_target: None,
+                    cq_lease: Some(cq_lease),
+                }),
+                local_manager,
+                peer_manager,
+                is_loopback,
+                init_timeout,
+                cancellation: CancellationToken::new(),
+                task: None,
+                #[cfg(test)]
+                completion_sender,
+            },
+            sender,
+        )
     }
+}
 
-    fn state(&self) -> &QueuePairState<Qp> {
-        self.state
-            .as_ref()
-            .expect("the queue pair has not been detached")
-    }
-
-    fn state_mut(&mut self) -> &mut QueuePairState<Qp> {
-        self.state
-            .as_mut()
-            .expect("the queue pair has not been detached")
-    }
-
-    /// One scheduler round: post everything that fits, consume routed
-    /// completions, emit replies for finished ops, and re-arm
-    /// `Tick` if work remains. Returns `Err` for fatal QP-level
-    /// failures; the surrounding handler propagates the error so
-    /// supervision tears the actor down.
-    fn advance(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
-        let has_work = {
-            let state = self.state_mut();
-            state.post_ready()?;
-            state.drain_completions()?;
-            state.has_work()
-        };
-
-        if has_work && !self.tick_armed {
-            self.tick_armed = true;
-            cx.handle().try_post(cx, Tick)?;
-        }
-        Ok(())
+impl<M: Manager, Qp: IbvQueuePair> Drop for QueuePairActor<M, Qp> {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
     }
 }
 
 impl<Qp: IbvQueuePair> QueuePairState<Qp> {
-    fn new(
-        qp_key: QpKey,
-        qp: Qp,
-        max_send_wr: u32,
-        posted_wrs: Arc<AtomicU64>,
-        completions: CompletionInbox,
-    ) -> Self {
+    fn new(qp_key: QpKey, qp: Qp, max_send_wr: u32, posted_wrs: Arc<AtomicU64>) -> Self {
         Self {
             qp_key,
             qp,
@@ -926,7 +956,6 @@ impl<Qp: IbvQueuePair> QueuePairState<Qp> {
             next_op_id: 0,
             in_flight: 0,
             posted_wrs,
-            completions,
             poller_wake: None,
         }
     }
@@ -950,8 +979,7 @@ impl<Qp: IbvQueuePair> QueuePairState<Qp> {
     ///   `max_send_wr`. The op stays at the head; caller should stop
     ///   walking.
     /// * `Err(_)` — `qp.put`/`qp.get` failed (e.g. the QP is in
-    ///   error state). Fatal: the actor's handler returns this,
-    ///   which raises a supervision event.
+    ///   error state). Fatal: the worker reports this to its supervising actor.
     fn try_post_head(&mut self) -> Result<bool, anyhow::Error> {
         let pending = self.queue.pop_front().expect("non-empty queue");
         let PendingOp { op, reply, wrs } = pending;
@@ -1045,18 +1073,6 @@ impl<Qp: IbvQueuePair> QueuePairState<Qp> {
         Ok(())
     }
 
-    fn drain_completions(&mut self) -> Result<(), anyhow::Error> {
-        loop {
-            match self.completions.try_recv() {
-                Ok(completion) => self.complete_wr(completion)?,
-                Err(mpsc::error::TryRecvError::Empty) => return Ok(()),
-                Err(mpsc::error::TryRecvError::Disconnected) => {
-                    return Err(anyhow::anyhow!("completion queue poller stopped"));
-                }
-            }
-        }
-    }
-
     fn complete_wr(&mut self, completion: CompletionResult) -> Result<(), anyhow::Error> {
         let (wr_id, wr_error) = match completion {
             Ok(wc) => (wc.wr_id(), None),
@@ -1091,10 +1107,6 @@ impl<Qp: IbvQueuePair> QueuePairState<Qp> {
         Ok(())
     }
 
-    fn has_work(&self) -> bool {
-        !self.queue.is_empty() || !self.posted.is_empty()
-    }
-
     fn into_detached(self) -> DetachedQueuePair {
         DetachedQueuePair::new(DetachedQueuePairResources {
             _qp: self.qp,
@@ -1106,7 +1118,88 @@ impl<Qp: IbvQueuePair> QueuePairState<Qp> {
     }
 }
 
-impl<M: Manager, Qp: IbvQueuePair> Drop for QueuePairActor<M, Qp> {
+impl<Qp: IbvQueuePair> QueuePairWorker<Qp> {
+    fn state(&self) -> &QueuePairState<Qp> {
+        self.state
+            .as_ref()
+            .expect("the queue pair has not been detached")
+    }
+
+    fn state_mut(&mut self) -> &mut QueuePairState<Qp> {
+        self.state
+            .as_mut()
+            .expect("the queue pair has not been detached")
+    }
+
+    async fn run(&mut self, cancellation: CancellationToken) -> Result<(), anyhow::Error> {
+        if cancellation.is_cancelled() {
+            return Ok(());
+        }
+        let qp_num = self.state_mut().qp.get_qp_info()?.qp_num;
+        let cq = Arc::clone(
+            self.cq_lease
+                .as_ref()
+                .expect("the queue pair worker starts with a CQ lease")
+                .cq(),
+        );
+        let cq_id = cq.cq_id();
+        let route = self
+            .completion_route
+            .take()
+            .expect("the queue pair attaches its completion route once");
+        let posted = Arc::clone(&self.state().posted_wrs);
+        let (reply, installed) = tokio::sync::oneshot::channel();
+        self.cq_poller.try_post(
+            Instance::<()>::self_client(),
+            Attach {
+                cq,
+                qp_num,
+                route,
+                posted,
+                reply,
+            },
+        )?;
+        self.detach_target = Some((cq_id, qp_num));
+        let poller_wake = tokio::select! {
+            biased;
+
+            _ = cancellation.cancelled() => return Ok(()),
+            result = installed => result.map_err(|error| {
+                anyhow::anyhow!("CQ poller did not attach queue pair: {error}")
+            })?,
+        };
+        self.state_mut().poller_wake = Some(poller_wake);
+
+        loop {
+            tokio::select! {
+                biased;
+
+                _ = cancellation.cancelled() => return Ok(()),
+                // A closed completion channel is only a QP failure while work
+                // is outstanding. An idle QP need not observe CQ teardown.
+                completion = self.completions.recv(), if self.state().in_flight > 0 => {
+                    let completion = completion.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "completion queue poller stopped [qp_key={:?}]",
+                            self.state().qp_key,
+                        )
+                    })?;
+                    self.state_mut().complete_wr(completion)?;
+                    self.state_mut().post_ready()?;
+                }
+                message = self.process_ops.recv() => {
+                    let message = message.expect(
+                        "the queue pair worker retains a submission sender while it runs",
+                    );
+                    self.state_mut().enqueue(message);
+                    self.state_mut().post_ready()?;
+                }
+            }
+        }
+    }
+}
+
+impl<Qp: IbvQueuePair> Drop for QueuePairWorker<Qp> {
     fn drop(&mut self) {
         let Some((cq_id, qp_num)) = self.detach_target else {
             return;
@@ -1121,7 +1214,7 @@ impl<M: Manager, Qp: IbvQueuePair> Drop for QueuePairActor<M, Qp> {
             .expect("a queue pair with a detach target has a CQ lease");
         let qp_key = state.qp_key.clone();
         if let Err(error) = self.cq_poller.try_post(
-            Instance::<Self>::self_client(),
+            Instance::<()>::self_client(),
             Detach {
                 cq_id,
                 qp_num,
@@ -1140,45 +1233,46 @@ impl<M: Manager, Qp: IbvQueuePair> Drop for QueuePairActor<M, Qp> {
     }
 }
 
+async fn run_queue_pair_worker<Qp: IbvQueuePair>(
+    mut worker: QueuePairWorker<Qp>,
+    cancellation: CancellationToken,
+    failed: PortHandle<QueuePairWorkerFailed>,
+) {
+    let result = AssertUnwindSafe(worker.run(cancellation))
+        .catch_unwind()
+        .await;
+    let error = match result {
+        Ok(Ok(())) => return,
+        Ok(Err(error)) => error.to_string(),
+        Err(_) => "queue pair worker panicked".to_owned(),
+    };
+    let error_for_log = error.clone();
+    if let Err(post_error) = failed.try_post(
+        Instance::<()>::self_client(),
+        QueuePairWorkerFailed { error },
+    ) {
+        tracing::error!(
+            error = %error_for_log,
+            %post_error,
+            "reporting queue pair worker failure failed",
+        );
+    }
+}
+
 #[async_trait]
 impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         this.set_system();
-        let qp_key = self.state().qp_key.clone();
-        let local_info = self.state_mut().qp.get_qp_info().map_err(|e| {
-            tracing::error!(?qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
-            anyhow::anyhow!("could not extract local QP info: {e}")
-        })?;
-
-        let qp_num = local_info.qp_num;
-        let cq = Arc::clone(
-            self.cq_lease
-                .as_ref()
-                .expect("the queue pair was constructed with a CQ lease")
-                .cq(),
-        );
-        let cq_id = cq.cq_id();
-        let (reply, installed) = this.mailbox().open_once_port();
-        self.cq_poller
-            .try_post(
-                Instance::<Self>::self_client(),
-                Attach {
-                    cq,
-                    qp_num,
-                    route: self
-                        .completion_route
-                        .take()
-                        .expect("the completion route has not been attached"),
-                    posted: Arc::clone(&self.state().posted_wrs),
-                    reply,
-                },
-            )
-            .map_err(|error| anyhow::anyhow!("could not reach the CQ poller: {error}"))?;
-        self.detach_target = Some((cq_id, qp_num));
-        self.state_mut().poller_wake =
-            Some(installed.recv().await.map_err(|error| {
-                anyhow::anyhow!("CQ poller did not attach queue pair: {error}")
-            })?);
+        let qp_key = self.worker_mut().state().qp_key.clone();
+        let local_info = self
+            .worker_mut()
+            .state_mut()
+            .qp
+            .get_qp_info()
+            .map_err(|e| {
+                tracing::error!(?qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
+                anyhow::anyhow!("could not extract local QP info: {e}")
+            })?;
 
         let peer_info = if self.is_loopback {
             // The "peer" is ourselves; skip the round-trip and
@@ -1231,16 +1325,42 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
             }
         };
 
-        self.state_mut().qp.connect(&peer_info).map_err(|e| {
-            tracing::error!(
-                ?qp_key,
-                peer_info = ?peer_info,
-                error = %e,
-                "QueuePairActor init: connect failed",
-            );
-            anyhow::anyhow!("could not connect QP to peer: {e}")
-        })?;
+        self.worker_mut()
+            .state_mut()
+            .qp
+            .connect(&peer_info)
+            .map_err(|e| {
+                tracing::error!(
+                    ?qp_key,
+                    peer_info = ?peer_info,
+                    error = %e,
+                    "QueuePairActor init: connect failed",
+                );
+                anyhow::anyhow!("could not connect QP to peer: {e}")
+            })?;
+
+        let worker = self
+            .worker
+            .take()
+            .expect("the queue pair worker starts only once");
+        let failed = this.handle().port::<QueuePairWorkerFailed>();
+        self.task = Some(crate::rdma_runtime::spawn_on_rdma_runtime(
+            run_queue_pair_worker(worker, self.cancellation.clone(), failed),
+        ));
         Ok(())
+    }
+
+    async fn cleanup(
+        &mut self,
+        _this: &Instance<Self>,
+        _err: Option<&ActorError>,
+    ) -> Result<(), anyhow::Error> {
+        self.cancellation.cancel();
+        let Some(task) = self.task.take() else {
+            return Ok(());
+        };
+        task.await
+            .map_err(|error| anyhow::anyhow!("joining queue pair worker failed: {error}"))
     }
 
     // This actor is implemented in Rust, but the RDMA registration path may enter
@@ -1256,24 +1376,16 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
 }
 
 #[async_trait]
-impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps> for QueuePairActor<M, Qp> {
-    async fn handle(&mut self, cx: &Context<Self>, msg: ProcessOps) -> Result<(), anyhow::Error> {
-        self.state_mut().enqueue(msg);
-        // If a tick is already armed it will pick up the new ops on
-        // its next round; advancing here would just duplicate work.
-        if !self.tick_armed {
-            self.advance(cx)?;
-        }
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl<M: Manager, Qp: IbvQueuePair> Handler<Tick> for QueuePairActor<M, Qp> {
-    async fn handle(&mut self, cx: &Context<Self>, _msg: Tick) -> Result<(), anyhow::Error> {
-        self.tick_armed = false;
-        self.advance(cx)?;
-        Ok(())
+impl<M: Manager, Qp: IbvQueuePair> Handler<QueuePairWorkerFailed> for QueuePairActor<M, Qp> {
+    async fn handle(
+        &mut self,
+        _cx: &Context<Self>,
+        message: QueuePairWorkerFailed,
+    ) -> Result<(), anyhow::Error> {
+        Err(anyhow::anyhow!(
+            "queue pair worker failed: {}",
+            message.error
+        ))
     }
 }
 
@@ -1453,7 +1565,7 @@ mod tests {
 
     /// Local message that spawns a `QueuePairActor` as a child of
     /// this manager so supervision events route here. The reply
-    /// carries the resulting `ActorHandle` so the test can observe
+    /// carries the resulting handle so the test can observe
     /// lifecycle transitions.
     #[derive(Debug)]
     struct SpawnQpaChild {
@@ -1462,7 +1574,7 @@ mod tests {
         qp: MockQp,
         is_loopback: bool,
         max_send_wr: u32,
-        reply: hyperactor::OncePortHandle<ActorHandle<QueuePairActor<QpaMockManager, MockQp>>>,
+        reply: hyperactor::OncePortHandle<QueuePairHandle<QpaMockManager, MockQp>>,
     }
 
     #[async_trait]
@@ -1471,7 +1583,7 @@ mod tests {
             let local_manager = cx.bind::<QpaMockManager>();
             let cq_poller = cx.spawn(CompletionQueueActor::<IbvCq>::new());
             let test_qp = msg.qp.clone();
-            let actor = QueuePairActor::new(
+            let (actor, sender) = QueuePairActor::new(
                 msg.qp_key,
                 local_manager,
                 msg.peer_manager,
@@ -1482,7 +1594,7 @@ mod tests {
                 msg.max_send_wr,
             );
             test_qp.set_completion_sender(actor.completion_sender.clone());
-            let handle = cx.spawn(actor);
+            let handle = QueuePairHandle::new(cx.spawn(actor), sender);
             msg.reply.try_post(cx, handle)?;
             Ok(())
         }
@@ -1709,12 +1821,12 @@ mod tests {
         }
 
         /// Await the next forwarded child-error supervision event.
-        async fn next_supervision_failure(
+        async fn next_supervision_event(
             &mut self,
         ) -> hyperactor::supervision::ActorSupervisionEvent {
             tokio::time::timeout(Duration::from_secs(5), self.supervision_rx.recv())
                 .await
-                .expect("timed out waiting for child failure event")
+                .expect("timed out waiting for child supervision event")
                 .expect("supervision channel closed")
         }
 
@@ -1742,7 +1854,7 @@ mod tests {
             peer_manager: ActorRef<QpaMockManager>,
             qp: MockQp,
             is_loopback: bool,
-        ) -> Result<ActorHandle<QueuePairActor<QpaMockManager, MockQp>>> {
+        ) -> Result<QueuePairHandle<QpaMockManager, MockQp>> {
             self.spawn_actor_with_caps(qp_key, peer_manager, qp, is_loopback, 4)
                 .await
         }
@@ -1754,7 +1866,7 @@ mod tests {
             qp: MockQp,
             is_loopback: bool,
             max_send_wr: u32,
-        ) -> Result<ActorHandle<QueuePairActor<QpaMockManager, MockQp>>> {
+        ) -> Result<QueuePairHandle<QpaMockManager, MockQp>> {
             let (reply, rx) = self.client.mailbox().open_once_port();
             self.parent.try_post(
                 &self.client,
@@ -1772,10 +1884,10 @@ mod tests {
     }
 
     async fn await_status(
-        handle: &ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
+        handle: &QueuePairHandle<QpaMockManager, MockQp>,
         expected: impl Fn(&hyperactor::actor::ActorStatus) -> bool,
     ) -> hyperactor::actor::ActorStatus {
-        let mut status = handle.status();
+        let mut status = handle.actor().status();
         status.wait_for(|s| expected(s)).await.unwrap();
         status.borrow().clone()
     }
@@ -1877,8 +1989,8 @@ mod tests {
             .spawn_actor(qp_key, harness.peer.bind::<QpaMockManager>(), qp, false)
             .await?;
 
-        let event = harness.next_supervision_failure().await;
-        assert_eq!(&event.actor_id, handle.actor_addr());
+        let event = harness.next_supervision_event().await;
+        assert_eq!(&event.actor_id, handle.actor().actor_addr());
         let report = event.failure_report().expect("event should be a failure");
         assert!(
             report.contains("peer rejected"),
@@ -1912,8 +2024,8 @@ mod tests {
             .spawn_actor(qp_key, harness.peer.bind::<QpaMockManager>(), qp, false)
             .await?;
 
-        let event = harness.next_supervision_failure().await;
-        assert_eq!(&event.actor_id, handle.actor_addr());
+        let event = harness.next_supervision_event().await;
+        assert_eq!(&event.actor_id, handle.actor().actor_addr());
         let report = event.failure_report().expect("event should be a failure");
         assert!(
             report.contains("timed out"),
@@ -2086,7 +2198,7 @@ mod tests {
             &self,
             max_send_wr: u32,
         ) -> Result<(
-            ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
+            QueuePairHandle<QpaMockManager, MockQp>,
             MockQp,
             tokio::sync::mpsc::UnboundedReceiver<PostedOp>,
         )> {
@@ -2157,12 +2269,11 @@ mod tests {
     /// Open a result channel and send a `ProcessOps` batch. Returns
     /// the receiver so the caller can await per-op results.
     fn submit_ops(
-        harness: &QpaHarness,
-        actor: &ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
+        actor: &QueuePairHandle<QpaMockManager, MockQp>,
         items: Vec<QueuePairOp>,
     ) -> Result<mpsc::UnboundedReceiver<OpResult>> {
         let (reply, rx) = mpsc::unbounded_channel();
-        actor.try_post(&harness.client, ProcessOps { items, reply })?;
+        actor.send(ProcessOps { items, reply })?;
         Ok(rx)
     }
 
@@ -2203,7 +2314,7 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4).await?;
 
         let items = vec![make_op(7, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
-        let mut rx = submit_ops(&harness, &actor, items)?;
+        let mut rx = submit_ops(&actor, items)?;
 
         // wr_ids start at 0 (fresh MockQp), so the single WR is wr 0.
         let (lhandle, rhandle, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
@@ -2225,11 +2336,70 @@ mod tests {
     }
 
     #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_cleanup_joins_worker_and_closes_submission_channel() -> Result<()> {
+        let mut harness = QpaHarness::build()?;
+        let (actor, _qp, _posted_rx) = harness.spawn_ready_actor(4).await?;
+
+        actor.drain_and_stop("test complete")?;
+        await_status(&actor, |status| {
+            matches!(status, hyperactor::actor::ActorStatus::Stopped(_))
+        })
+        .await;
+        let event = harness.next_supervision_event().await;
+        assert_eq!(&event.actor_id, actor.actor().actor_addr());
+        assert!(matches!(
+            event.actor_status,
+            hyperactor::actor::ActorStatus::Stopped(_)
+        ));
+
+        let (reply, _rx) = mpsc::unbounded_channel();
+        assert!(
+            actor
+                .send(ProcessOps {
+                    items: Vec::new(),
+                    reply,
+                })
+                .is_err(),
+            "the submission receiver must be closed after actor cleanup",
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_stays_alive_after_external_submission_handles_are_dropped() -> Result<()> {
+        let mut harness = QpaHarness::build()?;
+        let (actor, _qp, _posted_rx) = harness.spawn_ready_actor(4).await?;
+        let actor_handle = actor.actor().clone();
+        let mut status = actor_handle.status();
+
+        drop(actor);
+        assert!(
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                status.wait_for(hyperactor::actor::ActorStatus::is_terminal),
+            )
+            .await
+            .is_err(),
+            "dropping external submission handles must not stop the worker",
+        );
+
+        actor_handle.drain_and_stop("test complete")?;
+        let event = harness.next_supervision_event().await;
+        assert_eq!(&event.actor_id, actor_handle.actor_addr());
+        assert!(matches!(
+            event.actor_status,
+            hyperactor::actor::ActorStatus::Stopped(_)
+        ));
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn qpa_survives_a_dropped_operation_result_receiver() -> Result<()> {
         let harness = QpaHarness::build()?;
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(1).await?;
         let abandoned = submit_ops(
-            &harness,
             &actor,
             vec![make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 4096)],
         )?;
@@ -2238,7 +2408,6 @@ mod tests {
         qp.queue_completion(first_wrs[0]);
 
         let mut reply = submit_ops(
-            &harness,
             &actor,
             vec![make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096)],
         )?;
@@ -2270,7 +2439,7 @@ mod tests {
             ),
             make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
-        let mut rx = submit_ops(&harness, &actor, items)?;
+        let mut rx = submit_ops(&actor, items)?;
 
         let (_, _, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
         let (_, _, other_wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
@@ -2313,7 +2482,7 @@ mod tests {
             ),
             make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
-        let mut rx = submit_ops(&harness, &actor, items)?;
+        let mut rx = submit_ops(&actor, items)?;
 
         let (_, _, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
         let (_, _, other_wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
@@ -2347,7 +2516,7 @@ mod tests {
             0x1000,
             3 * MAX_RDMA_MSG_SIZE,
         )];
-        let mut rx = submit_ops(&harness, &actor, items)?;
+        let mut rx = submit_ops(&actor, items)?;
 
         let (_, _, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
         assert_eq!(wr_ids, vec![0, 1, 2]);
@@ -2384,7 +2553,7 @@ mod tests {
             0x1000,
             3 * MAX_RDMA_MSG_SIZE,
         )];
-        let mut rx = submit_ops(&harness, &actor, items)?;
+        let mut rx = submit_ops(&actor, items)?;
 
         let (_, _, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
         assert_eq!(wr_ids.len(), 3);
@@ -2430,7 +2599,7 @@ mod tests {
             make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
             make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
-        let mut rx = submit_ops(&harness, &actor, items)?;
+        let mut rx = submit_ops(&actor, items)?;
 
         let (_, _, big_wrs) = expect_put(recv_posted(&mut posted_rx).await);
         let (_, _, small_wrs) = expect_put(recv_posted(&mut posted_rx).await);
@@ -2471,7 +2640,7 @@ mod tests {
         let items = (0..3usize)
             .map(|i| make_op(i, RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096))
             .collect();
-        let mut rx = submit_ops(&harness, &actor, items)?;
+        let mut rx = submit_ops(&actor, items)?;
 
         // Two reads fit the send-queue cap; the third parks.
         let (_, _, r0_wrs) = expect_get(recv_posted(&mut posted_rx).await);
@@ -2502,7 +2671,7 @@ mod tests {
         let items = (0..4usize)
             .map(|i| make_op(i, RdmaOpType::WriteFromLocal, 0x1000 + i * 0x1000, 4096))
             .collect();
-        let mut rx = submit_ops(&harness, &actor, items)?;
+        let mut rx = submit_ops(&actor, items)?;
 
         let (_, _, w0_wrs) = expect_put(recv_posted(&mut posted_rx).await);
         let (_, _, w1_wrs) = expect_put(recv_posted(&mut posted_rx).await);
@@ -2546,7 +2715,7 @@ mod tests {
             make_op(3, RdmaOpType::WriteFromLocal, 0x4000, 4096),
             make_op(4, RdmaOpType::ReadIntoLocal, 0x5000, 2 * MAX_RDMA_MSG_SIZE),
         ];
-        let mut rx = submit_ops(&harness, &actor, items)?;
+        let mut rx = submit_ops(&actor, items)?;
 
         // The first four ops fill all four slots: 1 read WR + 3 write WRs.
         let (_, _, r0_wrs) = expect_get(recv_posted(&mut posted_rx).await);
@@ -2594,7 +2763,7 @@ mod tests {
             make_op(10, RdmaOpType::WriteFromLocal, 0x1000, 4096),
             make_op(11, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
-        let mut rx_a = submit_ops(&harness, &actor, batch_a)?;
+        let mut rx_a = submit_ops(&actor, batch_a)?;
 
         // Batch B: 2 writes with op_idx 20, 21. Shares the QP with
         // Batch A — together they sit at 4/4 max_send_wr.
@@ -2602,7 +2771,7 @@ mod tests {
             make_op(20, RdmaOpType::WriteFromLocal, 0x3000, 4096),
             make_op(21, RdmaOpType::WriteFromLocal, 0x4000, 4096),
         ];
-        let mut rx_b = submit_ops(&harness, &actor, batch_b)?;
+        let mut rx_b = submit_ops(&actor, batch_b)?;
 
         // Collect 4 post events (one per write).
         let mut all_wr_ids = Vec::new();
@@ -2632,7 +2801,7 @@ mod tests {
             make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 2 * MAX_RDMA_MSG_SIZE),
             make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
-        let mut rx = submit_ops(&harness, &actor, items)?;
+        let mut rx = submit_ops(&actor, items)?;
 
         // Only op_idx 1 reaches the wire (op_idx 0 was rejected).
         let (_, _, wrs) = expect_put(recv_posted(&mut posted_rx).await);
@@ -2660,10 +2829,10 @@ mod tests {
 
         qp.queue_post_error("simulated post failure");
         let items = vec![make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
-        let _rx = submit_ops(&harness, &actor, items)?;
+        let _rx = submit_ops(&actor, items)?;
 
-        let event = harness.next_supervision_failure().await;
-        assert_eq!(&event.actor_id, actor.actor_addr());
+        let event = harness.next_supervision_event().await;
+        assert_eq!(&event.actor_id, actor.actor().actor_addr());
         let report = event.failure_report().expect("event should be a failure");
         assert!(
             report.contains("qp.put failed") && report.contains("simulated post failure"),

--- a/monarch_rdma/src/backend/ibverbs/queue_pair/legacy.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair/legacy.rs
@@ -9,6 +9,7 @@
 use super::*;
 use crate::backend::ibverbs::cq_pool::cq_entries_for;
 use crate::backend::ibverbs::primitives::IbvPd;
+use crate::backend::ibverbs::primitives::IbvWc;
 
 /// An RDMA Queue Pair (QP) for communication between two endpoints.
 ///

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -57,18 +57,6 @@ declare_attrs! {
     ))
     pub attr RDMA_TCP_FALLBACK_PARALLELISM: usize = 1;
 
-    /// Cooperative-yield window for the ibverbs CQ poll loop. While
-    /// the policy is within this window it calls
-    /// `tokio::task::yield_now` between polls; past it, polls fall
-    /// into an exponential backoff sleep (1ms initial, x2, capped at
-    /// 10ms). `None` (the default) disables the cutoff entirely:
-    /// the loop only ever yields, never sleeps.
-    @meta(CONFIG = ConfigAttr::new(
-        Some("MONARCH_RDMA_CQ_BUSY_POLL_WINDOW".to_string()),
-        Some("rdma_cq_busy_poll_window".to_string()),
-    ))
-    pub attr RDMA_CQ_BUSY_POLL_WINDOW: Option<Duration> = None;
-
     /// Per-side budget for the `QueuePairInitializer` handshake. The
     /// timer arms once when we send `EnsureQueuePair` and is rearmed
     /// after we hit RTS while still waiting for the peer's

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -132,9 +132,6 @@ declare_attrs! {
     /// (`rdma_qps_per_cq * max_send_wr` entries), so raising this trades
     /// completion-queue memory for fewer completion queues to poll. Opening a
     /// device fails outright if it cannot hold a completion queue that large.
-    ///
-    /// Only 1 is accepted for now: each queue pair polls its own completion
-    /// queue, so sharing one would give it several pollers.
     @meta(CONFIG = ConfigAttr::new(
         Some("MONARCH_RDMA_QPS_PER_CQ".to_string()),
         Some("rdma_qps_per_cq".to_string()),
@@ -142,8 +139,18 @@ declare_attrs! {
     pub attr RDMA_QPS_PER_CQ: NonZeroUsize =
         NonZeroUsize::new(1).expect("1 is non-zero");
 
-    /// Worker-thread count for the shared rdma data-plane runtime, which
-    /// every `QueuePairActor` poll loop runs on.
+    /// Whether each device gets its own completion-queue poller.
+    ///
+    /// When true (the default), the manager spawns one poller per RDMA device.
+    /// When false, one poller serves every device in the process.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_CQ_POLLER_PER_DEVICE".to_string()),
+        Some("rdma_cq_poller_per_device".to_string()),
+    ))
+    pub attr RDMA_CQ_POLLER_PER_DEVICE: bool = true;
+
+    /// Worker-thread count for the shared rdma data-plane runtime, which runs
+    /// each `QueuePairActor`.
     ///
     /// The runtime is built once, lazily, so this value is latched at the
     /// first RDMA use in a process and later changes have no effect.

--- a/monarch_rdma/src/rdma_runtime.rs
+++ b/monarch_rdma/src/rdma_runtime.rs
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! A shared, dedicated Tokio runtime for the RDMA manager actors.
+//! A shared, dedicated Tokio runtime for RDMA actors and data-plane tasks.
 //!
 //! RDMA buffer registration scans `torch.cuda` segments under the GIL
 //! (`backend::ibverbs::mlx_domain` -> `pytorch_cuda_segments`), so the RDMA actor
@@ -17,9 +17,9 @@
 //! - **RR-1 (process-singleton):** one shared rdma runtime exists per process
 //!   (built once, lazily), serving all RDMA actors rather than one per actor.
 //!   Sharing is safe because RDMA keeps no per-thread state that would pin an
-//!   actor to a worker, and the `QueuePairActor`s are cooperative (each re-arms a
-//!   `Tick` and yields rather than busy-polling), so a small worker pool serves
-//!   many without starving.
+//!   actor or queue-pair task to a worker. Queue-pair tasks await tokio channels,
+//!   whose cooperative scheduling prevents a ready task from monopolizing a
+//!   runtime worker.
 //! - **RR-2 (shared-runtime-routing):** the RDMA actors (`RdmaManagerActor`,
 //!   `IbvManagerActor`, `QueuePairActor`) route `spawn_server_task` through
 //!   [`spawn_on_rdma_runtime`], not ad hoc `tokio::spawn`.
@@ -49,10 +49,9 @@ fn rdma_runtime() -> &'static tokio::runtime::Handle {
     RT.get_or_init(|| build_data_plane_runtime("rdma", worker_threads()))
 }
 
-/// Spawn an actor server loop onto the shared rdma runtime and return its
-/// `JoinHandle`. Used as `Actor::spawn_server_task` by the RDMA actors. The
-/// rdma-runtime handle is returned directly: a tokio `JoinHandle` can be awaited
-/// from any runtime, including the caller's.
+/// Spawn an actor server loop or data-plane task onto the shared RDMA runtime
+/// and return its `JoinHandle`. The handle can be awaited from any runtime,
+/// including the caller's.
 ///
 /// Must not be called after `shutdown_data_plane_runtimes` has torn the rdma
 /// runtime down: the cached handle would then point at a dropped runtime and


### PR DESCRIPTION
Summary:

Move each active queue pair’s hot data path from actor mailbox handlers into a dedicated tokio task on the shared RDMA runtime. The supervising `QueuePairActor` retains connection setup, actor lifecycle, and failure propagation, while a new `QueuePairHandle` lets the manager submit `ProcessOps` directly over an unbounded MPSC channel.

The worker owns the QP, credit bookkeeping, pending operations, and completion receiver. Its biased select loop prioritizes cancellation and completions and refills the QP immediately after completions. It only checks the completion channel while work requests are outstanding, so idle CQ teardown does not create a false QP failure.

Actor cleanup cancels and joins the worker. The actor retains a submission sender until cleanup so dropping external handles cannot terminate a healthy worker, and the worker transfers the QP, CQ lease, and in-flight memory keepalives to the CQ poller on every exit. Worker errors and panics are relayed through the supervising actor, while failed per-operation result delivery remains a nonfatal caller cancellation.

The completed 8-host sweep compared 205 post-CQ-actor cells with their configuration-matched pre-CQ-actor baselines. Post-CQ cells used unlimited NICs per buffer, 64 QPs/CQ, the default unset busy-poll window, and both global and per-device poller modes. The pre-CQ benchmark had no poller-topology dimension, so both post-CQ modes compare with the same corresponding baseline cell.

Reported aggregate throughput is conservative: it divides total bytes by the driver-observed span from releasing all initiators until receiving the final actor reply. The span therefore includes control-message delivery, initiator start skew, and reply collection; this is broader than RDMA network RTT. The benchmark records `overhead_ms` as `span - slowest initiator submit duration`.

The measured column below reports the geometric-mean change in aggregate warm-phase throughput. The overhead-subtracted column scales each aggregate result by `span / (span - overhead)` before comparison. It is an optimistic sensitivity estimate, not a formal upper bound: the CSV stores span and overhead as independent medians rather than paired per-iteration values, and the estimate assumes perfect overlap among initiators. Wins count direction-level results where measured post-CQ throughput was higher.

| Machine | Workload | Matched results | Wins | Measured vs. pre-CQ | Overhead-subtracted estimate |
|---|---|---|---|---|---|
| H100 | 64 KiB × 8192 | 128 | 128/128 | +170.8% | +174.7% |
| H100 | 8/16 MiB × 1024 | 74 | 59/74 | +6.8% | +6.8% |
| GB200 | 64 KiB × 8192 | 128 | 128/128 | +156.6% | +189.9% |
| GB200 | 16 MiB × 1024 | 80 | 70/80 | +4.5% | +4.1% |

Reviewed By: zdevito

Differential Revision: D118533142


