### PR TITLE
Fix License link rendering in Monarch docs index

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -69,8 +69,8 @@ actors
 
 Monarch is BSD-3 licensed, as found in the [LICENSE](https://github.com/meta-pytorch/monarch/blob/main/LICENSE) file.
 
-* `Terms of Use <https://opensource.fb.com/legal/terms>`_
-* `Privacy Policy <https://opensource.fb.com/legal/privacy>`_
+* [Terms of Use](https://opensource.fb.com/legal/terms)
+* [Privacy Policy](https://opensource.fb.com/legal/privacy)
 
 ## Community
 


### PR DESCRIPTION
Summary:
`docs/source/index.md` is parsed by MyST (Markdown), but the two License
bullets used reStructuredText inline-link syntax:

```
* `Terms of Use <https://opensource.fb.com/legal/terms>`_
```

MyST treats the backticks as inline code, so the bullets rendered as
literal code spans showing the raw angle-bracket URL followed by a stray
trailing underscore, instead of hyperlinks. Converted both to Markdown
link syntax, matching the `[LICENSE]` link directly above them.

Differential Revision: D119439963


