### PR TITLE
Add idle-flush reducer mode (#4853)

### DIFF
--- a/hyperactor/src/accum.rs
+++ b/hyperactor/src/accum.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use algebra::JoinSemilattice;
 use enum_as_inner::EnumAsInner;
+use hyperactor_config::NonZeroUsize;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -60,6 +61,17 @@ pub struct StreamingReducerOpts {
     pub initial_update_interval: Option<Duration>,
 }
 
+/// Options carried by an idle-flush port before a cast resolves its destination count.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named)]
+pub struct IdleFlushReducerOpts {
+    /// Time with no new replies before the current reduced batch is emitted.
+    pub idle_timeout: Duration,
+    /// Time with no new replies before an incomplete split port is removed.
+    pub abandon_timeout: Duration,
+    /// Number of logical replies expected from each cast destination.
+    pub expected_updates_per_destination: NonZeroUsize,
+}
+
 /// The mode in which a reducer operates.
 #[derive(
     Debug,
@@ -75,6 +87,16 @@ pub enum ReducerMode {
     Streaming(StreamingReducerOpts),
     /// Once mode: accumulate exactly `n` values, emit a single reduced update, then tear down.
     Once(usize),
+    /// Idle-flush mode: emit after an idle interval and continue until all logical
+    /// replies have arrived or the incomplete split port is abandoned.
+    IdleFlush {
+        /// Total number of logical replies expected by this split port.
+        expected: NonZeroUsize,
+        /// Time with no new replies before the current reduced batch is emitted.
+        idle_timeout: Duration,
+        /// Time with no new replies before an incomplete split port is removed.
+        abandon_timeout: Duration,
+    },
 }
 
 impl Default for ReducerMode {
@@ -89,7 +111,7 @@ impl ReducerMode {
             ReducerMode::Streaming(opts) => opts
                 .max_update_interval
                 .unwrap_or(hyperactor_config::global::get(config::SPLIT_MAX_BUFFER_AGE)),
-            ReducerMode::Once(_) => Duration::MAX,
+            ReducerMode::Once(_) | ReducerMode::IdleFlush { .. } => Duration::MAX,
         }
     }
 
@@ -98,7 +120,7 @@ impl ReducerMode {
             ReducerMode::Streaming(opts) => opts
                 .initial_update_interval
                 .unwrap_or(Duration::from_millis(1)),
-            ReducerMode::Once(_) => Duration::MAX,
+            ReducerMode::Once(_) | ReducerMode::IdleFlush { .. } => Duration::MAX,
         }
     }
 }

--- a/hyperactor/src/context.rs
+++ b/hyperactor/src/context.rs
@@ -18,14 +18,17 @@ use std::mem::take;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use backoff::ExponentialBackoffBuilder;
 use backoff::backoff::Backoff;
 use dashmap::DashSet;
 use hyperactor_config::Flattrs;
+use hyperactor_config::NonZeroUsize;
 use hyperactor_config::attrs::OPERATION_CONTEXT_HEADER;
 use hyperactor_config::attrs::copy_marked_flattrs;
+use hyperactor_config::attrs::declare_attrs;
 
 use crate::ActorAddr;
 use crate::Instance;
@@ -43,6 +46,11 @@ use crate::mailbox::MessageEnvelope;
 use crate::ordering::SEQ_INFO;
 use crate::port::Port;
 use crate::time::Alarm;
+
+declare_attrs! {
+    /// Number of logical replies accumulated into a reduced update.
+    attr REDUCER_ACCUMULATED_UPDATES: NonZeroUsize;
+}
 
 /// Policy for handling SEQ_INFO in message headers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -449,6 +457,147 @@ impl<T: Actor + Send + Sync> MailboxExt for T {
                         }
                     })
                 }
+                ReducerMode::IdleFlush {
+                    expected,
+                    idle_timeout,
+                    abandon_timeout,
+                } => {
+                    let buffer: Arc<Mutex<IdleFlushBuffer>> =
+                        Arc::new(Mutex::new(IdleFlushBuffer::new(reducer, expected)));
+                    let mut alarm = Alarm::new();
+                    alarm.arm(abandon_timeout);
+                    let alarm = Arc::new(Mutex::new(alarm));
+
+                    // The alarm starts with `abandon_timeout`, so a split port that
+                    // receives no updates is eventually removed. Each buffered update
+                    // switches the alarm to `idle_timeout`. After flushing, the alarm is
+                    // rearmed for the remaining `abandon_timeout` measured from the last
+                    // update. If no further update arrives, the buffer is marked done and
+                    // the split port is unbound from the mailbox.
+                    {
+                        let mut sleeper = alarm.lock().unwrap().sleeper();
+                        let buffer = Arc::clone(&buffer);
+                        let alarm = Arc::clone(&alarm);
+                        let port_id = port_id.clone();
+                        let proc = proc.clone();
+                        let sender = sender.clone();
+                        let sequencer = sequencer.clone();
+                        let mailbox = self.mailbox().clone();
+                        let split_port = split_port.clone();
+
+                        tokio::spawn(async move {
+                            while sleeper.sleep().await {
+                                let mut buf = buffer.lock().unwrap();
+
+                                if buf.done {
+                                    break;
+                                }
+
+                                let timeout = if buf.has_buffered_updates() {
+                                    idle_timeout
+                                } else {
+                                    abandon_timeout
+                                };
+
+                                let duration_until_timeout =
+                                    timeout.saturating_sub(buf.inactive_for());
+
+                                if !duration_until_timeout.is_zero() {
+                                    alarm.lock().unwrap().arm(duration_until_timeout);
+                                    continue;
+                                }
+
+                                if let Some((mut headers, reduced, count)) = buf.flush() {
+                                    headers.set(REDUCER_ACCUMULATED_UPDATES, count);
+
+                                    post(
+                                        &proc,
+                                        &sender,
+                                        &sequencer,
+                                        port_id.clone(),
+                                        headers,
+                                        reduced,
+                                        return_undeliverable,
+                                    );
+
+                                    let duration_until_abandonment =
+                                        abandon_timeout.saturating_sub(buf.inactive_for());
+
+                                    if !duration_until_abandonment.is_zero() {
+                                        alarm.lock().unwrap().arm(duration_until_abandonment);
+                                        continue;
+                                    }
+                                }
+
+                                buf.done = true;
+
+                                drop(buf);
+
+                                mailbox.unbind_untyped(&split_port);
+                                break;
+                            }
+                        });
+                    }
+
+                    let error_port_id = split_port.clone();
+                    let sequencer = sequencer.clone();
+
+                    Box::new(move |headers: Flattrs, update: wirevalue::Any| {
+                        let accumulated_updates = headers
+                            .get(REDUCER_ACCUMULATED_UPDATES)
+                            .unwrap_or(NonZeroUsize::MIN);
+
+                        let mut buf = buffer.lock().unwrap();
+
+                        if buf.done {
+                            return Err(mailbox::SerializedSendFailure::Dead {
+                                data: update,
+                                headers,
+                            });
+                        }
+
+                        match buf.push(headers.clone(), update, accumulated_updates) {
+                            Ok(IdleFlushPush::Complete {
+                                mut headers,
+                                reduced,
+                                count,
+                            }) => {
+                                alarm.lock().unwrap().fire();
+
+                                headers.set(REDUCER_ACCUMULATED_UPDATES, count);
+
+                                post(
+                                    &proc,
+                                    &sender,
+                                    &sequencer,
+                                    port_id.clone(),
+                                    headers,
+                                    reduced,
+                                    return_undeliverable,
+                                );
+
+                                Ok(mailbox::SerializedSendDisposition::DeliveredAndExhausted)
+                            }
+                            Ok(IdleFlushPush::Buffered) => {
+                                // This is an idle-flush interval. Each accepted reply
+                                // starts a fresh countdown from now.
+                                alarm.lock().unwrap().arm(idle_timeout);
+
+                                Ok(mailbox::SerializedSendDisposition::Delivered)
+                            }
+                            Err((data, error)) => Err(mailbox::SerializedSendFailure::Error(
+                                mailbox::SerializedSendError {
+                                    data,
+                                    error: crate::mailbox::MailboxSenderError::new_bound(
+                                        error_port_id.clone(),
+                                        crate::mailbox::MailboxSenderErrorKind::Other(error),
+                                    ),
+                                    headers,
+                                },
+                            )),
+                        }
+                    })
+                }
             },
         };
         self.mailbox().bind_untyped(
@@ -506,7 +655,7 @@ impl UpdateBuffer {
         if self.buffered.is_empty() {
             None
         } else {
-            let headers = self.headers.take().unwrap_or_else(Flattrs::new);
+            let headers = self.headers.take().unwrap_or_default();
             match self.reducer.reduce_updates(take(&mut self.buffered)) {
                 Ok(reduced) => Some(Ok((headers, reduced))),
                 Err((e, b)) => {
@@ -571,9 +720,136 @@ impl OnceBuffer {
             Ok(self
                 .accumulated
                 .take()
-                .map(|reduced| (self.headers.take().unwrap_or_else(Flattrs::new), reduced)))
+                .map(|reduced| (self.headers.take().unwrap_or_default(), reduced)))
         } else {
             Ok(None)
         }
+    }
+}
+
+struct IdleFlushBuffer {
+    accumulated: Option<wirevalue::Any>,
+    headers: Option<Flattrs>,
+    reducer: Box<dyn ErasedCommReducer + Send + Sync + 'static>,
+    expected: NonZeroUsize,
+    received: usize,
+    buffered: usize,
+    last_activity: tokio::time::Instant,
+    done: bool,
+}
+
+enum IdleFlushPush {
+    Buffered,
+    Complete {
+        headers: Flattrs,
+        reduced: wirevalue::Any,
+        count: NonZeroUsize,
+    },
+}
+
+impl IdleFlushBuffer {
+    fn new(
+        reducer: Box<dyn ErasedCommReducer + Send + Sync + 'static>,
+        expected: NonZeroUsize,
+    ) -> Self {
+        Self {
+            accumulated: None,
+            headers: None,
+            reducer,
+            expected,
+            received: 0,
+            buffered: 0,
+            last_activity: tokio::time::Instant::now(),
+            done: false,
+        }
+    }
+
+    /// Add an update that represents one or more logical replies. A completed
+    /// batch is returned when all expected replies have arrived.
+    fn push(
+        &mut self,
+        headers: Flattrs,
+        value: wirevalue::Any,
+        accumulated_updates: NonZeroUsize,
+    ) -> Result<IdleFlushPush, (wirevalue::Any, anyhow::Error)> {
+        let received = match self.received.checked_add(accumulated_updates.get()) {
+            Some(received) if received <= self.expected.get() => received,
+            _ => {
+                return Err((
+                    value,
+                    anyhow::anyhow!(
+                        "received more reducer updates than expected: {} + {} > {}",
+                        self.received,
+                        accumulated_updates,
+                        self.expected
+                    ),
+                ));
+            }
+        };
+
+        let buffered = self
+            .buffered
+            .checked_add(accumulated_updates.get())
+            .expect("buffered reply count cannot exceed expected reply count");
+
+        if self.headers.is_none() {
+            self.headers = Some(operation_context_headers(&headers));
+        }
+
+        self.accumulated = match self.accumulated.take() {
+            None => Some(value),
+            Some(acc) => match self.reducer.reduce_updates(vec![acc, value]) {
+                Ok(reduced) => Some(reduced),
+                Err((error, mut rejected)) => {
+                    let value = rejected.pop().unwrap_or_else(|| {
+                        wirevalue::Any::serialize(&()).expect("unit serialization must succeed")
+                    });
+
+                    self.accumulated = rejected.pop();
+
+                    return Err((value, error));
+                }
+            },
+        };
+
+        self.received = received;
+        self.buffered = buffered;
+        self.last_activity = tokio::time::Instant::now();
+
+        if self.received == self.expected.get() {
+            self.done = true;
+
+            let (headers, reduced, count) = self
+                .flush()
+                .expect("a completed idle-flush buffer contains an update");
+
+            Ok(IdleFlushPush::Complete {
+                headers,
+                reduced,
+                count,
+            })
+        } else {
+            Ok(IdleFlushPush::Buffered)
+        }
+    }
+
+    fn has_buffered_updates(&self) -> bool {
+        self.accumulated.is_some()
+    }
+
+    fn inactive_for(&self) -> Duration {
+        tokio::time::Instant::now().saturating_duration_since(self.last_activity)
+    }
+
+    /// Return the current reduced batch without completing the buffer.
+    fn flush(&mut self) -> Option<(Flattrs, wirevalue::Any, NonZeroUsize)> {
+        self.accumulated.take().map(|reduced| {
+            let headers = self.headers.take().unwrap_or_default();
+
+            let count = NonZeroUsize::new(take(&mut self.buffered))
+                .expect("a nonempty idle-flush buffer represents at least one reply");
+
+            (headers, reduced, count)
+        })
     }
 }

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2094,6 +2094,16 @@ impl Mailbox {
         }
     }
 
+    pub(crate) fn unbind_untyped(&self, port_id: &PortAddr) {
+        assert_eq!(
+            port_id.actor_addr(),
+            *self.actor_addr(),
+            "port does not belong to mailbox"
+        );
+
+        self.inner.ports.remove(&port_id.port());
+    }
+
     pub(crate) fn close(&self, status: ActorStatus) {
         let mut closed = self.inner.closed.write().unwrap();
         if closed.is_some() {
@@ -3979,6 +3989,7 @@ mod tests {
     use std::time::Duration;
 
     use async_trait::async_trait;
+    use hyperactor_config::NonZeroUsize;
     use timed_test::async_timed_test;
 
     use super::*;
@@ -5676,6 +5687,179 @@ mod tests {
         // No further messages
         let msg = receiver.try_recv().unwrap();
         assert_eq!(msg, None);
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_split_port_idle_flush_complete() {
+        let proc = Proc::isolated();
+        let actor = proc.client("actor");
+
+        let (port_handle, mut receiver) = actor.open_port::<u64>();
+
+        let port_id = port_handle.bind().port_addr().clone();
+
+        let split_port_id = port_id
+            .split(
+                &actor,
+                accum::sum::<u64>().reducer_spec(),
+                ReducerMode::IdleFlush {
+                    expected: NonZeroUsize::new(3).expect("3 is non-zero"),
+                    idle_timeout: Duration::from_secs(10),
+                    abandon_timeout: Duration::from_secs(30),
+                },
+                true,
+            )
+            .unwrap();
+
+        post(&actor, split_port_id.clone(), 10);
+        post(&actor, split_port_id.clone(), 20);
+
+        assert_eq!(
+            receiver.try_recv().unwrap(),
+            None,
+            "the reducer should not emit before receiving all expected updates"
+        );
+
+        post(&actor, split_port_id, 30);
+
+        let reduced = tokio::time::timeout(Duration::from_secs(2), receiver.recv())
+            .await
+            .expect("complete idle-flush result should arrive")
+            .unwrap();
+
+        assert_eq!(reduced, 60, "10 + 20 + 30 should reduce to 60");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_split_port_idle_flush_partial() {
+        let proc = Proc::isolated();
+        let actor = proc.client("actor");
+        let (port_handle, mut receiver) = actor.open_port::<u64>();
+        let port_id = port_handle.bind().port_addr().clone();
+        let split_port_id = port_id
+            .split(
+                &actor,
+                accum::sum::<u64>().reducer_spec(),
+                ReducerMode::IdleFlush {
+                    expected: NonZeroUsize::new(3).expect("3 is non-zero"),
+                    idle_timeout: Duration::from_millis(50),
+                    abandon_timeout: Duration::from_secs(30),
+                },
+                true,
+            )
+            .unwrap();
+
+        post(&actor, split_port_id.clone(), 10);
+        post(&actor, split_port_id, 20);
+
+        let reduced = tokio::time::timeout(Duration::from_secs(2), receiver.recv())
+            .await
+            .expect("partial idle-flush result should arrive after the idle interval")
+            .unwrap();
+        assert_eq!(reduced, 30, "10 + 20 should reduce to the partial value 30");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_split_port_idle_flush_restarts_idle_timeout() {
+        let proc = Proc::isolated();
+        let actor = proc.client("actor");
+        let (port_handle, mut receiver) = actor.open_port::<u64>();
+        let port_id = port_handle.bind().port_addr().clone();
+        let split_port_id = port_id
+            .split(
+                &actor,
+                accum::sum::<u64>().reducer_spec(),
+                ReducerMode::IdleFlush {
+                    expected: NonZeroUsize::new(6).expect("6 is non-zero"),
+                    idle_timeout: Duration::from_millis(50),
+                    abandon_timeout: Duration::from_secs(30),
+                },
+                true,
+            )
+            .unwrap();
+
+        post(&actor, split_port_id.clone(), 10);
+        tokio::task::yield_now().await;
+
+        for update in [20, 30, 40, 50] {
+            tokio::time::advance(Duration::from_millis(25)).await;
+            post(&actor, split_port_id.clone(), update);
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            receiver.try_recv().unwrap(),
+            None,
+            "the reducer should not flush while replies arrive within the idle timeout"
+        );
+
+        tokio::time::advance(Duration::from_millis(49)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            receiver.try_recv().unwrap(),
+            None,
+            "the final reply should restart the full idle timeout"
+        );
+
+        tokio::time::advance(Duration::from_millis(11)).await;
+        let reduced = receiver.recv().await.unwrap();
+        assert_eq!(reduced, 150, "10 + 20 + 30 + 40 + 50 should reduce to 150");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_split_port_idle_flush_abandons_incomplete_port() {
+        let proc = Proc::isolated();
+        let actor = proc.client("actor");
+        let (port_handle, mut receiver) = actor.open_port::<u64>();
+        let port_id = port_handle.bind().port_addr().clone();
+        let split_port_id = port_id
+            .split(
+                &actor,
+                accum::sum::<u64>().reducer_spec(),
+                ReducerMode::IdleFlush {
+                    expected: NonZeroUsize::new(2).expect("2 is non-zero"),
+                    idle_timeout: Duration::from_millis(50),
+                    abandon_timeout: Duration::from_millis(200),
+                },
+                false,
+            )
+            .unwrap();
+
+        assert!(
+            actor
+                .mailbox()
+                .inner
+                .ports
+                .contains_key(&split_port_id.port()),
+            "the split port should initially be bound"
+        );
+
+        post(&actor, split_port_id.clone(), 10);
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(50)).await;
+        assert_eq!(receiver.recv().await.unwrap(), 10);
+
+        tokio::time::advance(Duration::from_millis(149)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            actor
+                .mailbox()
+                .inner
+                .ports
+                .contains_key(&split_port_id.port()),
+            "the incomplete split port should remain bound before abandonment"
+        );
+
+        tokio::time::advance(Duration::from_millis(2)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !actor
+                .mailbox()
+                .inner
+                .ports
+                .contains_key(&split_port_id.port()),
+            "the incomplete split port should be removed after abandonment"
+        );
     }
 
     #[async_timed_test(timeout_secs = 30)]


### PR DESCRIPTION
Summary:

The streaming reducer sends back every single reply to the previous layer which causes the sender to receive n replies making it unperformant in contrast to the OnceBuffer reducer which accumulates all replies before sending back a single aggregated reply.

The tradeoff of OnceBuffer is that any missing reply causes the entire subtree to not send a reply.

This is unacceptable for cases like heartbeating where we want to know precisely which rank it was that timed out, forcing us to use the streaming reducer.

We can get the best of both worlds with an `IdleFlushReducer` which accumulates replies as it receives them, but sends back the accumulated replies after some timeout.

Under healthy conditions it will behave exactly like the OnceBuffer.

Under unhealthy conditions, the timeout will cause it to send back any partial results. If there are stragglers, those stragglers will be accumulated and sent back if they come in later.

Reviewed By: shayne-fletcher

Differential Revision: D119564081


