### PR TITLE
characterize receive and response ownership (#4842)

### DIFF
--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -1629,9 +1629,21 @@ impl Accumulator for PythonResponseMessageAccumulator {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
     use hyperactor::ActorAddr;
+    use hyperactor::OncePortRef;
+    use hyperactor::Proc;
+    use hyperactor::mailbox::MessageEnvelope;
+    use hyperactor::mailbox::PortSender as _;
+    use hyperactor::mailbox::Undeliverable;
     use hyperactor::mailbox::headers::OPERATION_ADVERB;
     use hyperactor::mailbox::headers::OPERATION_ENDPOINT;
+    use pyo3::PyTypeInfo;
+    use pyo3::exceptions::PyValueError;
 
     use super::*;
 
@@ -1729,5 +1741,397 @@ mod tests {
             Some("call_one"),
             "OPERATION_ADVERB should still be stamped",
         );
+    }
+
+    const WAIT: Duration = Duration::from_secs(30);
+
+    fn test_instance(name: &str) -> Instance<PythonActor> {
+        Proc::isolated()
+            .actor_instance::<PythonActor>(name)
+            .expect("the test actor instance should be created")
+            .instance
+    }
+
+    fn result_message(rank: Option<usize>) -> PythonMessage {
+        PythonMessage {
+            kind: PythonMessageKind::Result { rank },
+            ..Default::default()
+        }
+    }
+
+    fn unexpected_message(name: &str) -> (PythonMessage, String) {
+        let kind = PythonMessageKind::CallMethod {
+            name: MethodSpecifier::ReturnsResponse {
+                name: name.to_string(),
+            },
+            response_port: None,
+            correlation_id: None,
+        };
+        let error = format!("unexpected message kind {kind:?}");
+        (
+            PythonMessage {
+                kind,
+                ..Default::default()
+            },
+            error,
+        )
+    }
+
+    fn test_span(instance: &Instance<PythonActor>, adverb: EndpointAdverb) -> SpanGuard {
+        SpanGuard::actor_endpoint(
+            adverb.as_str(),
+            instance.self_addr(),
+            "ownership_test_mesh",
+            "ownership_test",
+            0,
+        )
+    }
+
+    #[pyclass]
+    struct IdentityFuture;
+
+    #[pymethods]
+    impl IdentityFuture {
+        #[staticmethod]
+        fn _from_coro(task: Py<PyPythonTask>) -> Py<PyPythonTask> {
+            task
+        }
+    }
+
+    // `Endpoint::call` always resolves `Future._from_coro` through its Python
+    // module. The Rust unit-test target does not package that module, so expose
+    // only the identity wrapper needed to exercise the real `call` method.
+    fn install_future_test_module(py: Python<'_>) -> PyResult<()> {
+        let modules = py
+            .import("sys")?
+            .getattr("modules")?
+            .cast_into::<PyDict>()
+            .map_err(PyErr::from)?;
+        let mut path = String::new();
+        let mut parent: Option<Bound<'_, PyModule>> = None;
+        for part in "monarch._src.actor.future".split('.') {
+            if !path.is_empty() {
+                path.push('.');
+            }
+            path.push_str(part);
+            let module = match modules.get_item(&path)? {
+                Some(module) => module.cast_into::<PyModule>().map_err(PyErr::from)?,
+                None => {
+                    let module = PyModule::new(py, &path)?;
+                    modules.set_item(&path, &module)?;
+                    module
+                }
+            };
+            if let Some(parent) = &parent
+                && parent.getattr(part).is_err()
+            {
+                parent.setattr(part, &module)?;
+            }
+            parent = Some(module);
+        }
+        let module = parent.expect("the dotted module path is not empty");
+        if module.getattr("Future").is_err() {
+            module.setattr("Future", py.get_type::<IdentityFuture>())?;
+        }
+        Ok(())
+    }
+
+    async fn drive_task(task: Py<PyPythonTask>) -> PyResult<Py<PyAny>> {
+        let task = monarch_with_gil_blocking(GilSite::Test, |py| task.borrow_mut(py).take_task())
+            .expect("the task should be unconsumed");
+        tokio::time::timeout(WAIT, task)
+            .await
+            .expect("timed out driving the task")
+    }
+
+    fn assert_message_error(error: PyErr, expected: &str) {
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            assert!(error.get_type(py).is(PyValueError::type_object(py)));
+            assert_eq!(error.value(py).to_string(), expected);
+        });
+    }
+
+    async fn assert_task_message_error(task: Py<PyPythonTask>, expected: &str) {
+        let error = match drive_task(task).await {
+            Ok(_) => panic!("the unexpected message kind should be rejected"),
+            Err(error) => error,
+        };
+        assert_message_error(error, expected);
+    }
+
+    fn value_stream(
+        instance: &Instance<PythonActor>,
+        receiver: PortReceiver<PythonMessage>,
+        remaining: usize,
+    ) -> PyValueStream {
+        let future_class = monarch_with_gil_blocking(GilSite::Test, |py| {
+            py.get_type::<IdentityFuture>().into_any().unbind()
+        });
+        PyValueStream {
+            receiver: Arc::new(tokio::sync::Mutex::new(receiver)),
+            supervision_monitor: None,
+            instance: instance.clone_for_py(),
+            remaining: AtomicUsize::new(remaining),
+            attrs: Arc::new(EndpointAttrs::new("ownership_test", None)),
+            qualified_endpoint_name: None,
+            start: tokio::time::Instant::now(),
+            future_class,
+        }
+    }
+
+    fn next_task(stream: &PyValueStream) -> Option<Py<PyPythonTask>> {
+        monarch_with_gil_blocking(GilSite::Test, |py| -> PyResult<Option<Py<PyPythonTask>>> {
+            stream
+                .__next__(py)?
+                .map(|task| task.extract(py).map_err(Into::<PyErr>::into))
+                .transpose()
+        })
+        .expect("ValueStream.__next__ should construct its task")
+    }
+
+    #[tokio::test]
+    async fn value_collector_drop_discards_its_reply() {
+        pyo3::Python::initialize();
+        let instance = test_instance("value_collector_drop_discards_its_reply");
+        let (handle, receiver) = instance.mailbox_for_py().open_port::<PythonMessage>();
+        handle
+            .try_post(&instance, result_message(None))
+            .expect("the positive-control reply should be queued");
+
+        let task = value_collector(
+            receiver,
+            Arc::new(EndpointAttrs::new("ownership_test", None)),
+            None,
+            instance.clone_for_py(),
+            None,
+            EndpointAdverb::Choose,
+            test_span(&instance, EndpointAdverb::Choose),
+        )
+        .expect("value_collector should return a task");
+        drop(task);
+
+        assert!(
+            handle.try_post(&instance, result_message(None)).is_err(),
+            "dropping the task should close its sole response receiver"
+        );
+    }
+
+    #[tokio::test]
+    async fn value_stream_observers_receive_in_observation_order() {
+        pyo3::Python::initialize();
+        let instance = test_instance("value_stream_observers_receive_in_observation_order");
+        let (handle, receiver) = instance.mailbox_for_py().open_port::<PythonMessage>();
+        let (first_reply, first_error) = unexpected_message("first reply");
+        let (second_reply, second_error) = unexpected_message("second reply");
+        handle
+            .try_post(&instance, first_reply)
+            .expect("the first reply should be queued");
+        handle
+            .try_post(&instance, second_reply)
+            .expect("the second reply should be queued");
+        let stream = value_stream(&instance, receiver, 2);
+
+        let first = next_task(&stream).expect("the first slot should yield a task");
+        let second = next_task(&stream).expect("the second slot should yield a task");
+
+        assert_task_message_error(second, &first_error).await;
+        assert_task_message_error(first, &second_error).await;
+        assert!(
+            next_task(&stream).is_none(),
+            "the two constructed observers should exhaust the stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn dropped_value_stream_observer_leaves_reply_but_burns_slot_stranding_tail() {
+        pyo3::Python::initialize();
+        let instance = test_instance("dropped_value_stream_observer_leaves_reply_but_burns_slot");
+        let (handle, receiver) = instance.mailbox_for_py().open_port::<PythonMessage>();
+        let (first_reply, first_error) = unexpected_message("first reply");
+        let (second_reply, _) = unexpected_message("second reply");
+        let second_kind = second_reply.kind.clone();
+        handle
+            .try_post(&instance, first_reply)
+            .expect("the first reply should be queued");
+        handle
+            .try_post(&instance, second_reply)
+            .expect("the second reply should be queued");
+        let stream = value_stream(&instance, receiver, 2);
+
+        let discarded = next_task(&stream).expect("the first slot should yield a task");
+        monarch_with_gil_blocking(GilSite::Test, |_py| drop(discarded));
+
+        let retained = next_task(&stream).expect("the second slot should yield a task");
+        assert_task_message_error(retained, &first_error).await;
+        assert!(
+            next_task(&stream).is_none(),
+            "discarding an observer should still consume its iteration slot"
+        );
+
+        let stranded = stream
+            .receiver
+            .lock()
+            .await
+            .try_recv()
+            .expect("the shared receiver should remain usable")
+            .expect("the final reply should remain queued but unreachable by iteration");
+        assert_eq!(stranded.kind, second_kind);
+    }
+
+    struct RecordingCallEndpoint {
+        instance: Instance<PythonActor>,
+        attrs: Arc<EndpointAttrs>,
+        submissions: AtomicUsize,
+        response_ports: Mutex<Vec<OncePortRef<PythonMessage>>>,
+    }
+
+    impl RecordingCallEndpoint {
+        fn new(instance: Instance<PythonActor>) -> Self {
+            Self {
+                instance,
+                attrs: Arc::new(EndpointAttrs::new("ownership_test", None)),
+                submissions: AtomicUsize::new(0),
+                response_ports: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn take_response_port(&self) -> OncePortRef<PythonMessage> {
+            self.response_ports
+                .lock()
+                .expect("the response-port recorder should not be poisoned")
+                .pop()
+                .expect("call should have supplied a response port")
+        }
+    }
+
+    impl Endpoint for RecordingCallEndpoint {
+        fn get_extent(&self, _py: Python<'_>) -> PyResult<Extent> {
+            Ok(Extent::unity())
+        }
+
+        fn get_method_name(&self) -> &str {
+            "ownership_test"
+        }
+
+        fn metric_attrs(&self) -> &Arc<EndpointAttrs> {
+            &self.attrs
+        }
+
+        fn send_message<'py>(
+            &self,
+            _py: Python<'py>,
+            _args: &Bound<'py, PyTuple>,
+            _kwargs: Option<&Bound<'py, PyDict>>,
+            port_ref: Option<EitherPortRef>,
+            _selection: AllOrChoose,
+            _instance: &Instance<PythonActor>,
+            _correlation_id: Option<u64>,
+        ) -> PyResult<()> {
+            let Some(EitherPortRef::Once(PythonOncePortRef { inner: Some(port) })) = port_ref
+            else {
+                panic!("call should submit one reducible response port");
+            };
+            self.response_ports
+                .lock()
+                .expect("the response-port recorder should not be poisoned")
+                .push(port);
+            self.submissions.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn get_supervision_monitor(&self) -> Option<Arc<dyn Supervisable>> {
+            None
+        }
+
+        fn get_qualified_name(&self) -> Option<String> {
+            Some("ownership_test.call()".to_string())
+        }
+
+        fn enter_endpoint_span(
+            &self,
+            adverb: EndpointAdverb,
+            actor_id: &ActorAddr,
+            correlation_id: u64,
+        ) -> SpanGuard {
+            SpanGuard::actor_endpoint(
+                adverb.as_str(),
+                actor_id,
+                "ownership_test_mesh",
+                "ownership_test",
+                correlation_id,
+            )
+        }
+
+        fn get_current_instance(&self, _py: Python<'_>) -> PyResult<Instance<PythonActor>> {
+            Ok(self.instance.clone_for_py())
+        }
+    }
+
+    fn call_observer(endpoint: &RecordingCallEndpoint) -> Py<PyPythonTask> {
+        monarch_with_gil_blocking(GilSite::Test, |py| -> PyResult<Py<PyPythonTask>> {
+            install_future_test_module(py)?;
+            endpoint
+                .call(py, &PyTuple::empty(py), None)?
+                .extract(py)
+                .map_err(Into::<PyErr>::into)
+        })
+        .expect("call should return an observer")
+    }
+
+    #[tokio::test]
+    async fn call_submits_cast_before_observer_and_drop_closes_response_port() {
+        pyo3::Python::initialize();
+        let instance = test_instance("call_submits_cast_before_observer_and_drop_closes_port");
+        let endpoint = RecordingCallEndpoint::new(instance.clone_for_py());
+
+        let retained = call_observer(&endpoint);
+        assert_eq!(
+            endpoint.submissions.load(Ordering::SeqCst),
+            1,
+            "submission should happen before the observer is driven"
+        );
+        let retained_port = endpoint.take_response_port();
+        let (return_handle, _return_receiver) = instance
+            .mailbox_for_py()
+            .open_port::<Undeliverable<MessageEnvelope>>();
+        instance
+            .mailbox_for_py()
+            .serialize_and_send_once(retained_port, result_message(Some(0)), return_handle)
+            .expect("the retained observer's response should serialize");
+        let collected = drive_task(retained)
+            .await
+            .expect("the retained observer should collect its response");
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            collected
+                .extract::<Py<PyValueMesh>>(py)
+                .expect("the retained observer should collect its response");
+        });
+
+        let discarded = call_observer(&endpoint);
+        assert_eq!(
+            endpoint.submissions.load(Ordering::SeqCst),
+            2,
+            "the second operation should also be submitted before observation"
+        );
+        let dropped_port = endpoint.take_response_port();
+        let dropped_destination = dropped_port.port_addr().clone();
+        monarch_with_gil_blocking(GilSite::Test, |_py| drop(discarded));
+
+        let (return_handle, mut return_receiver) = instance
+            .mailbox_for_py()
+            .open_port::<Undeliverable<MessageEnvelope>>();
+        instance
+            .mailbox_for_py()
+            .serialize_and_send_once(dropped_port, result_message(Some(0)), return_handle)
+            .expect("the post should serialize before delivery is rejected");
+        let undeliverable = tokio::time::timeout(WAIT, return_receiver.recv())
+            .await
+            .expect("timed out waiting for the dropped port's delivery failure")
+            .expect("the return port should receive the delivery failure");
+        let Undeliverable::Returned(envelope) = undeliverable else {
+            panic!("the failed response should retain its original envelope");
+        };
+        assert_eq!(envelope.dest(), &dropped_destination);
+        assert_eq!(endpoint.submissions.load(Ordering::SeqCst), 2);
     }
 }

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -743,3 +743,91 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
     hyperactor_mod.add_class::<PythonUndeliverableMessageEnvelope>()?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use hyperactor::Proc;
+    use pyo3::PyTypeInfo;
+
+    use super::*;
+
+    fn test_message(rank: usize) -> PythonMessage {
+        PythonMessage {
+            kind: PythonMessageKind::Result { rank: Some(rank) },
+            ..Default::default()
+        }
+    }
+
+    // `recv_task()` takes the native once receiver before it constructs the
+    // returned task. Dropping that task cannot put the receiver back.
+    #[test]
+    fn once_recv_task_consumes_receiver_at_construction() {
+        pyo3::Python::initialize();
+        let proc = Proc::isolated();
+        let client = proc.client("once_recv_task_consumes_receiver_at_construction");
+        let (handle, receiver) = client.open_once_port::<PythonMessage>();
+        handle
+            .try_post(&client, test_message(13))
+            .expect("the message should be queued before recv_task is called");
+        let mut receiver = PythonOncePortReceiver {
+            inner: Arc::new(std::sync::Mutex::new(Some(receiver))),
+        };
+
+        let first = receiver
+            .recv_task()
+            .expect("the first recv_task call should construct a task");
+        drop(first);
+
+        let error = match receiver.recv_task() {
+            Ok(_) => panic!("the second recv_task call should fail"),
+            Err(error) => error,
+        };
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            assert!(error.get_type(py).is(PyValueError::type_object(py)));
+            assert_eq!(error.value(py).to_string(), "OncePort is already used");
+        });
+    }
+
+    // A regular receiver is only cloned at construction. Even with a message
+    // already pending, dropping one task leaves it for the next driven task.
+    #[tokio::test]
+    async fn port_recv_task_claims_only_when_driven() {
+        pyo3::Python::initialize();
+        let proc = Proc::isolated();
+        let client = proc.client("port_recv_task_claims_only_when_driven");
+        let (handle, receiver) = client.open_port::<PythonMessage>();
+        let expected = test_message(17);
+        handle
+            .try_post(&client, expected.clone())
+            .expect("the message should be queued before either task exists");
+        let mut receiver = PythonPortReceiver {
+            inner: Arc::new(tokio::sync::Mutex::new(receiver)),
+        };
+
+        let first = receiver
+            .recv_task()
+            .expect("the first recv_task call should construct a task");
+        let mut second = receiver
+            .recv_task()
+            .expect("the second recv_task call should also construct a task");
+        drop(first);
+
+        let received = tokio::time::timeout(
+            Duration::from_secs(30),
+            second
+                .take_task()
+                .expect("the second receive task should be unconsumed"),
+        )
+        .await
+        .expect("timed out driving the second receive task")
+        .expect("the second receive task should succeed");
+        let received = monarch_with_gil_blocking(GilSite::Test, |py| {
+            received
+                .extract::<PythonMessage>(py)
+                .expect("recv_task should return the posted PythonMessage")
+        });
+        assert_eq!(received, expected);
+    }
+}

--- a/python/tests/test_accumulator_characterization.py
+++ b/python/tests/test_accumulator_characterization.py
@@ -1,0 +1,316 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import asyncio
+import operator
+import sys
+import unittest.mock
+
+import pytest
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._src.actor import future as future_mod
+from monarch._src.actor.future import Future
+from monarch.actor import Accumulator
+
+
+class _CombineError(Exception):
+    pass
+
+
+class _StreamError(Exception):
+    pass
+
+
+def _future_of(value):
+    """A real, single-use monarch Future resolving to value."""
+
+    async def _v():
+        return value
+
+    return Future._from_coro(_v())
+
+
+def _stream_endpoint(values):
+    """A fake Endpoint whose .stream() yields one real Future per value."""
+    ep = unittest.mock.MagicMock()
+    ep.stream.return_value = iter([_future_of(v) for v in values])
+    return ep
+
+
+def _recording_stream_endpoint(values, events, *, make_future=_future_of):
+    """A fake Endpoint that records stream calls and iterator advancement."""
+    ep = unittest.mock.MagicMock()
+
+    def stream(*args, **kwargs):
+        events.append(("stream", args, kwargs))
+
+        def iterator():
+            for value in values:
+                events.append(("next", value))
+                yield make_future(value)
+
+        return iterator()
+
+    ep.stream.side_effect = stream
+    return ep
+
+
+async def _await_result(future):
+    return await future
+
+
+async def _capture_error(future, error_type):
+    with pytest.raises(error_type) as caught:
+        await future
+    return caught.value
+
+
+def _failing_combine():
+    def combine(total, value):
+        if value == 2:
+            raise _CombineError("combine failed on 2")
+        return total + value
+
+    return unittest.mock.MagicMock(side_effect=combine)
+
+
+def test_accumulate_folds_with_combine():
+    """accumulate reduces the per-rank stream through combine from identity."""
+    acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
+    assert acc.accumulate().get() == 6
+
+
+def test_accumulate_empty_stream_returns_identity():
+    """With no streamed values, accumulate returns the identity seed."""
+    acc = Accumulator(_stream_endpoint([]), 42, operator.add)
+    assert acc.accumulate().get() == 42
+
+
+def test_accumulate_folds_left_to_right():
+    """combine is applied left-to-right over the stream, seeded by identity."""
+    acc = Accumulator(_stream_endpoint([1, 2, 3]), [], lambda a, r: a + [r])
+    assert acc.accumulate().get() == [1, 2, 3]
+
+
+def test_accumulate_forwards_args_to_stream():
+    """accumulate forwards its args/kwargs to endpoint.stream()."""
+    ep = _stream_endpoint([1])
+    Accumulator(ep, 0, operator.add).accumulate("a", k=1).get()
+    ep.stream.assert_called_once_with("a", k=1)
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_invokes_stream_before_any_observation():
+    events = []
+    endpoint = _recording_stream_endpoint([2], events)
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    accumulator = Accumulator(endpoint, 1, combine)
+
+    unobserved = accumulator.accumulate()
+    # The private state check is intentional: the event assertions alone could
+    # race a producer that started eagerly but has not advanced the iterator yet.
+    assert isinstance(unobserved._status, future_mod._Unawaited)
+    assert events == [("stream", (), {})]
+    combine.assert_not_called()
+    del unobserved
+    assert events == [("stream", (), {})]
+    combine.assert_not_called()
+
+    assert accumulator.accumulate().get() == 3
+    assert events == [
+        ("stream", (), {}),
+        ("stream", (), {}),
+        ("next", 2),
+    ]
+    combine.assert_called_once_with(1, 2)
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_short_circuits_and_propagates_combine_error():
+    events = []
+    combine = _failing_combine()
+    endpoint = _recording_stream_endpoint([1, 2, 3], events)
+    result = Accumulator(endpoint, 0, combine).accumulate()
+
+    with pytest.raises(_CombineError) as caught:
+        result.get()
+
+    assert type(caught.value) is _CombineError
+    assert str(caught.value) == "combine failed on 2"
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+    ]
+    assert events == [
+        ("stream", (), {}),
+        ("next", 1),
+        ("next", 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_short_circuits_and_propagates_stream_error():
+    events = []
+
+    def make_future(value):
+        if value != 2:
+            return _future_of(value)
+
+        async def fail():
+            raise _StreamError("stream failed on 2")
+
+        return Future._from_coro(fail())
+
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    endpoint = _recording_stream_endpoint([1, 2, 3], events, make_future=make_future)
+    result = Accumulator(endpoint, 0, combine).accumulate()
+
+    with pytest.raises(_StreamError) as first:
+        result.get()
+    second = asyncio.run(_capture_error(result, _StreamError))
+
+    assert type(first.value) is _StreamError
+    assert type(second) is _StreamError
+    assert str(first.value) == "stream failed on 2"
+    assert str(second) == "stream failed on 2"
+    assert second is first.value
+    assert combine.call_args_list == [unittest.mock.call(0, 1)]
+    assert events == [
+        ("stream", (), {}),
+        ("next", 1),
+        ("next", 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_get_then_await_does_not_rerun_combine():
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    assert result.get() == 6
+    assert asyncio.run(_await_result(result)) == 6
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+        unittest.mock.call(3, 3),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_await_then_get_does_not_rerun_combine():
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    assert asyncio.run(_await_result(result)) == 6
+    assert result.get() == 6
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+        unittest.mock.call(3, 3),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_replays_combine_error_get_then_await():
+    combine = _failing_combine()
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    with pytest.raises(_CombineError) as first:
+        result.get()
+    second = asyncio.run(_capture_error(result, _CombineError))
+
+    assert type(first.value) is _CombineError
+    assert type(second) is _CombineError
+    assert str(first.value) == "combine failed on 2"
+    assert str(second) == "combine failed on 2"
+    assert second is first.value
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_replays_combine_error_await_then_get():
+    combine = _failing_combine()
+    result = Accumulator(_stream_endpoint([1, 2, 3]), 0, combine).accumulate()
+
+    first = asyncio.run(_capture_error(result, _CombineError))
+    with pytest.raises(_CombineError) as second:
+        result.get()
+
+    assert type(first) is _CombineError
+    assert type(second.value) is _CombineError
+    assert str(first) == "combine failed on 2"
+    assert str(second.value) == "combine failed on 2"
+    assert combine.call_args_list == [
+        unittest.mock.call(0, 1),
+        unittest.mock.call(1, 2),
+    ]
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_post_start_abandonment_completes_fold_once():
+    gate = {"entered": False, "released": False, "completed": False}
+
+    async def gated_value():
+        gate["entered"] = True
+        while not gate["released"]:
+            await PythonTask.sleep(0.005)
+        gate["completed"] = True
+        return 2
+
+    endpoint = unittest.mock.MagicMock()
+    endpoint.stream.return_value = iter([Future._from_coro(gated_value())])
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(endpoint, 1, combine).accumulate()
+
+    async def cancel_after_start():
+        observer = result.as_asyncio()
+
+        async def wait_for_entry():
+            while not gate["entered"]:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(wait_for_entry(), timeout=5)
+        assert not gate["completed"]
+        assert observer.cancel()
+        # asyncio.Future.cancel() changes the state synchronously; callbacks run
+        # on a later loop turn, but cancelled() is true when cancel() returns true.
+        assert observer.cancelled()
+        gate["released"] = True
+        return await asyncio.wait_for(result.as_asyncio(), timeout=5)
+
+    try:
+        observed = asyncio.run(cancel_after_start())
+    finally:
+        original_error = sys.exc_info()[1]
+        gate["released"] = True
+        try:
+            drained = result.get(timeout=5)
+        except Exception as cleanup_error:
+            if original_error is None:
+                raise
+            # BaseException.add_note() is unavailable on the Python 3.10 OSS
+            # test lane. The original failure still takes precedence there.
+            if hasattr(original_error, "add_note"):
+                original_error.add_note(f"cleanup also failed: {cleanup_error!r}")
+
+    assert observed == 3
+    assert drained == 3
+    assert gate["completed"]
+    combine.assert_called_once_with(1, 2)
+
+
+@pytest.mark.timeout(10)
+def test_accumulate_empty_stream_makes_no_combine_call():
+    combine = unittest.mock.MagicMock(side_effect=operator.add)
+    result = Accumulator(_stream_endpoint([]), 42, combine).accumulate()
+
+    assert result.get() == 42
+    combine.assert_not_called()

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import asyncio
 import contextlib
 import os
 import pickle
@@ -26,6 +27,7 @@ import monarch._src.job._job_sidecar_worker as js_worker
 import monarch._src.job.job_sidecar as js
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.proc import ProcId, Uid
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 
 # Import directly from _src since job module isn't properly exposed
 from monarch._src.job.job import (
@@ -1930,3 +1932,324 @@ def test_exec_command_output_dir_suppresses_printing(capsys):
     )
     exec_command(host_mesh, ["echo", "hi"], output_dir="/tmp/out").get()
     assert "SHOULD_NOT_PRINT" not in capsys.readouterr().out
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_spawns_no_procs_before_observation():
+    """Discarding an unobserved command does not enter its deferred body."""
+    host_mesh, procs, bash_actors, markers = _exec_env()
+    selected = MagicMock()
+    selected.spawn_procs.return_value = procs
+    host_mesh.slice.return_value = selected
+    bash_actors.run.call.return_value = _results_future(
+        [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
+    )
+
+    discarded = exec_command(host_mesh, ["echo", "hi"], point={"gpu": 2})
+    del discarded
+
+    host_mesh.slice.assert_not_called()
+    host_mesh.spawn_procs.assert_not_called()
+    selected.spawn_procs.assert_not_called()
+    procs.spawn.assert_not_called()
+    bash_actors.run.call.assert_not_called()
+    procs.stop.assert_not_called()
+    assert not markers["stop_driven"]
+
+    assert exec_command(host_mesh, ["echo", "hi"], point={"gpu": 2}).get() == 0
+    host_mesh.slice.assert_called_once_with(gpu=2)
+    host_mesh.spawn_procs.assert_not_called()
+    selected.spawn_procs.assert_called_once_with(per_host=None)
+    procs.spawn.assert_called_once()
+    bash_actors.run.call.assert_called_once()
+    procs.stop.assert_called_once()
+    assert markers["stop_driven"]
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_repeated_get_spawns_and_cleans_up_once():
+    """Repeated blocking observation replays one command result."""
+    host_mesh, procs, bash_actors, markers = _exec_env()
+    bash_actors.run.call.return_value = _results_future(
+        [("rank0", {"returncode": 4, "stdout": "", "stderr": ""})]
+    )
+
+    result = exec_command(host_mesh, ["exit", "4"])
+    assert result.get() == 4
+    assert result.get() == 4
+
+    host_mesh.spawn_procs.assert_called_once_with(per_host=None)
+    bash_actors.run.call.assert_called_once()
+    procs.stop.assert_called_once()
+    assert markers["stop_driven"]
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_reobserved_asyncio_shares_one_run():
+    """Repeated asyncio observation shares the running command producer."""
+    gate = {"entries": 0, "released": False, "completed": False}
+
+    async def gated_results():
+        gate["entries"] += 1
+        while not gate["released"]:
+            await PythonTask.sleep(0.005)
+        gate["completed"] = True
+        return [("rank0", {"returncode": 5, "stdout": "", "stderr": ""})]
+
+    host_mesh, procs, bash_actors, markers = _exec_env()
+    bash_actors.run.call.return_value = Future._from_coro(gated_results())
+    result = exec_command(host_mesh, ["exit", "5"])
+
+    async def observe_twice():
+        first = result.as_asyncio()
+        second = result.as_asyncio()
+
+        async def wait_for_entry():
+            while gate["entries"] == 0:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(wait_for_entry(), timeout=2)
+        assert not first.done()
+        assert not second.done()
+        gate["released"] = True
+        return await asyncio.wait_for(asyncio.gather(first, second), timeout=2)
+
+    try:
+        observed = asyncio.run(observe_twice())
+    finally:
+        original_error = sys.exc_info()[1]
+        gate["released"] = True
+        try:
+            drained = result.get(timeout=2)
+        except BaseException as cleanup_error:
+            if original_error is None:
+                raise
+            original_error.add_note(f"cleanup also failed: {cleanup_error!r}")
+
+    assert observed == [5, 5]
+    assert drained == 5
+    assert gate == {"entries": 1, "released": True, "completed": True}
+    host_mesh.spawn_procs.assert_called_once_with(per_host=None)
+    bash_actors.run.call.assert_called_once()
+    procs.stop.assert_called_once()
+    assert markers["stop_driven"]
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_dispatches_to_run_python_for_dash_m():
+    """A -m command routes to run_python.call, not run.call."""
+    host_mesh, _procs, bash_actors, _markers = _exec_env()
+    bash_actors.run_python.call.return_value = _results_future(
+        [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
+    )
+
+    exec_command(host_mesh, ["-m", "pkg.mod"]).get()
+
+    bash_actors.run_python.call.assert_called_once()
+    bash_actors.run.call.assert_not_called()
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_forwards_env_workdir_per_host_and_output_dir(capsys):
+    """exec_command forwards process and Python-command configuration."""
+    host_mesh, _procs, bash_actors, _markers = _exec_env()
+    bash_actors.run_python.call.return_value = _results_future(
+        [
+            (
+                "rank0",
+                {
+                    "returncode": 0,
+                    "stdout": "REDIRECTED_STDOUT",
+                    "stderr": "REDIRECTED_STDERR",
+                },
+            )
+        ]
+    )
+    env = {"MODE": "test"}
+    per_host = {"gpu": 2}
+
+    assert (
+        exec_command(
+            host_mesh,
+            ["-m", "pkg.mod"],
+            env=env,
+            workdir="/work",
+            output_dir="/logs",
+            per_host=per_host,
+        ).get()
+        == 0
+    )
+
+    host_mesh.spawn_procs.assert_called_once_with(per_host=per_host)
+    bash_actors.run_python.call.assert_called_once_with(
+        ["-m", "pkg.mod"],
+        env=env,
+        workdir="/work",
+        client_cwd=os.getcwd(),
+        output_dir="/logs",
+    )
+    captured = capsys.readouterr()
+    captured_output = captured.out + captured.err
+    assert "REDIRECTED_STDOUT" not in captured_output
+    assert "REDIRECTED_STDERR" not in captured_output
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_drives_cleanup_on_base_exception():
+    """A BaseException raised while awaiting the command still drives cleanup."""
+
+    class _CommandAbort(BaseException):
+        pass
+
+    async def fail_command():
+        raise _CommandAbort("command aborted")
+
+    host_mesh, procs, bash_actors, markers = _exec_env()
+    bash_actors.run.call.return_value = Future._from_coro(fail_command())
+
+    with pytest.raises(_CommandAbort) as raised:
+        exec_command(host_mesh, ["echo", "hi"]).get()
+
+    assert type(raised.value) is _CommandAbort
+    assert str(raised.value) == "command aborted"
+    procs.stop.assert_called_once()
+    assert markers["stop_driven"]
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_cleanup_failure_supersedes_command_failure():
+    """An awaited cleanup failure surfaces with the command failure as context."""
+
+    class _CommandError(Exception):
+        pass
+
+    class _CleanupError(Exception):
+        pass
+
+    command_error = _CommandError("command failed")
+    cleanup_error = _CleanupError("cleanup failed")
+    cleanup_calls = 0
+
+    async def fail_command():
+        raise command_error
+
+    async def fail_cleanup():
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        raise cleanup_error
+
+    bash_actors = MagicMock()
+    procs = MagicMock()
+    procs.spawn.return_value = bash_actors
+    host_mesh = MagicMock()
+    host_mesh.spawn_procs.return_value = procs
+    bash_actors.run.call.return_value = Future._from_coro(fail_command())
+    procs.stop.return_value = Future._from_coro(fail_cleanup())
+    result = exec_command(host_mesh, ["echo", "hi"])
+
+    for _ in range(2):
+        with pytest.raises(_CleanupError) as raised:
+            result.get()
+        assert raised.value is cleanup_error
+        assert raised.value.__context__ is command_error
+
+    procs.stop.assert_called_once()
+    assert cleanup_calls == 1
+
+
+@pytest.mark.timeout(10)
+def test_exec_command_observer_cancellation_still_cleans_up():
+    """Cancelling one observer does not abort a command that already started."""
+    state = {
+        "command_entries": 0,
+        "command_released": False,
+        "command_completions": 0,
+        "cleanup_entries": 0,
+        "cleanup_released": False,
+        "cleanup_completions": 0,
+    }
+
+    async def gated_command():
+        state["command_entries"] += 1
+        while not state["command_released"]:
+            await PythonTask.sleep(0.005)
+        state["command_completions"] += 1
+        return [("rank0", {"returncode": 6, "stdout": "", "stderr": ""})]
+
+    async def gated_cleanup():
+        state["cleanup_entries"] += 1
+        while not state["cleanup_released"]:
+            await PythonTask.sleep(0.005)
+        state["cleanup_completions"] += 1
+
+    bash_actors = MagicMock()
+    procs = MagicMock()
+    procs.spawn.return_value = bash_actors
+    procs.stop.return_value = Future._from_coro(gated_cleanup())
+    host_mesh = MagicMock()
+    host_mesh.spawn_procs.return_value = procs
+    bash_actors.run.call.return_value = Future._from_coro(gated_command())
+    result = exec_command(host_mesh, ["exit", "6"])
+
+    async def cancel_after_start():
+        # Observation starts the outer producer; without this first step the
+        # command cannot reach the gate and the entry wait would deadlock.
+        observer = result.as_asyncio()
+
+        async def wait_for_command_entry():
+            while state["command_entries"] == 0:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(wait_for_command_entry(), timeout=2)
+        assert state["command_entries"] == 1
+        assert state["command_completions"] == 0
+        assert observer.cancel()
+        assert observer.cancelled()
+        state["command_released"] = True
+
+        retained_observer = result.as_asyncio()
+
+        async def wait_for_cleanup_entry():
+            while state["cleanup_entries"] == 0:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(wait_for_cleanup_entry(), timeout=2)
+        assert state["command_completions"] == 1
+        assert state["cleanup_entries"] == 1
+        assert state["cleanup_completions"] == 0
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                asyncio.shield(retained_observer),
+                timeout=0.05,
+            )
+        assert not retained_observer.done()
+        assert state["cleanup_completions"] == 0
+        state["cleanup_released"] = True
+        return await asyncio.wait_for(retained_observer, timeout=2)
+
+    try:
+        observed = asyncio.run(cancel_after_start())
+    finally:
+        original_error = sys.exc_info()[1]
+        state["command_released"] = True
+        state["cleanup_released"] = True
+        try:
+            drained = result.get(timeout=2)
+        except BaseException as cleanup_error:
+            if original_error is None:
+                raise
+            original_error.add_note(f"cleanup also failed: {cleanup_error!r}")
+
+    assert observed == 6
+    assert drained == 6
+    assert state == {
+        "command_entries": 1,
+        "command_released": True,
+        "command_completions": 1,
+        "cleanup_entries": 1,
+        "cleanup_released": True,
+        "cleanup_completions": 1,
+    }
+    host_mesh.spawn_procs.assert_called_once_with(per_host=None)
+    bash_actors.run.call.assert_called_once()
+    procs.stop.assert_called_once()

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -241,6 +241,10 @@ class SyncActor(Actor):
     def sync_endpoint(self, a_counter: Counter):
         return a_counter.value.choose().get()
 
+    @endpoint
+    def accumulate_sync_endpoint(self, a_counter: Counter) -> int:
+        return Accumulator(a_counter.value, 0, operator.add).accumulate().get()
+
 
 @pytest.mark.timeout(60)
 async def test_sync_actor():
@@ -250,6 +254,17 @@ async def test_sync_actor():
     r = await a.sync_endpoint.choose(c)
     assert r == 5
     await proc.stop()
+
+
+@pytest.mark.timeout(60)
+async def test_accumulate_get_works_inside_sync_endpoint() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 2})
+    try:
+        actor = proc.spawn("accumulator_sync_actor", SyncActor)
+        counter = proc.spawn("accumulator_counter", Counter, 3)
+        assert await actor.accumulate_sync_endpoint.choose(counter) == 6
+    finally:
+        await proc.stop()
 
 
 @pytest.mark.timeout(60)
@@ -2232,47 +2247,3 @@ async def test_del_runs_on_proc_mesh_stop() -> None:
             f"file {marker_path} should have contents 'finalized' if the finalizers were run"
         )
     os.unlink(marker_path)
-
-
-# ── Accumulator.accumulate characterization tests ──────────────────────────
-
-
-def _future_of(value):
-    """A real, single-use monarch Future resolving to value."""
-
-    async def _v():
-        return value
-
-    return Future._from_coro(_v())
-
-
-def _stream_endpoint(values):
-    """A fake Endpoint whose .stream() yields one real Future per value."""
-    ep = unittest.mock.MagicMock()
-    ep.stream.return_value = iter([_future_of(v) for v in values])
-    return ep
-
-
-def test_accumulate_folds_with_combine():
-    """accumulate reduces the per-rank stream through combine from identity."""
-    acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
-    assert acc.accumulate().get() == 6
-
-
-def test_accumulate_empty_stream_returns_identity():
-    """With no streamed values, accumulate returns the identity seed."""
-    acc = Accumulator(_stream_endpoint([]), 42, operator.add)
-    assert acc.accumulate().get() == 42
-
-
-def test_accumulate_folds_left_to_right():
-    """combine is applied left-to-right over the stream, seeded by identity."""
-    acc = Accumulator(_stream_endpoint([1, 2, 3]), [], lambda a, r: a + [r])
-    assert acc.accumulate().get() == [1, 2, 3]
-
-
-def test_accumulate_forwards_args_to_stream():
-    """accumulate forwards its args/kwargs to endpoint.stream()."""
-    ep = _stream_endpoint([1])
-    Accumulator(ep, 0, operator.add).accumulate("a", k=1).get()
-    ep.stream.assert_called_once_with("a", k=1)

--- a/python/tests/test_receive_ownership_characterization.py
+++ b/python/tests/test_receive_ownership_characterization.py
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import pytest
+from monarch.actor import Channel
+
+
+@pytest.mark.timeout(10)
+def test_recv_futures_observed_in_reverse_receive_in_observation_order() -> None:
+    """A public receive claims its message when observed, not when created."""
+    sender, receiver = Channel[int].open()
+    sender.send(11)
+    sender.send(22)
+
+    first = receiver.recv()
+    second = receiver.recv()
+
+    assert second.get(timeout=2) == 11
+    assert first.get(timeout=2) == 22
+
+
+@pytest.mark.timeout(10)
+def test_discarded_regular_recv_claims_nothing() -> None:
+    """Dropping an unobserved regular receive leaves its message pending."""
+    sender, receiver = Channel[int].open()
+    sender.send(31)
+
+    discarded = receiver.recv()
+    del discarded
+
+    assert receiver.recv().get(timeout=2) == 31
+
+
+@pytest.mark.timeout(10)
+def test_discarded_once_recv_at_public_boundary_claims_nothing() -> None:
+    """The public wrapper defers even though native once-receive does not."""
+    sender, receiver = Channel[int].open(once=True)
+    sender.send(41)
+
+    discarded = receiver.recv()
+    del discarded
+
+    assert receiver.recv().get(timeout=2) == 41

--- a/scripts/pytokio_removal_census.py
+++ b/scripts/pytokio_removal_census.py
@@ -334,13 +334,14 @@ def oracle_reference_problem(reference: object) -> str | None:
     return None
 
 
-def oracle_problem(value: object) -> str | None:
+def oracle_problem(value: object, *, allow_legacy: bool) -> str | None:
     """Why a present ``oracle`` value is unusable, or ``None``.
 
-    Two accepted shapes while rows are being converted: the canonical list of
-    references, and a legacy prose label. Any bare string that starts with the
-    Buck prefix is rejected rather than read as prose -- valid or malformed --
-    because it is a half-finished conversion wearing the old shape.
+    Active rows require a canonical list of references. Historical tombstones
+    may retain a legacy prose label because the code and its live test no
+    longer exist. Any bare string that starts with the Buck prefix is rejected
+    rather than read as prose -- valid or malformed -- because it is a
+    half-finished conversion wearing the old shape.
     """
     if isinstance(value, str):
         if not value.strip():
@@ -355,12 +356,19 @@ def oracle_problem(value: object) -> str | None:
                 f"oracle is a bare reference string{syntax}; canonical "
                 "references go in a list, as oracle = [...]"
             )
-        return None
-    if not isinstance(value, list):
+        if allow_legacy:
+            return None
         return (
-            f"oracle is {type(value).__name__}; expected a list of references "
-            "or a legacy label"
+            "oracle is a legacy prose label; active rows require a canonical "
+            "list of test references"
         )
+    if not isinstance(value, list):
+        expected = (
+            "a list of references or a legacy label"
+            if allow_legacy
+            else "a list of references"
+        )
+        return f"oracle is {type(value).__name__}; expected {expected}"
     if not value:
         return "oracle is an empty list; give at least one reference"
     seen: set[str] = set()
@@ -376,9 +384,8 @@ def oracle_problem(value: object) -> str | None:
             # is a botched reference rather than prose, so it falls through to
             # the reference diagnostic, which can name the actual defect.
             return (
-                f"oracle[{position}] {reference!r} is not a reference; a legacy "
-                "prose label stays a bare string, and list entries must be "
-                "canonical references"
+                f"oracle[{position}] {reference!r} is not a reference; "
+                "list entries must be canonical references"
             )
         problem = oracle_reference_problem(reference)
         if problem is not None:
@@ -1242,14 +1249,16 @@ def validate_rows(rows: list[dict], schema: dict, config: dict) -> list[str]:
         if row["category"] not in BEHAVIOR_KINDS:
             continue
         if "oracle" in row:
-            # Shape first, for this field only. While rows are being converted
-            # `oracle` accepts two representations, so a present value can be
-            # structurally wrong rather than merely absent, and the truthiness
-            # gate below would misreport it as missing. The other required
-            # fields are single free-form values with nothing to check, so this
-            # is a local exception and not the start of a field-validation
-            # framework.
-            problem = oracle_problem(row["oracle"])
+            # Shape first, for this field only. Active rows require canonical
+            # references, while historical tombstones may keep a prose label,
+            # so a present value can be structurally wrong rather than merely
+            # absent and the truthiness gate below would misreport it as
+            # missing. The other required fields are single free-form values
+            # with nothing to check, so this is a local exception and not the
+            # start of a field-validation framework.
+            problem = oracle_problem(
+                row["oracle"], allow_legacy=row["state"] in TOMBSTONES
+            )
             if problem is not None:
                 errors.append(f"{row['id']}: {problem}")
                 continue

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -356,7 +356,7 @@ shared_reconstruction = 2
 reserve_binding = 1
 py_mesh_reserve = 2
 py_is_tokio_thread = 3
-pytokio_import = 32
+pytokio_import = 33
 pytokio_module_ref = 17
 helper_symbol = 26
 helper_definition = 6
@@ -779,6 +779,7 @@ owns = [
   "im.test_client_context_guard.module",
   "im.test_future_characterization.module",
   "im.test_host_mesh.module",
+  "im.test_job.module",
   "im.test_hyperactor.module",
   "im.test_logging_initialization_characterization.module",
   "im.test_logging.module",
@@ -1323,16 +1324,34 @@ public_operation = "job.exec_command(...)"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code"
-driver = "awaited or blocked on by the caller"
-start_point = "lazy; no proc is spawned until the Future is observed"
-abandonment = "possible; dropping prevents the spawn and therefore the finally-block cleanup"
-eager_effect = "starts a side effect"
-drop_behavior = "nothing runs, and no cleanup is owed"
-first_side_effect = "the proc spawn"
-unobserved_error = "silently dropped"
+driver = "Future refusal and warning checks run before work starts; a first no-timeout get() drives inline, while a successful first await/as_asyncio observation or a first get() with a valid timeout starts a non-aborting Handle producer that continues independently; result() and exception() delegate to get()"
+start_point = "Tested: mesh selection, spawn_procs, the BashActor spawn, and command dispatch wait for observation. Source-grounded: Future._from_coro calls PythonTask.from_coroutine during construction, synchronously capturing the Monarch context and potentially bootstrapping a fresh client before returning the Future"
+abandonment = "Never observed: _impl never runs, no proc spawns, and no cleanup is owed, but dropping cannot undo the construction-time context capture. After asyncio observation starts the producer, cancelling that observer does not abort it; the command completes and the finally block drives procs.stop()"
+eager_effect = "an eager Handle would make _impl eligible to run independently before observation; it would not guarantee that mesh selection, proc spawn, BashActor spawn, and command dispatch all execute synchronously inside exec_command()"
+drop_behavior = "Before observation, dropping the Future leaves _impl unrun and no cleanup owed after the already-completed context capture. After Handle-backed observation starts, dropping or cancelling that observer does not abort the producer or its cleanup. Mesh selection and spawn_procs are outside the try, so cleanup is owed only after spawn_procs returns procs. Once reached, the command and cleanup Futures are spent one-shot by ot.job.exec_command._impl[bash_actors.run.callscript, output_dir=output_dir._take_inner], ot.job.exec_command._impl[bash_actors.run_python.callcmd, env=env, workdir=workdir, client_cwd=client_cwd, output_dir=output_dir._take_inner], and ot.job.exec_command._impl[procs.stop._take_inner]"
+first_side_effect = "source-grounded: synchronous construction-time context capture is the first effect; tested: proc spawn is the first worker-visible effect and waits for observation"
+unobserved_error = "A synchronous construction or context failure raises before any Future exists. A never-driven _impl produces no error. Tested: an ordinary cleanup Exception that supersedes an awaited command Exception is replayed on a second observation with procs.stop() still called once. Source-grounded: after Handle-backed start, cancelling one asyncio observer does not abort an ordinary failure; another observer of the live outer Future can still receive it, while the cancelled observer receives nothing. A get-first BaseException is not cached: cleanup runs, but the consumed task leaves the outer Future poisoned for a second observation, as pinned by fbcode//monarch/python/tests:test_future_characterization::test_fm_terminal_baseexception_current_poisons_the_future"
 disposition = "require a binding-specific design"
 semantic_class = "deferred_side_effect"
-oracle = "job.exec_command operation-root behavior (6.0c item 6)"
+oracle = [
+  "fbcode//monarch/python/tests:test_job::test_exec_command_returns_max_returncode",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_drives_cleanup_on_success",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_drives_cleanup_on_error",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_dispatches_to_run_python_for_py_scripts",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_dispatches_to_run_for_shell_commands",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_slices_by_point",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_slices_by_rank",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_prints_output_when_no_output_dir",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_output_dir_suppresses_printing",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_spawns_no_procs_before_observation",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_repeated_get_spawns_and_cleans_up_once",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_reobserved_asyncio_shares_one_run",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_dispatches_to_run_python_for_dash_m",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_forwards_env_workdir_per_host_and_output_dir",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_drives_cleanup_on_base_exception",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_cleanup_failure_supersedes_command_failure",
+  "fbcode//monarch/python/tests:test_job::test_exec_command_observer_cancellation_still_cleans_up",
+]
 
 [[site]]
 id = "fc.rdma.RDMAAction.submit[Future._from_coroself._inner.submitclient=client, timeout=timeout, rdma_manager_init=ready]"
@@ -3151,6 +3170,18 @@ scope = "test"
 state = "legacy"
 transition = "6.8"
 members = ["PythonTask", "Shared"]
+
+[[site]]
+id = "im.test_job.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_job.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
 
 [[site]]
 id = "im.test_logging_initialization_characterization.module"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -356,7 +356,7 @@ shared_reconstruction = 2
 reserve_binding = 1
 py_mesh_reserve = 2
 py_is_tokio_thread = 3
-pytokio_import = 31
+pytokio_import = 32
 pytokio_module_ref = 17
 helper_symbol = 26
 helper_definition = 6
@@ -775,6 +775,7 @@ owns = [
   "im.test_actor_driver_characterization.module",
   "im.test_admin_spawn_characterization.module",
   "im.test_actor_mesh.module",
+  "im.test_accumulator_characterization.module",
   "im.test_client_context_guard.module",
   "im.test_future_characterization.module",
   "im.test_host_mesh.module",
@@ -969,16 +970,30 @@ public_operation = "Accumulator.accumulate(...)"
 caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code"
-driver = "awaited or blocked on by the caller"
-start_point = "the endpoint stream is dispatched when accumulate() is called; combine runs only on observation"
-abandonment = "possible; the stream was already dispatched, so dropping abandons its replies"
-eager_effect = "observes already-running work"
-drop_behavior = "the combine never runs and the dispatched replies are never collected"
-first_side_effect = "endpoint stream dispatch at call time"
-unobserved_error = "silently dropped"
+driver = "after the shared Future refusal and warning checks, a first no-timeout get() drives the fold inline; a successful first await/as_asyncio() observation or first get() with a valid timeout starts a non-aborting Handle producer that continues independently; result() and exception() delegate to get()"
+start_point = "accumulate() calls endpoint.stream() before constructing the returned Future, but iteration, _take_inner(), and combine begin only when that Future is driven. Source-grounded for ActorEndpoint: stream() opens the response port and submits the cast path before returning PyValueStream; AsyncActorMesh queues resolve-and-cast for later, while a bare PythonActorMeshImpl resolves and casts synchronously"
+abandonment = "dropping a never-observed Future abandons the fold before iteration, _take_inner(), or combine, after endpoint.stream() has already run. After asyncio observation starts the non-aborting Handle producer, cancelling that observer does not stop the fold and a later observer receives the shared result"
+eager_effect = "would start the fold when the replacement Handle is created, allowing iterator advancement, streamed-result waits, and combine to begin before any caller observation; today accumulate() stops after endpoint.stream() returns, whether its mesh queued the cast or completed it synchronously"
+drop_behavior = "before observation, dropping the Future does not advance the iterator or run combine; after asyncio observation starts, observer cancellation does not stop the fold. Every streamed Future already reached by the fold is spent by _take_inner()"
+first_side_effect = "calls endpoint.stream() during accumulate(); ActorEndpoint opens a response port and submits the mesh-dependent cast path before returning"
+unobserved_error = "source-grounded: synchronous endpoint.stream() construction or submission errors raise directly from accumulate(), while remote execution and replies may proceed after the call. A never-driven fold cannot materialize or observe a streamed-result error and never invokes combine. Once driven, an ordinary Exception from either a streamed Future or combine short-circuits and later observers receive the same type and message; the get-first BaseException poisoning case is characterized separately by fbcode//monarch/python/tests:test_future_characterization::test_fm_terminal_baseexception_current_poisons_the_future"
 disposition = "require a binding-specific design"
 semantic_class = "already_started_lazy_observer"
-oracle = "Accumulator exact-once and error behavior (6.0c item 5)"
+oracle = [
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_folds_with_combine",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_empty_stream_returns_identity",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_folds_left_to_right",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_invokes_stream_before_any_observation",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_short_circuits_and_propagates_combine_error",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_short_circuits_and_propagates_stream_error",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_get_then_await_does_not_rerun_combine",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_await_then_get_does_not_rerun_combine",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_replays_combine_error_get_then_await",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_replays_combine_error_await_then_get",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_post_start_abandonment_completes_fold_once",
+  "fbcode//monarch/python/tests:test_accumulator_characterization::test_accumulate_empty_stream_makes_no_combine_call",
+  "fbcode//monarch/python/tests:test_python_actors::test_accumulate_get_works_inside_sync_endpoint",
+]
 
 [[site]]
 id = "fc.actor_mesh.ActorMesh._name[Future._from_coroself._inner.name]"
@@ -3016,6 +3031,18 @@ scope = "production"
 state = "legacy"
 transition = "6.2"
 members = ["Handle"]
+
+[[site]]
+id = "im.test_accumulator_characterization.module"
+category = "module_import"
+language = "python"
+path = "fbcode/monarch/python/tests/test_accumulator_characterization.py"
+symbol = "<module>"
+operation = "pytokio_import"
+scope = "test"
+state = "legacy"
+transition = "6.8"
+members = ["PythonTask"]
 
 [[site]]
 id = "im.test_actor_mesh.module"

--- a/scripts/pytokio_removal_census.toml
+++ b/scripts/pytokio_removal_census.toml
@@ -182,15 +182,11 @@
 #                       ::pickle::tests::resolve_fills_slots_in_order"
 #                      "fbcode//monarch/python/tests:test_job::TestJob::test_exec_command"
 #
-#                    A legacy label stays a *bare string*. Prose inside the list
-#                    is rejected: the list is the canonical form and every entry
-#                    in it must be a reference.
-#
-#                    A prose label on an *active* row is transitional: those
-#                    rows are being converted to exact references and the label
-#                    will be replaced. A historical tombstone may keep its prose
-#                    label permanently, because the path it described is gone
-#                    and there is no live test left to name.
+#                    Active behavior rows require a non-empty list of canonical
+#                    references. Prose inside that list is rejected: every entry
+#                    must be a reference. Only a historical tombstone may keep a
+#                    bare prose label, because the path it described is gone and
+#                    there is no live test left to name.
 #
 #                    A bare string starting with "fbcode//" is rejected whether
 #                    or not it parses, because that is a half-finished
@@ -1055,15 +1051,19 @@ caller_contexts = "sync and asyncio"
 return_surface = "Future[T]"
 consumer = "user code"
 driver = "awaited or blocked on by the caller"
-start_point = "lazy; the native recv_task binding is not called until the coroutine is driven"
-abandonment = "possible; discarding claims nothing because the binding was never called"
-eager_effect = "claims a receive"
-drop_behavior = "no message is consumed"
-first_side_effect = "the native recv_task call"
-unobserved_error = "silently dropped"
+start_point = "Future._from_coro synchronously captures the Monarch context and may bootstrap or fail before returning; the coroutine body and native recv_task call begin only when the Future is driven"
+abandonment = "after successful construction, dropping an unobserved Future cannot undo context capture but calls neither native receiver and claims no message"
+eager_effect = "an eager replacement would enter _recv and call the native recv_task binding during recv(); current construction only captures context"
+drop_behavior = "no message is consumed; a later regular or once receive gets the pending message"
+first_side_effect = "source-grounded: construction-time context capture and possible client bootstrap; tested: recv_task is the first receive effect and waits for observation"
+unobserved_error = "a synchronous context or task-construction failure raises before any Future exists; a never-driven Future enters no receive and produces no receive or decode error; driven errors surface to the observer"
 disposition = "require a binding-specific design"
 semantic_class = "deferred_receive_claim"
-oracle = "mailbox ownership (6.0c item 2)"
+oracle = [
+  "fbcode//monarch/python/tests:test_receive_ownership_characterization::test_recv_futures_observed_in_reverse_receive_in_observation_order",
+  "fbcode//monarch/python/tests:test_receive_ownership_characterization::test_discarded_regular_recv_claims_nothing",
+  "fbcode//monarch/python/tests:test_receive_ownership_characterization::test_discarded_once_recv_at_public_boundary_claims_nothing",
+]
 
 [[site]]
 id = "fc.actor_mesh._Actor.handle[Future._from_cororesponse]"
@@ -3493,14 +3493,17 @@ constructor = "raw PythonTask"
 return_surface = "raw PythonTask returned from PyValueStream::__next__"
 consumer = "the per-element Future yielded by ValueStream iteration"
 driver = "awaited by the caller, one element at a time"
-start_point = "lazy; the raw task is not polled at construction, and the receiver claim begins only when it is driven"
-abandonment = "possible; a yielded element Future may be discarded"
-eager_effect = "claims a receive"
-drop_behavior = "the reply is left for the next observer"
-unobserved_error = "surfaced on observation"
+start_point = "remaining is decremented synchronously before the fallible task and Future construction; the shared receiver is not locked and no receive begins until the returned observer is driven"
+abandonment = "possible after successful construction; discarding the yielded observer claims no reply, but its iteration slot is already consumed"
+eager_effect = "an eager replacement would begin receiving for the already-reserved slot during __next__; current construction only decrements remaining"
+drop_behavior = "the reply stays in the shared queue for the next observer, but the discarded observer burns a slot; a later reply can therefore remain queued after the stream reports exhaustion"
+unobserved_error = "task or Future construction can fail after remaining is decremented, leaving no observer while the slot stays burned; after successful construction, receive, decode and supervision errors surface only when driven"
 disposition = "require a binding-specific design"
-semantic_class = "deferred_receive_claim"
-oracle = "ValueStream reverse observation (6.0c item 2)"
+semantic_class = "sync_partial_effect_lazy_tail"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::endpoint::tests::value_stream_observers_receive_in_observation_order",
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::endpoint::tests::dropped_value_stream_observer_leaves_reply_but_burns_slot_stranding_tail",
+]
 
 [[site]]
 id = "np.endpoint.call"
@@ -3513,17 +3516,19 @@ scope = "production"
 state = "legacy"
 transition = "6.5a"
 constructor = "raw PythonTask"
-return_surface = "raw PythonTask returned from call"
-consumer = "the public Future built by make_future for call"
-driver = "awaited by the caller through Future.get or as_asyncio"
-start_point = "the cast already happened; only ValueMesh accumulation is deferred"
-abandonment = "possible; a caller may drop the returned Future"
-eager_effect = "observes already-running work"
-drop_behavior = "accumulation is abandoned"
-unobserved_error = "surfaced on observation"
+return_surface = "public Future wrapping the raw PythonTask created by call"
+consumer = "production wraps the raw task with monarch._src.actor.future.Future._from_coro; that wrapper is source-grounded at endpoint.rs:615-618, while the oracle substitutes a test-only identity adapter so it can retain the exact response port"
+driver = "production callers drive the public wrapper through Future.get or as_asyncio; the oracle drives the raw task directly and proves submission, task construction, response collection and response-port lifetime, not the real Future wrapper"
+start_point = "the response port is opened and send_message_with_headers returns before observer construction; actual cast completion is mesh-dependent, and only ValueMesh collection waits for the observer"
+abandonment = "possible after successful construction; dropping the public Future closes the sole response receiver while the submitted operation continues"
+eager_effect = "an eager replacement would begin ValueMesh collection during call; it would not newly submit the operation"
+drop_behavior = "the response port closes and later replies are undeliverable, while the operation submitted before observer construction is not cancelled"
+unobserved_error = "PythonTask::new or Future wrapping can fail after submission and close the response port with no observer; after successful construction, collection, decode and supervision failures surface only when driven"
 disposition = "preserve timing"
 semantic_class = "already_started_lazy_observer"
-oracle = "collect_valuemesh refs and lazy-decode coverage"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::endpoint::tests::call_submits_cast_before_observer_and_drop_closes_response_port",
+]
 
 [[site]]
 id = "np.endpoint.value_collector"
@@ -3536,17 +3541,19 @@ scope = "production"
 state = "legacy"
 transition = "6.5a"
 constructor = "raw PythonTask"
-return_surface = "raw PythonTask returned from value_collector"
+return_surface = "raw PythonTask immediately wrapped by call_one or choose"
 consumer = "the public Future built by make_future for call_one and choose"
 driver = "awaited by the caller through Future.get or as_asyncio"
-start_point = "the request was already cast; only reply collection is deferred"
-abandonment = "possible; a caller may drop the returned Future"
-eager_effect = "observes already-running work"
-drop_behavior = "collection is abandoned and the reply is discarded"
-unobserved_error = "surfaced on observation"
+start_point = "the caller has already submitted the request; value_collector moves the sole response receiver into a task, while receive and conversion wait for the public observer"
+abandonment = "possible after successful construction; dropping the public Future drops the task and its sole response receiver"
+eager_effect = "an eager replacement would begin reply collection immediately; it would not resubmit the request"
+drop_behavior = "the response receiver closes, any queued reply is discarded, and later posts are undeliverable"
+unobserved_error = "PythonTask::new can fail after taking ownership of the receiver, closing it with no task; after successful construction, receive, conversion and supervision failures surface only when driven"
 disposition = "preserve timing"
 semantic_class = "already_started_lazy_observer"
-oracle = "endpoint reply coverage"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::endpoint::tests::value_collector_drop_discards_its_reply",
+]
 
 [[site]]
 id = "np.mailbox.PythonOncePortReceiver.recv_task"
@@ -3564,12 +3571,14 @@ consumer = "PortReceiver._recv for a once port"
 driver = "awaited by the PortReceiver.recv coroutine"
 start_point = "the once receiver is taken synchronously at construction; only the await is deferred"
 abandonment = "possible, and the receiver is already consumed"
-eager_effect = "claims a receive at construction"
+eager_effect = "an eager replacement would begin awaiting the receiver during recv_task; current construction only takes ownership"
 drop_behavior = "the reply is lost; the receiver cannot be reused"
-unobserved_error = "surfaced on observation"
+unobserved_error = "PythonTask::new can fail after the synchronous take, leaving the receiver consumed with no task; after successful construction, receive and conversion failures occur only when driven and surface to the observer"
 disposition = "require a binding-specific design"
 semantic_class = "sync_partial_effect_lazy_tail"
-oracle = "mailbox ownership, once receiver (6.0c item 2)"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::mailbox::tests::once_recv_task_consumes_receiver_at_construction",
+]
 
 [[site]]
 id = "np.mailbox.PythonPortReceiver.recv_task"
@@ -3587,12 +3596,14 @@ consumer = "PortReceiver._recv, which decodes the message"
 driver = "awaited by the PortReceiver.recv coroutine"
 start_point = "lazy; the receiver Arc is cloned but the lock and recv happen only when driven"
 abandonment = "possible; discarding the task claims nothing"
-eager_effect = "claims a receive"
+eager_effect = "an eager replacement would lock the receiver and begin recv during recv_task; current construction only clones the Arc"
 drop_behavior = "no message is consumed; the next observer gets it"
-unobserved_error = "surfaced on observation"
+unobserved_error = "PythonTask::new can fail after cloning the Arc, but dropping that clone leaves the receiver reusable; after successful construction, receive and conversion failures occur only when driven and surface to the observer"
 disposition = "require a binding-specific design"
 semantic_class = "deferred_receive_claim"
-oracle = "mailbox ownership, regular receiver (6.0c item 2)"
+oracle = [
+  "fbcode//monarch/monarch_hyperactor:monarch_hyperactor-unittest::mailbox::tests::port_recv_task_claims_only_when_driven",
+]
 
 [[site]]
 id = "ms.pickle.reserve_mesh_reference"

--- a/scripts/test_pytokio_removal_census.py
+++ b/scripts/test_pytokio_removal_census.py
@@ -1348,11 +1348,14 @@ class CensusCheckerTest(unittest.TestCase):
         ]
         self.assertEqual(self.fixture.check(manifest), [])
 
-    def test_oracle_legacy_label_accepted_on_active_row(self) -> None:
-        """Prose is still accepted while rows are being converted."""
+    def test_oracle_legacy_label_rejected_on_active_row(self) -> None:
+        """Every live behavior row must identify its canonical test."""
         manifest = self.fixture.manifest()
         self._behavior_row(manifest)["oracle"] = "endpoint reply coverage"
-        self.assertEqual(self.fixture.check(manifest), [])
+        self.assert_reports(
+            self.fixture.check(manifest),
+            "legacy prose label; active rows require a canonical list",
+        )
 
     def test_oracle_legacy_label_accepted_on_tombstone(self) -> None:
         """A deleted path has no live test to name, so its label stays."""
@@ -1451,7 +1454,7 @@ class CensusCheckerTest(unittest.TestCase):
         manifest = self.fixture.manifest()
         self._behavior_row(manifest)["oracle"] = ["endpoint reply coverage"]
         self.assert_reports(
-            self.fixture.check(manifest), "a legacy prose label stays a bare string"
+            self.fixture.check(manifest), "list entries must be canonical references"
         )
 
         manifest = self.fixture.manifest()
@@ -1472,15 +1475,6 @@ class CensusCheckerTest(unittest.TestCase):
                 manifest = self.fixture.manifest()
                 self._behavior_row(manifest)["oracle"] = blank
                 self.assert_reports(self.fixture.check(manifest), "oracle is empty")
-
-    def test_oracle_ordinary_prose_label_still_passes(self) -> None:
-        """The contrast case: prose that does not reach for the canonical form
-        is untouched by the prefix rule."""
-        for label in ("endpoint reply coverage", "lifecycle edge behavior"):
-            with self.subTest(label=label):
-                manifest = self.fixture.manifest()
-                self._behavior_row(manifest)["oracle"] = label
-                self.assertEqual(self.fixture.check(manifest), [])
 
     def test_oracle_empty_list_reports_shape_not_missing_field(self) -> None:
         """The empty list is present but unusable; the truthiness gate would


### PR DESCRIPTION
Summary:

receiving a message is lazy at the public Python API, but the two native receivers behave differently. an ordinary receiver claims a queued message only when its task runs, while a one-shot receiver gives up its sole receive handle as soon as `recv_task()` is called. the tests also show that discarding an untouched public `Future` claims nothing for either channel type.

endpoint replies have a second ownership split. `Endpoint.call()` submits the request before returning, but its observer owns the one-shot response port; dropping that observer does not cancel the request, but makes its eventual reply undeliverable. dropping a `value_collector` task closes its receiver and discards the queued reply. `ValueStream` instead shares one receiver between observers, so the order in which observers run determines which replies they receive; discarding one observer consumes a stream slot while leaving a reply stranded in the queue.

because `Endpoint.call()` resolves `Future._from_coro` through a Python import and the Rust unit target does not package Monarch’s Python tree, its test installs a test-only identity adapter at that module path. the test exercises the real call through submission, task construction, response collection, and response-port teardown; it does not claim to exercise the production Python `Future` wrapper.

the census now links all 41 live production behaviors to exact tests. its checker rejects prose-only evidence on active rows while continuing to permit historical labels on tombstones. this changes tests and migration metadata only; production behavior is unchanged.

Reviewed By: dulinriley

Differential Revision: D119364355


