### PR TITLE
Key bookkeeping by logical process identity

### DIFF
--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -72,6 +72,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use hyperactor::ActorAddr;
+use hyperactor::ActorId;
 use hyperactor::ProcAddr;
 use hyperactor::ProcId;
 use hyperactor::channel::ChannelAddr;
@@ -1739,15 +1740,38 @@ impl HostMeshRef {
     }
 }
 
-/// An ordered set of host entries, deduplicated by `HostAgent` `ActorAddr`
-/// in first-seen order.
+/// A key that identifies a host agent independently of its advertised location.
 ///
-/// Insertion is idempotent by construction — SA-3 (dedup by ActorAddr)
+/// Legacy service pseudo-singletons still require their location because their
+/// actor IDs are shared by every host.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum HostAgentKey {
+    /// A host agent with a globally unique actor ID.
+    Id(ActorId),
+    /// A legacy host agent whose location disambiguates its singleton ID.
+    Legacy(ActorAddr),
+}
+
+impl HostAgentKey {
+    /// Construct the identity key for a host-agent address.
+    pub(crate) fn new(addr: &ActorAddr) -> Self {
+        if addr.proc_id() == &legacy_service_proc_id() {
+            Self::Legacy(addr.clone())
+        } else {
+            Self::Id(addr.id().clone())
+        }
+    }
+}
+
+/// An ordered set of host entries, deduplicated by host-agent identity in
+/// first-seen order.
+///
+/// Insertion is idempotent by construction — SA-3 (dedup by identity)
 /// is a property of this type, not a comment on careful control flow.
 /// First-seen order is preserved: the first occurrence of a given
-/// ActorAddr wins; subsequent duplicates are silently dropped.
+/// identity wins; subsequent duplicates are silently dropped.
 struct HostSet {
-    seen: HashSet<ActorAddr>,
+    seen: HashSet<HostAgentKey>,
     entries: Vec<(String, ActorRef<HostAgent>)>,
 }
 
@@ -1759,10 +1783,10 @@ impl HostSet {
         }
     }
 
-    /// Insert a host entry. No-op if `ActorAddr` already present (SA-3).
+    /// Insert a host entry. No-op if its identity is already present (SA-3).
     /// First-seen order is preserved.
     fn insert(&mut self, addr: String, agent_ref: ActorRef<HostAgent>) {
-        if self.seen.insert(agent_ref.actor_addr().clone()) {
+        if self.seen.insert(HostAgentKey::new(agent_ref.actor_addr())) {
             self.entries.push((addr, agent_ref));
         }
     }
@@ -1779,9 +1803,8 @@ impl HostSet {
     }
 }
 
-/// Ordered union of hosts from meshes and optional client host
-/// entries, deduplicated by `HostAgent` `ActorAddr` in first-seen
-/// order.
+/// Ordered union of hosts from meshes and optional client host entries,
+/// deduplicated by host-agent identity in first-seen order.
 ///
 /// SA-3 dedup and SA-6 client-host merge are structural properties
 /// of [`HostSet`], not invariants on this function's control flow.
@@ -2591,7 +2614,7 @@ mod tests {
     }
 
     /// SA-3: `HostSet::insert` is idempotent — inserting the same
-    /// `ActorAddr` twice does not add a duplicate entry, and first-seen
+    /// host identity twice does not add a duplicate entry, and first-seen
     /// order is preserved. This is a structural property of `HostSet`,
     /// not an invariant on `aggregate_hosts` control flow.
     #[test]
@@ -2612,7 +2635,7 @@ mod tests {
         assert_eq!(
             result.len(),
             2,
-            "SA-3: duplicate ActorAddr must not add entry"
+            "SA-3: duplicate host identity must not add entry"
         );
         assert_eq!(
             result[0].0,

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -386,6 +386,7 @@ use typeuri::Named;
 
 use crate::config_dump::ConfigDump;
 use crate::config_dump::ConfigDumpResult;
+use crate::host_mesh::HostAgentKey;
 use crate::host_mesh::host_agent::HOST_MESH_AGENT_ACTOR_NAME;
 use crate::host_mesh::host_agent::HostAgent;
 use crate::introspect::NodePayload;
@@ -680,16 +681,16 @@ pub struct MeshAdminAgent {
     /// fan out our target admin queries.
     hosts: HashMap<String, ActorRef<HostAgent>>,
 
-    /// Reverse index: `HostAgent` `ActorAddr` → host address
+    /// Reverse index: `HostAgent` identity → host address
     /// string.
     ///
     /// The host agent itself is an actor that can appear in multiple
     /// places (e.g., as a host node and as a child actor under a
     /// system proc). This index lets reference resolution treat that
-    /// `ActorAddr` as a *Host* node (via `resolve_host_node`) rather
+    /// identity as a *Host* node (via `resolve_host_node`) rather
     /// than a generic *Actor* node, avoiding cycles / dropped nodes
     /// in clients like the TUI.
-    host_agents_by_actor_id: HashMap<hyperactor::ActorAddr, String>,
+    host_agents_by_identity: HashMap<HostAgentKey, String>,
 
     /// `ActorAddr` of the process-global root client (`client[0]` on
     /// the singleton Host's `local_proc`), exposed as a first-class
@@ -748,8 +749,8 @@ impl MeshAdminAgent {
     /// Builds both:
     /// - `hosts`: the forward map used to route admin queries to the
     ///   correct `HostAgent`, and
-    /// - `host_agents_by_actor_id`: a reverse index used during
-    ///   reference resolution to recognize host-agent `ActorAddr`s and
+    /// - `host_agents_by_identity`: a reverse index used during
+    ///   reference resolution to recognize host-agent identities and
     ///   resolve them as `NodeProperties::Host` rather than as
     ///   generic actors.
     ///
@@ -765,9 +766,9 @@ impl MeshAdminAgent {
         admin_addr: Option<std::net::SocketAddr>,
         telemetry_url: Option<String>,
     ) -> Self {
-        let host_agents_by_actor_id: HashMap<hyperactor::ActorAddr, String> = hosts
+        let host_agents_by_identity: HashMap<HostAgentKey, String> = hosts
             .iter()
-            .map(|(addr, agent_ref)| (agent_ref.actor_addr().clone(), addr.clone()))
+            .map(|(addr, agent_ref)| (HostAgentKey::new(agent_ref.actor_addr()), addr.clone()))
             .collect();
 
         // Capture start time and username
@@ -778,7 +779,7 @@ impl MeshAdminAgent {
 
         Self {
             hosts: hosts.into_iter().collect(),
-            host_agents_by_actor_id,
+            host_agents_by_identity,
             root_client_actor_id,
             self_actor_id: None,
             admin_addr_override: admin_addr,
@@ -795,7 +796,7 @@ impl std::fmt::Debug for MeshAdminAgent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MeshAdminAgent")
             .field("hosts", &self.hosts.keys().collect::<Vec<_>>())
-            .field("host_agents", &self.host_agents_by_actor_id.len())
+            .field("host_agents", &self.host_agents_by_identity.len())
             .field("root_client_actor_id", &self.root_client_actor_id)
             .field("self_actor_id", &self.self_actor_id)
             .field("admin_addr", &self.admin_addr)
@@ -860,7 +861,7 @@ struct BridgeState {
     /// reference resolution.
     admin_ref: ActorRef<MeshAdminAgent>,
     /// Exact actor identities of the HostAgents managed by this admin.
-    host_agents: HashSet<hyperactor::ActorAddr>,
+    host_agents: HashSet<HostAgentKey>,
     /// Dedicated client mailbox on system_proc for HTTP bridge reply
     /// ports. Using a separate `Instance<()>` avoids sharing the
     /// actor's own mailbox with the HTTP bridge and ensures the
@@ -1056,7 +1057,7 @@ impl Actor for MeshAdminAgent {
             mesh_admin_access_instructions(&admin_url, tls.as_ref().map(|(_, bundle)| bundle));
         let bridge_state = Arc::new(BridgeState {
             admin_ref: ActorRef::attest(this.self_addr().clone()),
-            host_agents: self.host_agents_by_actor_id.keys().cloned().collect(),
+            host_agents: self.host_agents_by_identity.keys().cloned().collect(),
             bridge_cx,
             resolve_semaphore: tokio::sync::Semaphore::new(hyperactor_config::global::get(
                 crate::config::MESH_ADMIN_MAX_CONCURRENT_RESOLVES,
@@ -2324,12 +2325,12 @@ impl ResolvedProcHandler {
 /// minting point. Used by `config_bridge` which intentionally skips
 /// the probe (CFG-4).
 fn route_proc_handler(
-    host_agents: &HashSet<hyperactor::ActorAddr>,
+    host_agents: &HashSet<HostAgentKey>,
     raw_proc_reference: &str,
 ) -> Result<ResolvedProcHandler, ApiError> {
     let (_proc_reference, proc_id) = parse_proc_reference(raw_proc_reference)?;
     let host_agent_id = proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME);
-    if host_agents.contains(&host_agent_id) {
+    if host_agents.contains(&HostAgentKey::new(&host_agent_id)) {
         return Ok(ResolvedProcHandler::Host(ActorRef::attest(host_agent_id)));
     }
 
@@ -4593,7 +4594,9 @@ mod tests {
     fn route_proc_handler_service_proc_yields_host() {
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
         let proc_id = ResourceId::proc_addr_from_name(ChannelAddr::Tcp(addr), SERVICE_PROC_NAME);
-        let host_agents = HashSet::from([proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME)]);
+        let host_agents = HashSet::from([HostAgentKey::new(
+            &proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME),
+        )]);
         let handler = route_proc_handler(&host_agents, &proc_id.to_string()).unwrap();
         assert!(
             matches!(handler, ResolvedProcHandler::Host(_)),
@@ -4621,7 +4624,9 @@ mod tests {
             ProcId::instance(Label::strip("host-control")),
             ChannelAddr::Tcp(addr).into(),
         );
-        let host_agents = HashSet::from([proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME)]);
+        let host_agents = HashSet::from([HostAgentKey::new(
+            &proc_id.actor_addr(HOST_MESH_AGENT_ACTOR_NAME),
+        )]);
         let handler = route_proc_handler(&host_agents, &proc_id.to_string()).unwrap();
         assert!(
             matches!(handler, ResolvedProcHandler::Host(_)),

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -106,9 +106,9 @@ impl _Controller {
         let proc_mesh = py_proc_mesh.cast::<PyProcMesh>()?.borrow().mesh_ref()?;
 
         // Build rank map from proc ids to ranks.
-        let rank_map: HashMap<reference::ProcAddr, usize> = proc_mesh
+        let rank_map: HashMap<reference::ProcId, usize> = proc_mesh
             .iter()
-            .map(|(point, proc)| (proc.proc_addr().clone(), point.rank()))
+            .map(|(point, proc)| (proc.proc_addr().id().clone(), point.rank()))
             .collect();
 
         let region = Ranked::region(&proc_mesh);
@@ -736,13 +736,13 @@ struct MeshControllerActor {
     id: usize,
     debugger_active: Option<reference::ActorRef<DebuggerActor>>,
     debugger_paused: VecDeque<reference::ActorRef<DebuggerActor>>,
-    rank_map: HashMap<reference::ProcAddr, usize>,
+    rank_map: HashMap<reference::ProcId, usize>,
 }
 
 struct MeshControllerActorParams {
     proc_mesh_ref: ProcMeshRef,
     id: usize,
-    rank_map: HashMap<reference::ProcAddr, usize>,
+    rank_map: HashMap<reference::ProcId, usize>,
 }
 
 impl MeshControllerActor {
@@ -960,7 +960,7 @@ impl MeshControllerActor {
     fn rank_of_worker(&self, actor_id: &reference::ActorAddr) -> usize {
         *self
             .rank_map
-            .get(&actor_id.proc_addr())
+            .get(actor_id.proc_id())
             .expect("rank map should contain worker")
     }
 }


### PR DESCRIPTION
Summary:
Use `ProcId` for worker rank lookups so worker-reported addresses can differ from controller-side routes.

Deduplicate and classify instance-backed host agents by `ActorId`. Preserve full-address keys for legacy `service` pseudo-singletons, whose IDs are shared across hosts.

Reviewed By: shayne-fletcher

Differential Revision: D119398053


