### PR TITLE
make detail loading nonblocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3671,6 +3671,7 @@ name = "hyperactor_mesh_admin_tui_lib"
 version = "0.0.0"
 dependencies = [
  "algebra",
+ "axum",
  "chrono",
  "clap",
  "crossterm",

--- a/hyperactor_mesh_admin_tui/Cargo.toml
+++ b/hyperactor_mesh_admin_tui/Cargo.toml
@@ -33,6 +33,7 @@ urlencoding = "2.1.0"
 wezterm-dynamic = { git = "https://github.com/wezterm/wezterm.git", rev = "05343b387085842b434d267f91b6b0ec157e4331", features = ["std"] }
 
 [dev-dependencies]
+axum = { version = "0.8.9", features = ["macros", "multipart", "ws"] }
 uuid = { version = "1.24.1", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 
 [lints]

--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -613,17 +613,14 @@ impl App {
     /// current cursor position.
     ///
     /// - Proc selected → proc's own reference.
-    /// - Actor selected → owning proc from `detail.parent`.
+    /// - Actor selected → owning proc from visible-tree ancestry.
     /// - Root/Host selected → `None` (PY-4).
     pub(crate) fn pyspy_proc_ref(&self) -> Option<hyperactor::ProcAddr> {
         let rows = self.visible_rows();
         let row = rows.get(&self.cursor)?;
         match (&row.node.node_type, &row.node.reference) {
             (NodeType::Proc, NodeRef::Proc(proc_id)) => Some(proc_id.clone()),
-            (NodeType::Actor, _) => self.detail.as_ref().and_then(|p| match &p.parent {
-                Some(NodeRef::Proc(proc_id)) => Some(proc_id.clone()),
-                _ => None,
-            }),
+            (NodeType::Actor, _) => row.owning_proc.cloned(),
             _ => None,
         }
     }

--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io;
 
+use algebra::JoinSemilattice;
 use crossterm::event::Event;
 use crossterm::event::EventStream;
 use crossterm::event::KeyCode;
@@ -24,15 +25,20 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::text::Line;
 use ratatui::text::Span;
 use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 
 use crate::ActiveJob;
 use crate::ActiveJobEvent;
 use crate::ColorScheme;
 use crate::Cursor;
+use crate::DetailFreshness;
+use crate::DetailState;
 use crate::FetchState;
 use crate::KeyResult;
 use crate::LangName;
 use crate::NodeType;
+use crate::Stamp;
+use crate::StampAllocator;
 use crate::Theme;
 use crate::ThemeName;
 use crate::TreeNode;
@@ -44,6 +50,7 @@ use crate::collect_failed_refs;
 use crate::collect_refs;
 use crate::derive_label;
 use crate::diagnostics::run_diagnostics;
+use crate::fetch_node_state_raw;
 use crate::fetch_with_join;
 use crate::find_at_depth_from_root_mut;
 use crate::flatten_tree;
@@ -57,6 +64,25 @@ use crate::sorted_children;
 use crate::timeouts::TuiTimeoutPolicy;
 
 // Application state
+
+struct DetailRequest {
+    reference: NodeRef,
+    token: u64,
+    stamp: Stamp,
+    task: JoinHandle<FetchState<NodePayload>>,
+}
+
+impl Drop for DetailRequest {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+pub(crate) struct DetailFetchResult {
+    pub(crate) reference: NodeRef,
+    pub(crate) token: u64,
+    pub(crate) state: FetchState<NodePayload>,
+}
 
 /// Runtime state for the admin TUI.
 ///
@@ -88,12 +114,12 @@ pub(crate) struct App {
     /// Height of the topology tree viewport in rows (updated during
     /// rendering).
     pub(crate) tree_viewport_height: usize,
-    /// Detail payload for the selected node (usually served from
-    /// `node_cache`).
-    pub(crate) detail: Option<NodePayload>,
-    /// Error string for the detail pane when fetching/parsing the
-    /// selected node fails.
-    pub(crate) detail_error: Option<String>,
+    /// Complete state of the selected node's detail pane.
+    pub(crate) detail: DetailState,
+    /// Background fetch for the current detail selection, if any.
+    detail_request: Option<DetailRequest>,
+    /// Latest selection token; only a matching result may update the pane.
+    detail_token: u64,
 
     /// Human-readable refresh interval (e.g. "1s", "5s").
     pub(crate) refresh_interval_label: String,
@@ -113,8 +139,8 @@ pub(crate) struct App {
     pub(crate) fetch_cache: HashMap<NodeRef, FetchState<NodePayload>>,
     /// Current refresh generation for cache invalidation.
     pub(crate) refresh_gen: u64,
-    /// Monotonic sequence counter for timestamp ordering.
-    pub(crate) seq_counter: u64,
+    /// Shared allocator for foreground and background fetch stamps.
+    pub(crate) stamps: StampAllocator,
 
     /// Visual presentation (colors + labels).
     pub(crate) theme: Theme,
@@ -159,15 +185,16 @@ impl App {
             cursor: Cursor::new(0),
             tree_scroll_offset: 0,
             tree_viewport_height: 20, // Default, updated during rendering
-            detail: None,
-            detail_error: None,
+            detail: DetailState::Empty,
+            detail_request: None,
+            detail_token: 0,
             refresh_interval_label: String::new(),
             error: None,
             show_system: false,
             show_stopped: false,
             fetch_cache: HashMap::new(),
             refresh_gen: 0,
-            seq_counter: 0,
+            stamps: StampAllocator::default(),
             theme: Theme::new(theme_name, lang_name),
             theme_name,
             lang_name,
@@ -226,7 +253,7 @@ impl App {
             reference,
             &mut self.fetch_cache,
             self.refresh_gen,
-            &mut self.seq_counter,
+            &self.stamps,
             force,
             self.policy
                 .request_timeout(crate::timeouts::RequestOp::InteractiveFetch),
@@ -332,7 +359,7 @@ impl App {
                 &expanded_keys,
                 &failed_keys,
                 self.refresh_gen,
-                &mut self.seq_counter,
+                &self.stamps,
                 self.policy
                     .request_timeout(crate::timeouts::RequestOp::InteractiveFetch),
             )
@@ -397,8 +424,7 @@ impl App {
             self.cursor.update_len(rows.len());
         }
 
-        // Update detail from cache for current selection.
-        self.update_selected_detail().await;
+        self.schedule_selected_detail();
     }
 
     /// Lazily expand a single node by fetching its children.
@@ -559,32 +585,200 @@ impl App {
         false
     }
 
-    /// Update the right-hand detail pane for the currently selected
-    /// row.
-    ///
-    /// Looks up the selected node's reference and populates
-    /// `self.detail` from `fetch_cache` when available; otherwise
-    /// fetches the payload from the admin API and caches it. On fetch
-    /// failure, clears `detail` and records a human-readable error in
-    /// `detail_error` so the UI can display it.
-    pub(crate) async fn update_selected_detail(&mut self) {
-        self.detail = None;
-        self.detail_error = None;
+    /// Display cached detail immediately and schedule any required fetch.
+    pub(crate) fn schedule_selected_detail(&mut self) {
+        let Some(reference) = self.selected_reference().cloned() else {
+            self.detail_request = None;
+            self.detail_token = self.stamps.next().seq;
+            self.detail = DetailState::Empty;
+            return;
+        };
 
-        // Get reference first (releases tree borrow).
-        let reference = self.selected_reference().cloned();
-
-        if let Some(node_ref) = reference {
-            let state = self.fetch_node_state(&node_ref, false).await;
-            match state {
-                FetchState::Ready { value, .. } => {
-                    self.detail = Some(value);
-                }
-                FetchState::Error { msg, .. } => {
-                    self.detail_error = Some(format!("Fetch failed: {}", msg));
-                }
-                FetchState::Unknown => {}
+        match self.fetch_cache.get(&reference) {
+            Some(FetchState::Ready {
+                generation, value, ..
+            }) if *generation >= self.refresh_gen => {
+                self.detail_request = None;
+                self.detail_token = self.stamps.next().seq;
+                self.detail = DetailState::Ready {
+                    payload: Box::new(value.clone()),
+                    freshness: DetailFreshness::Fresh,
+                };
+                return;
             }
+            Some(FetchState::Ready { value, .. }) => {
+                self.detail = DetailState::Ready {
+                    payload: Box::new(value.clone()),
+                    freshness: DetailFreshness::Revalidating,
+                };
+            }
+            Some(FetchState::Unknown | FetchState::Error { .. }) | None => {
+                self.detail = DetailState::Loading;
+            }
+        }
+
+        if self
+            .detail_request
+            .as_ref()
+            .is_some_and(|request| request.reference == reference)
+        {
+            return;
+        }
+
+        self.detail_request = None;
+        let stamp = self.stamps.next();
+        let token = stamp.seq;
+        self.detail_token = token;
+        let client = self.client.clone();
+        let base_url = self.base_url.clone();
+        let request_reference = reference.clone();
+        let generation = self.refresh_gen;
+        let debounce = self.policy.detail_debounce;
+        let timeout = self
+            .policy
+            .request_timeout(crate::timeouts::RequestOp::InteractiveFetch);
+        let task = tokio::spawn(async move {
+            tokio::time::sleep(debounce).await;
+            fetch_node_state_raw(
+                &client,
+                &base_url,
+                &request_reference,
+                generation,
+                stamp,
+                timeout,
+            )
+            .await
+        });
+        self.detail_request = Some(DetailRequest {
+            reference,
+            token,
+            stamp,
+            task,
+        });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_detail_reference(&self) -> Option<&NodeRef> {
+        self.detail_request
+            .as_ref()
+            .map(|request| &request.reference)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_detail_token(&self) -> u64 {
+        self.detail_token
+    }
+
+    #[cfg(test)]
+    pub(crate) fn detail_request_is_finished(&self) -> Option<bool> {
+        self.detail_request
+            .as_ref()
+            .map(|request| request.task.is_finished())
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn receive_pending_detail_for_test(&mut self) -> DetailFetchResult {
+        recv_detail_request(&mut self.detail_request).await
+    }
+
+    /// Merge a completed detail fetch and update the pane only if it still
+    /// belongs to the current selection.
+    pub(crate) fn apply_detail_result(&mut self, result: DetailFetchResult) {
+        let is_current_request = self.detail_request.as_ref().is_some_and(|request| {
+            request.token == result.token && request.reference == result.reference
+        });
+        if is_current_request {
+            self.detail_request = None;
+        }
+
+        let selected = self.selected_reference().cloned();
+        let may_update_pane = self.detail_token == result.token
+            && selected
+                .as_ref()
+                .is_some_and(|reference| reference == &result.reference);
+
+        match result.state {
+            FetchState::Ready {
+                stamp,
+                generation,
+                value,
+            } => {
+                let ready = FetchState::Ready {
+                    stamp,
+                    generation: if is_current_request && may_update_pane {
+                        self.refresh_gen
+                    } else {
+                        generation
+                    },
+                    value,
+                };
+                let joined = self
+                    .fetch_cache
+                    .entry(result.reference.clone())
+                    .and_modify(|state| *state = state.join(&ready))
+                    .or_insert(ready)
+                    .clone();
+                if may_update_pane {
+                    match joined {
+                        FetchState::Ready { value, .. } => {
+                            self.detail = DetailState::Ready {
+                                payload: Box::new(value),
+                                freshness: DetailFreshness::Fresh,
+                            };
+                        }
+                        FetchState::Error { msg, .. } => {
+                            self.detail = DetailState::Failed {
+                                message: format!("Fetch failed: {msg}"),
+                            };
+                        }
+                        FetchState::Unknown => {}
+                    }
+                }
+            }
+            FetchState::Error { stamp, msg } => {
+                let cached_ready = self.fetch_cache.get(&result.reference).and_then(|state| {
+                    if let FetchState::Ready {
+                        stamp: cached_stamp,
+                        value,
+                        ..
+                    } = state
+                    {
+                        Some((*cached_stamp, value.clone()))
+                    } else {
+                        None
+                    }
+                });
+                if let Some((cached_stamp, payload)) = cached_ready {
+                    if may_update_pane {
+                        let freshness = if cached_stamp > stamp {
+                            DetailFreshness::Fresh
+                        } else {
+                            DetailFreshness::Stale {
+                                message: format!("Refresh failed: {msg}"),
+                            }
+                        };
+                        self.detail = DetailState::Ready {
+                            payload: Box::new(payload),
+                            freshness,
+                        };
+                    }
+                } else {
+                    let error = FetchState::Error {
+                        stamp,
+                        msg: msg.clone(),
+                    };
+                    self.fetch_cache
+                        .entry(result.reference.clone())
+                        .and_modify(|state| *state = state.join(&error))
+                        .or_insert(error);
+                    if may_update_pane {
+                        self.detail = DetailState::Failed {
+                            message: format!("Fetch failed: {msg}"),
+                        };
+                    }
+                }
+            }
+            FetchState::Unknown => {}
         }
     }
 
@@ -998,6 +1192,43 @@ impl App {
         }
     }
 
+    /// Apply work requested by one keyboard event.
+    pub(crate) async fn apply_key_result(&mut self, result: KeyResult) {
+        match result {
+            KeyResult::DetailChanged => {
+                self.schedule_selected_detail();
+            }
+            KeyResult::NeedsRefresh => {
+                self.refresh().await;
+            }
+            KeyResult::ExpandNode(reference, depth) => {
+                if self.expand_node(&reference, depth).await {
+                    let rows = self.visible_rows();
+                    self.cursor.update_len(rows.len());
+                    self.cursor.move_down();
+                    self.ensure_cursor_visible();
+                }
+                self.schedule_selected_detail();
+            }
+            KeyResult::RunDiagnostics => {
+                let rx = run_diagnostics(self.client.clone(), self.base_url.clone(), &self.policy);
+                self.set_job(ActiveJob::Diagnostics {
+                    results: Vec::new(),
+                    running: true,
+                    rx: Some(rx),
+                    completed_at: None,
+                });
+            }
+            KeyResult::RunPySpy(proc_id) => {
+                self.start_pyspy(proc_id);
+            }
+            KeyResult::RunConfig(proc_id) => {
+                self.start_config(proc_id);
+            }
+            KeyResult::None => {}
+        }
+    }
+
     /// Dispatch variant-specific rerun keys when an overlay is active.
     pub(crate) fn overlay_rerun_key(&self, key: KeyEvent) -> KeyResult {
         match &self.active_job {
@@ -1352,6 +1583,28 @@ async fn recv_active_job(job: &mut Option<ActiveJob>) -> ActiveJobEvent {
     }
 }
 
+/// Await the selected node's current background detail request.
+async fn recv_detail_request(request: &mut Option<DetailRequest>) -> DetailFetchResult {
+    let Some(request) = request else {
+        return std::future::pending().await;
+    };
+    let reference = request.reference.clone();
+    let token = request.token;
+    let stamp = request.stamp;
+    let state = match (&mut request.task).await {
+        Ok(state) => state,
+        Err(error) => FetchState::Error {
+            stamp,
+            msg: format!("detail task failed: {error}"),
+        },
+    };
+    DetailFetchResult {
+        reference,
+        token,
+        state,
+    }
+}
+
 /// TP-10: derive refresh policy from active job state.
 ///
 /// Suspend refresh while any foreground job is active — both
@@ -1403,7 +1656,6 @@ pub(crate) async fn run_app(
                 // policy is Baseline. When the in-flight operation
                 // completes, refresh resumes on the next scheduled
                 // tick, not immediately.
-                use algebra::JoinSemilattice;
                 use crate::timeouts::RefreshPolicy;
                 let effective = RefreshPolicy::Baseline
                     .join(&refresh_policy_for_job(&app.active_job));
@@ -1414,46 +1666,8 @@ pub(crate) async fn run_app(
             maybe_event = events.next() => {
                 match maybe_event {
                     Some(Ok(Event::Key(key))) => {
-                        match app.on_key(key) {
-                            KeyResult::DetailChanged => {
-                                app.update_selected_detail().await;
-                            }
-                            KeyResult::NeedsRefresh => {
-                                app.refresh().await;
-                            }
-                            KeyResult::ExpandNode(reference, depth) => {
-                                if app.expand_node(&reference, depth).await {
-                                    // Update cursor length to reflect new children
-                                    let rows = app.visible_rows();
-                                    app.cursor.update_len(rows.len());
-                                    // Move cursor to first child after expanding
-                                    app.cursor.move_down();
-                                    app.ensure_cursor_visible();
-                                }
-                                app.update_selected_detail().await;
-                            }
-                            KeyResult::RunDiagnostics => {
-                                let rx = run_diagnostics(
-                                    app.client.clone(),
-                                    app.base_url.clone(),
-                                    &app.policy,
-                                );
-                                // PY-5: set_job drops any prior PySpy variant.
-                                app.set_job(ActiveJob::Diagnostics {
-                                    results: Vec::new(),
-                                    running: true,
-                                    rx: Some(rx),
-                                    completed_at: None,
-                                });
-                            }
-                            KeyResult::RunPySpy(proc_id) => {
-                                app.start_pyspy(proc_id);
-                            }
-                            KeyResult::RunConfig(proc_id) => {
-                                app.start_config(proc_id);
-                            }
-                            KeyResult::None => {}
-                        }
+                        let result = app.on_key(key);
+                        app.apply_key_result(result).await;
                     }
                     Some(Ok(Event::Resize(_, _))) => {}
                     _ => {}
@@ -1464,6 +1678,9 @@ pub(crate) async fn run_app(
                     job.on_event(job_event);
                 }
                 app.rebuild_overlay();
+            }
+            detail_result = recv_detail_request(&mut app.detail_request) => {
+                app.apply_detail_result(detail_result);
             }
         }
 

--- a/hyperactor_mesh_admin_tui/src/fetch.rs
+++ b/hyperactor_mesh_admin_tui/src/fetch.rs
@@ -10,6 +10,9 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
 use algebra::JoinSemilattice;
 use hyperactor_mesh::introspect::NodePayload;
@@ -36,6 +39,30 @@ pub(crate) struct Stamp {
     /// Monotonic tie-breaker for identical timestamps in this
     /// process.
     pub(crate) seq: u64,
+}
+
+/// Clone-shared allocator for fetch ordering stamps.
+///
+/// Clones share the same sequence so foreground and background fetches
+/// that receive the same wall-clock timestamp still have distinct ordering
+/// keys.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct StampAllocator {
+    next_seq: Arc<AtomicU64>,
+}
+
+impl StampAllocator {
+    pub(crate) fn next(&self) -> Stamp {
+        let seq = self
+            .next_seq
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_add(1);
+        let ts_micros = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+        Stamp { ts_micros, seq }
+    }
 }
 
 /// Cached result of fetching a node, with ordering metadata.
@@ -107,6 +134,31 @@ impl<T: Clone> JoinSemilattice for FetchState<T> {
     }
 }
 
+/// Fetch one node and package the outcome with an already allocated stamp.
+pub(crate) async fn fetch_node_state_raw(
+    client: &reqwest::Client,
+    base_url: &str,
+    reference: &NodeRef,
+    generation: u64,
+    stamp: Stamp,
+    timeout: std::time::Duration,
+) -> FetchState<NodePayload> {
+    let fetch_result =
+        tokio::time::timeout(timeout, fetch_node_raw(client, base_url, reference)).await;
+    match fetch_result {
+        Err(_) => FetchState::Error {
+            stamp,
+            msg: format!("request timed out after {}s", timeout.as_secs()),
+        },
+        Ok(Ok(payload)) => FetchState::Ready {
+            stamp,
+            generation,
+            value: payload,
+        },
+        Ok(Err(msg)) => FetchState::Error { stamp, msg },
+    }
+}
+
 /// Unified fetch+join path for all cache writes.
 ///
 /// Checks cache first, only fetches if needed (not present, stale, or
@@ -120,7 +172,7 @@ pub(crate) async fn fetch_with_join(
     reference: &NodeRef,
     cache: &mut HashMap<NodeRef, FetchState<NodePayload>>,
     refresh_gen: u64,
-    seq_counter: &mut u64,
+    stamps: &StampAllocator,
     force: bool,
     timeout: std::time::Duration,
 ) -> FetchState<NodePayload> {
@@ -137,33 +189,17 @@ pub(crate) async fn fetch_with_join(
     };
 
     if should_fetch {
-        // Generate stamp.
-        *seq_counter += 1;
-        let ts_micros = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_micros() as u64;
-        let stamp = Stamp {
-            ts_micros,
-            seq: *seq_counter,
-        };
-
         // TP-9: timeout covers the full fetch lifecycle at the
         // operation boundary.
-        let fetch_result =
-            tokio::time::timeout(timeout, fetch_node_raw(client, base_url, reference)).await;
-        let new_state = match fetch_result {
-            Err(_) => FetchState::Error {
-                stamp,
-                msg: format!("request timed out after {}s", timeout.as_secs()),
-            },
-            Ok(Ok(payload)) => FetchState::Ready {
-                stamp,
-                generation: refresh_gen,
-                value: payload,
-            },
-            Ok(Err(e)) => FetchState::Error { stamp, msg: e },
-        };
+        let new_state = fetch_node_state_raw(
+            client,
+            base_url,
+            reference,
+            refresh_gen,
+            stamps.next(),
+            timeout,
+        )
+        .await;
 
         // Join into cache.
         cache
@@ -241,7 +277,7 @@ pub(crate) fn build_tree_node<'a>(
     expanded_keys: &'a HashSet<(NodeRef, usize)>,
     failed_keys: &'a HashSet<(NodeRef, usize)>,
     refresh_gen: u64,
-    seq_counter: &'a mut u64,
+    stamps: &'a StampAllocator,
     timeout: std::time::Duration,
 ) -> Pin<Box<dyn Future<Output = Option<TreeNode>> + Send + 'a>> {
     Box::pin(async move {
@@ -264,7 +300,7 @@ pub(crate) fn build_tree_node<'a>(
             reference,
             cache,
             refresh_gen,
-            seq_counter,
+            stamps,
             false,
             timeout,
         )
@@ -377,7 +413,7 @@ pub(crate) fn build_tree_node<'a>(
                             expanded_keys,
                             failed_keys,
                             refresh_gen,
-                            seq_counter,
+                            stamps,
                             timeout,
                         )
                         .await
@@ -451,7 +487,7 @@ pub(crate) fn build_tree_node<'a>(
                         expanded_keys,
                         failed_keys,
                         refresh_gen,
-                        seq_counter,
+                        stamps,
                         timeout,
                     )
                     .await

--- a/hyperactor_mesh_admin_tui/src/lib.rs
+++ b/hyperactor_mesh_admin_tui/src/lib.rs
@@ -35,10 +35,14 @@
 //!
 //! - **TUI-4 (failed-always-visible):** Failed nodes are always
 //!   visible regardless of the `show_stopped` toggle.
-//! - **TUI-5 (single-fetch-path):** All cache writes go through
-//!   `fetch_with_join` (no direct inserts).
+//! - **TUI-5 (single-cache-owner):** Fetch work returns stamped
+//!   results; `App` owns the cache and merges every completed write
+//!   through `FetchState::join`.
 //! - **TUI-6 (refresh-staleness):** `FetchState::Ready` with
-//!   `generation < refresh_gen` is refetched; errors always retry.
+//!   `generation < refresh_gen` is revalidated while its payload
+//!   remains displayable; errors always retry. A completed detail
+//!   request accepted for the current selection joins at the current
+//!   generation, including when it spans a topology refresh.
 //! - **TUI-7 (synthetic-root):** The root node is synthetic and
 //!   always expanded; only its children are rendered at depth 0.
 //! - **TUI-8 (cycle-safety):** Tree building rejects only true
@@ -53,8 +57,9 @@
 //! - **TUI-12 (serial-topology-fetches):** Topology cache fetches
 //!   (via `fetch_with_join` / `build_tree_node`) are serial within
 //!   a refresh cycle; join semantics handle retries and reordering.
-//!   Overlay fetches (py-spy, config, diagnostics) are concurrent
-//!   via `tokio::spawn` and do not participate in the topology cache.
+//!   Detail and overlay fetches are concurrent via `tokio::spawn`;
+//!   detail results rejoin the topology cache on the event loop,
+//!   while overlay results do not participate in that cache.
 //! - **TUI-13 (stopped-detection):** `is_stopped_node` matches
 //!   `Actor` variants whose `actor_status` starts with `"stopped:"`
 //!   or `"failed:"`. All other variants return false.
@@ -103,6 +108,17 @@
 //!   still requests quit. Rendering gives the help overlay precedence
 //!   over `app.overlay` and node detail, and help never mutates the
 //!   topology or detail cache.
+//! - **TUI-23 (nonblocking-detail):** The input/render loop never
+//!   awaits node-detail network I/O. Selection schedules background
+//!   work and returns immediately.
+//! - **TUI-24 (latest-selection-wins):** Only a detail result whose
+//!   reference and request token still match the current selection
+//!   may update the visible pane. A topology refresh preserves an
+//!   active request for the same selected reference unless its cache
+//!   result has already superseded that request.
+//! - **TUI-25 (stale-while-revalidate):** Any present detail payload
+//!   is displayed immediately and never regresses to loading while
+//!   its reference is revalidated.
 //!
 //! Py-spy overlay invariants:
 //!

--- a/hyperactor_mesh_admin_tui/src/lib.rs
+++ b/hyperactor_mesh_admin_tui/src/lib.rs
@@ -119,7 +119,8 @@
 //!   arrival.
 //! - **PY-4 (selection-totality):** `p` is a no-op on Root/Host;
 //!   targets the proc ref directly on Proc; targets the owning proc
-//!   via `detail.parent` on Actor.
+//!   from visible-tree ancestry on Actor, independently of detail
+//!   loading.
 //! - **PY-5 (overlay-isolation):** Diagnostics and py-spy overlays
 //!   must not write into each other's display surface. Enforced by
 //!   `set_job`: `RunDiagnostics` calls `set_job` with the
@@ -148,8 +149,8 @@
 //!   arrival.
 //! - **CFG-4 (selection-totality):** `C` targets the proc ref directly
 //!   on Proc (worker or service); targets the owning proc via
-//!   `detail.parent` on Actor; no-op on Root/Host. Backend routes to
-//!   ProcAgent or HostAgent per proc type (same as PY-4).
+//!   visible-tree ancestry on Actor; no-op on Root/Host. Backend
+//!   routes to ProcAgent or HostAgent per proc type (same as PY-4).
 //! - **CFG-5 (overlay-isolation):** Config, Diagnostics, and PySpy
 //!   overlays must not write into each other's display surface.
 //!   Enforced by `set_job`: each variant drops any prior receiver;

--- a/hyperactor_mesh_admin_tui/src/model.rs
+++ b/hyperactor_mesh_admin_tui/src/model.rs
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use hyperactor::ProcAddr;
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
 use hyperactor_mesh::introspect::NodeRef;
@@ -288,6 +289,8 @@ pub(crate) struct FlatRow<'a> {
     pub(crate) node: &'a TreeNode,
     /// Visual indentation level for this row.
     pub(crate) depth: usize,
+    /// Owning process for a proc or actor occurrence in this tree.
+    pub(crate) owning_proc: Option<&'a ProcAddr>,
 }
 
 /// Wrapper for flattened visible rows with cursor helpers.

--- a/hyperactor_mesh_admin_tui/src/model.rs
+++ b/hyperactor_mesh_admin_tui/src/model.rs
@@ -334,6 +334,42 @@ impl<'a> VisibleRows<'a> {
     }
 }
 
+/// Status attached to a detail payload that remains visible.
+#[derive(Debug, Clone)]
+pub(crate) enum DetailFreshness {
+    /// The payload is current for this refresh generation.
+    Fresh,
+    /// A newer payload is being requested in the background.
+    Revalidating,
+    /// Revalidation failed, so the last usable payload remains visible.
+    Stale { message: String },
+}
+
+/// Complete state of the right-hand node-detail pane.
+#[derive(Debug, Clone)]
+pub(crate) enum DetailState {
+    /// No node is selected.
+    Empty,
+    /// The selected node has no cached payload and is being fetched.
+    Loading,
+    /// A payload is available for the selected node.
+    Ready {
+        payload: Box<NodePayload>,
+        freshness: DetailFreshness,
+    },
+    /// The selected node has no usable payload and its fetch failed.
+    Failed { message: String },
+}
+
+impl DetailState {
+    pub(crate) fn payload(&self) -> Option<&NodePayload> {
+        match self {
+            Self::Ready { payload, .. } => Some(payload.as_ref()),
+            Self::Empty | Self::Loading | Self::Failed { .. } => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::SystemTime;

--- a/hyperactor_mesh_admin_tui/src/render.rs
+++ b/hyperactor_mesh_admin_tui/src/render.rs
@@ -11,7 +11,6 @@
 // - base_url
 // - cursor
 // - detail
-// - detail_error
 // - error
 // - lang_name
 // - refresh_interval_label

--- a/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
+++ b/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
@@ -29,6 +29,8 @@ use ratatui::widgets::Paragraph;
 use ratatui::widgets::Wrap;
 
 use crate::App;
+use crate::DetailFreshness;
+use crate::DetailState;
 use crate::Theme;
 use crate::diagnostics::DiagNodeRole;
 use crate::diagnostics::DiagOutcome;
@@ -50,14 +52,11 @@ use crate::theme::Labels;
 ///
 /// Precedence: the help glossary (`app.show_help`, TUI-22) takes priority,
 /// then the active `app.overlay` (py-spy / config / diagnostics), then node
-/// detail. For node detail, if a `NodePayload` for the current selection is
-/// available in `app.detail`, dispatches to `render_node_detail` to show a
-/// type-specific view (root/host/proc/actor); otherwise shows either the
-/// last fetch error (`app.detail_error`) or a neutral "select a node"
-/// placeholder message.
+/// detail. Ready detail remains visible while it is revalidated; cold loads
+/// and failures render explicit status messages.
 pub(crate) fn render_detail_pane(frame: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
     if app.show_help {
-        render_help_overlay(frame, area, app.detail.as_ref(), &app.theme.scheme);
+        render_help_overlay(frame, area, app.detail.payload(), &app.theme.scheme);
         return;
     }
     if let Some(overlay) = &app.overlay {
@@ -65,27 +64,67 @@ pub(crate) fn render_detail_pane(frame: &mut ratatui::Frame<'_>, area: Rect, app
         return;
     }
     match &app.detail {
-        Some(payload) => {
-            render_node_detail(frame, area, payload, &app.theme.scheme, &app.theme.labels)
-        }
-        None => {
-            let msg = app
-                .detail_error
-                .as_deref()
-                .unwrap_or("Select a node to view details");
-            let msg_style = if app.detail_error.is_some() {
-                app.theme.scheme.error
-            } else {
-                app.theme.scheme.info
+        DetailState::Ready {
+            payload, freshness, ..
+        } => {
+            let status = match freshness {
+                DetailFreshness::Fresh => None,
+                DetailFreshness::Revalidating => Some(("Refreshing…", app.theme.scheme.info)),
+                DetailFreshness::Stale { message } => {
+                    Some((message.as_str(), app.theme.scheme.error))
+                }
             };
-            let block = Block::default()
-                .title(app.theme.labels.pane_details)
-                .borders(Borders::ALL)
-                .border_style(app.theme.scheme.border);
-            let p = Paragraph::new(Span::styled(msg, msg_style)).block(block);
-            frame.render_widget(p, area);
+            let (detail_area, status_area) = if status.is_some() && area.height > 1 {
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(1), Constraint::Length(1)])
+                    .split(area);
+                (chunks[0], Some(chunks[1]))
+            } else {
+                (area, None)
+            };
+            render_node_detail(
+                frame,
+                detail_area,
+                payload,
+                &app.theme.scheme,
+                &app.theme.labels,
+            );
+            if let (Some((message, style)), Some(status_area)) = (status, status_area) {
+                frame.render_widget(Paragraph::new(Span::styled(message, style)), status_area);
+            }
+        }
+        DetailState::Empty => {
+            render_detail_message(
+                frame,
+                area,
+                "Select a node to view details",
+                app.theme.scheme.info,
+                app,
+            );
+        }
+        DetailState::Loading => {
+            render_detail_message(frame, area, "Loading…", app.theme.scheme.info, app);
+        }
+        DetailState::Failed { message, .. } => {
+            render_detail_message(frame, area, message, app.theme.scheme.error, app);
         }
     }
+}
+
+fn render_detail_message(
+    frame: &mut ratatui::Frame<'_>,
+    area: Rect,
+    message: &str,
+    style: Style,
+    app: &App,
+) {
+    let block = Block::default()
+        .title(app.theme.labels.pane_details)
+        .borders(Borders::ALL)
+        .border_style(app.theme.scheme.border);
+    let paragraph = Paragraph::new(Span::styled(message, style)).block(block);
+    frame.render_widget(paragraph, area);
 }
 
 /// A single field-help entry: a field name, its one-line meaning, and an
@@ -833,7 +872,7 @@ pub(crate) fn detail_content_clipped(app: &App, detail_height: u16) -> bool {
     if app.show_help || app.overlay.is_some() {
         return false;
     }
-    let Some(payload) = app.detail.as_ref() else {
+    let Some(payload) = app.detail.payload() else {
         return false;
     };
     let NodeProperties::Actor {
@@ -845,8 +884,19 @@ pub(crate) fn detail_content_clipped(app: &App, detail_height: u16) -> bool {
     else {
         return false;
     };
+    let status_height = if matches!(
+        &app.detail,
+        DetailState::Ready {
+            freshness: DetailFreshness::Revalidating | DetailFreshness::Stale { .. },
+            ..
+        }
+    ) {
+        1
+    } else {
+        0
+    };
     actor_detail_clipped(
-        detail_height,
+        detail_height.saturating_sub(status_height),
         inbound_ordering.as_deref(),
         execution.as_deref(),
         failure_info.as_ref(),

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -23,6 +23,8 @@ use crate::diagnostics::DiagPhase;
 use crate::diagnostics::DiagResult;
 use crate::timeouts::TuiTimeoutPolicy;
 
+mod responsive_navigation;
+
 /// Test-only convenience policy with current production defaults.
 /// Not a `Default` impl — forces production code through `from_config`.
 fn test_policy() -> TuiTimeoutPolicy {
@@ -2743,32 +2745,35 @@ fn detail_content_clipped_guards() {
     use crate::render::detail_pane::detail_content_clipped;
 
     let mut app = make_app_with_cursor(vec![actor_node("a")], 0);
-    app.detail = Some(NodePayload {
-        identity: actor("a"),
-        properties: NodeProperties::Actor {
-            actor_status: "running".into(),
-            actor_type: "TestActor".into(),
-            instance_id: String::new(),
-            messages_processed: 0,
-            created_at: Some(SystemTime::UNIX_EPOCH),
-            last_message_handler: None,
-            total_processing_time_us: 0,
-            queue_depth: 0,
-            flight_recorder: None,
-            is_system: false,
-            inbound_ordering: None,
-            failure_info: None,
-            execution: Some(Box::new(Execution {
-                active_count: 2,
-                active_handlers: vec![],
-                complete: true,
-                truncated: false,
-            })),
-        },
-        children: vec![],
-        parent: Some(proc_ref("worker")),
-        as_of: SystemTime::now(),
-    });
+    app.detail = DetailState::Ready {
+        payload: Box::new(NodePayload {
+            identity: actor("a"),
+            properties: NodeProperties::Actor {
+                actor_status: "running".into(),
+                actor_type: "TestActor".into(),
+                instance_id: String::new(),
+                messages_processed: 0,
+                created_at: Some(SystemTime::UNIX_EPOCH),
+                last_message_handler: None,
+                total_processing_time_us: 0,
+                queue_depth: 0,
+                flight_recorder: None,
+                is_system: false,
+                inbound_ordering: None,
+                failure_info: None,
+                execution: Some(Box::new(Execution {
+                    active_count: 2,
+                    active_handlers: vec![],
+                    complete: true,
+                    truncated: false,
+                })),
+            },
+            children: vec![],
+            parent: Some(proc_ref("worker")),
+            as_of: SystemTime::now(),
+        }),
+        freshness: DetailFreshness::Fresh,
+    };
     // Live execution starved to zero height -> alert; roomy -> no alert.
     assert!(detail_content_clipped(&app, 18));
     assert!(!detail_content_clipped(&app, 45));
@@ -2794,21 +2799,24 @@ fn detail_content_clipped_guards() {
 
     // Non-actor selection -> no alert.
     let mut host_app = make_app_with_cursor(vec![], 0);
-    host_app.detail = Some(NodePayload {
-        identity: host("h"),
-        properties: NodeProperties::Host {
-            addr: "10.0.0.1:8080".into(),
-            num_procs: 1,
-            system_children: vec![],
-            memory: hyperactor_mesh::introspect::ProcessMemoryStats {
-                process_rss_bytes: None,
-                process_vm_size_bytes: None,
+    host_app.detail = DetailState::Ready {
+        payload: Box::new(NodePayload {
+            identity: host("h"),
+            properties: NodeProperties::Host {
+                addr: "10.0.0.1:8080".into(),
+                num_procs: 1,
+                system_children: vec![],
+                memory: hyperactor_mesh::introspect::ProcessMemoryStats {
+                    process_rss_bytes: None,
+                    process_vm_size_bytes: None,
+                },
             },
-        },
-        children: vec![],
-        parent: Some(NodeRef::Root),
-        as_of: SystemTime::now(),
-    });
+            children: vec![],
+            parent: Some(NodeRef::Root),
+            as_of: SystemTime::now(),
+        }),
+        freshness: DetailFreshness::Fresh,
+    };
     assert!(!detail_content_clipped(&host_app, 18));
 }
 

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -53,8 +53,11 @@ fn host(name: &str) -> NodeRef {
 }
 
 fn proc_ref(name: &str) -> NodeRef {
-    let proc_id = hyperactor_mesh::mesh_id::ResourceId::proc_addr_from_name(test_addr(), name);
-    NodeRef::Proc(proc_id)
+    NodeRef::Proc(proc_addr(name))
+}
+
+fn proc_addr(name: &str) -> hyperactor::ProcAddr {
+    hyperactor_mesh::mesh_id::ResourceId::proc_addr_from_name(test_addr(), name)
 }
 
 fn actor(name: &str) -> NodeRef {
@@ -1541,6 +1544,14 @@ fn actor_node(reference: &str) -> TreeNode {
     }
 }
 
+fn expanded_proc_with_actor(proc_name: &str, actor_name: &str) -> TreeNode {
+    let mut proc = proc_node(proc_name);
+    proc.expanded = true;
+    proc.has_children = true;
+    proc.children.push(actor_node(actor_name));
+    proc
+}
+
 // PY-4: Proc selected → own reference returned.
 #[test]
 fn pyspy_proc_ref_proc_node() {
@@ -1548,32 +1559,11 @@ fn pyspy_proc_ref_proc_node() {
     assert!(app.pyspy_proc_ref().is_some());
 }
 
-// PY-4: Actor selected with detail.parent → owning proc returned.
+// PY-4: Actor selected → owning proc comes from visible-tree ancestry.
 #[test]
-fn pyspy_proc_ref_actor_node_with_parent() {
-    let mut app = make_app_with_cursor(vec![actor_node("actor1")], 0);
-    app.detail = Some(NodePayload {
-        identity: actor("actor1"),
-        properties: NodeProperties::Actor {
-            actor_status: "running".into(),
-            actor_type: "TestActor".into(),
-            instance_id: String::new(),
-            messages_processed: 0,
-            created_at: Some(SystemTime::UNIX_EPOCH),
-            last_message_handler: None,
-            total_processing_time_us: 0,
-            queue_depth: 0,
-            flight_recorder: None,
-            is_system: false,
-            inbound_ordering: None,
-            failure_info: None,
-            execution: None,
-        },
-        children: vec![],
-        parent: Some(proc_ref("worker")),
-        as_of: SystemTime::now(),
-    });
-    assert!(app.pyspy_proc_ref().is_some());
+fn pyspy_proc_ref_actor_uses_visible_proc_ancestor() {
+    let app = make_app_with_cursor(vec![expanded_proc_with_actor("worker", "actor1")], 1);
+    assert_eq!(app.pyspy_proc_ref(), Some(proc_addr("worker")));
 }
 
 // PY-4: Root node selected → None.
@@ -1618,11 +1608,22 @@ fn pyspy_proc_ref_host_node() {
     assert_eq!(app.pyspy_proc_ref(), None);
 }
 
-// PY-4: Actor selected with detail=None → None (no panic).
+// PY-4: Actor without a proc ancestor → None (no panic).
 #[test]
-fn pyspy_proc_ref_actor_no_detail() {
+fn pyspy_proc_ref_actor_without_proc_ancestor() {
     let app = make_app_with_cursor(vec![actor_node("actor1")], 0);
     assert_eq!(app.pyspy_proc_ref(), None);
+}
+
+// PY-4: `p` on an actor does not depend on the detail payload.
+#[test]
+fn on_key_pyspy_on_actor_without_detail() {
+    let mut app = make_app_with_cursor(vec![expanded_proc_with_actor("worker", "actor1")], 1);
+    let key = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE);
+    match app.on_key(key) {
+        KeyResult::RunPySpy(actual) => assert_eq!(actual, proc_addr("worker")),
+        other => panic!("p on an actor should target its owning proc, got: {other:?}"),
+    }
 }
 
 // PY-5: parse_error_envelope renders ApiErrorEnvelope body so py-spy
@@ -2431,6 +2432,17 @@ fn on_key_config_on_proc() {
         matches!(result, KeyResult::RunConfig(_)),
         "C on Proc should dispatch RunConfig, got: {result:?}"
     );
+}
+
+// CFG-4: `C` on an actor does not depend on the detail payload.
+#[test]
+fn on_key_config_on_actor_without_detail() {
+    let mut app = make_app_with_cursor(vec![expanded_proc_with_actor("worker", "actor1")], 1);
+    let key = KeyEvent::new(KeyCode::Char('C'), KeyModifiers::SHIFT);
+    match app.on_key(key) {
+        KeyResult::RunConfig(actual) => assert_eq!(actual, proc_addr("worker")),
+        other => panic!("C on an actor should target its owning proc, got: {other:?}"),
+    }
 }
 
 // CFG-4: 'C' on a Root node is a no-op.

--- a/hyperactor_mesh_admin_tui/src/tests/responsive_navigation.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/responsive_navigation.rs
@@ -1,0 +1,770 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use axum::Json;
+use axum::Router;
+use axum::extract::Path;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::routing::get;
+use hyperactor_mesh::introspect::NodePayload;
+use hyperactor_mesh::introspect::NodeProperties;
+use hyperactor_mesh::introspect::NodeRef;
+use hyperactor_mesh::introspect::dto::NodePayloadDto;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use super::*;
+
+#[derive(Clone)]
+struct ServerState {
+    responses: Arc<HashMap<String, NodePayloadDto>>,
+    requests: mpsc::UnboundedSender<String>,
+    request_history: Arc<Mutex<Vec<String>>>,
+    holds: Arc<HashMap<String, watch::Receiver<bool>>>,
+}
+
+struct HeldAdminServer {
+    base_url: String,
+    requests: mpsc::UnboundedReceiver<String>,
+    request_history: Arc<Mutex<Vec<String>>>,
+    releases: HashMap<String, watch::Sender<bool>>,
+    task: JoinHandle<()>,
+}
+
+impl HeldAdminServer {
+    async fn spawn(
+        responses: HashMap<String, NodePayloadDto>,
+        held_references: impl IntoIterator<Item = NodeRef>,
+    ) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test server should bind an ephemeral port");
+        let address = listener
+            .local_addr()
+            .expect("test server should have a local address");
+        let (request_tx, request_rx) = mpsc::unbounded_channel();
+        let request_history = Arc::new(Mutex::new(Vec::new()));
+        let mut releases = HashMap::new();
+        let holds = held_references
+            .into_iter()
+            .map(|reference| {
+                let reference = reference.to_string();
+                let (release, held) = watch::channel(false);
+                releases.insert(reference.clone(), release);
+                (reference, held)
+            })
+            .collect();
+        let state = ServerState {
+            responses: Arc::new(responses),
+            requests: request_tx,
+            request_history: Arc::clone(&request_history),
+            holds: Arc::new(holds),
+        };
+        let router = Router::new()
+            .route("/v1/{*reference}", get(held_node))
+            .with_state(state);
+        let task = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .await
+                .expect("test admin server should run");
+        });
+
+        Self {
+            base_url: format!("http://{address}"),
+            requests: request_rx,
+            request_history,
+            releases,
+            task,
+        }
+    }
+
+    async fn next_request(&mut self) -> String {
+        self.requests
+            .recv()
+            .await
+            .expect("detail request should reach the test server")
+    }
+
+    async fn wait_for_request(&mut self, expected: &NodeRef) {
+        let expected = expected.to_string();
+        loop {
+            if self.next_request().await == expected {
+                return;
+            }
+        }
+    }
+
+    fn release(&self, reference: &NodeRef) {
+        self.releases
+            .get(&reference.to_string())
+            .expect("reference should have a configured hold")
+            .send(true)
+            .expect("test server should still hold the response");
+    }
+
+    fn request_count(&self, reference: &NodeRef) -> usize {
+        let expected = reference.to_string();
+        self.request_history
+            .lock()
+            .expect("request history lock should not be poisoned")
+            .iter()
+            .filter(|actual| **actual == expected)
+            .count()
+    }
+
+    fn total_request_count(&self) -> usize {
+        self.request_history
+            .lock()
+            .expect("request history lock should not be poisoned")
+            .len()
+    }
+
+    fn assert_no_additional_request(&mut self) {
+        assert!(
+            matches!(
+                self.requests.try_recv(),
+                Err(mpsc::error::TryRecvError::Empty)
+            ),
+            "rapid navigation should not issue detail requests for crossed rows"
+        );
+    }
+}
+
+impl Drop for HeldAdminServer {
+    fn drop(&mut self) {
+        self.releases.values().for_each(|release| {
+            let _ = release.send(true);
+        });
+        self.task.abort();
+    }
+}
+
+async fn held_node(
+    Path(reference): Path<String>,
+    State(state): State<ServerState>,
+) -> Result<Json<NodePayloadDto>, StatusCode> {
+    let response = state
+        .responses
+        .get(&reference)
+        .cloned()
+        .ok_or(StatusCode::NOT_FOUND)?;
+    state
+        .request_history
+        .lock()
+        .expect("request history lock should not be poisoned")
+        .push(reference.clone());
+    let _ = state.requests.send(reference.clone());
+    if let Some(held) = state.holds.get(&reference) {
+        let mut held = held.clone();
+        let released = *held.borrow();
+        if !released {
+            let _ = held.changed().await;
+        }
+    }
+    Ok(Json(response))
+}
+
+struct TestTopology {
+    tree: TreeNode,
+    responses: HashMap<String, NodePayloadDto>,
+    target_proc: NodeRef,
+    target_actor: NodeRef,
+}
+
+fn actor_ref_for(proc_name: &str, actor_name: &str) -> NodeRef {
+    NodeRef::Actor(proc_addr(proc_name).actor_addr(actor_name))
+}
+
+fn large_topology() -> TestTopology {
+    let target_proc_name = "host-0-proc-0";
+    let target_proc = proc_ref(target_proc_name);
+    let target_actor = actor_ref_for(target_proc_name, "detail-target");
+    let mut responses = HashMap::new();
+    let mut root_children = Vec::new();
+    let mut tree_hosts = Vec::new();
+
+    for host_index in 0..25 {
+        let host_reference = host(&format!("host-{host_index}"));
+        let mut proc_references = Vec::new();
+        let mut tree_procs = Vec::new();
+
+        for proc_index in 0..4 {
+            let proc_name = format!("host-{host_index}-proc-{proc_index}");
+            let proc_reference = proc_ref(&proc_name);
+            let is_target = proc_reference == target_proc;
+            let actor_children = if is_target {
+                vec![target_actor.clone()]
+            } else {
+                Vec::new()
+            };
+            responses.insert(
+                proc_reference.to_string(),
+                NodePayloadDto::from(NodePayload {
+                    identity: proc_reference.clone(),
+                    properties: NodeProperties::Proc {
+                        proc_name,
+                        num_actors: actor_children.len(),
+                        system_children: Vec::new(),
+                        stopped_children: Vec::new(),
+                        stopped_retention_cap: 0,
+                        is_poisoned: false,
+                        failed_actor_count: 0,
+                        debug: Default::default(),
+                    },
+                    children: actor_children.clone(),
+                    parent: Some(host_reference.clone()),
+                    as_of: SystemTime::UNIX_EPOCH,
+                }),
+            );
+            proc_references.push(proc_reference.clone());
+            tree_procs.push(TreeNode {
+                reference: proc_reference,
+                label: format!("proc {proc_index}"),
+                node_type: NodeType::Proc,
+                expanded: is_target,
+                fetched: true,
+                has_children: is_target,
+                stopped: false,
+                failed: false,
+                is_system: false,
+                children: if is_target {
+                    vec![TreeNode {
+                        reference: target_actor.clone(),
+                        label: "detail target".to_string(),
+                        node_type: NodeType::Actor,
+                        expanded: false,
+                        fetched: false,
+                        has_children: false,
+                        stopped: false,
+                        failed: false,
+                        is_system: false,
+                        children: Vec::new(),
+                    }]
+                } else {
+                    Vec::new()
+                },
+            });
+        }
+
+        responses.insert(
+            host_reference.to_string(),
+            NodePayloadDto::from(NodePayload {
+                identity: host_reference.clone(),
+                properties: NodeProperties::Host {
+                    addr: format!("host-{host_index}"),
+                    num_procs: proc_references.len(),
+                    system_children: Vec::new(),
+                    memory: Default::default(),
+                },
+                children: proc_references,
+                parent: Some(NodeRef::Root),
+                as_of: SystemTime::UNIX_EPOCH,
+            }),
+        );
+        root_children.push(host_reference.clone());
+        tree_hosts.push(TreeNode {
+            reference: host_reference,
+            label: format!("host {host_index}"),
+            node_type: NodeType::Host,
+            expanded: true,
+            fetched: true,
+            has_children: true,
+            stopped: false,
+            failed: false,
+            is_system: false,
+            children: tree_procs,
+        });
+    }
+
+    responses.insert(
+        NodeRef::Root.to_string(),
+        NodePayloadDto::from(NodePayload {
+            identity: NodeRef::Root,
+            properties: NodeProperties::Root {
+                num_hosts: root_children.len(),
+                started_at: SystemTime::UNIX_EPOCH,
+                started_by: "responsive-navigation-test".to_string(),
+                system_children: Vec::new(),
+            },
+            children: root_children,
+            parent: None,
+            as_of: SystemTime::UNIX_EPOCH,
+        }),
+    );
+    responses.insert(
+        target_actor.to_string(),
+        NodePayloadDto::from(NodePayload {
+            identity: target_actor.clone(),
+            properties: NodeProperties::Actor {
+                actor_status: "running".to_string(),
+                actor_type: "ResponsiveNavigationActor".to_string(),
+                instance_id: String::new(),
+                messages_processed: 0,
+                created_at: Some(SystemTime::UNIX_EPOCH),
+                last_message_handler: None,
+                total_processing_time_us: 0,
+                queue_depth: 0,
+                flight_recorder: None,
+                is_system: false,
+                inbound_ordering: None,
+                failure_info: None,
+                execution: None,
+            },
+            children: Vec::new(),
+            parent: Some(target_proc.clone()),
+            as_of: SystemTime::UNIX_EPOCH,
+        }),
+    );
+
+    TestTopology {
+        tree: TreeNode {
+            reference: NodeRef::Root,
+            label: "Root".to_string(),
+            node_type: NodeType::Root,
+            expanded: true,
+            fetched: true,
+            has_children: true,
+            stopped: false,
+            failed: false,
+            is_system: false,
+            children: tree_hosts,
+        },
+        responses,
+        target_proc,
+        target_actor,
+    }
+}
+
+fn detail_payload(reference: NodeRef) -> NodePayload {
+    NodePayload {
+        identity: reference,
+        properties: NodeProperties::Error {
+            code: "held_for_test".to_string(),
+            message: "response is controlled by the test".to_string(),
+        },
+        children: Vec::new(),
+        parent: None,
+        as_of: SystemTime::now(),
+    }
+}
+
+fn app_with_tree(base_url: String, tree: TreeNode, detail_debounce: std::time::Duration) -> App {
+    let mut policy = test_policy();
+    policy.detail_debounce = detail_debounce;
+    let mut app = App::new(
+        base_url,
+        reqwest::Client::new(),
+        ThemeName::Nord,
+        LangName::En,
+        policy,
+    );
+    app.set_tree(Some(tree));
+    app.cursor.update_len(app.visible_rows().len());
+    app
+}
+
+fn select_reference(app: &mut App, reference: &NodeRef) {
+    let position = app
+        .visible_rows()
+        .as_slice()
+        .iter()
+        .position(|row| &row.node.reference == reference)
+        .expect("reference should be visible in the test topology");
+    app.cursor.set_pos(position);
+}
+
+#[tokio::test]
+async fn navigation_does_not_wait_for_detail_fetch() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let held_reference = flatten_tree(&tree)[6].node.reference.clone();
+    let mut server = HeldAdminServer::spawn(responses, [held_reference.clone()]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+
+    let navigation = tokio::spawn(async move {
+        for _ in 0..6 {
+            let result = app.on_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+            app.apply_key_result(result).await;
+        }
+        app
+    });
+
+    server.wait_for_request(&held_reference).await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        navigation.is_finished(),
+        "cursor navigation waited for the held detail response"
+    );
+    let app = navigation
+        .await
+        .expect("navigation task should finish without the held response");
+    assert_eq!(app.cursor.pos(), 6, "all Down keys should be processed");
+    let selected = app
+        .selected_reference()
+        .expect("the final cursor position should select a node");
+    assert_eq!(&held_reference, selected);
+    assert!(
+        matches!(&app.detail, DetailState::Loading),
+        "the final cold selection should render as loading"
+    );
+    server.release(&held_reference);
+}
+
+#[tokio::test(start_paused = true)]
+async fn detail_request_waits_for_debounce() {
+    let TestTopology {
+        tree, target_actor, ..
+    } = large_topology();
+    let debounce = std::time::Duration::from_millis(100);
+    let mut app = app_with_tree("::invalid-url::".to_string(), tree, debounce);
+    select_reference(&mut app, &target_actor);
+
+    app.schedule_selected_detail();
+    tokio::task::yield_now().await;
+    assert_eq!(app.detail_request_is_finished(), Some(false));
+
+    tokio::time::advance(debounce - std::time::Duration::from_millis(1)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(app.detail_request_is_finished(), Some(false));
+
+    tokio::time::advance(std::time::Duration::from_millis(1)).await;
+    let result = app.receive_pending_detail_for_test().await;
+    assert!(matches!(result.state, FetchState::Error { .. }));
+    app.apply_detail_result(result);
+}
+
+#[tokio::test(start_paused = true)]
+async fn rapid_navigation_fetches_only_final_selection() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let final_reference = flatten_tree(&tree)[6].node.reference.clone();
+    let mut server = HeldAdminServer::spawn(responses, [final_reference.clone()]).await;
+    let debounce = std::time::Duration::from_millis(100);
+    let mut app = app_with_tree(server.base_url.clone(), tree, debounce);
+
+    for _ in 0..6 {
+        let result = app.on_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        app.apply_key_result(result).await;
+        tokio::task::yield_now().await;
+    }
+
+    assert_eq!(
+        server.total_request_count(),
+        0,
+        "crossed rows should remain inside the debounce window"
+    );
+    tokio::time::advance(debounce - std::time::Duration::from_millis(1)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(server.total_request_count(), 0);
+
+    tokio::time::advance(std::time::Duration::from_millis(1)).await;
+    assert_eq!(server.next_request().await, final_reference.to_string());
+    assert_eq!(server.request_count(&final_reference), 1);
+    server.assert_no_additional_request();
+    server.release(&final_reference);
+}
+
+async fn wait_for_detail_request_to_finish(app: &App) {
+    for _ in 0..100 {
+        if app.detail_request_is_finished() == Some(true) {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("detail request should finish after its held response is released");
+}
+
+#[tokio::test]
+async fn refresh_does_not_cancel_pending_detail_fetch() {
+    let TestTopology {
+        tree,
+        responses,
+        target_actor,
+        ..
+    } = large_topology();
+    let mut server = HeldAdminServer::spawn(responses, [target_actor.clone()]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+    select_reference(&mut app, &target_actor);
+    app.schedule_selected_detail();
+    server.wait_for_request(&target_actor).await;
+    let token = app.current_detail_token();
+
+    for _ in 0..3 {
+        app.refresh().await;
+        assert_eq!(app.pending_detail_reference(), Some(&target_actor));
+        assert_eq!(app.current_detail_token(), token);
+    }
+    assert_eq!(
+        server.request_count(&target_actor),
+        1,
+        "refresh should retain one detail request for the selected actor"
+    );
+
+    server.release(&target_actor);
+    let result = app.receive_pending_detail_for_test().await;
+    app.apply_detail_result(result);
+    assert!(matches!(
+        app.detail,
+        DetailState::Ready {
+            freshness: DetailFreshness::Fresh,
+            ..
+        }
+    ));
+    assert!(matches!(
+        app.fetch_cache.get(&target_actor),
+        Some(FetchState::Ready { generation, .. }) if *generation == app.refresh_gen
+    ));
+
+    app.schedule_selected_detail();
+    assert!(app.pending_detail_reference().is_none());
+    assert_eq!(server.request_count(&target_actor), 1);
+}
+
+#[tokio::test]
+async fn refresh_preserves_completed_detail_result() {
+    let TestTopology {
+        tree,
+        responses,
+        target_actor,
+        ..
+    } = large_topology();
+    let mut server = HeldAdminServer::spawn(responses, [target_actor.clone()]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+    select_reference(&mut app, &target_actor);
+    app.schedule_selected_detail();
+    server.wait_for_request(&target_actor).await;
+    let token = app.current_detail_token();
+    server.release(&target_actor);
+    wait_for_detail_request_to_finish(&app).await;
+
+    app.refresh().await;
+
+    assert_eq!(app.pending_detail_reference(), Some(&target_actor));
+    assert_eq!(app.current_detail_token(), token);
+    assert_eq!(server.request_count(&target_actor), 1);
+    let result = app.receive_pending_detail_for_test().await;
+    app.apply_detail_result(result);
+    assert!(matches!(
+        app.detail,
+        DetailState::Ready {
+            freshness: DetailFreshness::Fresh,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn refresh_supersedes_redundant_detail_request() {
+    let TestTopology {
+        tree,
+        responses,
+        target_proc,
+        ..
+    } = large_topology();
+    let mut server = HeldAdminServer::spawn(responses, [target_proc.clone()]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+    select_reference(&mut app, &target_proc);
+    app.schedule_selected_detail();
+    server.wait_for_request(&target_proc).await;
+    let token = app.current_detail_token();
+    server.release(&target_proc);
+    wait_for_detail_request_to_finish(&app).await;
+
+    app.refresh().await;
+
+    assert!(app.pending_detail_reference().is_none());
+    assert_ne!(app.current_detail_token(), token);
+    assert!(matches!(
+        &app.detail,
+        DetailState::Ready {
+            payload,
+            freshness: DetailFreshness::Fresh,
+        } if payload.identity == target_proc
+    ));
+    assert_eq!(server.request_count(&target_proc), 2);
+}
+
+#[test]
+fn fresh_cached_detail_is_displayed_without_a_request() {
+    let tree = large_topology().tree;
+    let mut app = app_with_tree(
+        "http://127.0.0.1:1".to_string(),
+        tree,
+        std::time::Duration::from_secs(60),
+    );
+    let reference = app
+        .selected_reference()
+        .expect("large tree should have a selection")
+        .clone();
+    app.fetch_cache.insert(
+        reference.clone(),
+        FetchState::Ready {
+            stamp: app.stamps.next(),
+            generation: app.refresh_gen,
+            value: detail_payload(reference),
+        },
+    );
+
+    app.schedule_selected_detail();
+
+    assert!(app.pending_detail_reference().is_none());
+    assert!(matches!(
+        app.detail,
+        DetailState::Ready {
+            freshness: DetailFreshness::Fresh,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn stale_cached_detail_is_displayed_while_revalidating() {
+    let tree = large_topology().tree;
+    let mut app = app_with_tree(
+        "http://127.0.0.1:1".to_string(),
+        tree,
+        std::time::Duration::from_secs(60),
+    );
+    let reference = app
+        .selected_reference()
+        .expect("large tree should have a selection")
+        .clone();
+    app.fetch_cache.insert(
+        reference.clone(),
+        FetchState::Ready {
+            stamp: app.stamps.next(),
+            generation: 0,
+            value: detail_payload(reference.clone()),
+        },
+    );
+    app.refresh_gen = 1;
+
+    app.schedule_selected_detail();
+
+    assert_eq!(app.pending_detail_reference(), Some(&reference));
+    assert!(matches!(
+        app.detail,
+        DetailState::Ready {
+            freshness: DetailFreshness::Revalidating,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn stale_detail_result_does_not_replace_current_selection() {
+    let tree = large_topology().tree;
+    let mut app = app_with_tree(
+        "http://127.0.0.1:1".to_string(),
+        tree,
+        std::time::Duration::from_secs(60),
+    );
+
+    app.schedule_selected_detail();
+    let stale_reference = app
+        .selected_reference()
+        .expect("large tree should have an initial selection")
+        .clone();
+    let stale_token = app.current_detail_token();
+
+    assert!(app.cursor.move_down());
+    app.schedule_selected_detail();
+    let current_reference = app
+        .selected_reference()
+        .expect("second row should be selected")
+        .clone();
+
+    app.apply_detail_result(DetailFetchResult {
+        reference: stale_reference.clone(),
+        token: stale_token,
+        state: FetchState::Ready {
+            stamp: app.stamps.next(),
+            generation: app.refresh_gen,
+            value: detail_payload(stale_reference),
+        },
+    });
+
+    assert_eq!(app.pending_detail_reference(), Some(&current_reference));
+    assert!(matches!(app.detail, DetailState::Loading));
+}
+
+#[tokio::test]
+async fn failed_revalidation_keeps_cached_detail_visible() {
+    let tree = large_topology().tree;
+    let mut app = app_with_tree(
+        "http://127.0.0.1:1".to_string(),
+        tree,
+        std::time::Duration::from_secs(60),
+    );
+    let reference = app
+        .selected_reference()
+        .expect("large tree should have a selection")
+        .clone();
+    app.fetch_cache.insert(
+        reference.clone(),
+        FetchState::Ready {
+            stamp: app.stamps.next(),
+            generation: 0,
+            value: detail_payload(reference.clone()),
+        },
+    );
+    app.refresh_gen = 1;
+    app.schedule_selected_detail();
+    let token = app.current_detail_token();
+
+    app.apply_detail_result(DetailFetchResult {
+        reference,
+        token,
+        state: FetchState::Error {
+            stamp: app.stamps.next(),
+            msg: "injected failure".to_string(),
+        },
+    });
+
+    assert!(matches!(
+        app.detail,
+        DetailState::Ready {
+            freshness: DetailFreshness::Stale { ref message },
+            ..
+        } if message.contains("injected failure")
+    ));
+}
+
+#[test]
+fn detail_pane_renders_loading_state() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let mut app = app_with_tree(
+        "http://127.0.0.1:1".to_string(),
+        large_topology().tree,
+        std::time::Duration::ZERO,
+    );
+    app.detail = DetailState::Loading;
+    let backend = TestBackend::new(60, 10);
+    let mut terminal = Terminal::new(backend).expect("test terminal should initialize");
+    terminal
+        .draw(|frame| crate::render::detail_pane::render_detail_pane(frame, frame.area(), &app))
+        .expect("detail pane should render");
+    let buffer = terminal.backend().buffer();
+    let text = (0..buffer.area.height)
+        .flat_map(|y| (0..buffer.area.width).map(move |x| buffer[(x, y)].symbol()))
+        .collect::<String>();
+
+    assert!(text.contains("Loading…"));
+}

--- a/hyperactor_mesh_admin_tui/src/timeouts.rs
+++ b/hyperactor_mesh_admin_tui/src/timeouts.rs
@@ -32,6 +32,8 @@
 //!   is suspended while any foreground job exists (both in-flight
 //!   and completed overlays). Refresh resumes only when the overlay
 //!   is dismissed.
+//! - **TP-11:** Detail-fetch debounce is owned by
+//!   `TuiTimeoutPolicy`, separately from request timeout budgets.
 
 use std::time::Duration;
 
@@ -87,6 +89,8 @@ pub(crate) struct TuiTimeoutPolicy {
     /// probes: below this is `Pass`, at or above this is `Slow`.
     /// This is not a timeout budget and does not cancel the probe.
     pub diagnostics_probe_slow: Duration,
+    /// Delay before fetching detail for a newly selected row.
+    pub detail_debounce: Duration,
     // Private fields; accessed via typed accessors.
     interactive_fetch: Duration,
     config_dump: Duration,
@@ -111,6 +115,7 @@ impl TuiTimeoutPolicy {
         Self {
             refresh_interval: Duration::from_millis(config.refresh_ms),
             diagnostics_probe_slow: Duration::from_millis(500),
+            detail_debounce: Duration::from_millis(100),
             interactive_fetch: Duration::from_secs(5),
             config_dump: Duration::from_secs(8),
             pyspy_dump: hyperactor_config::global::get(
@@ -281,6 +286,13 @@ mod tests {
     fn refresh_interval_default_cadence() {
         let policy = TuiTimeoutPolicy::from_config(&default_config());
         assert_eq!(policy.refresh_interval, Duration::from_secs(2));
+    }
+
+    // TP-11: detail debounce is explicit and independent of request budgets.
+    #[test]
+    fn detail_debounce_default() {
+        let policy = TuiTimeoutPolicy::from_config(&default_config());
+        assert_eq!(policy.detail_debounce, Duration::from_millis(100));
     }
 
     // TP-10: RefreshPolicy semilattice laws. Intentionally minimal

--- a/hyperactor_mesh_admin_tui/src/tree.rs
+++ b/hyperactor_mesh_admin_tui/src/tree.rs
@@ -39,15 +39,32 @@ pub(crate) fn flatten_tree(root: &TreeNode) -> Vec<FlatRow<'_>> {
 /// Includes current node and recursively includes children only if
 /// current node is expanded.
 pub(crate) fn flatten_visible<'a>(node: &'a TreeNode, depth: usize) -> Vec<FlatRow<'a>> {
-    fold_tree_with_depth(node, depth, &|n, d, child_results| {
-        let mut rows = vec![FlatRow { node: n, depth: d }];
-        if n.expanded {
-            for child_rows in child_results {
-                rows.extend(child_rows);
+    fold_tree_with_depth(
+        node,
+        depth,
+        &|n, d, child_results: Vec<Vec<FlatRow<'a>>>| {
+            let owning_proc = match &n.reference {
+                NodeRef::Proc(proc_id) => Some(proc_id),
+                _ => None,
+            };
+            let mut rows = vec![FlatRow {
+                node: n,
+                depth: d,
+                owning_proc,
+            }];
+            if n.expanded {
+                for child_rows in child_results {
+                    rows.extend(child_rows.into_iter().map(|mut row| {
+                        if row.owning_proc.is_none() {
+                            row.owning_proc = owning_proc;
+                        }
+                        row
+                    }));
+                }
             }
-        }
-        rows
-    })
+            rows
+        },
+    )
 }
 
 /// Generic tree fold - unified traversal abstraction.
@@ -577,13 +594,20 @@ mod tests {
             ],
         };
         let rows = flatten_tree(&tree);
+        let expected_proc = match proc_ref("proc1") {
+            NodeRef::Proc(proc_id) => proc_id,
+            _ => unreachable!("proc_ref constructs a proc reference"),
+        };
         assert_eq!(rows.len(), 3);
         assert_eq!(rows[0].node.reference, proc_ref("proc1"));
         assert_eq!(rows[0].depth, 0);
+        assert_eq!(rows[0].owning_proc, Some(&expected_proc));
         assert_eq!(rows[1].node.reference, actor("actor1"));
         assert_eq!(rows[1].depth, 1);
+        assert_eq!(rows[1].owning_proc, Some(&expected_proc));
         assert_eq!(rows[2].node.reference, actor("actor1"));
         assert_eq!(rows[2].depth, 0);
+        assert_eq!(rows[2].owning_proc, None);
     }
 
     #[test]


### PR DESCRIPTION
Summary:
the TUI currently waits for each uncached or stale right-pane detail request before it can draw or accept another key. on a large or slow deployment, navigation can therefore pause behind requests for rows the user is only passing through.

run detail requests in the background, debounce transient selections, and apply results only to the current selection. keep cached content visible while it revalidates, and preserve an active same-selection request across topology refresh unless the refresh has already supplied current detail.

add a deterministic 25-host × 4-process fixture with an actor row to exercise navigation, refresh, and request-ordering behavior.

this changes right-pane detail loading; topology refresh and Tab expansion remain synchronous.

Differential Revision: D119333343


