### PR TITLE
use tree ancestry for actor actions

### DIFF
--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -613,17 +613,14 @@ impl App {
     /// current cursor position.
     ///
     /// - Proc selected → proc's own reference.
-    /// - Actor selected → owning proc from `detail.parent`.
+    /// - Actor selected → owning proc from visible-tree ancestry.
     /// - Root/Host selected → `None` (PY-4).
     pub(crate) fn pyspy_proc_ref(&self) -> Option<hyperactor::ProcAddr> {
         let rows = self.visible_rows();
         let row = rows.get(&self.cursor)?;
         match (&row.node.node_type, &row.node.reference) {
             (NodeType::Proc, NodeRef::Proc(proc_id)) => Some(proc_id.clone()),
-            (NodeType::Actor, _) => self.detail.as_ref().and_then(|p| match &p.parent {
-                Some(NodeRef::Proc(proc_id)) => Some(proc_id.clone()),
-                _ => None,
-            }),
+            (NodeType::Actor, _) => row.owning_proc.cloned(),
             _ => None,
         }
     }

--- a/hyperactor_mesh_admin_tui/src/lib.rs
+++ b/hyperactor_mesh_admin_tui/src/lib.rs
@@ -119,7 +119,8 @@
 //!   arrival.
 //! - **PY-4 (selection-totality):** `p` is a no-op on Root/Host;
 //!   targets the proc ref directly on Proc; targets the owning proc
-//!   via `detail.parent` on Actor.
+//!   from visible-tree ancestry on Actor, independently of detail
+//!   loading.
 //! - **PY-5 (overlay-isolation):** Diagnostics and py-spy overlays
 //!   must not write into each other's display surface. Enforced by
 //!   `set_job`: `RunDiagnostics` calls `set_job` with the
@@ -148,8 +149,8 @@
 //!   arrival.
 //! - **CFG-4 (selection-totality):** `C` targets the proc ref directly
 //!   on Proc (worker or service); targets the owning proc via
-//!   `detail.parent` on Actor; no-op on Root/Host. Backend routes to
-//!   ProcAgent or HostAgent per proc type (same as PY-4).
+//!   visible-tree ancestry on Actor; no-op on Root/Host. Backend
+//!   routes to ProcAgent or HostAgent per proc type (same as PY-4).
 //! - **CFG-5 (overlay-isolation):** Config, Diagnostics, and PySpy
 //!   overlays must not write into each other's display surface.
 //!   Enforced by `set_job`: each variant drops any prior receiver;

--- a/hyperactor_mesh_admin_tui/src/model.rs
+++ b/hyperactor_mesh_admin_tui/src/model.rs
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use hyperactor::ProcAddr;
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
 use hyperactor_mesh::introspect::NodeRef;
@@ -288,6 +289,8 @@ pub(crate) struct FlatRow<'a> {
     pub(crate) node: &'a TreeNode,
     /// Visual indentation level for this row.
     pub(crate) depth: usize,
+    /// Owning process for a proc or actor occurrence in this tree.
+    pub(crate) owning_proc: Option<&'a ProcAddr>,
 }
 
 /// Wrapper for flattened visible rows with cursor helpers.

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -53,8 +53,11 @@ fn host(name: &str) -> NodeRef {
 }
 
 fn proc_ref(name: &str) -> NodeRef {
-    let proc_id = hyperactor_mesh::mesh_id::ResourceId::proc_addr_from_name(test_addr(), name);
-    NodeRef::Proc(proc_id)
+    NodeRef::Proc(proc_addr(name))
+}
+
+fn proc_addr(name: &str) -> hyperactor::ProcAddr {
+    hyperactor_mesh::mesh_id::ResourceId::proc_addr_from_name(test_addr(), name)
 }
 
 fn actor(name: &str) -> NodeRef {
@@ -1541,6 +1544,14 @@ fn actor_node(reference: &str) -> TreeNode {
     }
 }
 
+fn expanded_proc_with_actor(proc_name: &str, actor_name: &str) -> TreeNode {
+    let mut proc = proc_node(proc_name);
+    proc.expanded = true;
+    proc.has_children = true;
+    proc.children.push(actor_node(actor_name));
+    proc
+}
+
 // PY-4: Proc selected → own reference returned.
 #[test]
 fn pyspy_proc_ref_proc_node() {
@@ -1548,32 +1559,11 @@ fn pyspy_proc_ref_proc_node() {
     assert!(app.pyspy_proc_ref().is_some());
 }
 
-// PY-4: Actor selected with detail.parent → owning proc returned.
+// PY-4: Actor selected → owning proc comes from visible-tree ancestry.
 #[test]
-fn pyspy_proc_ref_actor_node_with_parent() {
-    let mut app = make_app_with_cursor(vec![actor_node("actor1")], 0);
-    app.detail = Some(NodePayload {
-        identity: actor("actor1"),
-        properties: NodeProperties::Actor {
-            actor_status: "running".into(),
-            actor_type: "TestActor".into(),
-            instance_id: String::new(),
-            messages_processed: 0,
-            created_at: Some(SystemTime::UNIX_EPOCH),
-            last_message_handler: None,
-            total_processing_time_us: 0,
-            queue_depth: 0,
-            flight_recorder: None,
-            is_system: false,
-            inbound_ordering: None,
-            failure_info: None,
-            execution: None,
-        },
-        children: vec![],
-        parent: Some(proc_ref("worker")),
-        as_of: SystemTime::now(),
-    });
-    assert!(app.pyspy_proc_ref().is_some());
+fn pyspy_proc_ref_actor_uses_visible_proc_ancestor() {
+    let app = make_app_with_cursor(vec![expanded_proc_with_actor("worker", "actor1")], 1);
+    assert_eq!(app.pyspy_proc_ref(), Some(proc_addr("worker")));
 }
 
 // PY-4: Root node selected → None.
@@ -1618,11 +1608,22 @@ fn pyspy_proc_ref_host_node() {
     assert_eq!(app.pyspy_proc_ref(), None);
 }
 
-// PY-4: Actor selected with detail=None → None (no panic).
+// PY-4: Actor without a proc ancestor → None (no panic).
 #[test]
-fn pyspy_proc_ref_actor_no_detail() {
+fn pyspy_proc_ref_actor_without_proc_ancestor() {
     let app = make_app_with_cursor(vec![actor_node("actor1")], 0);
     assert_eq!(app.pyspy_proc_ref(), None);
+}
+
+// PY-4: `p` on an actor does not depend on the detail payload.
+#[test]
+fn on_key_pyspy_on_actor_without_detail() {
+    let mut app = make_app_with_cursor(vec![expanded_proc_with_actor("worker", "actor1")], 1);
+    let key = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE);
+    match app.on_key(key) {
+        KeyResult::RunPySpy(actual) => assert_eq!(actual, proc_addr("worker")),
+        other => panic!("p on an actor should target its owning proc, got: {other:?}"),
+    }
 }
 
 // PY-5: parse_error_envelope renders ApiErrorEnvelope body so py-spy
@@ -2431,6 +2432,17 @@ fn on_key_config_on_proc() {
         matches!(result, KeyResult::RunConfig(_)),
         "C on Proc should dispatch RunConfig, got: {result:?}"
     );
+}
+
+// CFG-4: `C` on an actor does not depend on the detail payload.
+#[test]
+fn on_key_config_on_actor_without_detail() {
+    let mut app = make_app_with_cursor(vec![expanded_proc_with_actor("worker", "actor1")], 1);
+    let key = KeyEvent::new(KeyCode::Char('C'), KeyModifiers::SHIFT);
+    match app.on_key(key) {
+        KeyResult::RunConfig(actual) => assert_eq!(actual, proc_addr("worker")),
+        other => panic!("C on an actor should target its owning proc, got: {other:?}"),
+    }
 }
 
 // CFG-4: 'C' on a Root node is a no-op.

--- a/hyperactor_mesh_admin_tui/src/tree.rs
+++ b/hyperactor_mesh_admin_tui/src/tree.rs
@@ -39,15 +39,32 @@ pub(crate) fn flatten_tree(root: &TreeNode) -> Vec<FlatRow<'_>> {
 /// Includes current node and recursively includes children only if
 /// current node is expanded.
 pub(crate) fn flatten_visible<'a>(node: &'a TreeNode, depth: usize) -> Vec<FlatRow<'a>> {
-    fold_tree_with_depth(node, depth, &|n, d, child_results| {
-        let mut rows = vec![FlatRow { node: n, depth: d }];
-        if n.expanded {
-            for child_rows in child_results {
-                rows.extend(child_rows);
+    fold_tree_with_depth(
+        node,
+        depth,
+        &|n, d, child_results: Vec<Vec<FlatRow<'a>>>| {
+            let owning_proc = match &n.reference {
+                NodeRef::Proc(proc_id) => Some(proc_id),
+                _ => None,
+            };
+            let mut rows = vec![FlatRow {
+                node: n,
+                depth: d,
+                owning_proc,
+            }];
+            if n.expanded {
+                for child_rows in child_results {
+                    rows.extend(child_rows.into_iter().map(|mut row| {
+                        if row.owning_proc.is_none() {
+                            row.owning_proc = owning_proc;
+                        }
+                        row
+                    }));
+                }
             }
-        }
-        rows
-    })
+            rows
+        },
+    )
 }
 
 /// Generic tree fold - unified traversal abstraction.
@@ -577,13 +594,20 @@ mod tests {
             ],
         };
         let rows = flatten_tree(&tree);
+        let expected_proc = match proc_ref("proc1") {
+            NodeRef::Proc(proc_id) => proc_id,
+            _ => unreachable!("proc_ref constructs a proc reference"),
+        };
         assert_eq!(rows.len(), 3);
         assert_eq!(rows[0].node.reference, proc_ref("proc1"));
         assert_eq!(rows[0].depth, 0);
+        assert_eq!(rows[0].owning_proc, Some(&expected_proc));
         assert_eq!(rows[1].node.reference, actor("actor1"));
         assert_eq!(rows[1].depth, 1);
+        assert_eq!(rows[1].owning_proc, Some(&expected_proc));
         assert_eq!(rows[2].node.reference, actor("actor1"));
         assert_eq!(rows[2].depth, 0);
+        assert_eq!(rows[2].owning_proc, None);
     }
 
     #[test]


### PR DESCRIPTION
Summary:
the `p` and `C` actor actions currently find their owning process through the right-pane detail payload. this couples action routing to detail-loading state.

record the nearest process on each visible tree row and use that ancestry for actor actions. this allows detail loading to become asynchronous without changing how those actions resolve today.

this is a data-model refactor; detail loading, network behavior, and user-visible behavior are unchanged.

Differential Revision: D119329855


