### PR TITLE
monarch

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -375,7 +375,7 @@ impl RemoteSpawn for CudaRdmaActor {
             let mut prop: rdmaxcel_sys::CUmemAllocationProp = std::mem::zeroed();
             prop.type_ = rdmaxcel_sys::CU_MEM_ALLOCATION_TYPE_PINNED;
             prop.location.type_ = rdmaxcel_sys::CU_MEM_LOCATION_TYPE_DEVICE;
-            prop.location.id = device;
+            rdmaxcel_sys::rdmaxcel_set_mem_location_id(&mut prop.location, device);
             prop.allocFlags.gpuDirectRDMACapable = 1;
             prop.requestedHandleTypes = rdmaxcel_sys::CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
 
@@ -421,7 +421,7 @@ impl RemoteSpawn for CudaRdmaActor {
             // set access
             let mut access_desc: rdmaxcel_sys::CUmemAccessDesc = std::mem::zeroed();
             access_desc.location.type_ = rdmaxcel_sys::CU_MEM_LOCATION_TYPE_DEVICE;
-            access_desc.location.id = device;
+            rdmaxcel_sys::rdmaxcel_set_mem_location_id(&mut access_desc.location, device);
             access_desc.flags = rdmaxcel_sys::CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
             cu_check!(rdmaxcel_sys::rdmaxcel_cuMemSetAccess(
                 dptr,

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -177,7 +177,7 @@ impl Handler<CudaActorMessage> for CudaActor {
                     let mut prop: rdmaxcel_sys::CUmemAllocationProp = std::mem::zeroed();
                     prop.type_ = rdmaxcel_sys::CU_MEM_ALLOCATION_TYPE_PINNED;
                     prop.location.type_ = rdmaxcel_sys::CU_MEM_LOCATION_TYPE_DEVICE;
-                    prop.location.id = device;
+                    rdmaxcel_sys::rdmaxcel_set_mem_location_id(&mut prop.location, device);
                     prop.allocFlags.gpuDirectRDMACapable = 1;
                     // ROCm bindgen generates a different struct layout with anonymous union
                     #[cfg(feature = "rocm")]
@@ -224,7 +224,7 @@ impl Handler<CudaActorMessage> for CudaActor {
 
                     let mut access_desc: rdmaxcel_sys::CUmemAccessDesc = std::mem::zeroed();
                     access_desc.location.type_ = rdmaxcel_sys::CU_MEM_LOCATION_TYPE_DEVICE;
-                    access_desc.location.id = device;
+                    rdmaxcel_sys::rdmaxcel_set_mem_location_id(&mut access_desc.location, device);
                     access_desc.flags = rdmaxcel_sys::CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
                     cu_check!(rdmaxcel_sys::rdmaxcel_cuMemSetAccess(
                         dptr,

--- a/rdmaxcel-sys/src/test_rdmaxcel.c
+++ b/rdmaxcel-sys/src/test_rdmaxcel.c
@@ -10,7 +10,10 @@
 #include "rdmaxcel.h"
 
 int main() {
-  void* func_ptr = (void*)&cu_db_ring;
-  printf("cu_db_ring function address: %p\n", func_ptr);
+  // Reference the host launcher rather than the `cu_db_ring` kernel itself:
+  // CUDA 13 emits `__global__` host stubs with hidden visibility, so they are
+  // not linkable from another translation unit.
+  void* func_ptr = (void*)&launch_db_ring;
+  printf("launch_db_ring function address: %p\n", func_ptr);
   return 0;
 }


### PR DESCRIPTION
Summary:
The second harvest of the day from `track_campaign.py`, all recorded in one
pass at `2026-09-09T18:56Z` while dispatching `CodemodConfigCuda133`. The cache
goes from 17 entries to 25 (23 `build`, 2 `test`).

Every new entry is `pre_existing` -- the failure reproduces at the master
baseline with the campaign's change nowhere near it -- so `fix_diffs` is empty
and `fix_summary` just names the target that was already broken:

- `f6/modules/core/trainers/lightning/tests:trainers_lightning_tests`
- `ai_codesign/gen_ai/cpu_trainer/cpu_nccl_emulation` -- both the `libcudart`
  and `libcuda` hook libraries, under `mode/dev` asan-ubsan
- `mivilm/.../sft_multi_task/tests:test_content_pref_cpt_v1_config`, breaking
  in `third-party/nvidia-transformer-engine/v2.11.0`
- `aimp/validators/tests:config_validators_test`
- `neteng/ai/rdma_gen/e2e_tests:...iris_2_ranks_1_sunics_0_sonics` -- the one
  entry with two hits, so it carries two cluster ids
- `silvertorch/agentic/entity_search/models/igr/tests:model_test`
- the `test` entry is `monarch/ci/wait_for_github_ci.sky:main`, a GitHub CI
  check that timed out rather than a build break

Checking them in is the whole point of the cache: the next run recognises them
by error signature -- and by cluster id, for as long as Phabricator leaves the
id alone -- and skips spending an agent on breakage that was never ours.

The `playbooks` section is untouched, and no existing `solutions` entry is
modified. The change is purely additive.

Differential Revision: D119386614


