### PR TITLE
Cache initialized backend handles locally (#4846)

### DIFF
--- a/monarch_rdma/src/action.rs
+++ b/monarch_rdma/src/action.rs
@@ -18,7 +18,6 @@ use std::time::Duration;
 use hyperactor::context;
 
 use crate::RdmaManagerActor;
-use crate::RdmaManagerMessageClient;
 use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::backend::RdmaBackendHandle;
@@ -111,9 +110,7 @@ impl RdmaAction {
         }
 
         // This proc's spawned backends, in priority order.
-        let handles = RdmaManagerActor::local_handle(client)
-            .get_backend_handles(client)
-            .await?;
+        let handles = RdmaManagerActor::local_backend_handles(client).await?;
         let mut buckets: Vec<(RdmaBackendHandle, Vec<RdmaOp>)> =
             handles.into_iter().map(|h| (h, Vec::new())).collect();
 

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -36,7 +36,10 @@
 //! every controller monitoring that actor reports the failure to the owner.
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::LazyLock;
 use std::sync::OnceLock;
+use std::sync::RwLock;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
@@ -49,11 +52,13 @@ use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
 use hyperactor::OncePortRef;
+use hyperactor::ProcAddr;
 use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
 use hyperactor::context;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::OnceCell;
 use typeuri::Named;
 
 use crate::backend::RdmaBackendHandle;
@@ -68,6 +73,12 @@ use crate::rdma_manager_owner::RdmaManagerOwnerActor;
 use crate::rdma_manager_owner::RdmaManagerReady;
 use crate::rdma_manager_owner::RdmaManagerReadyHandler;
 use crate::rdma_manager_owner::ReadyAckClient;
+
+// Each proc has one RDMA manager for its lifetime, so its backend handles never
+// need replacement or invalidation while they can still be used.
+static BACKEND_HANDLE_CACHE: LazyLock<
+    RwLock<HashMap<ProcAddr, Arc<OnceCell<Vec<RdmaBackendHandle>>>>>,
+> = LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Helper function to get detailed error messages from RDMAXCEL error codes
 pub fn get_rdmaxcel_error_message(error_code: i32) -> String {
@@ -155,6 +166,29 @@ impl RdmaManagerActor {
         actor_ref
             .downcast_handle(client)
             .expect("RdmaManagerActor is not in the local process")
+    }
+
+    pub async fn local_backend_handles(
+        client: &(impl context::Actor + Send + Sync),
+    ) -> Result<Vec<RdmaBackendHandle>, anyhow::Error> {
+        let key = client.mailbox().actor_addr().proc_addr();
+        let cell = BACKEND_HANDLE_CACHE
+            .read()
+            .expect("backend handle cache lock should not be poisoned")
+            .get(&key)
+            .cloned();
+        let cell = cell.unwrap_or_else(|| {
+            Arc::clone(
+                BACKEND_HANDLE_CACHE
+                    .write()
+                    .expect("backend handle cache lock should not be poisoned")
+                    .entry(key)
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        });
+        cell.get_or_try_init(async || Self::local_handle(client).get_backend_handles(client).await)
+            .await
+            .cloned()
     }
 }
 


### PR DESCRIPTION
Summary:

Cache each initialized RDMA manager backend handle vector by `ProcAddr` so `RdmaAction.submit` can select a backend without a manager-actor round trip. The actor request remains as the initialization fallback

Use `ProcAddr`, rather than `ProcId`, because Hyperactor documents that legacy local/service proc IDs are not globally unique. The cache stores `Vec<RdmaBackendHandle>`.

A local-only 64 KiB CPU loopback benchmark using synchronous `Future.get()` reduced median read/write p50 latency from 108.5/107.9 us to 70.1/69.9 us. Average p50 fell from 108.2 us to 70.0 us, a 35.3% reduction.

Reviewed By: zdevito

Differential Revision: D119396265


