### PR TITLE
Add minimum stripe size config

### DIFF
--- a/monarch_rdma/src/action.rs
+++ b/monarch_rdma/src/action.rs
@@ -18,7 +18,6 @@ use std::time::Duration;
 use hyperactor::context;
 
 use crate::RdmaManagerActor;
-use crate::RdmaManagerMessageClient;
 use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::backend::RdmaBackendHandle;
@@ -111,9 +110,7 @@ impl RdmaAction {
         }
 
         // This proc's spawned backends, in priority order.
-        let handles = RdmaManagerActor::local_handle(client)
-            .get_backend_handles(client)
-            .await?;
+        let handles = RdmaManagerActor::local_backend_handles(client).await?;
         let mut buckets: Vec<(RdmaBackendHandle, Vec<RdmaOp>)> =
             handles.into_iter().map(|h| (h, Vec::new())).collect();
 

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -18,11 +18,13 @@
 
 use std::collections::HashMap;
 use std::fmt::Write as _;
+use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use dashmap::DashMap;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
@@ -101,7 +103,7 @@ wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<EfaDevice>>);
 /// execution. The manager iterates the batch, resolves each op's
 /// local MRs via [`IbvManagerActor::resolve_local_mrs`], settles on the
 /// NIC pair to run it over with
-/// [`IbvManagerActor::pick_peer_pair`], looks up (or spawns) the
+/// [`QueuePairRouter::pick_registrations_for_transfer`], looks up (or spawns) the
 /// active-side [`QueuePairActor`] for the op's [`QpKey`], and
 /// immediately dispatches a one-item [`ProcessOps`] to that QP — so
 /// the QP can start posting op `i` while the manager resolves the MRs
@@ -110,8 +112,116 @@ wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<EfaDevice>>);
 /// Per-op completion notifications stream back on `reply` as
 /// [`OpResult`] values.
 pub(super) struct SubmitOps<I: IbvDeviceImpl> {
-    pub(super) ops: Vec<IbvOp<IbvManagerActor<I>>>,
+    pub(super) ops: Vec<(usize, IbvOp<IbvManagerActor<I>>)>,
     pub(super) reply: mpsc::UnboundedSender<OpResult>,
+}
+
+/// Shared state for selecting a compatible registration pair and dispatching
+/// operations directly to initialized queue-pair workers.
+///
+/// The manager installs a route after creating a queue pair and removes all
+/// routes before tearing its queue pairs down. Each [`IbvBackend`] shares this
+/// router with the manager so warm submissions can bypass the manager mailbox;
+/// operations without local registrations or a matching route fall back to
+/// [`SubmitOps`].
+#[derive(Debug)]
+struct QueuePairRouter {
+    peer_device_affinity: PeerDeviceAffinityPolicy,
+    queue_pairs: DashMap<QpKey, mpsc::UnboundedSender<ProcessOps>>,
+}
+
+impl QueuePairRouter {
+    fn new(peer_device_affinity: PeerDeviceAffinityPolicy) -> Self {
+        Self {
+            peer_device_affinity,
+            queue_pairs: DashMap::new(),
+        }
+    }
+
+    /// Given local and remote registrations, uses
+    /// [`Self::peer_device_affinity`] to choose one compatible pair. Errors
+    /// when the policy gives no valid pair.
+    fn pick_registrations_for_transfer<'a>(
+        &self,
+        local: &'a [IbvMemoryRegionView],
+        remote: &'a [IbvRemoteMemoryRegionView],
+    ) -> Result<(&'a IbvMemoryRegionView, &'a IbvRemoteMemoryRegionView), anyhow::Error> {
+        // `PeerDeviceAffinityPolicy::pairs` is sensitive to input order. Sort
+        // both sides so selection depends only on the unordered registration
+        // sets and is consistent across processes.
+        let mut local: Vec<&IbvMemoryRegionView> = local.iter().collect();
+        local.sort_by(|a, b| a.device_name.cmp(&b.device_name));
+        let mut remote: Vec<&IbvRemoteMemoryRegionView> = remote.iter().collect();
+        remote.sort_by(|a, b| a.device_name.cmp(&b.device_name));
+
+        let local_names: Vec<String> = local.iter().map(|mr| mr.device_name.clone()).collect();
+        let remote_names: Vec<String> = remote.iter().map(|mr| mr.device_name.clone()).collect();
+        self.peer_device_affinity
+            .pairs(&local_names, &remote_names)
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, peer)| peer.map(|j| (local[i], remote[j])))
+            .choose(&mut rand::rng())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no NIC of {local_names:?} pairs with a peer NIC of {remote_names:?} under \
+                     {:?}",
+                    self.peer_device_affinity,
+                )
+            })
+    }
+
+    fn try_dispatch<I: IbvDeviceImpl>(
+        &self,
+        op_idx: usize,
+        op: IbvOp<IbvManagerActor<I>>,
+        reply: &mpsc::UnboundedSender<OpResult>,
+    ) -> Option<IbvOp<IbvManagerActor<I>>> {
+        let local_mrs = op.local_memory.registered_mrs::<I>();
+        if local_mrs.is_empty() {
+            return Some(op);
+        }
+        let (local, remote) =
+            match self.pick_registrations_for_transfer(&local_mrs, &op.remote_buffers) {
+                Ok(pair) => pair,
+                Err(error) => {
+                    let _ = reply.send(OpResult {
+                        op_idx,
+                        result: Err(error.to_string()),
+                    });
+                    return None;
+                }
+            };
+        let local = local.clone();
+        let remote = remote.clone();
+        let qp_key = QpKey {
+            self_device: local.device_name.clone(),
+            other_id: op.remote_manager.actor_addr().id().clone(),
+            other_device: remote.device_name.clone(),
+        };
+        let Some(sender) = self.queue_pairs.get(&qp_key) else {
+            return Some(op);
+        };
+        if sender
+            .send(ProcessOps {
+                items: vec![QueuePairOp {
+                    op_idx,
+                    op_type: op.op_type,
+                    local_memory: op.local_memory,
+                    local,
+                    remote,
+                }],
+                reply: reply.clone(),
+            })
+            .is_err()
+        {
+            let _ = reply.send(OpResult {
+                op_idx,
+                result: Err("queue pair worker stopped".to_owned()),
+            });
+        }
+        None
+    }
 }
 
 /// Local-only message: create a fresh, unconnected legacy
@@ -191,6 +301,10 @@ pub struct IbvManagerActor<I: IbvDeviceImpl> {
     /// Read once, when the manager starts.
     peer_device_affinity: PeerDeviceAffinityPolicy,
 
+    /// Warm QP routes shared with [`IbvBackend`] for direct steady-state
+    /// submission without a manager-mailbox round trip.
+    queue_pair_router: Arc<QueuePairRouter>,
+
     /// Completion pollers, keyed by device name when each device gets its own
     /// poller and by the empty string when all devices share one.
     cq_pollers: HashMap<String, ActorHandle<CompletionQueueActor<IbvCq>>>,
@@ -227,6 +341,8 @@ impl<I: IbvDeviceImpl> Actor for IbvManagerActor<I> {
 
 impl<I: IbvDeviceImpl> Drop for IbvManagerActor<I> {
     fn drop(&mut self) {
+        self.queue_pair_router.queue_pairs.clear();
+
         // Stop each supervising QP actor; its cleanup cancels and joins the
         // data-plane worker that owns the QP.
         for (_key, handle) in self.qp_handles.drain() {
@@ -285,17 +401,23 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             }
         }
 
+        let peer_device_affinity = configured_peer_device_affinity()?;
         let actor = Self {
             owner: OnceLock::new(),
             qp_handles: HashMap::new(),
             peer_created_qps: HashMap::new(),
             devices: HashMap::new(),
-            peer_device_affinity: configured_peer_device_affinity()?,
+            peer_device_affinity: peer_device_affinity.clone(),
+            queue_pair_router: Arc::new(QueuePairRouter::new(peer_device_affinity)),
             cq_pollers: HashMap::new(),
             config,
         };
 
         Ok(actor)
+    }
+
+    fn queue_pair_router(&self) -> Arc<QueuePairRouter> {
+        Arc::clone(&self.queue_pair_router)
     }
 
     /// Get or create the `DEFAULT_DOMAIN` for the named RDMA device, opening
@@ -439,40 +561,6 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             .choose(&names, max.map(hyperactor_config::NonZeroUsize::into_std)))
     }
 
-    /// Given a list of local registrations and remote registrations, uses
-    /// [`Self::peer_device_affinity`] to decide on one local/remote pair
-    /// to use. Errors when the policy gives no valid pair.
-    fn pick_peer_pair<'a>(
-        &self,
-        local: &'a [IbvMemoryRegionView],
-        remote: &'a [IbvRemoteMemoryRegionView],
-    ) -> Result<(&'a IbvMemoryRegionView, &'a IbvRemoteMemoryRegionView), anyhow::Error> {
-        // Sort both sides by device name because `PeerDeviceAffinityPolicy::pairs` is
-        // sensitive to input order. This ensures that `pick_peer_pair`'s behavior is
-        // dependent only on the unordered set of local and remote devices, and it is
-        // therefore consistent across processes.
-        let mut local: Vec<&IbvMemoryRegionView> = local.iter().collect();
-        local.sort_by(|a, b| a.device_name.cmp(&b.device_name));
-        let mut remote: Vec<&IbvRemoteMemoryRegionView> = remote.iter().collect();
-        remote.sort_by(|a, b| a.device_name.cmp(&b.device_name));
-
-        let local_names: Vec<String> = local.iter().map(|mr| mr.device_name.clone()).collect();
-        let remote_names: Vec<String> = remote.iter().map(|mr| mr.device_name.clone()).collect();
-        self.peer_device_affinity
-            .pairs(&local_names, &remote_names)
-            .into_iter()
-            .enumerate()
-            .filter_map(|(i, peer)| peer.map(|j| (local[i], remote[j])))
-            .choose(&mut rand::rng())
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no NIC of {local_names:?} pairs with a peer NIC of {remote_names:?} under \
-                     {:?}",
-                    self.peer_device_affinity,
-                )
-            })
-    }
-
     /// Build a passive-side mirror QP for `qp_key`, connect it to
     /// `sender_info`, and store it in [`Self::peer_created_qps`].
     /// Returns the local endpoint the active side needs to finish
@@ -552,6 +640,9 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             config.max_send_wr,
         );
         let handle = QueuePairHandle::new(cx.spawn(actor), sender);
+        self.queue_pair_router
+            .queue_pairs
+            .insert(qp_key.clone(), handle.sender());
         self.qp_handles.insert(qp_key.clone(), handle.clone());
         Ok(handle)
     }
@@ -566,7 +657,7 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
         // local MRs are resolved and its QP actor is in place, ship a
         // one-item `ProcessOps` to that QP. The QP can then post and
         // retire op `i` while we run `resolve_local_mrs` for op `i+1`.
-        for (i, op) in ops.into_iter().enumerate() {
+        for (i, op) in ops {
             let local_mrs = match self.resolve_local_mrs(&op.local_memory) {
                 Ok(mrs) => mrs,
                 Err(e) => {
@@ -577,7 +668,10 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
                     continue;
                 }
             };
-            let (local, remote) = match self.pick_peer_pair(&local_mrs, &op.remote_buffers) {
+            let (local, remote) = match self
+                .queue_pair_router
+                .pick_registrations_for_transfer(&local_mrs, &op.remote_buffers)
+            {
                 Ok((local, remote)) => (local.clone(), remote.clone()),
                 Err(e) => {
                     let _ = reply.send(OpResult {
@@ -696,18 +790,24 @@ impl<I: IbvDeviceImpl> Handler<IbvManagerLocalMessage> for IbvManagerActor<I> {
 /// state-mutating operations (MR registration/deregistration, QP management)
 /// serialized through actor messages.
 #[derive(Debug)]
-pub struct IbvBackend<I: IbvDeviceImpl>(pub ActorHandle<IbvManagerActor<I>>);
+pub struct IbvBackend<I: IbvDeviceImpl> {
+    manager: ActorHandle<IbvManagerActor<I>>,
+    queue_pair_router: Arc<QueuePairRouter>,
+}
 
 impl<I: IbvDeviceImpl> Clone for IbvBackend<I> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            manager: self.manager.clone(),
+            queue_pair_router: Arc::clone(&self.queue_pair_router),
+        }
     }
 }
 
 impl<I: IbvDeviceImpl> std::ops::Deref for IbvBackend<I> {
     type Target = ActorHandle<IbvManagerActor<I>>;
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.manager
     }
 }
 
@@ -777,7 +877,11 @@ where
         config: &RdmaConfig,
     ) -> Result<Self> {
         let actor = IbvManagerActor::<I>::new(config.ibv.clone()).await?;
-        Ok(IbvBackend(cx.spawn(actor)))
+        let queue_pair_router = actor.queue_pair_router();
+        Ok(Self {
+            manager: cx.spawn(actor),
+            queue_pair_router,
+        })
     }
 
     async fn register_remote_buffer(
@@ -787,12 +891,12 @@ where
         local: KeepaliveLocalMemory,
     ) -> Result<IbvRemoteBackendContext<I>> {
         let buffers = self
-            .0
+            .manager
             .register_remote_buffer(cx, local)
             .await?
             .map_err(|e| anyhow::anyhow!(e))?;
         Ok(IbvRemoteBackendContext {
-            manager: self.0.bind(),
+            manager: self.manager.bind(),
             buffers,
         })
     }
@@ -840,16 +944,23 @@ where
             });
         }
         let n = ibv_ops.len();
-
         let (reply, mut reply_rx) = mpsc::unbounded_channel();
 
-        self.0.try_post(
-            cx,
-            SubmitOps {
-                ops: ibv_ops,
-                reply,
-            },
-        )?;
+        let mut manager_ops = Vec::new();
+        for (op_idx, op) in ibv_ops.into_iter().enumerate() {
+            if let Some(op) = self.queue_pair_router.try_dispatch::<I>(op_idx, op, &reply) {
+                manager_ops.push((op_idx, op));
+            }
+        }
+        if !manager_ops.is_empty() {
+            self.manager.try_post(
+                cx,
+                SubmitOps {
+                    ops: manager_ops,
+                    reply,
+                },
+            )?;
+        }
 
         let mut failures: Vec<(usize, String)> = Vec::with_capacity(n);
         let mut received = 0usize;

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -839,6 +839,10 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairHandle<M, Qp> {
             .map_err(|_| anyhow::anyhow!("queue pair worker stopped"))
     }
 
+    pub(super) fn sender(&self) -> mpsc::UnboundedSender<ProcessOps> {
+        self.sender.clone()
+    }
+
     pub(super) fn drain_and_stop(&self, reason: &str) -> Result<(), ActorError> {
         self.actor.drain_and_stop(reason)
     }

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -124,6 +124,17 @@ declare_attrs! {
     ))
     pub attr RDMA_MAX_NICS_PER_BUFFER: Option<NonZeroUsize> = None;
 
+    /// Minimum RDMA stripe size, in KiB.
+    ///
+    /// A transfer uses as many compatible NIC pairs as this minimum allows.
+    /// Transfers smaller than the minimum use one pair.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_MIN_STRIPE_SIZE_KB".to_string()),
+        Some("rdma_min_stripe_size_kb".to_string()),
+    ))
+    pub attr RDMA_MIN_STRIPE_SIZE_KB: NonZeroUsize =
+        NonZeroUsize::new(512).expect("512 is non-zero");
+
     /// How many queue pairs share one completion queue.
     ///
     /// Sharing is what lets one poller reap for several queue pairs. Each

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -36,7 +36,10 @@
 //! every controller monitoring that actor reports the failure to the owner.
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::LazyLock;
 use std::sync::OnceLock;
+use std::sync::RwLock;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
@@ -49,11 +52,13 @@ use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
 use hyperactor::OncePortRef;
+use hyperactor::ProcAddr;
 use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
 use hyperactor::context;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::OnceCell;
 use typeuri::Named;
 
 use crate::backend::RdmaBackendHandle;
@@ -68,6 +73,12 @@ use crate::rdma_manager_owner::RdmaManagerOwnerActor;
 use crate::rdma_manager_owner::RdmaManagerReady;
 use crate::rdma_manager_owner::RdmaManagerReadyHandler;
 use crate::rdma_manager_owner::ReadyAckClient;
+
+// Each proc has one RDMA manager for its lifetime, so its backend handles never
+// need replacement or invalidation while they can still be used.
+static BACKEND_HANDLE_CACHE: LazyLock<
+    RwLock<HashMap<ProcAddr, Arc<OnceCell<Vec<RdmaBackendHandle>>>>>,
+> = LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Helper function to get detailed error messages from RDMAXCEL error codes
 pub fn get_rdmaxcel_error_message(error_code: i32) -> String {
@@ -155,6 +166,29 @@ impl RdmaManagerActor {
         actor_ref
             .downcast_handle(client)
             .expect("RdmaManagerActor is not in the local process")
+    }
+
+    pub async fn local_backend_handles(
+        client: &(impl context::Actor + Send + Sync),
+    ) -> Result<Vec<RdmaBackendHandle>, anyhow::Error> {
+        let key = client.mailbox().actor_addr().proc_addr();
+        let cell = BACKEND_HANDLE_CACHE
+            .read()
+            .expect("backend handle cache lock should not be poisoned")
+            .get(&key)
+            .cloned();
+        let cell = cell.unwrap_or_else(|| {
+            Arc::clone(
+                BACKEND_HANDLE_CACHE
+                    .write()
+                    .expect("backend handle cache lock should not be poisoned")
+                    .entry(key)
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        });
+        cell.get_or_try_init(async || Self::local_handle(client).get_backend_handles(client).await)
+            .await
+            .cloned()
     }
 }
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -86,6 +86,7 @@ def configure(
     rdma_ibverbs_target: str = ...,
     rdma_peer_device_affinity: str = ...,
     rdma_max_nics_per_buffer: Optional[int] = ...,
+    rdma_min_stripe_size_kb: int = ...,
     rdma_qps_per_cq: int = ...,
     rdma_cq_poller_per_device: bool = ...,
     rdma_runtime_worker_threads: int = ...,
@@ -213,6 +214,8 @@ def configure(
             data-plane runtime (default: 4), which runs RDMA actors and
             queue-pair worker tasks. Latched at the first RDMA use in a process;
             setting it later has no effect.
+        rdma_min_stripe_size_kb: Minimum RDMA stripe size in KiB (default: 512).
+            Transfers use as many compatible NIC pairs as this minimum allows.
         **kwargs: Reserved for future configuration keys
 
     For historical reasons, this API is named ``configure(...)``;

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -90,6 +90,7 @@ if TYPE_CHECKING:
             rdma_ibverbs_target: NotRequired[str]
             rdma_peer_device_affinity: NotRequired[str]
             rdma_max_nics_per_buffer: NotRequired[int | None]
+            rdma_min_stripe_size_kb: NotRequired[int]
             rdma_qps_per_cq: NotRequired[int]
             rdma_cq_poller_per_device: NotRequired[bool]
             rdma_runtime_worker_threads: NotRequired[int]
@@ -212,6 +213,9 @@ def configure(**kwargs: "ConfigureKwargsType") -> None:
                 validated when the RDMA manager starts.
             rdma_max_nics_per_buffer: How many NICs a buffer is registered on,
                 at most; ``None``, the default, sets no limit.
+            rdma_min_stripe_size_kb: Minimum RDMA stripe size in KiB
+                (default: 512). Transfers use as many compatible NIC pairs as
+                this minimum allows.
             rdma_qps_per_cq: How many queue pairs share one completion queue
                 (default 64).
             rdma_cq_poller_per_device: Whether each RDMA device gets a separate


### PR DESCRIPTION
Summary: Add `RDMA_MIN_STRIPE_SIZE_KB`, defaulting to 512 KiB, to control the minimum stripe size for an RDMA transfer. Expose the setting through the environment, runtime configuration, and typed Python configuration APIs.

Differential Revision: D119713605


