### PR TITLE
make topology refresh nonblocking

### DIFF
--- a/hyperactor_mesh_admin_tui/src/app.rs
+++ b/hyperactor_mesh_admin_tui/src/app.rs
@@ -9,6 +9,7 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io;
+use std::time::Duration;
 
 use algebra::JoinSemilattice;
 use crossterm::event::Event;
@@ -72,6 +73,142 @@ struct DetailRequest {
     task: JoinHandle<FetchState<NodePayload>>,
 }
 
+struct RefreshBuild {
+    client: reqwest::Client,
+    base_url: String,
+    cache: HashMap<NodeRef, FetchState<NodePayload>>,
+    show_system: bool,
+    show_stopped: bool,
+    expanded_keys: HashSet<(NodeRef, usize)>,
+    failed_keys: HashSet<(NodeRef, usize)>,
+    generation: u64,
+    stamps: StampAllocator,
+    timeout: Duration,
+}
+
+struct RefreshSnapshot {
+    tree: TreeNode,
+    cache: HashMap<NodeRef, FetchState<NodePayload>>,
+    generation: u64,
+    error: Option<String>,
+}
+
+enum RefreshBuildResult {
+    Ready(Box<RefreshSnapshot>),
+    Failed { message: Option<String> },
+}
+
+struct RefreshRequest {
+    view_revision: u64,
+    task: JoinHandle<RefreshBuildResult>,
+}
+
+impl Drop for RefreshRequest {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+pub(crate) struct RefreshCompletion {
+    view_revision: u64,
+    result: RefreshBuildResult,
+}
+
+#[cfg(test)]
+struct RefreshDropSignal(Option<oneshot::Sender<()>>);
+
+#[cfg(test)]
+impl Drop for RefreshDropSignal {
+    fn drop(&mut self) {
+        if let Some(sender) = self.0.take() {
+            let _ = sender.send(());
+        }
+    }
+}
+
+impl RefreshBuild {
+    async fn run(mut self) -> RefreshBuildResult {
+        let root_ref = NodeRef::Root;
+        let root_state = fetch_with_join(
+            &self.client,
+            &self.base_url,
+            &root_ref,
+            &mut self.cache,
+            self.generation,
+            &self.stamps,
+            true,
+            self.timeout,
+        )
+        .await;
+        let root_payload = match root_state {
+            FetchState::Ready { value, .. } => value,
+            FetchState::Error { msg, .. } => {
+                return RefreshBuildResult::Failed {
+                    message: Some(format!("Failed to connect: {msg}")),
+                };
+            }
+            FetchState::Unknown => return RefreshBuildResult::Failed { message: None },
+        };
+
+        let mut path = vec![NodeRef::Root];
+        let mut root_children = Vec::new();
+        let mut child_errors = Vec::new();
+        for child_ref in sorted_children(&root_payload) {
+            if let Some(child_node) = build_tree_node(
+                &self.client,
+                &self.base_url,
+                self.show_system,
+                self.show_stopped,
+                &mut self.cache,
+                &mut path,
+                &child_ref,
+                0,
+                &self.expanded_keys,
+                &self.failed_keys,
+                self.generation,
+                &self.stamps,
+                self.timeout,
+            )
+            .await
+            {
+                root_children.push(child_node);
+            } else if let Some(FetchState::Error { msg, .. }) = self.cache.get(&child_ref) {
+                child_errors.push(format!("{child_ref}: {msg}"));
+            }
+        }
+
+        let error = if root_children.is_empty() && !child_errors.is_empty() {
+            Some(format!(
+                "All host fetches failed: {}",
+                child_errors
+                    .first()
+                    .expect("non-empty child errors should have a first entry")
+            ))
+        } else {
+            None
+        };
+        let tree = TreeNode {
+            reference: NodeRef::Root,
+            label: "Root".to_string(),
+            node_type: NodeType::Root,
+            expanded: true,
+            fetched: true,
+            has_children: !root_children.is_empty(),
+            stopped: false,
+            failed: false,
+            is_system: false,
+            children: root_children,
+        };
+
+        RefreshBuildResult::Ready(Box::new(RefreshSnapshot {
+            tree,
+            cache: self.cache,
+            generation: self.generation,
+            error,
+        }))
+    }
+}
+
 impl Drop for DetailRequest {
     fn drop(&mut self) {
         self.task.abort();
@@ -120,6 +257,12 @@ pub(crate) struct App {
     detail_request: Option<DetailRequest>,
     /// Latest selection token; only a matching result may update the pane.
     detail_token: u64,
+    /// The one background topology refresh currently owned by this app.
+    refresh_request: Option<RefreshRequest>,
+    /// Whether one refresh should start when policy and the single-flight slot allow it.
+    refresh_pending: bool,
+    /// Monotonic revision of filter and expansion inputs used to build the tree.
+    view_revision: u64,
 
     /// Human-readable refresh interval (e.g. "1s", "5s").
     pub(crate) refresh_interval_label: String,
@@ -188,6 +331,9 @@ impl App {
             detail: DetailState::Empty,
             detail_request: None,
             detail_token: 0,
+            refresh_request: None,
+            refresh_pending: false,
+            view_revision: 0,
             refresh_interval_label: String::new(),
             error: None,
             show_system: false,
@@ -298,18 +444,7 @@ impl App {
         rows.get(&self.cursor).map(|row| &row.node.reference)
     }
 
-    /// Refresh the in-memory topology model by re-walking the
-    /// reference graph from `"root"`.
-    ///
-    /// Preserves expansion state (and tries to preserve the current
-    /// selection) across rebuilds, updates the node cache, and then
-    /// refreshes the detail pane for the currently selected row.
-    pub(crate) async fn refresh(&mut self) {
-        self.error = None;
-        self.refresh_gen += 1;
-
-        // Save expanded and failed state before rebuilding.
-        // Track (reference, depth) pairs to handle dual appearances correctly.
+    fn refresh_build(&self) -> RefreshBuild {
         let mut expanded_keys = HashSet::new();
         let mut failed_keys = HashSet::new();
         if let Some(root) = self.tree() {
@@ -319,79 +454,80 @@ impl App {
             }
         }
 
-        // Save current selection's reference and depth.
-        let rows = self.visible_rows();
-        let prev_selection = rows
+        RefreshBuild {
+            client: self.client.clone(),
+            base_url: self.base_url.clone(),
+            cache: self.fetch_cache.clone(),
+            show_system: self.show_system,
+            show_stopped: self.show_stopped,
+            expanded_keys,
+            failed_keys,
+            generation: self.refresh_gen.wrapping_add(1),
+            stamps: self.stamps.clone(),
+            timeout: self
+                .policy
+                .request_timeout(crate::timeouts::RequestOp::InteractiveFetch),
+        }
+    }
+
+    /// Load the first complete topology before entering the terminal event loop.
+    pub(crate) async fn load_initial_topology(&mut self) {
+        self.error = None;
+        match self.refresh_build().run().await {
+            RefreshBuildResult::Ready(snapshot) => self.apply_refresh_snapshot(*snapshot),
+            RefreshBuildResult::Failed { message } => self.error = message,
+        }
+    }
+
+    /// Remember one refresh request and start it when policy permits.
+    pub(crate) fn request_refresh(&mut self) {
+        self.refresh_pending = true;
+        self.start_pending_refresh_if_allowed();
+    }
+
+    pub(crate) fn start_pending_refresh_if_allowed(&mut self) {
+        if self.should_quit
+            || !self.refresh_pending
+            || self.refresh_request.is_some()
+            || !refresh_policy_for_job(&self.active_job).permits_refresh()
+        {
+            return;
+        }
+
+        self.refresh_pending = false;
+        self.error = None;
+        let view_revision = self.view_revision;
+        let task = tokio::spawn(self.refresh_build().run());
+        self.refresh_request = Some(RefreshRequest {
+            view_revision,
+            task,
+        });
+    }
+
+    fn note_view_inputs_changed(&mut self) {
+        self.view_revision = self.view_revision.wrapping_add(1);
+        if self.refresh_request.take().is_some() {
+            self.refresh_pending = true;
+        }
+    }
+
+    fn apply_refresh_snapshot(&mut self, snapshot: RefreshSnapshot) {
+        let current_selection = self
+            .visible_rows()
             .get(&self.cursor)
             .map(|row| (row.node.reference.clone(), row.depth));
 
-        // Fetch root using centralized fetch with force=true.
-        let root_ref = NodeRef::Root;
-        let root_state = self.fetch_node_state(&root_ref, true).await;
-        let root_payload = match root_state {
-            FetchState::Ready { value, .. } => value,
-            FetchState::Error { msg, .. } => {
-                self.error = Some(format!("Failed to connect: {}", msg));
-                return;
-            }
-            FetchState::Unknown => return,
-        };
-
-        // Path for cycle detection: tracks current path from root to
-        // Node being built. Start with root in the path.
-        let mut path = vec![NodeRef::Root];
-
-        // Build tree recursively from root's children.
-        let mut root_children = Vec::new();
-        let sorted = sorted_children(&root_payload);
-
-        let mut child_errors = Vec::new();
-        for child_ref in &sorted {
-            if let Some(child_node) = build_tree_node(
-                &self.client,
-                &self.base_url,
-                self.show_system,
-                self.show_stopped,
-                &mut self.fetch_cache,
-                &mut path,
-                child_ref,
-                0,
-                &expanded_keys,
-                &failed_keys,
-                self.refresh_gen,
-                &self.stamps,
-                self.policy
-                    .request_timeout(crate::timeouts::RequestOp::InteractiveFetch),
-            )
-            .await
-            {
-                root_children.push(child_node);
-            } else if let Some(FetchState::Error { msg, .. }) = self.fetch_cache.get(child_ref) {
-                child_errors.push(format!("{}: {}", child_ref, msg));
-            }
-        }
-        if root_children.is_empty() && !child_errors.is_empty() {
-            self.error = Some(format!(
-                "All host fetches failed: {}",
-                child_errors.first().unwrap()
-            ));
+        for (reference, state) in snapshot.cache {
+            self.fetch_cache
+                .entry(reference)
+                .and_modify(|current| *current = current.join(&state))
+                .or_insert(state);
         }
 
-        // Create synthetic root node.
-        self.set_tree(Some(TreeNode {
-            reference: NodeRef::Root,
-            label: "Root".to_string(),
-            node_type: NodeType::Root,
-            expanded: true,
-            fetched: true,
-            has_children: !root_children.is_empty(),
-            stopped: false,
-            failed: false,
-            is_system: false,
-            children: root_children,
-        }));
+        self.refresh_gen = snapshot.generation;
+        self.error = snapshot.error;
+        self.set_tree(Some(snapshot.tree));
 
-        // Prune stale cache entries (collect owned refs to avoid borrow issues).
         let live_refs: HashSet<NodeRef> = if let Some(root) = self.tree() {
             let mut refs = HashSet::new();
             collect_refs(root, &mut refs);
@@ -399,32 +535,97 @@ impl App {
         } else {
             HashSet::new()
         };
-        self.fetch_cache
-            .retain(|k, _| matches!(k, NodeRef::Root) || live_refs.contains(k));
+        self.fetch_cache.retain(|reference, _| {
+            matches!(reference, NodeRef::Root) || live_refs.contains(reference)
+        });
 
-        // Restore selection position.
-        let rows = self.visible_rows();
-        if let Some((prev_ref, prev_depth)) = prev_selection {
-            // Try to match both reference and depth first.
-            let depth_match = rows
-                .as_slice()
-                .iter()
-                .position(|row| row.node.reference == prev_ref && row.depth == prev_depth);
-            // Fall back to matching just reference.
-            let any_match = rows
-                .as_slice()
-                .iter()
-                .position(|row| row.node.reference == prev_ref);
+        let (row_count, restored_position) = {
+            let rows = self.visible_rows();
+            let restored_position = current_selection.and_then(|(reference, depth)| {
+                let depth_match = rows
+                    .as_slice()
+                    .iter()
+                    .position(|row| row.node.reference == reference && row.depth == depth);
+                let any_match = rows
+                    .as_slice()
+                    .iter()
+                    .position(|row| row.node.reference == reference);
+                depth_match.or(any_match)
+            });
+            (rows.len(), restored_position)
+        };
+        self.cursor.update_len(row_count);
+        if let Some(position) = restored_position {
+            self.cursor.set_pos(position);
+        }
+    }
 
-            self.cursor.update_len(rows.len());
-            if let Some(pos) = depth_match.or(any_match) {
-                self.cursor.set_pos(pos);
-            }
-        } else {
-            self.cursor.update_len(rows.len());
+    pub(crate) fn apply_refresh_completion(&mut self, completion: RefreshCompletion) {
+        let is_current_request = self
+            .refresh_request
+            .as_ref()
+            .is_some_and(|request| request.view_revision == completion.view_revision);
+        if !is_current_request {
+            return;
+        }
+        self.refresh_request = None;
+
+        if !refresh_policy_for_job(&self.active_job).permits_refresh()
+            || completion.view_revision != self.view_revision
+        {
+            self.refresh_pending = true;
+            return;
         }
 
-        self.schedule_selected_detail();
+        match completion.result {
+            RefreshBuildResult::Ready(snapshot) => {
+                self.apply_refresh_snapshot(*snapshot);
+                self.schedule_selected_detail();
+            }
+            RefreshBuildResult::Failed { message } => self.error = message,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn refresh_is_in_flight(&self) -> bool {
+        self.refresh_request.is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn refresh_is_pending(&self) -> bool {
+        self.refresh_pending
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_refresh_view_revision(&self) -> Option<u64> {
+        self.refresh_request
+            .as_ref()
+            .map(|request| request.view_revision)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn receive_pending_refresh_for_test(&mut self) -> RefreshCompletion {
+        recv_refresh_request(&mut self.refresh_request).await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_panicking_refresh_for_test(&mut self) {
+        self.refresh_request = Some(RefreshRequest {
+            view_revision: self.view_revision,
+            task: tokio::spawn(async { panic!("injected refresh panic") }),
+        });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_pending_refresh_for_test(&mut self, dropped: oneshot::Sender<()>) {
+        let signal = RefreshDropSignal(Some(dropped));
+        self.refresh_request = Some(RefreshRequest {
+            view_revision: self.view_revision,
+            task: tokio::spawn(async move {
+                let _signal = signal;
+                std::future::pending::<RefreshBuildResult>().await
+            }),
+        });
     }
 
     /// Lazily expand a single node by fetching its children.
@@ -655,6 +856,10 @@ impl App {
             stamp,
             task,
         });
+    }
+
+    pub(crate) fn seed_initial_detail(&mut self) {
+        self.schedule_selected_detail();
     }
 
     #[cfg(test)]
@@ -1098,6 +1303,7 @@ impl App {
                             node.expanded = false;
                             let rows = self.visible_rows();
                             self.cursor.update_len(rows.len());
+                            self.note_view_inputs_changed();
                             return KeyResult::DetailChanged;
                         }
                     } else {
@@ -1116,16 +1322,19 @@ impl App {
                 });
                 let rows = self.visible_rows();
                 self.cursor.update_len(rows.len());
+                self.note_view_inputs_changed();
                 KeyResult::DetailChanged
             }
             KeyCode::Char('s') => {
                 // Toggle system proc visibility
                 self.show_system = !self.show_system;
+                self.note_view_inputs_changed();
                 KeyResult::NeedsRefresh
             }
             KeyCode::Char('h') => {
                 // Toggle stopped actor visibility (failed always visible)
                 self.show_stopped = !self.show_stopped;
+                self.note_view_inputs_changed();
                 KeyResult::NeedsRefresh
             }
             KeyCode::Char('l') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -1199,7 +1408,7 @@ impl App {
                 self.schedule_selected_detail();
             }
             KeyResult::NeedsRefresh => {
-                self.refresh().await;
+                self.request_refresh();
             }
             KeyResult::ExpandNode(reference, depth) => {
                 if self.expand_node(&reference, depth).await {
@@ -1207,6 +1416,7 @@ impl App {
                     self.cursor.update_len(rows.len());
                     self.cursor.move_down();
                     self.ensure_cursor_visible();
+                    self.note_view_inputs_changed();
                 }
                 self.schedule_selected_detail();
             }
@@ -1227,6 +1437,7 @@ impl App {
             }
             KeyResult::None => {}
         }
+        self.start_pending_refresh_if_allowed();
     }
 
     /// Dispatch variant-specific rerun keys when an overlay is active.
@@ -1605,6 +1816,24 @@ async fn recv_detail_request(request: &mut Option<DetailRequest>) -> DetailFetch
     }
 }
 
+/// Await the one background topology refresh currently owned by the app.
+async fn recv_refresh_request(request: &mut Option<RefreshRequest>) -> RefreshCompletion {
+    let Some(request) = request else {
+        return std::future::pending().await;
+    };
+    let view_revision = request.view_revision;
+    let result = match (&mut request.task).await {
+        Ok(result) => result,
+        Err(error) => RefreshBuildResult::Failed {
+            message: Some(format!("Refresh task failed: {error}")),
+        },
+    };
+    RefreshCompletion {
+        view_revision,
+        result,
+    }
+}
+
 /// TP-10: derive refresh policy from active job state.
 ///
 /// Suspend refresh while any foreground job is active — both
@@ -1631,12 +1860,14 @@ pub(crate) async fn run_app(
 ) -> io::Result<()> {
     let refresh_ms = app.policy.refresh_interval.as_millis() as u64;
     let mut refresh_interval = tokio::time::interval(app.policy.refresh_interval);
+    refresh_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     app.refresh_interval_label = if refresh_ms >= 1000 && refresh_ms.is_multiple_of(1000) {
         format!("{}s", refresh_ms / 1000)
     } else {
         format!("{}ms", refresh_ms)
     };
     let mut events = EventStream::new();
+    app.seed_initial_detail();
 
     loop {
         // Update viewport height before rendering. The body area is
@@ -1648,20 +1879,7 @@ pub(crate) async fn run_app(
 
         tokio::select! {
             _ = refresh_interval.tick() => {
-                // Phase 3a: the effective refresh policy is the
-                // join of all refresh-pressure sources. Currently
-                // there is one source (foreground job state); later
-                // sources extend by more joins, not by rewriting
-                // the branch. Refresh runs only when effective
-                // policy is Baseline. When the in-flight operation
-                // completes, refresh resumes on the next scheduled
-                // tick, not immediately.
-                use crate::timeouts::RefreshPolicy;
-                let effective = RefreshPolicy::Baseline
-                    .join(&refresh_policy_for_job(&app.active_job));
-                if effective == RefreshPolicy::Baseline {
-                    app.refresh().await;
-                }
+                app.request_refresh();
             }
             maybe_event = events.next() => {
                 match maybe_event {
@@ -1682,7 +1900,12 @@ pub(crate) async fn run_app(
             detail_result = recv_detail_request(&mut app.detail_request) => {
                 app.apply_detail_result(detail_result);
             }
+            refresh_result = recv_refresh_request(&mut app.refresh_request) => {
+                app.apply_refresh_completion(refresh_result);
+            }
         }
+
+        app.start_pending_refresh_if_allowed();
 
         if app.should_quit {
             break;

--- a/hyperactor_mesh_admin_tui/src/fetch.rs
+++ b/hyperactor_mesh_admin_tui/src/fetch.rs
@@ -30,15 +30,15 @@ use crate::model::TreeNode;
 
 /// Monotonic ordering key for fetch results.
 ///
-/// `ts_micros` comes from wall-clock time and `seq`
-/// breaks ties to ensure a total order within this process.
+/// `seq` defines allocation order within this process. `ts_micros`
+/// records when the allocation occurred and breaks equal-sequence
+/// ties in constructed values.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct Stamp {
+    /// Monotonic ordering key shared by allocator clones.
+    pub(crate) seq: u64,
     /// Wall-clock timestamp in microseconds since UNIX epoch.
     pub(crate) ts_micros: u64,
-    /// Monotonic tie-breaker for identical timestamps in this
-    /// process.
-    pub(crate) seq: u64,
 }
 
 /// Clone-shared allocator for fetch ordering stamps.
@@ -61,7 +61,7 @@ impl StampAllocator {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_micros() as u64;
-        Stamp { ts_micros, seq }
+        Stamp { seq, ts_micros }
     }
 }
 
@@ -612,31 +612,42 @@ mod tests {
     }
 
     #[test]
-    fn stamp_orders_by_timestamp_first() {
-        let earlier = Stamp {
-            ts_micros: 1000,
-            seq: 2,
-        };
-        let later = Stamp {
-            ts_micros: 2000,
-            seq: 1,
-        };
-        assert!(earlier < later);
-        assert!(later > earlier);
-    }
-
-    #[test]
-    fn stamp_orders_by_seq_when_timestamp_equal() {
+    fn stamp_orders_by_sequence_first() {
         let first = Stamp {
-            ts_micros: 1000,
             seq: 1,
+            ts_micros: 2000,
         };
         let second = Stamp {
-            ts_micros: 1000,
             seq: 2,
+            ts_micros: 1000,
         };
         assert!(first < second);
         assert!(second > first);
+    }
+
+    #[test]
+    fn stamp_uses_timestamp_when_sequence_is_equal() {
+        let first = Stamp {
+            seq: 1,
+            ts_micros: 1000,
+        };
+        let second = Stamp {
+            seq: 1,
+            ts_micros: 2000,
+        };
+        assert!(first < second);
+        assert!(second > first);
+    }
+
+    #[test]
+    fn allocator_clones_share_sequence_order() {
+        let allocator = StampAllocator::default();
+        let clone = allocator.clone();
+
+        let first = allocator.next();
+        let second = clone.next();
+
+        assert!(first < second);
     }
 
     #[test]
@@ -841,20 +852,20 @@ mod tests {
     }
 
     #[test]
-    fn join_uses_seq_for_tie_break() {
+    fn join_prefers_later_sequence() {
         let payload = mock_payload(mock_actor_ref("test"));
         let first = FetchState::Ready {
             stamp: Stamp {
-                ts_micros: 1000,
                 seq: 1,
+                ts_micros: 2000,
             },
             generation: 1,
             value: payload.clone(),
         };
         let second = FetchState::Ready {
             stamp: Stamp {
-                ts_micros: 1000,
                 seq: 2,
+                ts_micros: 1000,
             },
             generation: 1,
             value: payload.clone(),

--- a/hyperactor_mesh_admin_tui/src/lib.rs
+++ b/hyperactor_mesh_admin_tui/src/lib.rs
@@ -23,7 +23,9 @@
 //!
 //! 1. **TUI-1 (join-semilattice):** All fetch results merge via
 //!    `FetchState::join`, guaranteeing commutativity, associativity,
-//!    and idempotence under retries and reordering.
+//!    and idempotence under retries and reordering. `Stamp` compares
+//!    allocator sequence before wall-clock time, so cloned foreground
+//!    and background allocators agree on result precedence.
 //! 2. **TUI-2 (cursor-bounds):** Selection is managed by `Cursor`, which
 //!    enforces the invariant `pos < len` (or `pos == 0` when empty).
 //! 3. **TUI-3 (tree-recursion):** The mesh topology is stored
@@ -43,6 +45,9 @@
 //!   remains displayable; errors always retry. A completed detail
 //!   request accepted for the current selection joins at the current
 //!   generation, including when it spans a topology refresh.
+//!   `refresh_gen` advances only when a current, successful topology
+//!   snapshot is applied; discarded and failed snapshots leave it
+//!   unchanged.
 //! - **TUI-7 (synthetic-root):** The root node is synthetic and
 //!   always expanded; only its children are rendered at depth 0.
 //! - **TUI-8 (cycle-safety):** Tree building rejects only true
@@ -53,13 +58,15 @@
 //!   abstractions, not bespoke recursion.
 //! - **TUI-11 (selection-semantics):** Cursor restoration prefers
 //!   `(reference, depth)` to disambiguate; falls back to
-//!   reference-only if depth changes.
+//!   reference-only if depth changes. Background snapshot application
+//!   preserves the selection live at application time, not the one
+//!   present when its walk started.
 //! - **TUI-12 (serial-topology-fetches):** Topology cache fetches
 //!   (via `fetch_with_join` / `build_tree_node`) are serial within
-//!   a refresh cycle; join semantics handle retries and reordering.
-//!   Detail and overlay fetches are concurrent via `tokio::spawn`;
-//!   detail results rejoin the topology cache on the event loop,
-//!   while overlay results do not participate in that cache.
+//!   a refresh cycle, while one background refresh may overlap detail
+//!   and overlay work. Join semantics handle retries and reordering.
+//!   Detail and refresh results rejoin the topology cache on the event
+//!   loop; overlay results do not participate in that cache.
 //! - **TUI-13 (stopped-detection):** `is_stopped_node` matches
 //!   `Actor` variants whose `actor_status` starts with `"stopped:"`
 //!   or `"failed:"`. All other variants return false.
@@ -108,9 +115,9 @@
 //!   still requests quit. Rendering gives the help overlay precedence
 //!   over `app.overlay` and node detail, and help never mutates the
 //!   topology or detail cache.
-//! - **TUI-23 (nonblocking-detail):** The input/render loop never
-//!   awaits node-detail network I/O. Selection schedules background
-//!   work and returns immediately.
+//! - **TUI-23 (nonblocking-network-work):** The input/render loop never
+//!   awaits node-detail or topology-refresh network I/O. Selection and
+//!   refresh requests schedule background work and return immediately.
 //! - **TUI-24 (latest-selection-wins):** Only a detail result whose
 //!   reference and request token still match the current selection
 //!   may update the visible pane. A topology refresh preserves an
@@ -119,6 +126,16 @@
 //! - **TUI-25 (stale-while-revalidate):** Any present detail payload
 //!   is displayed immediately and never regresses to loading while
 //!   its reference is revalidated.
+//! - **TUI-26 (snapshot-input-currency):** A topology snapshot is
+//!   installed only while the filter flags and expansion state it was
+//!   built from remain current. Superseded snapshots are cancelled or
+//!   discarded without advancing `refresh_gen`, and one replacement is
+//!   remembered.
+//! - **TUI-27 (refresh-lifecycle):** `App` owns at most one refresh
+//!   task and cancels it when superseded or dropped. Every terminal
+//!   outcome releases the single-flight slot; only a successful,
+//!   input-current snapshot may replace the tree or advance
+//!   `refresh_gen`.
 //!
 //! Py-spy overlay invariants:
 //!
@@ -368,7 +385,7 @@ pub async fn run(config: TuiConfig) -> io::Result<()> {
     spinner.enable_steady_tick(Duration::from_millis(80));
 
     let splash_start = tokio::time::Instant::now();
-    app.refresh().await;
+    app.load_initial_topology().await;
     let elapsed = splash_start.elapsed();
     let min_splash = Duration::from_secs(2);
     if elapsed < min_splash {

--- a/hyperactor_mesh_admin_tui/src/tests/responsive_navigation.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/responsive_navigation.rs
@@ -489,6 +489,13 @@ async fn wait_for_detail_request_to_finish(app: &App) {
     panic!("detail request should finish after its held response is released");
 }
 
+async fn run_refresh(app: &mut App) {
+    app.request_refresh();
+    let completion = app.receive_pending_refresh_for_test().await;
+    app.apply_refresh_completion(completion);
+    app.start_pending_refresh_if_allowed();
+}
+
 #[tokio::test]
 async fn refresh_does_not_cancel_pending_detail_fetch() {
     let TestTopology {
@@ -505,7 +512,7 @@ async fn refresh_does_not_cancel_pending_detail_fetch() {
     let token = app.current_detail_token();
 
     for _ in 0..3 {
-        app.refresh().await;
+        run_refresh(&mut app).await;
         assert_eq!(app.pending_detail_reference(), Some(&target_actor));
         assert_eq!(app.current_detail_token(), token);
     }
@@ -552,7 +559,7 @@ async fn refresh_preserves_completed_detail_result() {
     server.release(&target_actor);
     wait_for_detail_request_to_finish(&app).await;
 
-    app.refresh().await;
+    run_refresh(&mut app).await;
 
     assert_eq!(app.pending_detail_reference(), Some(&target_actor));
     assert_eq!(app.current_detail_token(), token);
@@ -585,7 +592,7 @@ async fn refresh_supersedes_redundant_detail_request() {
     server.release(&target_proc);
     wait_for_detail_request_to_finish(&app).await;
 
-    app.refresh().await;
+    run_refresh(&mut app).await;
 
     assert!(app.pending_detail_reference().is_none());
     assert_ne!(app.current_detail_token(), token);
@@ -767,4 +774,395 @@ fn detail_pane_renders_loading_state() {
         .collect::<String>();
 
     assert!(text.contains("Loading…"));
+}
+
+#[tokio::test]
+async fn refresh_does_not_block_navigation() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let mut server = HeldAdminServer::spawn(responses, [NodeRef::Root]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+    let initial_generation = app.refresh_gen;
+
+    app.request_refresh();
+
+    server.wait_for_request(&NodeRef::Root).await;
+    let result = app.on_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+    app.apply_key_result(result).await;
+
+    assert_eq!(app.cursor.pos(), 1, "Down should move immediately");
+    assert!(app.refresh_is_in_flight());
+    assert_eq!(app.refresh_gen, initial_generation);
+    let selected = app
+        .selected_reference()
+        .expect("the moved cursor should select a row")
+        .clone();
+
+    server.release(&NodeRef::Root);
+    let completion = app.receive_pending_refresh_for_test().await;
+    app.apply_refresh_completion(completion);
+
+    assert_eq!(app.selected_reference(), Some(&selected));
+}
+
+#[tokio::test]
+async fn refresh_keeps_previous_tree_visible() {
+    let TestTopology {
+        tree,
+        mut responses,
+        ..
+    } = large_topology();
+    let retained_host = host("host-0");
+    responses.insert(
+        NodeRef::Root.to_string(),
+        NodePayloadDto::from(NodePayload {
+            identity: NodeRef::Root,
+            properties: NodeProperties::Root {
+                num_hosts: 1,
+                started_at: SystemTime::UNIX_EPOCH,
+                started_by: "responsive-navigation-test".to_string(),
+                system_children: Vec::new(),
+            },
+            children: vec![retained_host],
+            parent: None,
+            as_of: SystemTime::UNIX_EPOCH,
+        }),
+    );
+    let mut server = HeldAdminServer::spawn(responses, [NodeRef::Root]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+    let previous_rows = app.visible_rows().len();
+
+    app.request_refresh();
+    server.wait_for_request(&NodeRef::Root).await;
+
+    assert_eq!(app.visible_rows().len(), previous_rows);
+
+    server.release(&NodeRef::Root);
+    let completion = app.receive_pending_refresh_for_test().await;
+    app.apply_refresh_completion(completion);
+
+    assert!(app.visible_rows().len() < previous_rows);
+}
+
+#[tokio::test]
+async fn refresh_ticks_are_coalesced_while_one_is_in_flight() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let mut server = HeldAdminServer::spawn(responses, [NodeRef::Root]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+
+    app.request_refresh();
+    server.wait_for_request(&NodeRef::Root).await;
+    for _ in 0..5 {
+        app.request_refresh();
+    }
+
+    assert!(app.refresh_is_in_flight());
+    assert!(app.refresh_is_pending());
+
+    server.release(&NodeRef::Root);
+    let first = app.receive_pending_refresh_for_test().await;
+    app.apply_refresh_completion(first);
+    app.start_pending_refresh_if_allowed();
+    server.wait_for_request(&NodeRef::Root).await;
+
+    let second = app.receive_pending_refresh_for_test().await;
+    app.apply_refresh_completion(second);
+    app.start_pending_refresh_if_allowed();
+
+    assert_eq!(server.request_count(&NodeRef::Root), 2);
+    assert!(!app.refresh_is_in_flight());
+    assert!(!app.refresh_is_pending());
+}
+
+#[tokio::test]
+async fn completed_refresh_preserves_selection_by_reference() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let mut server = HeldAdminServer::spawn(responses, [NodeRef::Root]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+
+    app.request_refresh();
+    server.wait_for_request(&NodeRef::Root).await;
+    for _ in 0..7 {
+        let result = app.on_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        app.apply_key_result(result).await;
+    }
+    let selected = app
+        .selected_reference()
+        .expect("navigation should leave a selected row")
+        .clone();
+
+    server.release(&NodeRef::Root);
+    let completion = app.receive_pending_refresh_for_test().await;
+    app.apply_refresh_completion(completion);
+
+    assert_eq!(app.selected_reference(), Some(&selected));
+}
+
+#[tokio::test]
+async fn refresh_completion_is_deferred_across_foreground_overlay() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let server = HeldAdminServer::spawn(responses, []).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+    let generation = app.refresh_gen;
+
+    app.request_refresh();
+    let completion = app.receive_pending_refresh_for_test().await;
+    app.set_job(ActiveJob::Diagnostics {
+        results: Vec::new(),
+        running: true,
+        rx: None,
+        completed_at: None,
+    });
+    app.apply_refresh_completion(completion);
+
+    assert_eq!(app.refresh_gen, generation);
+    assert!(app.refresh_is_pending());
+    assert!(!app.refresh_is_in_flight());
+
+    app.dismiss_job();
+    app.start_pending_refresh_if_allowed();
+    assert!(app.refresh_is_in_flight());
+    let completion = app.receive_pending_refresh_for_test().await;
+    app.apply_refresh_completion(completion);
+    assert_eq!(app.refresh_gen, generation + 1);
+}
+
+#[tokio::test]
+async fn startup_schedules_detail_for_initial_selection() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let selected = flatten_tree(&tree)[0].node.reference.clone();
+    let mut server = HeldAdminServer::spawn(responses, [selected.clone()]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+
+    app.seed_initial_detail();
+
+    server.wait_for_request(&selected).await;
+    assert_eq!(app.pending_detail_reference(), Some(&selected));
+    server.release(&selected);
+}
+
+#[tokio::test]
+async fn background_refresh_does_not_mark_visible_rows_stale() {
+    let TestTopology {
+        tree,
+        responses,
+        target_actor,
+        ..
+    } = large_topology();
+    let mut server = HeldAdminServer::spawn(responses, [NodeRef::Root]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+    select_reference(&mut app, &target_actor);
+    app.fetch_cache.insert(
+        target_actor.clone(),
+        FetchState::Ready {
+            stamp: app.stamps.next(),
+            generation: app.refresh_gen,
+            value: detail_payload(target_actor.clone()),
+        },
+    );
+
+    app.request_refresh();
+    server.wait_for_request(&NodeRef::Root).await;
+    app.schedule_selected_detail();
+
+    assert!(app.pending_detail_reference().is_none());
+    assert_eq!(server.request_count(&target_actor), 0);
+    assert!(matches!(
+        app.detail,
+        DetailState::Ready {
+            freshness: DetailFreshness::Fresh,
+            ..
+        }
+    ));
+    server.release(&NodeRef::Root);
+}
+
+#[tokio::test]
+async fn discarded_snapshot_does_not_advance_generation() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let server = HeldAdminServer::spawn(responses, []).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+    let generation = app.refresh_gen;
+
+    app.request_refresh();
+    let completion = app.receive_pending_refresh_for_test().await;
+    app.set_job(ActiveJob::Diagnostics {
+        results: Vec::new(),
+        running: true,
+        rx: None,
+        completed_at: None,
+    });
+    app.apply_refresh_completion(completion);
+
+    assert_eq!(app.refresh_gen, generation);
+}
+
+#[tokio::test]
+async fn filter_change_supersedes_in_flight_refresh() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let mut server = HeldAdminServer::spawn(responses, [NodeRef::Root]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+
+    app.request_refresh();
+    server.wait_for_request(&NodeRef::Root).await;
+    let first_revision = app
+        .current_refresh_view_revision()
+        .expect("the first refresh should record its view revision");
+
+    let result = app.on_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+    app.apply_key_result(result).await;
+    server.wait_for_request(&NodeRef::Root).await;
+
+    assert!(app.show_system);
+    assert!(
+        app.current_refresh_view_revision()
+            .is_some_and(|revision| revision > first_revision)
+    );
+    assert_eq!(app.refresh_gen, 0);
+    assert_eq!(server.request_count(&NodeRef::Root), 2);
+
+    server.release(&NodeRef::Root);
+    let completion = app.receive_pending_refresh_for_test().await;
+    app.apply_refresh_completion(completion);
+}
+
+#[tokio::test]
+async fn collapse_supersedes_in_flight_refresh() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let mut server = HeldAdminServer::spawn(responses, [NodeRef::Root]).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+    assert!(
+        app.tree()
+            .and_then(|root| root.children.first())
+            .is_some_and(|host| host.expanded)
+    );
+
+    app.request_refresh();
+    server.wait_for_request(&NodeRef::Root).await;
+    let result = app.on_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE));
+    app.apply_key_result(result).await;
+    server.wait_for_request(&NodeRef::Root).await;
+
+    assert!(
+        app.tree()
+            .and_then(|root| root.children.first())
+            .is_some_and(|host| !host.expanded)
+    );
+
+    server.release(&NodeRef::Root);
+    let completion = app.receive_pending_refresh_for_test().await;
+    app.apply_refresh_completion(completion);
+
+    assert!(
+        app.tree()
+            .and_then(|root| root.children.first())
+            .is_some_and(|host| !host.expanded)
+    );
+}
+
+#[tokio::test]
+async fn stale_refresh_completion_does_not_cancel_current_refresh() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let server = HeldAdminServer::spawn(responses, []).await;
+    let mut app = app_with_tree(server.base_url.clone(), tree, std::time::Duration::ZERO);
+
+    app.request_refresh();
+    let stale_revision = app
+        .current_refresh_view_revision()
+        .expect("the first refresh should record its view revision");
+    let stale_completion = app.receive_pending_refresh_for_test().await;
+
+    let result = app.on_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE));
+    app.apply_key_result(result).await;
+    app.start_pending_refresh_if_allowed();
+    assert!(
+        app.current_refresh_view_revision()
+            .is_some_and(|revision| revision > stale_revision)
+    );
+
+    app.apply_refresh_completion(stale_completion);
+
+    assert!(app.refresh_is_in_flight());
+}
+
+#[tokio::test]
+async fn failed_refresh_preserves_last_good_tree_and_allows_retry() {
+    let TestTopology {
+        tree, responses, ..
+    } = large_topology();
+    let server = HeldAdminServer::spawn(responses, []).await;
+    let mut app = app_with_tree(
+        "::invalid-url::".to_string(),
+        tree,
+        std::time::Duration::ZERO,
+    );
+    let expected_references: Vec<_> = app
+        .visible_rows()
+        .as_slice()
+        .iter()
+        .map(|row| row.node.reference.clone())
+        .collect();
+    let generation = app.refresh_gen;
+
+    run_refresh(&mut app).await;
+
+    assert_eq!(app.refresh_gen, generation);
+    assert_eq!(
+        app.visible_rows()
+            .as_slice()
+            .iter()
+            .map(|row| row.node.reference.clone())
+            .collect::<Vec<_>>(),
+        expected_references
+    );
+    assert!(!app.refresh_is_in_flight());
+
+    app.base_url = server.base_url.clone();
+    run_refresh(&mut app).await;
+    assert_eq!(app.refresh_gen, generation + 1);
+
+    let generation = app.refresh_gen;
+    app.install_panicking_refresh_for_test();
+    let completion = app.receive_pending_refresh_for_test().await;
+    app.apply_refresh_completion(completion);
+    assert_eq!(app.refresh_gen, generation);
+    assert!(!app.refresh_is_in_flight());
+
+    run_refresh(&mut app).await;
+    assert_eq!(app.refresh_gen, generation + 1);
+}
+
+#[tokio::test]
+async fn in_flight_refresh_is_cancelled_when_owner_is_dropped() {
+    let mut app = app_with_tree(
+        "http://127.0.0.1:1".to_string(),
+        large_topology().tree,
+        std::time::Duration::ZERO,
+    );
+    let (dropped, cancelled) = tokio::sync::oneshot::channel();
+    app.install_pending_refresh_for_test(dropped);
+
+    drop(app);
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), cancelled)
+        .await
+        .expect("refresh cancellation should be bounded")
+        .expect("refresh task should report that its future was dropped");
 }

--- a/hyperactor_mesh_admin_tui/src/timeouts.rs
+++ b/hyperactor_mesh_admin_tui/src/timeouts.rs
@@ -30,8 +30,9 @@
 //!   job state. `RefreshPolicy` implements `JoinSemilattice` so
 //!   multiple sources can be combined when added. Background refresh
 //!   is suspended while any foreground job exists (both in-flight
-//!   and completed overlays). Refresh resumes only when the overlay
-//!   is dismissed.
+//!   and completed overlays). A refresh completing under suspension is
+//!   discarded, one replacement is remembered, and refresh resumes
+//!   only when the overlay is dismissed.
 //! - **TP-11:** Detail-fetch debounce is owned by
 //!   `TuiTimeoutPolicy`, separately from request timeout budgets.
 
@@ -167,6 +168,19 @@ pub(crate) enum RefreshPolicy {
     Baseline,
     /// Do not schedule background refresh.
     Suspend,
+}
+
+impl RefreshPolicy {
+    /// Whether this fully joined policy permits a background refresh.
+    ///
+    /// Keep this match exhaustive so adding a policy variant requires an
+    /// explicit scheduling decision.
+    pub(crate) fn permits_refresh(self) -> bool {
+        match self {
+            Self::Baseline => true,
+            Self::Suspend => false,
+        }
+    }
 }
 
 impl algebra::JoinSemilattice for RefreshPolicy {
@@ -331,5 +345,11 @@ mod tests {
             RefreshPolicy::Suspend.join(&RefreshPolicy::Suspend),
             RefreshPolicy::Suspend,
         );
+    }
+
+    #[test]
+    fn refresh_policy_permission_is_explicit() {
+        assert!(RefreshPolicy::Baseline.permits_refresh());
+        assert!(!RefreshPolicy::Suspend.permits_refresh());
     }
 }


### PR DESCRIPTION
Summary:
the TUI currently rebuilds its topology inside the input loop. a slow root, host, or proc query therefore prevents navigation and redraw until the walk finishes.

move periodic and `s`/`h` refreshes into one owned background task while keeping the last complete tree visible. coalesce overlapping requests, cancel work using obsolete filter or expansion state, preserve the current selection, and merge concurrent cache results in allocation order.

failed, cancelled, or suspended refreshes leave the displayed tree unchanged and allow later refreshes to proceed. initial topology loading and Tab expansion remain synchronous.

Reviewed By: thomasywang

Differential Revision: D119354981


