### PR TITLE
Add configurable Slurm worker bind address

### DIFF
--- a/python/monarch/_src/job/_slurm_batch.py
+++ b/python/monarch/_src/job/_slurm_batch.py
@@ -20,6 +20,7 @@ When this process exits the allocation is freed with the client's exit status.
 """
 
 import argparse
+import ipaddress
 import os
 import shlex
 import subprocess
@@ -29,20 +30,30 @@ from typing import List, Optional
 from monarch._src.job._batch_env import MONARCH_BATCH_JOB_ENV
 
 
-# Bootstraps one monarch worker bound to this node's hostname. Passed as python
-# ``-c`` argv (no shell), so quoting inside is irrelevant.
+# Bootstraps one Monarch worker that advertises this node's hostname. Passed as
+# Python ``-c`` argv (no shell), so quoting inside is irrelevant.
 _WORKER_BOOTSTRAP: str = (
     "import os, socket; from monarch.actor import run_worker_loop_forever; "
     "from monarch._src.job.service_identity import service_proc_addr, ranked_service_proc_id_from_env; "
-    'run_worker_loop_forever(address=service_proc_addr(f"tcp://{socket.gethostname()}:%d", '
+    'run_worker_loop_forever(address=service_proc_addr(f"%s", '
     'ranked_service_proc_id_from_env(rank_env="SLURM_NODEID")), '
     'ca="trust_all_connections")'
 )
 
 
+def _worker_bootstrap(port: int, bind_to: Optional[str]) -> str:
+    address = f"tcp://{{socket.gethostname()}}:{port}"
+    if bind_to is not None:
+        bind_ip = ipaddress.ip_address(bind_to)
+        bind_host = f"[{bind_ip}]" if bind_ip.version == 6 else str(bind_ip)
+        address += f"@tcp://{bind_host}:{port}"
+    return _WORKER_BOOTSTRAP % address
+
+
 def main(argv: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser(prog="monarch._src.job._slurm_batch")
     parser.add_argument("--port", type=int, default=22222)
+    parser.add_argument("--bind-to")
     parser.add_argument("client", help="client command to run inside the allocation")
     args = parser.parse_args(argv)
 
@@ -54,7 +65,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             "--ntasks-per-node=1",
             sys.executable,
             "-c",
-            _WORKER_BOOTSTRAP % args.port,
+            _worker_bootstrap(args.port, args.bind_to),
         ]
     )
     try:

--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import ipaddress
 import json
 import logging
 import os
@@ -19,7 +20,7 @@ from monarch._rust_bindings.monarch_hyperactor.config import configure
 from monarch._rust_bindings.monarch_hyperactor.proc import ProcId
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job
-from monarch._src.job._slurm_batch import _WORKER_BOOTSTRAP
+from monarch._src.job._slurm_batch import _worker_bootstrap
 from monarch._src.job.job import BatchJob, JobState, JobTrait
 from monarch._src.job.service_identity import (
     allocate_service_proc_ids,
@@ -76,6 +77,7 @@ class SlurmJob(JobTrait):
         qos: Optional[str] = None,
         out_of_cluster: bool = False,
         attach_to: Optional[str] = None,
+        bind_to: Optional[str] = None,
     ) -> None:
         """
         Args:
@@ -102,6 +104,10 @@ class SlurmJob(JobTrait):
             attach_to: ZMQ-style address of the worker gateway for out-of-cluster
                       access. When omitted in out-of-cluster mode, the first
                       allocated worker's Monarch address is used.
+            bind_to: Optional IP address on which workers listen, without a port.
+                      When set, workers advertise their Slurm hostname while
+                      binding this address through the ``dial_to@bind_to`` alias
+                      format. The bind address uses ``monarch_port``.
         """
         configure(default_transport=ChannelTransport.TcpWithHostname)
         self._meshes = meshes
@@ -122,6 +128,14 @@ class SlurmJob(JobTrait):
         self._qos = qos
         self._out_of_cluster = out_of_cluster
         self._attach_to = attach_to
+        try:
+            self._bind_to = (
+                str(ipaddress.ip_address(bind_to)) if bind_to is not None else None
+            )
+        except ValueError as error:
+            raise ValueError(
+                "bind_to must be an IPv4 or IPv6 address without a port"
+            ) from error
         # Track the single SLURM job ID and all allocated hostnames
         self._slurm_job_id: Optional[str] = None
         self._all_hostnames: List[str] = []
@@ -139,6 +153,8 @@ class SlurmJob(JobTrait):
         # address remote workers can dial back, instead of an abstract unix
         # socket whose namespace is local to the original (head) node.
         self.__dict__.update(state)
+        if "_bind_to" not in state:
+            self._bind_to = None
         # Attachment belongs to this process's global client context, not the
         # serialized job state.
         self._client_attached_to = None
@@ -273,16 +289,21 @@ class SlurmJob(JobTrait):
         )
         if client_script is None:
             # Workers only; an external controller attaches and manages the
-            # lifetime. Shares _WORKER_BOOTSTRAP with the batch runner.
-            worker_cmd = _WORKER_BOOTSTRAP % self._port
+            # lifetime. Shares worker bootstrap generation with the batch runner.
+            worker_cmd = _worker_bootstrap(self._port, self._bind_to)
             batch_script += f"\nsrun {self._python_exe} -c '{worker_cmd}'\n"
         else:
             # Batch mode: the in-allocation runner seeds the workers, runs the
             # client (MONARCH_BATCH_JOB=1 so its cached BatchJob reconnects to
             # this allocation), and tears the workers down in a finally.
+            bind_to_arg = (
+                f" --bind-to {shlex.quote(self._bind_to)}"
+                if self._bind_to is not None
+                else ""
+            )
             batch_script += (
                 f"\n{self._python_exe} -m monarch._src.job._slurm_batch "
-                f"--port {self._port} {shlex.quote(client_script)}\n"
+                f"--port {self._port}{bind_to_arg} {shlex.quote(client_script)}\n"
             )
 
         logger.info(f"Submitting SLURM job with {num_nodes} nodes")
@@ -464,6 +485,7 @@ class SlurmJob(JobTrait):
             and spec._qos == self._qos
             and spec._out_of_cluster == self._out_of_cluster
             and spec._attach_to == self._attach_to
+            and spec._bind_to == self._bind_to
             and self._jobs_active()
         )
 

--- a/python/tests/_src/job/test_slurm.py
+++ b/python/tests/_src/job/test_slurm.py
@@ -98,6 +98,7 @@ def test_batch_mode_invokes_in_allocation_runner(tmp_path, monkeypatch):
     # sbatch body is a single call to the runner with the (quoted) client command
     assert "-m monarch._src.job._slurm_batch" in script
     assert "--port 22222" in script
+    assert "--bind-to" not in script
     assert shlex.quote(client) in script
     assert "--nodes=2" in script
     # the shell stays dumb: worker srun + teardown now live in the runner
@@ -131,6 +132,28 @@ def test_external_controller_mode_has_no_client(tmp_path, monkeypatch):
     assert "MONARCH_BATCH_JOB" not in script
     assert f"export {SERVICE_PROC_IDS_ENV}=" in script
     assert not (tmp_path / ".monarch" / "job_state.pkl").exists()
+
+
+def test_external_controller_mode_uses_bind_alias(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with patch(
+        "monarch._src.job.slurm.subprocess.run", side_effect=_fake_sbatch
+    ) as mock:
+        _make_job(bind_to="0.0.0.0").apply()
+
+    script = _submitted_script(mock)
+    assert 'f"tcp://{socket.gethostname()}:22222@tcp://0.0.0.0:22222"' in script
+
+
+def test_batch_mode_passes_bind_to_to_runner(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with patch(
+        "monarch._src.job.slurm.subprocess.run", side_effect=_fake_sbatch
+    ) as mock:
+        _make_job(bind_to="0.0.0.0").apply(client_script="/venv/bin/python train.py")
+
+    script = _submitted_script(mock)
+    assert "--bind-to 0.0.0.0" in script
 
 
 def test_out_of_cluster_attaches_through_first_worker_before_meshes():
@@ -245,12 +268,51 @@ def test_worker_bootstrap_uses_preallocated_service_proc_id(monkeypatch):
         patch("socket.gethostname", return_value="worker-a"),
         patch("monarch.actor.run_worker_loop_forever") as run_worker,
     ):
-        exec(_slurm_batch._WORKER_BOOTSTRAP % 22222, {})
+        exec(_slurm_batch._worker_bootstrap(22222, None), {})
 
     run_worker.assert_called_once_with(
         address=f"{service_proc_ids[7]}@tcp://worker-a:22222",
         ca="trust_all_connections",
     )
+
+
+@pytest.mark.parametrize(
+    ("bind_to", "expected_bind_url"),
+    [
+        ("0.0.0.0", "tcp://0.0.0.0:22222"),
+        ("::", "tcp://[::]:22222"),
+    ],
+)
+def test_worker_bootstrap_uses_bind_alias(monkeypatch, bind_to, expected_bind_url):
+    service_proc_ids = SlurmJob._allocate_service_proc_ids(1)
+    monkeypatch.setenv(
+        SERVICE_PROC_IDS_ENV, serialize_service_proc_ids(service_proc_ids)
+    )
+    monkeypatch.setenv("SLURM_NODEID", "0")
+
+    with (
+        patch("socket.gethostname", return_value="worker-a"),
+        patch("monarch.actor.run_worker_loop_forever") as run_worker,
+    ):
+        exec(_slurm_batch._worker_bootstrap(22222, bind_to), {})
+
+    run_worker.assert_called_once_with(
+        address=(f"{service_proc_ids[0]}@tcp://worker-a:22222@{expected_bind_url}"),
+        ca="trust_all_connections",
+    )
+
+
+@pytest.mark.parametrize("bind_to", ["0.0.0.0:22222", "tcp://0.0.0.0", "worker"])
+def test_bind_to_rejects_values_that_are_not_ip_addresses(bind_to):
+    with pytest.raises(ValueError, match="without a port"):
+        _make_job(bind_to=bind_to)
+
+
+def test_can_run_compares_bind_to():
+    job = _make_job(bind_to="0.0.0.0")
+    with patch.object(job, "_jobs_active", return_value=True):
+        assert job.can_run(_make_job(bind_to="0.0.0.0"))
+        assert not job.can_run(_make_job(bind_to="127.0.0.1"))
 
 
 def test_state_pairs_controller_addresses_with_worker_service_proc_ids():


### PR DESCRIPTION
Summary:
Add an optional `bind_to` IP address to `SlurmJob`. When configured, each worker advertises its Slurm hostname and binds the same `monarch_port` on that address through the `dial_to@bind_to` alias format. A value of `None` preserves the existing launch behavior.

Validate the value as an IPv4 or IPv6 literal, format IPv6 aliases with brackets, propagate it through external-controller and batch launch modes, and include it in cached-job compatibility checks.

Reviewed By: pzhan9

Differential Revision: D119375366


