### PR TITLE
Use idle-flush replies for DrainHost (#4859)

### DIFF
--- a/docs/source/books/hyperactor-book/src/mailboxes/ports.md
+++ b/docs/source/books/hyperactor-book/src/mailboxes/ports.md
@@ -122,7 +122,7 @@ impl<M: RemoteMessage> OncePortHandle<M> {
 }
 ```
 
-## `PortRef` and `OncePortRef`
+## `PortRef`, `IdleFlushPortRef`, and `OncePortRef`
 
 A `PortRef<M>` is a cloneable, sendable reference to a bound typed port. These are used to send messages to an actor from outside its mailbox, typically after calling `.bind()` on a `PortHandle<M>`:
 ```rust
@@ -143,6 +143,15 @@ pub struct PortRef<M> {
 - **`phantom`**: Phantom data to retain the `M` type parameter. This enforces compile-time type safety without storing a value of type `M`.
 - **`return_undeliverable`**: Whether an undeliverable message is returned to the sender (the default) or silently dropped.
 - **`unsplit`**: When set, keeps the port out of cast/comm tree reduction so every destination replies to it directly. Set via `PortRef::unsplit()`.
+
+An `IdleFlushPortRef<M>` wraps a reusable `PortRef<M>` with `IdleFlushReducerOpts`. Its distinct serialized representation tells each cast split to install an idle-flush reducer, in the same way that `OncePortRef<M>` tells each split to install a one-shot reducer.
+
+```rust
+let reply = port.bind().into_idle_flush(IdleFlushReducerOpts {
+    idle_timeout: Duration::from_millis(50),
+    expected_updates_per_destination: NonZeroUsize::MIN,
+});
+```
 
 A `OncePortRef<M>` is a reference to a one-shot port. Unlike `PortRef`, it allows exactly one message to be sent. These are created by binding a `OncePortHandle<M>`.
 ```rust

--- a/docs/source/books/hyperactor-book/src/references/typed_refs.md
+++ b/docs/source/books/hyperactor-book/src/references/typed_refs.md
@@ -4,10 +4,11 @@ Typed references are strongly typed wrappers over addresses like `ActorAddr` and
 
 ## Overview
 
-There are three main typed reference types:
+There are four main typed reference types:
 
 - [`ActorRef<A>`](#actorrefa): A typed reference to an actor implementing the `Referable` trait.
 - [`PortRef<M>`](#portrefm): A reference to a reusable mailbox port for messages of type `M` implementing the `RemoteMessage` trait.
+- [`IdleFlushPortRef<M>`](#idleflushportrefm): A reusable reply port that applies idle-flush reduction in cast trees.
 - [`OncePortRef<M>`](#onceportrefm): A reference to a one-shot port for receiving a single response of type `M` implementing the `RemoteMessage` trait.
 
 These types are used as parameters in messages, return values from bindings, and components of the routing system.
@@ -62,6 +63,10 @@ pub struct PortRef<M> {
 }
 ```
 As with `ActorRef`, this is a typed wrapper around an address (`PortAddr`), carrying a phantom type for safety. It ensures that only messages of type `M` can be sent through this reference.
+
+## `IdleFlushPortRef<M>`
+
+`IdleFlushPortRef<M>` is a reusable reply port with a distinct serialized representation. Cast splitting recognizes it and installs `ReducerMode::IdleFlush` at each branch. Create one from a bound `PortRef` with `PortRef::into_idle_flush`.
 
 ## `OncePortRef<M>`
 

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -202,6 +202,9 @@ pub use proc::Proc;
 pub use proc::StatusMessage;
 pub use proc::WeakProc;
 pub use ref_::ActorRef;
+pub use ref_::IdleFlushPortRef;
+#[doc(hidden)]
+pub use ref_::IdleFlushPortRefRepr;
 pub use ref_::OncePortRef;
 #[doc(hidden)]
 pub use ref_::OncePortRefRepr;
@@ -271,6 +274,7 @@ mod private {
     impl<M: crate::Message> Sealed for &crate::mailbox::PortHandle<M> {}
     impl<M: crate::Message> Sealed for crate::mailbox::OncePortHandle<M> {}
     impl<A: crate::actor::Referable> Sealed for &crate::ref_::ActorRef<A> {}
+    impl<M: crate::RemoteMessage> Sealed for &crate::ref_::IdleFlushPortRef<M> {}
     impl<M: crate::RemoteMessage> Sealed for &crate::ref_::PortRef<M> {}
     impl<M: crate::RemoteMessage> Sealed for crate::ref_::OncePortRef<M> {}
 }

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -31,6 +31,7 @@ use crate::PortAddr;
 use crate::RemoteEndpoint;
 use crate::RemoteHandles;
 use crate::RemoteMessage;
+use crate::accum::IdleFlushReducerOpts;
 use crate::accum::ReducerSpec;
 use crate::accum::StreamingReducerOpts;
 use crate::actor::Binds;
@@ -378,6 +379,22 @@ impl<M: RemoteMessage> PortRef<M> {
         self.port_addr
     }
 
+    /// Convert this streaming reference into an idle-flush reference to the same port.
+    ///
+    /// For example, a reference to port `7` remains addressed to port `7`, while
+    /// `reducer_opts` tells each cast split when to flush its reduced replies.
+    pub fn into_idle_flush(self, reducer_opts: IdleFlushReducerOpts) -> IdleFlushPortRef<M> {
+        IdleFlushPortRef {
+            port_addr: self.port_addr,
+            reducer_spec: self.reducer_spec,
+            streaming_opts: self.streaming_opts,
+            reducer_opts,
+            return_undeliverable: self.return_undeliverable,
+            unsplit: self.unsplit,
+            phantom: PhantomData,
+        }
+    }
+
     /// coerce it into OncePortRef so we can send messages to this port from
     /// APIs requires OncePortRef.
     pub fn into_once(self) -> OncePortRef<M> {
@@ -487,6 +504,206 @@ impl<M: RemoteMessage> Clone for PortRef<M> {
 impl<M: RemoteMessage> fmt::Display for PortRef<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.port_addr, f)
+    }
+}
+
+/// A reusable remote port reference whose cast-tree proxies flush reduced updates after idling.
+#[derive(Debug, PartialEq, typeuri::Named)]
+pub struct IdleFlushPortRef<M> {
+    port_addr: PortAddr,
+    reducer_spec: Option<ReducerSpec>,
+    streaming_opts: StreamingReducerOpts,
+    reducer_opts: IdleFlushReducerOpts,
+    return_undeliverable: bool,
+    unsplit: bool,
+    phantom: PhantomData<M>,
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named)]
+pub struct IdleFlushPortRefRepr {
+    port_addr: PortAddr,
+    reducer_spec: Option<ReducerSpec>,
+    streaming_opts: StreamingReducerOpts,
+    reducer_opts: IdleFlushReducerOpts,
+    return_undeliverable: bool,
+    unsplit: bool,
+}
+
+impl IdleFlushPortRefRepr {
+    /// Return the destination address; for a reference to port `7`, this returns port `7`.
+    pub fn port_addr(&self) -> &PortAddr {
+        &self.port_addr
+    }
+
+    /// Return the reducer specification; a non-reducible port returns `None`.
+    pub fn reducer_spec(&self) -> Option<&ReducerSpec> {
+        self.reducer_spec.as_ref()
+    }
+
+    /// Return the idle-flush reducer options.
+    pub fn reducer_opts(&self) -> &IdleFlushReducerOpts {
+        &self.reducer_opts
+    }
+
+    /// Return the undeliverable policy; a port configured to drop failures returns `false`.
+    pub fn get_return_undeliverable(&self) -> bool {
+        self.return_undeliverable
+    }
+
+    /// Return whether splitting is disabled; an unsplit reference returns `true`.
+    pub fn unsplit(&self) -> bool {
+        self.unsplit
+    }
+
+    /// Replace the destination address; changing port `7` to port `8` makes later sends use `8`.
+    pub fn update_port_addr(&mut self, port_addr: PortAddr) {
+        self.port_addr = port_addr;
+    }
+}
+
+impl<M> TryFrom<&IdleFlushPortRef<M>> for IdleFlushPortRefRepr {
+    type Error = serde_multipart::Error;
+
+    fn try_from(port_ref: &IdleFlushPortRef<M>) -> serde_multipart::Result<Self> {
+        Ok(Self {
+            port_addr: port_ref.port_addr.clone(),
+            reducer_spec: port_ref.reducer_spec.clone(),
+            streaming_opts: port_ref.streaming_opts.clone(),
+            reducer_opts: port_ref.reducer_opts.clone(),
+            return_undeliverable: port_ref.return_undeliverable,
+            unsplit: port_ref.unsplit,
+        })
+    }
+}
+
+impl<M> TryFrom<IdleFlushPortRefRepr> for IdleFlushPortRef<M> {
+    type Error = serde_multipart::Error;
+
+    fn try_from(repr: IdleFlushPortRefRepr) -> serde_multipart::Result<Self> {
+        Ok(Self {
+            port_addr: repr.port_addr,
+            reducer_spec: repr.reducer_spec,
+            streaming_opts: repr.streaming_opts,
+            reducer_opts: repr.reducer_opts,
+            return_undeliverable: repr.return_undeliverable,
+            unsplit: repr.unsplit,
+            phantom: PhantomData,
+        })
+    }
+}
+
+serde_multipart::part_codec! {
+    impl<M> IdleFlushPortRef<M>
+    {
+        type Repr = IdleFlushPortRefRepr;
+    }
+}
+
+impl<M: RemoteMessage> IdleFlushPortRef<M> {
+    /// The typehash of this port's reducer, if any.
+    pub fn reducer_spec(&self) -> &Option<ReducerSpec> {
+        &self.reducer_spec
+    }
+
+    /// This port's address.
+    pub fn port_addr(&self) -> &PortAddr {
+        &self.port_addr
+    }
+
+    /// Convert this IdleFlushPortRef into its corresponding port address.
+    pub fn into_port_addr(self) -> PortAddr {
+        self.port_addr
+    }
+
+    /// Post a serialized message to this port, provided a sending capability, such as
+    /// [`crate::actor::Instance`].
+    pub fn post_serialized(
+        &self,
+        cx: &impl context::Actor,
+        mut headers: Flattrs,
+        message: wirevalue::Any,
+    ) {
+        crate::mailbox::headers::set_send_timestamp(&mut headers);
+        crate::mailbox::headers::set_rust_message_type::<M>(&mut headers);
+        cx.post(
+            self.port_addr.clone(),
+            headers,
+            message,
+            self.return_undeliverable,
+            context::SeqInfoPolicy::AssignNew,
+        );
+    }
+
+    /// Get whether or not messages sent to this port that are undeliverable should
+    /// be returned to the sender.
+    pub fn get_return_undeliverable(&self) -> bool {
+        self.return_undeliverable
+    }
+
+    /// Set whether or not messages sent to this port that are undeliverable
+    /// should be returned to the sender.
+    pub fn return_undeliverable(&mut self, return_undeliverable: bool) {
+        self.return_undeliverable = return_undeliverable;
+    }
+}
+
+impl<M> Endpoint<M> for &IdleFlushPortRef<M>
+where
+    M: RemoteMessage,
+{
+    fn endpoint_location(&self) -> EndpointLocation {
+        EndpointLocation::Port(self.port_addr.clone())
+    }
+
+    fn post<C>(self, cx: &C, message: M)
+    where
+        C: context::Actor,
+    {
+        RemoteEndpoint::post_with_headers(self, cx, Flattrs::new(), message)
+    }
+}
+
+impl<M> RemoteEndpoint<M> for &IdleFlushPortRef<M>
+where
+    M: RemoteMessage,
+{
+    fn post_with_headers<C>(self, cx: &C, headers: Flattrs, message: M)
+    where
+        C: context::Actor,
+    {
+        let serialized = match wirevalue::Any::serialize(&message).map_err(|err| {
+            MailboxSenderError::new_bound(
+                self.port_addr.clone(),
+                MailboxSenderErrorKind::Serialize(err.into()),
+            )
+        }) {
+            Ok(serialized) => serialized,
+            Err(err) => {
+                cx.instance()
+                    .report_delivery_failure(DeliveryFailureReport::from_send_error::<M>(
+                        cx.mailbox().actor_addr().clone(),
+                        self.endpoint_location(),
+                        &err,
+                    ));
+                return;
+            }
+        };
+        self.post_serialized(cx, headers, serialized);
+    }
+}
+
+impl<M: RemoteMessage> Clone for IdleFlushPortRef<M> {
+    fn clone(&self) -> Self {
+        Self {
+            port_addr: self.port_addr.clone(),
+            reducer_spec: self.reducer_spec.clone(),
+            streaming_opts: self.streaming_opts.clone(),
+            reducer_opts: self.reducer_opts.clone(),
+            return_undeliverable: self.return_undeliverable,
+            unsplit: self.unsplit,
+            phantom: PhantomData,
+        }
     }
 }
 
@@ -707,6 +924,9 @@ impl<M: RemoteMessage> Named for OncePortRef<M> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use hyperactor_config::NonZeroUsize;
     use serde::Deserialize;
     use serde::Serialize;
     use serde_multipart::PartCodec;
@@ -739,9 +959,41 @@ mod tests {
         once_port_ref
     }
 
+    fn test_idle_flush_port_ref() -> IdleFlushPortRef<String> {
+        let proc_id = ProcId::singleton(Label::new("proc").unwrap());
+        let actor_id = ActorId::singleton(Label::new("actor").unwrap(), proc_id);
+        let port_id = PortId::new(actor_id, Port::from(9));
+        let port_addr = PortAddr::new(port_id, ChannelAddr::Local(44).into());
+        let mut port_ref = PortRef::<String>::attest_reducible(
+            port_addr,
+            Some(ReducerSpec {
+                typehash: 123,
+                builder_params: None,
+            }),
+            StreamingReducerOpts {
+                max_update_interval: Some(Duration::from_millis(250)),
+                initial_update_interval: Some(Duration::from_millis(5)),
+            },
+        )
+        .unsplit()
+        .into_idle_flush(IdleFlushReducerOpts {
+            idle_timeout: Duration::from_millis(50),
+            abandon_timeout: Duration::from_secs(30),
+            expected_updates_per_destination: NonZeroUsize::new(2).expect("2 is non-zero"),
+        });
+        port_ref.return_undeliverable(false);
+        port_ref
+    }
+
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
     struct PortRefEnvelope {
         port: PortRef<String>,
+        seq: u64,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct IdleFlushPortRefEnvelope {
+        port: IdleFlushPortRef<String>,
         seq: u64,
     }
 
@@ -770,6 +1022,20 @@ mod tests {
         assert_eq!(actual.unsplit, expected.unsplit);
     }
 
+    fn assert_same_idle_flush_port_ref(
+        actual: &IdleFlushPortRef<String>,
+        expected: &IdleFlushPortRef<String>,
+    ) {
+        let actual = actual.to_repr().unwrap();
+        let expected = expected.to_repr().unwrap();
+        assert_eq!(actual.port_addr, expected.port_addr);
+        assert_eq!(actual.reducer_spec, expected.reducer_spec);
+        assert_eq!(actual.streaming_opts, expected.streaming_opts);
+        assert_eq!(actual.reducer_opts, expected.reducer_opts);
+        assert_eq!(actual.return_undeliverable, expected.return_undeliverable);
+        assert_eq!(actual.unsplit, expected.unsplit);
+    }
+
     #[test]
     fn test_port_ref_serde_multipart_part_codec() {
         let value = PortRefEnvelope {
@@ -789,6 +1055,37 @@ mod tests {
         let deserialized: PortRefEnvelope = serde_multipart::deserialize_bincode(message).unwrap();
         assert_eq!(deserialized.seq, value.seq);
         assert_same_port_ref(&deserialized.port, &value.port);
+    }
+
+    #[test]
+    fn test_idle_flush_port_ref_serde_multipart_part_codec() {
+        let value = IdleFlushPortRefEnvelope {
+            port: test_idle_flush_port_ref(),
+            seq: 789,
+        };
+
+        let message = serde_multipart::serialize_bincode(&value).unwrap();
+        assert_eq!(message.num_parts(), 1);
+        assert_eq!(
+            message.parts()[0].typehash(),
+            Some(IdleFlushPortRefRepr::typehash())
+        );
+
+        let repr = message.parts()[0]
+            .deserialized::<IdleFlushPortRefRepr>()
+            .unwrap();
+        let expected = value.port.to_repr().unwrap();
+        assert_eq!(repr.port_addr, expected.port_addr);
+        assert_eq!(repr.reducer_spec, expected.reducer_spec);
+        assert_eq!(repr.streaming_opts, expected.streaming_opts);
+        assert_eq!(repr.reducer_opts, expected.reducer_opts);
+        assert_eq!(repr.return_undeliverable, expected.return_undeliverable);
+        assert_eq!(repr.unsplit, expected.unsplit);
+
+        let deserialized: IdleFlushPortRefEnvelope =
+            serde_multipart::deserialize_bincode(message).unwrap();
+        assert_eq!(deserialized.seq, value.seq);
+        assert_same_idle_flush_port_ref(&deserialized.port, &value.port);
     }
 
     #[test]

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -50,6 +50,7 @@ use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::EndpointLocation;
 use hyperactor::Handler;
+use hyperactor::IdleFlushPortRefRepr;
 use hyperactor::Instance;
 use hyperactor::Label;
 use hyperactor::OncePortRefRepr;
@@ -75,6 +76,7 @@ use hyperactor::ordering::SeqKey;
 use hyperactor::port::Port;
 use hyperactor::value_mesh::ValueMesh;
 use hyperactor_config::Flattrs;
+use hyperactor_config::NonZeroUsize as ConfigNonZeroUsize;
 use ndslice::Point;
 use ndslice::Region;
 use ndslice::view::RankedSliceable;
@@ -363,7 +365,16 @@ impl CastDomainRef {
             .collect::<Vec<_>>();
         // Split even for one subtree: a direct route bypasses the leaf
         // CastActor that would otherwise create the one-peer reducer proxy.
-        split_ports(cx, &mut data, self.subtrees.len(), false)?;
+        split_ports(
+            cx,
+            &mut data,
+            SplitFanout {
+                peer_count: self.subtrees.len(),
+                num_destinations: self.members.region().num_ranks(),
+                #[cfg(test)]
+                deliver_here: false,
+            },
+        )?;
 
         for (subtree, seqs) in self.subtrees.iter().zip(subtree_seqs) {
             match &subtree.route {
@@ -520,6 +531,8 @@ struct CastHop {
     local_destination: CastDestination,
     /// Precomputed outgoing routes to communication-child tiles.
     next_hops: Vec<CastRoute>,
+    /// Number of logical destinations reached through this hop.
+    num_destinations: usize,
 }
 
 /// One destination actor and its position in the cast domain.
@@ -824,6 +837,7 @@ impl Handler<CreateCastDomain> for CastActor {
         let cast_hop = CastHop {
             local_destination: CastDestination::try_from_tile(&region, &tile)?,
             next_hops,
+            num_destinations: tile.rank_count(),
         };
 
         #[cfg(test)]
@@ -837,6 +851,19 @@ impl Handler<CreateCastDomain> for CastActor {
     }
 }
 
+/// Fanout counts used to configure reducers for one cast hop.
+#[derive(Debug, Clone, Copy)]
+struct SplitFanout {
+    /// Number of immediate reply sources: child hops plus local delivery, if present.
+    peer_count: usize,
+    /// Total cast destinations covered by this subtree, including the local
+    /// destination.
+    num_destinations: usize,
+    /// Whether this hop also delivers the cast to a local destination.
+    #[cfg(test)]
+    deliver_here: bool,
+}
+
 /// Rewrite reply port parts in the serialized message so that downstream
 /// actors reply through local proxy ports on the current sender or CastActor
 /// instead of directly to the original sender. Each proxy port reduces replies
@@ -845,8 +872,7 @@ impl Handler<CreateCastDomain> for CastActor {
 fn split_ports(
     cx: &impl context::Actor,
     data: &mut wirevalue::Any<wirevalue::encoding::Multipart>,
-    num_next_hops: usize,
-    deliver_here: bool,
+    fanout: SplitFanout,
 ) -> Result<()> {
     data.visit_multipart_parts_mut::<PortRefRepr, anyhow::Error>(|port| {
         if port.unsplit() {
@@ -862,7 +888,42 @@ fn split_ports(
 
         #[cfg(test)]
         {
-            tests::collect_split_port(port.port_addr(), &split, deliver_here);
+            tests::collect_split_port(port.port_addr(), &split, fanout.deliver_here);
+        }
+
+        port.update_port_addr(split);
+        Ok(())
+    })?;
+
+    data.visit_multipart_parts_mut::<IdleFlushPortRefRepr, anyhow::Error>(|port| {
+        if port.unsplit() || port.reducer_spec().is_none() {
+            return Ok(());
+        }
+
+        let opts = port.reducer_opts();
+
+        let expected = fanout
+            .num_destinations
+            .checked_mul(opts.expected_updates_per_destination.get())
+            .and_then(ConfigNonZeroUsize::new)
+            .ok_or_else(|| {
+                anyhow::anyhow!("expected reducer update count must be nonzero and cannot overflow")
+            })?;
+
+        let split = port.port_addr().split(
+            cx,
+            port.reducer_spec().cloned(),
+            ReducerMode::IdleFlush {
+                expected,
+                idle_timeout: opts.idle_timeout,
+                abandon_timeout: opts.abandon_timeout,
+            },
+            port.get_return_undeliverable(),
+        )?;
+
+        #[cfg(test)]
+        {
+            tests::collect_split_port(port.port_addr(), &split, fanout.deliver_here);
         }
 
         port.update_port_addr(split);
@@ -876,17 +937,16 @@ fn split_ports(
             return Ok(());
         }
 
-        let peer_count = num_next_hops + if deliver_here { 1 } else { 0 };
         let split = port.port_addr().split(
             cx,
             port.reducer_spec().clone(),
-            ReducerMode::Once(peer_count),
+            ReducerMode::Once(fanout.peer_count),
             true,
         )?;
 
         #[cfg(test)]
         {
-            tests::collect_split_port(port.port_addr(), &split, deliver_here);
+            tests::collect_split_port(port.port_addr(), &split, fanout.deliver_here);
         }
 
         port.update_port_addr(split);
@@ -1092,7 +1152,16 @@ impl CastActor {
         // CastActor's local proxy ports instead of directly to the original
         // sender.
         let mut data = message.data.clone();
-        split_ports(cx, &mut data, domain.next_hops.len(), true)?;
+        split_ports(
+            cx,
+            &mut data,
+            SplitFanout {
+                peer_count: domain.next_hops.len() + 1,
+                num_destinations: domain.num_destinations,
+                #[cfg(test)]
+                deliver_here: true,
+            },
+        )?;
 
         let local_lineage = lineage.through(domain.local_destination.base_rank_in_domain);
         deliver_to_destination(
@@ -1222,8 +1291,10 @@ mod tests {
     use std::time::Duration;
 
     use hyperactor::Client;
+    use hyperactor::IdleFlushPortRef;
     use hyperactor::PortAddr;
     use hyperactor::ProcAddr;
+    use hyperactor::accum::IdleFlushReducerOpts;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::proc::Proc;
     use ndslice::Shape;
@@ -2399,6 +2470,7 @@ mod tests {
                     actor: ActorAddr::root(cast_proc.proc_addr().clone(), Label::strip("receiver")),
                 },
                 next_hops: Vec::new(),
+                num_destinations: 1,
             },
         );
         let seq_region = domain_region
@@ -2849,11 +2921,20 @@ mod tests {
     }
     wirevalue::register_type!(TestRequestWithReply);
 
+    #[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named)]
+    struct TestIdleFlushRequestWithReply {
+        delayed_proc: String,
+        delay: Duration,
+        replies_per_destination: usize,
+        reply_to: IdleFlushPortRef<TestReplyCounts>,
+    }
+    wirevalue::register_type!(TestIdleFlushRequestWithReply);
+
     /// An actor that receives a cast message and sends a reply back
     /// through the (potentially split) reply port.
     #[derive(Debug, Default)]
     #[hyperactor::export(
-        handlers = [TestRequestWithReply],
+        handlers = [TestRequestWithReply, TestIdleFlushRequestWithReply],
     )]
     struct SplitPortReceiver;
 
@@ -2875,6 +2956,28 @@ mod tests {
                 cx,
                 TestReplyCounts::single(cx.self_addr().proc_addr().log_name().to_string()),
             );
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<TestIdleFlushRequestWithReply> for SplitPortReceiver {
+        async fn handle(
+            &mut self,
+            cx: &Context<Self>,
+            msg: TestIdleFlushRequestWithReply,
+        ) -> Result<(), anyhow::Error> {
+            let proc_name = cx.self_addr().proc_addr().log_name().to_string();
+
+            if proc_name == msg.delayed_proc {
+                tokio::time::sleep(msg.delay).await;
+            }
+
+            for _ in 0..msg.replies_per_destination {
+                msg.reply_to
+                    .post(cx, TestReplyCounts::single(proc_name.clone()));
+            }
+
             Ok(())
         }
     }
@@ -2933,6 +3036,92 @@ mod tests {
         assert_eq!(
             rank_paths, expected,
             "split-port tree doesn't mirror cast tree"
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_idle_flush_split_reducer_preserves_late_reply() {
+        let n = 8;
+
+        let mut test_mesh = CastTestMesh::new(n);
+
+        test_mesh.spawn_split_port_receivers();
+        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2).into());
+
+        let (reply_handle, mut reply_rx) = context::Mailbox::mailbox(&test_mesh.client)
+            .open_accum_port(TestReplyCountsAccumulator);
+
+        let reply_to = reply_handle.bind().into_idle_flush(IdleFlushReducerOpts {
+            idle_timeout: Duration::from_millis(50),
+            abandon_timeout: Duration::from_secs(30),
+            expected_updates_per_destination: NonZeroUsize::new(2).expect("2 is non-zero").into(),
+        });
+        let split_port_recording = record_split_port_tree(reply_to.port_addr().clone());
+
+        root_domain
+            .cast(
+                &test_mesh.client,
+                Flattrs::new(),
+                TestIdleFlushRequestWithReply {
+                    delayed_proc: "proc_7".to_string(),
+                    delay: Duration::from_millis(1500),
+                    replies_per_destination: 2,
+                    reply_to,
+                },
+            )
+            .unwrap();
+
+        let partial = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let reply = reply_rx.recv().await.unwrap();
+                if reply.counts_by_proc.len() == n - 1 {
+                    break reply;
+                }
+            }
+        })
+        .await
+        .expect("responsive subtrees should flush before the delayed reply");
+
+        assert_eq!(
+            partial.counts_by_proc,
+            [
+                "proc_0", "proc_1", "proc_2", "proc_3", "proc_4", "proc_5", "proc_6"
+            ]
+            .into_iter()
+            .map(|proc_name| (proc_name.to_string(), 2))
+            .collect()
+        );
+
+        let complete = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let reply = reply_rx.recv().await.unwrap();
+                if reply.counts_by_proc.len() == n {
+                    break reply;
+                }
+            }
+        })
+        .await
+        .expect("the late reply should complete the idle-flush reduction");
+
+        assert_eq!(
+            complete.counts_by_proc,
+            (0..n).map(|rank| (format!("proc_{rank}"), 2)).collect()
+        );
+
+        let edges = split_port_recording.edges();
+        let paths = build_split_paths(&edges);
+
+        let rank_lookup: HashMap<String, usize> =
+            (0..n).map(|i| (format!("proc_{i}"), i)).collect();
+        let rank_paths = split_path_ranks(&paths, &rank_lookup);
+
+        let expected: BTreeMap<usize, Vec<usize>> = [(2, vec![2]), (4, vec![4]), (6, vec![4, 6])]
+            .into_iter()
+            .collect();
+
+        assert_eq!(
+            rank_paths, expected,
+            "idle-flush split-port tree doesn't mirror cast tree"
         );
     }
 

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -49,6 +49,7 @@ use hyperactor::ActorRef;
 use hyperactor::Endpoint as _;
 use hyperactor::Gateway;
 use hyperactor::Handler;
+use hyperactor::accum::IdleFlushReducerOpts;
 use hyperactor::accum::StreamingReducerOpts;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::id::Label;
@@ -56,6 +57,7 @@ use hyperactor::id::Uid;
 use hyperactor_cast::cast_actor::CastActor;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
+use hyperactor_config::NonZeroUsize;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::view::CollectMeshExt;
 
@@ -985,14 +987,15 @@ impl HostMeshRef {
         // Each host reports a single-rank `Stopped` overlay once it has
         // drained; reduce them into a full StatusMesh so we can tell which
         // hosts (if any) never acknowledged.
-        let (reply, rx) = cx.mailbox().open_accum_port_opts(
-            crate::StatusMesh::from_single(region.clone(), Status::NotExist),
-            StreamingReducerOpts {
-                max_update_interval: Some(std::time::Duration::from_millis(50)),
-                initial_update_interval: None,
-            },
-        );
-        let mut reply = reply.bind();
+        let (reply, rx) = cx.mailbox().open_accum_port(crate::StatusMesh::from_single(
+            region.clone(),
+            Status::NotExist,
+        ));
+        let mut reply = reply.bind().into_idle_flush(IdleFlushReducerOpts {
+            idle_timeout: Duration::from_millis(50),
+            abandon_timeout: Duration::from_secs(30),
+            expected_updates_per_destination: NonZeroUsize::MIN,
+        });
         reply.return_undeliverable(false);
 
         let terminate_timeout =

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -45,6 +45,7 @@ use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
+use hyperactor::IdleFlushPortRef;
 use hyperactor::Instance;
 use hyperactor::PortHandle;
 use hyperactor::PortRef;
@@ -433,7 +434,7 @@ struct PendingDrain {
 
 struct PendingDrainReply {
     rank: usize,
-    reply: PortRef<crate::StatusOverlay>,
+    reply: IdleFlushPortRef<crate::StatusOverlay>,
 }
 
 #[derive(Default)]
@@ -1784,10 +1785,10 @@ pub struct DrainHost {
     /// The recipient's ordinal within the drain cast region, stamped by
     /// the cast layer. Used to position this host's status overlay.
     pub rank: resource::Rank,
-    /// Streaming status reply. Each host reports a single-rank `Stopped`
+    /// Idle-flush status reply. Each host reports a single-rank `Stopped`
     /// overlay once it has drained; the caller reduces these into a
     /// `StatusMesh` barrier and can detect hosts that never reported.
-    pub reply: PortRef<crate::StatusOverlay>,
+    pub reply: IdleFlushPortRef<crate::StatusOverlay>,
 }
 wirevalue::register_type!(DrainHost);
 
@@ -2575,9 +2576,11 @@ mod tests {
     use hyperactor::Client;
     use hyperactor::PortReceiver;
     use hyperactor::Proc;
+    use hyperactor::accum::IdleFlushReducerOpts;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::id::Label;
     use hyperactor::id::Uid;
+    use hyperactor_config::NonZeroUsize;
     use timed_test::async_timed_test;
 
     use super::*;
@@ -2589,6 +2592,21 @@ mod tests {
     use crate::resource::GetStateClient;
     use crate::resource::Rank;
     use crate::resource::WaitRankStatusClient;
+
+    /// Wrap a direct test reply so it has the same type as a cast reply.
+    ///
+    /// For example, a bound status port becomes an idle-flush status port with
+    /// one expected update per destination. Direct sends do not split it, so
+    /// the idle-flush settings do not change delivery in these tests.
+    fn idle_flush_status_reply(
+        reply: PortRef<crate::StatusOverlay>,
+    ) -> IdleFlushPortRef<crate::StatusOverlay> {
+        reply.into_idle_flush(IdleFlushReducerOpts {
+            idle_timeout: Duration::from_millis(50),
+            expected_updates_per_destination: NonZeroUsize::MIN,
+            abandon_timeout: Duration::from_millis(500),
+        })
+    }
 
     /// Assert `overlay` holds exactly one run covering `rank..rank+1`. The
     /// reply must land at the message rank the caller requested, not at any
@@ -2734,7 +2752,7 @@ mod tests {
                     max_in_flight: 1,
                     host_mesh_id: None,
                     rank: resource::Rank::new(0),
-                    reply: drain_reply.bind(),
+                    reply: idle_flush_status_reply(drain_reply.bind()),
                 },
             )
             .expect("drain request should be delivered");
@@ -3174,7 +3192,7 @@ mod tests {
                     16,
                     Some(matching_mesh),
                     resource::Rank::new(0),
-                    drain_reply.bind(),
+                    idle_flush_status_reply(drain_reply.bind()),
                 )
                 .await
                 .expect("selective drain should be accepted");
@@ -3350,7 +3368,7 @@ mod tests {
                 16,
                 None,
                 resource::Rank::new(0),
-                drain_reply.bind(),
+                idle_flush_status_reply(drain_reply.bind()),
             )
             .await
             .expect("drain request should be accepted");
@@ -3895,7 +3913,7 @@ mod tests {
                     max_in_flight: 1,
                     host_mesh_id: None,
                     rank: resource::Rank::new(0),
-                    reply: drain_reply.bind(),
+                    reply: idle_flush_status_reply(drain_reply.bind()),
                 },
             )
             .expect("drain request should be delivered during shutdown");
@@ -4275,7 +4293,7 @@ mod tests {
                 max_in_flight: 16,
                 host_mesh_id: Some(host_mesh_id.clone()),
                 rank: resource::Rank::new(3),
-                reply: first_reply.bind(),
+                reply: idle_flush_status_reply(first_reply.bind()),
             },
         );
         agent_ref.post(
@@ -4285,7 +4303,7 @@ mod tests {
                 max_in_flight: 16,
                 host_mesh_id: Some(host_mesh_id),
                 rank: resource::Rank::new(7),
-                reply: second_reply.bind(),
+                reply: idle_flush_status_reply(second_reply.bind()),
             },
         );
 
@@ -4404,7 +4422,7 @@ mod tests {
                 16,
                 Some(mesh_a.clone()),
                 resource::Rank::new(0),
-                drain_reply.bind(),
+                idle_flush_status_reply(drain_reply.bind()),
             )
             .await
             .unwrap();
@@ -4491,7 +4509,7 @@ mod tests {
                 16,
                 None,
                 resource::Rank::new(0),
-                drain_reply.bind(),
+                idle_flush_status_reply(drain_reply.bind()),
             )
             .await
             .unwrap();


### PR DESCRIPTION
Summary:

Migrate `DrainHost.reply` to `IdleFlushPortRef` so responsive host subtrees can flush without discarding late drain acknowledgements.

Reviewed By: dulinriley

Differential Revision: D119564084


