### PR TITLE
characterize exec_command execution and cleanup (#4838)

### DIFF
--- a/python/tests/test_accumulator_characterization.py
+++ b/python/tests/test_accumulator_characterization.py
@@ -1,0 +1,316 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import asyncio
+import operator
+import sys
+import unittest.mock
+
+import pytest
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._src.actor import future as future_mod
+from monarch._src.actor.future import Future
+from monarch.actor import Accumulator
+
+
+class _CombineError(Exception):
+    pass
+
+
+class _StreamError(Exception):
+    pass
+
+
+def _future_of(value):
+    """A real, single-use monarch Future resolving to value."""
+
+    async def _v():
+        return value
+
+    return Future._from_coro(_v())
+
+
+def _stream_endpoint(values):
+    """A fake Endpoint whose .stream() yields one real Future per value."""
+    ep = unittest.mock.MagicMock()
+    ep.stream.return_value = iter([_future_of(v) for v in values])
+    return ep
+
+
+def _recording_stream_endpoint(values, events, *, make_future=_future_of):
+    """A fake Endpoint that records stream calls and iterator advancement."""
+    ep = unittest.mock.MagicMock()
+
+    def stream(*args, **kwargs):
+        events.append(("stream", args, kwargs))
+
+        def iterator():
+            for value in values:
+                events.append(("next", value))
+                yield make_future(value)
+
+        return iterator()
+
+    ep.stream.side_effect = stream
+    return ep
+
+
+async def _await_result(future):
+    return await future
+
+
+async def _capture_error(future, error_type):
+    with pytest.raises(error_type) as caught:
+        await future
+    return caught.value
+
+
+def _failing_combine():
+    def combine(total, value):
+        if value == 2:
+            raise _CombineError("combine failed on 2")
+        return total + value
+
+    return unittest.mock.MagicMock(side_effect=combine)
+
+
+def test_accumulate_folds_with_combine():
+    """accumulate reduces the per-rank stream through combine from identity."""
+    acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
+    assert acc.accumulate().get() == 6
+
+
+def test_accumulate_empty_stream_returns_identity():
+    """With no streamed values, accumulate returns the identity seed."""
+    acc = Accumulator(_stream_endpoint([]), 42, operator.add)
+    assert acc.accumulate().get() == 42
+
+
+def test_accumulate_folds_left_to_right():
+    """combine is applied left-to-right over the stream, seeded by identity."""
+    acc = Accumulator(_stream_endpoint([1, 2, 3]), [], lambda a, r: a + [r])
+    assert acc.accumulate().get() == [1, 2, 3]
+
+
+def test_accumulate_forwards_args_to_stream():
+    """accumulate forwards its args/kwargs to endpoint.stream()."""
+    ep = _stream_endpoint([1])
+    Accumulator(ep, 0, operator.add).accumulate("a", k=1).get()
+    ep.stream.assert_called_once_with("a", k=1)
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_invokes_stream_before_any_observation():
+    events = []
+    endpoint = _recording_stream_endpoint([2], events)
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    accumulator = Accumulator(endpoint, 1, combine)
+
+    unobserved = accumulator.accumulate()
+    # The private state check is intentional: the event assertions alone could
+    # race a producer that started eagerly but has not advanced the iterator yet.
+    assert isinstance(unobserved._status, future_mod._Unawaited)
+    assert events == [("stream", (), {})]
+    combine.assert_not_called()
+    del unobserved
+    assert events == [("stream", (), {})]
+    combine.assert_not_called()
+
+    assert accumulator.accumulate().get() == 3
+    assert events == [
+        ("stream", (), {}),
+        ("stream", (), {}),
+        ("next", 2),
+    ]
+    combine.assert_called_once_with(1, 2)
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_short_circuits_and_propagates_combine_error():
+    events = []
+    combine = _failing_combine()
+    endpoint = _recording_stream_endpoint([1, 2, 3], events)
+    result = Accumulator(endpoint, 0, combine).accumulate()
+
+    with pytest.raises(_CombineError) as caught:
+        result.get()
+
+    assert type(caught.value) is _CombineError
+    assert str(caught.value) == "combine failed on 2"
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+    ]
+    assert events == [
+        ("stream", (), {}),
+        ("next", 1),
+        ("next", 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_short_circuits_and_propagates_stream_error():
+    events = []
+
+    def make_future(value):
+        if value != 2:
+            return _future_of(value)
+
+        async def fail():
+            raise _StreamError("stream failed on 2")
+
+        return Future._from_coro(fail())
+
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    endpoint = _recording_stream_endpoint([1, 2, 3], events, make_future=make_future)
+    result = Accumulator(endpoint, 0, combine).accumulate()
+
+    with pytest.raises(_StreamError) as first:
+        result.get()
+    second = asyncio.run(_capture_error(result, _StreamError))
+
+    assert type(first.value) is _StreamError
+    assert type(second) is _StreamError
+    assert str(first.value) == "stream failed on 2"
+    assert str(second) == "stream failed on 2"
+    assert second is first.value
+    assert combine.call_args_list == [unittest.mock.call(0, 1)]
+    assert events == [
+        ("stream", (), {}),
+        ("next", 1),
+        ("next", 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_get_then_await_does_not_rerun_combine():
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    assert result.get() == 6
+    assert asyncio.run(_await_result(result)) == 6
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+        unittest.mock.call(3, 3),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_await_then_get_does_not_rerun_combine():
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    assert asyncio.run(_await_result(result)) == 6
+    assert result.get() == 6
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+        unittest.mock.call(3, 3),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_replays_combine_error_get_then_await():
+    combine = _failing_combine()
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    with pytest.raises(_CombineError) as first:
+        result.get()
+    second = asyncio.run(_capture_error(result, _CombineError))
+
+    assert type(first.value) is _CombineError
+    assert type(second) is _CombineError
+    assert str(first.value) == "combine failed on 2"
+    assert str(second) == "combine failed on 2"
+    assert second is first.value
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_replays_combine_error_await_then_get():
+    combine = _failing_combine()
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    first = asyncio.run(_capture_error(result, _CombineError))
+    with pytest.raises(_CombineError) as second:
+        result.get()
+
+    assert type(first) is _CombineError
+    assert type(second.value) is _CombineError
+    assert str(first) == "combine failed on 2"
+    assert str(second.value) == "combine failed on 2"
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_post_start_abandonment_completes_fold_once():
+    gate = {"entered": False, "released": False, "completed": False}
+
+    async def gated_value():
+        gate["entered"] = True
+        while not gate["released"]:
+            await PythonTask.sleep(0.005)
+        gate["completed"] = True
+        return 2
+
+    endpoint = unittest.mock.MagicMock()
+    endpoint.stream.return_value = iter([Future._from_coro(gated_value())])
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(endpoint, 1, combine).accumulate()
+
+    async def cancel_after_start():
+        observer = result.as_asyncio()
+
+        async def wait_for_entry():
+            while not gate["entered"]:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(wait_for_entry(), timeout=5)
+        assert not gate["completed"]
+        assert observer.cancel()
+        # asyncio.Future.cancel() changes the state synchronously; callbacks run
+        # on a later loop turn, but cancelled() is true when cancel() returns true.
+        assert observer.cancelled()
+        gate["released"] = True
+        return await asyncio.wait_for(result.as_asyncio(), timeout=5)
+
+    try:
+        observed = asyncio.run(cancel_after_start())
+    finally:
+        original_error = sys.exc_info()[1]
+        gate["released"] = True
+        try:
+            drained = result.get(timeout=5)
+        except Exception as cleanup_error:
+            if original_error is None:
+                raise
+            # BaseException.add_note() is unavailable on the Python 3.10 OSS
+            # test lane. The original failure still takes precedence there.
+            if hasattr(original_error, "add_note"):
+                original_error.add_note(f"cleanup also failed: {cleanup_error!r}")
+
+    assert observed == 3
+    assert drained == 3
+    assert gate["completed"]
+    combine.assert_called_once_with(1, 2)
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_empty_stream_makes_no_combine_call():
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(_stream_endpoint([]), 42, combine).accumulate()
+
+    assert result.get() == 42
+    combine.assert_not_called()

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import asyncio
 import contextlib
 import os
 import pickle
@@ -26,6 +27,7 @@ import monarch._src.job._job_sidecar_worker as js_worker
 import monarch._src.job.job_sidecar as js
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.proc import ProcId, Uid
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 
 # Import directly from _src since job module isn't properly exposed
 from monarch._src.job.job import (
@@ -1930,3 +1932,324 @@ def test_exec_command_output_dir_suppresses_printing(capsys):
     )
     exec_command(host_mesh, ["echo", "hi"], output_dir="/tmp/out").get()
     assert "SHOULD_NOT_PRINT" not in capsys.readouterr().out
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_spawns_no_procs_before_observation():
+    """Discarding an unobserved command does not enter its deferred body."""
+    host_mesh, procs, bash_actors, markers = _exec_env()
+    selected = MagicMock()
+    selected.spawn_procs.return_value = procs
+    host_mesh.slice.return_value = selected
+    bash_actors.run.call.return_value = _results_future(
+        [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
+    )
+
+    discarded = exec_command(host_mesh, ["echo", "hi"], point={"gpu": 2})
+    del discarded
+
+    host_mesh.slice.assert_not_called()
+    host_mesh.spawn_procs.assert_not_called()
+    selected.spawn_procs.assert_not_called()
+    procs.spawn.assert_not_called()
+    bash_actors.run.call.assert_not_called()
+    procs.stop.assert_not_called()
+    assert not markers["stop_driven"]
+
+    assert exec_command(host_mesh, ["echo", "hi"], point={"gpu": 2}).get() == 0
+    host_mesh.slice.assert_called_once_with(gpu=2)
+    host_mesh.spawn_procs.assert_not_called()
+    selected.spawn_procs.assert_called_once_with(per_host=None)
+    procs.spawn.assert_called_once()
+    bash_actors.run.call.assert_called_once()
+    procs.stop.assert_called_once()
+    assert markers["stop_driven"]
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_repeated_get_spawns_and_cleans_up_once():
+    """Repeated blocking observation replays one command result."""
+    host_mesh, procs, bash_actors, markers = _exec_env()
+    bash_actors.run.call.return_value = _results_future(
+        [("rank0", {"returncode": 4, "stdout": "", "stderr": ""})]
+    )
+
+    result = exec_command(host_mesh, ["exit", "4"])
+    assert result.get() == 4
+    assert result.get() == 4
+
+    host_mesh.spawn_procs.assert_called_once_with(per_host=None)
+    bash_actors.run.call.assert_called_once()
+    procs.stop.assert_called_once()
+    assert markers["stop_driven"]
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_reobserved_asyncio_shares_one_run():
+    """Repeated asyncio observation shares the running command producer."""
+    gate = {"entries": 0, "released": False, "completed": False}
+
+    async def gated_results():
+        gate["entries"] += 1
+        while not gate["released"]:
+            await PythonTask.sleep(0.005)
+        gate["completed"] = True
+        return [("rank0", {"returncode": 5, "stdout": "", "stderr": ""})]
+
+    host_mesh, procs, bash_actors, markers = _exec_env()
+    bash_actors.run.call.return_value = Future._from_coro(gated_results())
+    result = exec_command(host_mesh, ["exit", "5"])
+
+    async def observe_twice():
+        first = result.as_asyncio()
+        second = result.as_asyncio()
+
+        async def wait_for_entry():
+            while gate["entries"] == 0:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(wait_for_entry(), timeout=2)
+        assert not first.done()
+        assert not second.done()
+        gate["released"] = True
+        return await asyncio.wait_for(asyncio.gather(first, second), timeout=2)
+
+    try:
+        observed = asyncio.run(observe_twice())
+    finally:
+        original_error = sys.exc_info()[1]
+        gate["released"] = True
+        try:
+            drained = result.get(timeout=2)
+        except BaseException as cleanup_error:
+            if original_error is None:
+                raise
+            original_error.add_note(f"cleanup also failed: {cleanup_error!r}")
+
+    assert observed == [5, 5]
+    assert drained == 5
+    assert gate == {"entries": 1, "released": True, "completed": True}
+    host_mesh.spawn_procs.assert_called_once_with(per_host=None)
+    bash_actors.run.call.assert_called_once()
+    procs.stop.assert_called_once()
+    assert markers["stop_driven"]
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_dispatches_to_run_python_for_dash_m():
+    """A -m command routes to run_python.call, not run.call."""
+    host_mesh, _procs, bash_actors, _markers = _exec_env()
+    bash_actors.run_python.call.return_value = _results_future(
+        [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
+    )
+
+    exec_command(host_mesh, ["-m", "pkg.mod"]).get()
+
+    bash_actors.run_python.call.assert_called_once()
+    bash_actors.run.call.assert_not_called()
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_forwards_env_workdir_per_host_and_output_dir(capsys):
+    """exec_command forwards process and Python-command configuration."""
+    host_mesh, _procs, bash_actors, _markers = _exec_env()
+    bash_actors.run_python.call.return_value = _results_future(
+        [
+            (
+                "rank0",
+                {
+                    "returncode": 0,
+                    "stdout": "REDIRECTED_STDOUT",
+                    "stderr": "REDIRECTED_STDERR",
+                },
+            )
+        ]
+    )
+    env = {"MODE": "test"}
+    per_host = {"gpu": 2}
+
+    assert (
+        exec_command(
+            host_mesh,
+            ["-m", "pkg.mod"],
+            env=env,
+            workdir="/work",
+            output_dir="/logs",
+            per_host=per_host,
+        ).get()
+        == 0
+    )
+
+    host_mesh.spawn_procs.assert_called_once_with(per_host=per_host)
+    bash_actors.run_python.call.assert_called_once_with(
+        ["-m", "pkg.mod"],
+        env=env,
+        workdir="/work",
+        client_cwd=os.getcwd(),
+        output_dir="/logs",
+    )
+    captured = capsys.readouterr()
+    captured_output = captured.out + captured.err
+    assert "REDIRECTED_STDOUT" not in captured_output
+    assert "REDIRECTED_STDERR" not in captured_output
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_drives_cleanup_on_base_exception():
+    """A BaseException raised while awaiting the command still drives cleanup."""
+
+    class _CommandAbort(BaseException):
+        pass
+
+    async def fail_command():
+        raise _CommandAbort("command aborted")
+
+    host_mesh, procs, bash_actors, markers = _exec_env()
+    bash_actors.run.call.return_value = Future._from_coro(fail_command())
+
+    with pytest.raises(_CommandAbort) as raised:
+        exec_command(host_mesh, ["echo", "hi"]).get()
+
+    assert type(raised.value) is _CommandAbort
+    assert str(raised.value) == "command aborted"
+    procs.stop.assert_called_once()
+    assert markers["stop_driven"]
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_cleanup_failure_supersedes_command_failure():
+    """An awaited cleanup failure surfaces with the command failure as context."""
+
+    class _CommandError(Exception):
+        pass
+
+    class _CleanupError(Exception):
+        pass
+
+    command_error = _CommandError("command failed")
+    cleanup_error = _CleanupError("cleanup failed")
+    cleanup_calls = 0
+
+    async def fail_command():
+        raise command_error
+
+    async def fail_cleanup():
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        raise cleanup_error
+
+    bash_actors = MagicMock()
+    procs = MagicMock()
+    procs.spawn.return_value = bash_actors
+    host_mesh = MagicMock()
+    host_mesh.spawn_procs.return_value = procs
+    bash_actors.run.call.return_value = Future._from_coro(fail_command())
+    procs.stop.return_value = Future._from_coro(fail_cleanup())
+    result = exec_command(host_mesh, ["echo", "hi"])
+
+    for _ in range(2):
+        with pytest.raises(_CleanupError) as raised:
+            result.get()
+        assert raised.value is cleanup_error
+        assert raised.value.__context__ is command_error
+
+    procs.stop.assert_called_once()
+    assert cleanup_calls == 1
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_observer_cancellation_still_cleans_up():
+    """Cancelling one observer does not abort a command that already started."""
+    state = {
+        "command_entries": 0,
+        "command_released": False,
+        "command_completions": 0,
+        "cleanup_entries": 0,
+        "cleanup_released": False,
+        "cleanup_completions": 0,
+    }
+
+    async def gated_command():
+        state["command_entries"] += 1
+        while not state["command_released"]:
+            await PythonTask.sleep(0.005)
+        state["command_completions"] += 1
+        return [("rank0", {"returncode": 6, "stdout": "", "stderr": ""})]
+
+    async def gated_cleanup():
+        state["cleanup_entries"] += 1
+        while not state["cleanup_released"]:
+            await PythonTask.sleep(0.005)
+        state["cleanup_completions"] += 1
+
+    bash_actors = MagicMock()
+    procs = MagicMock()
+    procs.spawn.return_value = bash_actors
+    procs.stop.return_value = Future._from_coro(gated_cleanup())
+    host_mesh = MagicMock()
+    host_mesh.spawn_procs.return_value = procs
+    bash_actors.run.call.return_value = Future._from_coro(gated_command())
+    result = exec_command(host_mesh, ["exit", "6"])
+
+    async def cancel_after_start():
+        # Observation starts the outer producer; without this first step the
+        # command cannot reach the gate and the entry wait would deadlock.
+        observer = result.as_asyncio()
+
+        async def wait_for_command_entry():
+            while state["command_entries"] == 0:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(wait_for_command_entry(), timeout=2)
+        assert state["command_entries"] == 1
+        assert state["command_completions"] == 0
+        assert observer.cancel()
+        assert observer.cancelled()
+        state["command_released"] = True
+
+        retained_observer = result.as_asyncio()
+
+        async def wait_for_cleanup_entry():
+            while state["cleanup_entries"] == 0:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(wait_for_cleanup_entry(), timeout=2)
+        assert state["command_completions"] == 1
+        assert state["cleanup_entries"] == 1
+        assert state["cleanup_completions"] == 0
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                asyncio.shield(retained_observer),
+                timeout=0.05,
+            )
+        assert not retained_observer.done()
+        assert state["cleanup_completions"] == 0
+        state["cleanup_released"] = True
+        return await asyncio.wait_for(retained_observer, timeout=2)
+
+    try:
+        observed = asyncio.run(cancel_after_start())
+    finally:
+        original_error = sys.exc_info()[1]
+        state["command_released"] = True
+        state["cleanup_released"] = True
+        try:
+            drained = result.get(timeout=2)
+        except BaseException as cleanup_error:
+            if original_error is None:
+                raise
+            original_error.add_note(f"cleanup also failed: {cleanup_error!r}")
+
+    assert observed == 6
+    assert drained == 6
+    assert state == {
+        "command_entries": 1,
+        "command_released": True,
+        "command_completions": 1,
+        "cleanup_entries": 1,
+        "cleanup_released": True,
+        "cleanup_completions": 1,
+    }
+    host_mesh.spawn_procs.assert_called_once_with(per_host=None)
+    bash_actors.run.call.assert_called_once()
+    procs.stop.assert_called_once()

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -241,6 +241,10 @@ class SyncActor(Actor):
     def sync_endpoint(self, a_counter: Counter):
         return a_counter.value.choose().get()
 
+    @endpoint
+    def accumulate_sync_endpoint(self, a_counter: Counter) -> int:
+        return Accumulator(a_counter.value, 0, operator.add).accumulate().get()
+
 
 @pytest.mark.timeout(60)
 async def test_sync_actor():
@@ -250,6 +254,17 @@ async def test_sync_actor():
     r = await a.sync_endpoint.choose(c)
     assert r == 5
     await proc.stop()
+
+
+@pytest.mark.timeout(60)
+async def test_accumulate_get_works_inside_sync_endpoint() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
+    try:
+        actor = proc.spawn("accumulator_sync_actor", SyncActor)
+        counter = proc.spawn("accumulator_counter", Counter, 3)
+        assert await actor.accumulate_sync_endpoint.choose(counter) == 6
+    finally:
+        await proc.stop()
 
 
 @pytest.mark.timeout(60)
@@ -2232,47 +2247,3 @@ async def test_del_runs_on_proc_mesh_stop() -> None:
             f"file {marker_path} should have contents 'finalized' if the finalizers were run"
         )
     os.unlink(marker_path)
-
-
-# ── Accumulator.accumulate characterization tests ──────────────────────────
-
-
-def _future_of(value):
-    """A real, single-use monarch Future resolving to value."""
-
-    async def _v():
-        return value
-
-    return Future._from_coro(_v())
-
-
-def _stream_endpoint(values):
-    """A fake Endpoint whose .stream() yields one real Future per value."""
-    ep = unittest.mock.MagicMock()
-    ep.stream.return_value = iter([_future_of(v) for v in values])
-    return ep
-
-
-def test_accumulate_folds_with_combine():
-    """accumulate reduces the per-rank stream through combine from identity."""
-    acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
-    assert acc.accumulate().get() == 6
-
-
-def test_accumulate_empty_stream_returns_identity():
-    """With no streamed values, accumulate returns the identity seed."""
-    acc = Accumulator(_stream_endpoint([]), 42, operator.add)
-    assert acc.accumulate().get() == 42
-
-
-def test_accumulate_folds_left_to_right():
-    """combine is applied left-to-right over the stream, seeded by identity."""
-    acc = Accumulator(_stream_endpoint([1, 2, 3]), [], lambda a, r: a + [r])
-    assert acc.accumulate().get() == [1, 2, 3]
-
-
-def test_accumulate_forwards_args_to_stream():
-    """accumulate forwards its args/kwargs to endpoint.stream()."""
-    ep = _stream_endpoint([1])
-    Accumulator(ep, 0, operator.add).accumulate("a", k=1).get()
-    ep.stream.assert_called_once_with("a", k=1)

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -356,7 +356,7 @@ shared_reconstruction = 2
 reserve_binding = 1
 py_mesh_reserve = 2
 py_is_tokio_thread = 3
-pytokio_import = 32
+pytokio_import = 33
 pytokio_module_ref = 17
 helper_symbol = 26
 helper_definition = 6
@@ -779,6 +779,7 @@ owns = [
   "im.test_client_context_guard.module",
   "im.test_future_characterization.module",
   "im.test_host_mesh.module",
+  "im.test_job.module",
   "im.test_hyperactor.module",
   "im.test_logging_initialization_characterization.module",
   "im.test_logging.module",
@@ -1323,16 +1324,34 @@ public_operation = "job.exec_command(...)"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code"
-driver = "awaited or blocked on by the caller"
-start_point = "lazy; no proc is spawned until the Future is observed"
-abandonment = "possible; dropping prevents the spawn and therefore the finally-block cleanup"
-eager_effect = "starts a side effect"
-drop_behavior = "nothing runs, and no cleanup is owed"
-first_side_effect = "the proc spawn"
-unobserved_error = "silently dropped"
+driver = "Future refusal and warning checks run before work starts; a first no-timeout get() drives inline, while a successful first await/as_asyncio observation or a first get() with a valid timeout starts a non-aborting Handle producer that continues independently; result() and exception() delegate to get()"
+start_point = "Tested: mesh selection, spawn_procs, the BashActor spawn, and command dispatch wait for observation. Source-grounded: Future._from_coro calls PythonTask.from_coroutine during construction, synchronously capturing the Monarch context and potentially bootstrapping a fresh client before returning the Future"
+abandonment = "Never observed: _impl never runs, no proc spawns, and no cleanup is owed, but dropping cannot undo the construction-time context capture. After asyncio observation starts the producer, cancelling that observer does not abort it; the command completes and the finally block drives procs.stop()"
+eager_effect = "an eager Handle would make _impl eligible to run independently before observation; it would not guarantee that mesh selection, proc spawn, BashActor spawn, and command dispatch all execute synchronously inside exec_command()"
+drop_behavior = "Before observation, dropping the Future leaves _impl unrun and no cleanup owed after the already-completed context capture. After Handle-backed observation starts, dropping or cancelling that observer does not abort the producer or its cleanup. Mesh selection and spawn_procs are outside the try, so cleanup is owed only after spawn_procs returns procs. Once reached, the command and cleanup Futures are spent one-shot by ot.job.exec_command._impl[bash_actors.run.callscript, output_dir=output_dir._take_inner], ot.job.exec_command._impl[bash_actors.run_python.callcmd, env=env, workdir=workdir, client_cwd=client_cwd, output_dir=output_dir._take_inner], and ot.job.exec_command._impl[procs.stop._take_inner]"
+first_side_effect = "source-grounded: synchronous construction-time context capture is the first effect; tested: proc spawn is the first worker-visible effect and waits for observation"
+unobserved_error = "A synchronous construction or context failure raises before any Future exists. A never-driven _impl produces no error. Tested: an ordinary cleanup Exception that supersedes an awaited command Exception is replayed on a second observation with procs.stop() still called once. Source-grounded: after Handle-backed start, cancelling one asyncio observer does not abort an ordinary failure; another observer of the live outer Future can still receive it, while the cancelled observer receives nothing. A get-first BaseException is not cached: cleanup runs, but the consumed task leaves the outer Future poisoned for a second observation, as pinned by fbcode//monarch/python/tests:test_future_characterization::test_fm_terminal_baseexception_current_poisons_the_future"
 disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "job.exec_command operation-root behavior (6.0c item 6)"
+oracle = [
+  "fbcode//monarch/python/tests:test_job::test_exec_command_returns_max_returncode",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_drives_cleanup_on_success",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_drives_cleanup_on_error",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_dispatches_to_run_python_for_py_scripts",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_dispatches_to_run_for_shell_commands",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_slices_by_point",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_slices_by_rank",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_prints_output_when_no_output_dir",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_output_dir_suppresses_printing",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_spawns_no_procs_before_observation",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_repeated_get_spawns_and_cleans_up_once",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_reobserved_asyncio_shares_one_run",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_dispatches_to_run_python_for_dash_m",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_forwards_env_workdir_per_host_and_output_dir",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_drives_cleanup_on_base_exception",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_cleanup_failure_supersedes_command_failure",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_observer_cancellation_still_cleans_up",
+]
 
 [[site]]
 id = "fc.rdma.RDMAAction.submit[Future._from_coroself._inner.submitclient=client, timeout=timeout, rdma_manager_init=ready]"
@@ -3151,6 +3170,18 @@ scope = "test"
 state = "legacy"
 transition = "6.8"
 members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.test_job.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_job.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
 
 [[site]]
 id = "im.test_logging_initialization_characterization.module"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -356,7 +356,7 @@ shared_reconstruction = 2
 reserve_binding = 1
 py_mesh_reserve = 2
 py_is_tokio_thread = 3
-pytokio_import = 31
+pytokio_import = 32
 pytokio_module_ref = 17
 helper_symbol = 26
 helper_definition = 6
@@ -775,6 +775,7 @@ owns = [
   "im.test_actor_driver_characterization.module",
   "im.test_admin_spawn_characterization.module",
   "im.test_actor_mesh.module",
+  "im.test_accumulator_characterization.module",
   "im.test_client_context_guard.module",
   "im.test_future_characterization.module",
   "im.test_host_mesh.module",
@@ -969,16 +970,30 @@ public_operation = "Accumulator.accumulate(...)"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code"
-driver = "awaited or blocked on by the caller"
-start_point = "the endpoint stream is dispatched when accumulate() is called; combine runs only on observation"
-abandonment = "possible; the stream was already dispatched, so dropping abandons its replies"
-eager_effect = "observes already-running work"
-drop_behavior = "the combine never runs and the dispatched replies are never collected"
-first_side_effect = "endpoint stream dispatch at call time"
-unobserved_error = "silently dropped"
+driver = "after the shared Future refusal and warning checks, a first no-timeout get() drives the fold inline; a successful first await/as_asyncio() observation or first get() with a valid timeout starts a non-aborting Handle producer that continues independently; result() and exception() delegate to get()"
+start_point = "accumulate() calls endpoint.stream() before constructing the returned Future, but iteration, _take_inner(), and combine begin only when that Future is driven. Source-grounded for ActorEndpoint: stream() opens the response port and submits the cast path before returning PyValueStream; AsyncActorMesh queues resolve-and-cast for later, while a bare PythonActorMeshImpl resolves and casts synchronously"
+abandonment = "dropping a never-observed Future abandons the fold before iteration, _take_inner(), or combine, after endpoint.stream() has already run. After asyncio observation starts the non-aborting Handle producer, cancelling that observer does not stop the fold and a later observer receives the shared result"
+eager_effect = "would start the fold when the replacement Handle is created, allowing iterator advancement, streamed-result waits, and combine to begin before any caller observation; today accumulate() stops after endpoint.stream() returns, whether its mesh queued the cast or completed it synchronously"
+drop_behavior = "before observation, dropping the Future does not advance the iterator or run combine; after asyncio observation starts, observer cancellation does not stop the fold. Every streamed Future already reached by the fold is spent by _take_inner()"
+first_side_effect = "calls endpoint.stream() during accumulate(); ActorEndpoint opens a response port and submits the mesh-dependent cast path before returning"
+unobserved_error = "source-grounded: synchronous endpoint.stream() construction or submission errors raise directly from accumulate(), while remote execution and replies may proceed after the call. A never-driven fold cannot materialize or observe a streamed-result error and never invokes combine. Once driven, an ordinary Exception from either a streamed Future or combine short-circuits and later observers receive the same type and message; the get-first BaseException poisoning case is characterized separately by fbcode//monarch/python/tests:test_future_characterization::test_fm_terminal_baseexception_current_poisons_the_future"
 disposition = "require a binding-specific design"
 semantic_class = "already_started_lazy_observer"
-oracle = "Accumulator exact-once and error behavior (6.0c item 5)"
+oracle = [
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_folds_with_combine",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_empty_stream_returns_identity",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_folds_left_to_right",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_invokes_stream_before_any_observation",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_short_circuits_and_propagates_combine_error",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_short_circuits_and_propagates_stream_error",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_get_then_await_does_not_rerun_combine",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_await_then_get_does_not_rerun_combine",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_replays_combine_error_get_then_await",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_replays_combine_error_await_then_get",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_post_start_abandonment_completes_fold_once",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_empty_stream_makes_no_combine_call",
+  "fbcode//monarch/python/tests:test_python_actors::test_accumulate_get_works_inside_sync_endpoint",
+]
 
 [[site]]
 id = "fc.actor_mesh.ActorMesh._name[Future._from_coroself._inner.name]"
@@ -3016,6 +3031,18 @@ scope = "production"
 state = "legacy"
 transition = "6.2"
 members = ["Handle"]
+
+[[site]]
+id = "im.test_accumulator_characterization.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_accumulator_characterization.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
 
 [[site]]
 id = "im.test_actor_mesh.module"


### PR DESCRIPTION
Summary:

`exec_command()` returns a `Future` for running a command across a Monarch host mesh. creating that `Future` captures the caller's Monarch context, but worker selection, process creation, and command dispatch do not begin until someone calls `get()` or awaits it.

this adds tests showing that discarding an unobserved `Future` launches no workers. repeated blocking reads and concurrent asyncio observers share one command execution and one cleanup. after execution starts, cancelling one observer does not cancel the command; another observer receives the result only after process cleanup finishes.

the tests also cover Python `-m` dispatch, environment and working-directory forwarding, per-host process configuration, output redirection, cleanup after `BaseException`, and command-versus-cleanup failure precedence. the census links this behavior to the exact tests and records construction-time context capture separately from deferred worker work.

this changes tests, their timeout dependency, and migration metadata only. no production behavior changes.

Differential Revision: D119329281


