### PR TITLE
Upgrade cgroups-rs to 0.5.1 and repair zbus feature unification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8073,7 +8073,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -8082,7 +8082,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -9166,15 +9166,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -9360,8 +9351,8 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.14.0"
-source = "git+https://github.com/z-galaxy/zbus?rev=40d8995fa012652c1b1e1e9bd96e54327024be09#40d8995fa012652c1b1e1e9bd96e54327024be09"
+version = "5.19.0"
+source = "git+https://github.com/rrnewton/zbus?rev=29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752#29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -9387,7 +9378,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 0.7.15",
+ "winnow",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -9395,13 +9386,13 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.14.0"
-source = "git+https://github.com/z-galaxy/zbus?rev=40d8995fa012652c1b1e1e9bd96e54327024be09#40d8995fa012652c1b1e1e9bd96e54327024be09"
+version = "5.19.0"
+source = "git+https://github.com/rrnewton/zbus?rev=29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752#29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -9409,12 +9400,21 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.1"
-source = "git+https://github.com/z-galaxy/zbus?rev=40d8995fa012652c1b1e1e9bd96e54327024be09#40d8995fa012652c1b1e1e9bd96e54327024be09"
+version = "4.3.4"
+source = "git+https://github.com/rrnewton/zbus?rev=29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752#29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow",
  "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -9539,37 +9539,38 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.10.0"
-source = "git+https://github.com/z-galaxy/zbus?rev=40d8995fa012652c1b1e1e9bd96e54327024be09#40d8995fa012652c1b1e1e9bd96e54327024be09"
+version = "5.15.0"
+source = "git+https://github.com/rrnewton/zbus?rev=29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752#29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 0.7.15",
+ "winnow",
+ "zcheapstr",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.0"
-source = "git+https://github.com/z-galaxy/zbus?rev=40d8995fa012652c1b1e1e9bd96e54327024be09#40d8995fa012652c1b1e1e9bd96e54327024be09"
+version = "5.15.0"
+source = "git+https://github.com/rrnewton/zbus?rev=29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752#29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.0"
-source = "git+https://github.com/z-galaxy/zbus?rev=40d8995fa012652c1b1e1e9bd96e54327024be09#40d8995fa012652c1b1e1e9bd96e54327024be09"
+version = "4.2.0"
+source = "git+https://github.com/rrnewton/zbus?rev=29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752#29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.119",
- "winnow 0.7.15",
+ "syn 3.0.3",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ tonic = { git = "https://github.com/grpc/grpc-rust", rev = "de65d0a48783869d89b7
 wezterm-color-types = { git = "https://github.com/wezterm/wezterm.git", rev = "05343b387085842b434d267f91b6b0ec157e4331" }
 wezterm-dynamic = { git = "https://github.com/wezterm/wezterm.git", rev = "05343b387085842b434d267f91b6b0ec157e4331" }
 wezterm-input-types = { git = "https://github.com/wezterm/wezterm.git", rev = "05343b387085842b434d267f91b6b0ec157e4331" }
-zbus = { git = "https://github.com/z-galaxy/zbus", rev = "40d8995fa012652c1b1e1e9bd96e54327024be09" }
-zvariant = { git = "https://github.com/z-galaxy/zbus", rev = "40d8995fa012652c1b1e1e9bd96e54327024be09" }
-zvariant_derive = { git = "https://github.com/z-galaxy/zbus", rev = "40d8995fa012652c1b1e1e9bd96e54327024be09" }
+zbus = { git = "https://github.com/rrnewton/zbus", rev = "29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752" }
+zvariant = { git = "https://github.com/rrnewton/zbus", rev = "29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752" }
+zvariant_derive = { git = "https://github.com/rrnewton/zbus", rev = "29dc6b9fbd273758cf1fbe73d1011d1dbfc6a752" }
 
 [patch."https://github.com/wezterm/wezterm.git"]
 wezterm-bidi = "0.2.3"

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -66,7 +66,7 @@ urlencoding = "2.1.0"
 uuid = { version = "1.24.1", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }
 x509-parser = "0.18.1"
-zbus = { version = "5.14.0", features = ["async-executor", "async-fs", "async-io", "async-lock", "async-process", "async-task", "p2p", "tokio"], default-features = false }
+zbus = { version = "5.19.0", features = ["async-executor", "async-fs", "async-io", "async-lock", "async-process", "async-task", "p2p", "tokio"], default-features = false }
 
 [dev-dependencies]
 buck-resources = "1"


### PR DESCRIPTION
(Edit: Autonomous agents posted this)

Summary:
Upgrade the shared cgroups-rs dependency from 0.3.4 to 0.5.1 and update existing filesystem consumers to the upstream `cgroups_rs::fs` namespace. Keep a single vendored version and regenerate dependent Cargo manifests and lockfiles.

Resolve the D-Bus feature-unification issues through public upstream sources:

- Upgrade the maintained zbus family to 5.19 / zvariant 5.15. Backport accepted upstream commit `9ba6c6c06433` (PR 1944) to the maintained 5.x branch in https://github.com/z-galaxy/zbus/pull/1958. Blocking proxies now follow the target zbus feature, independent of host proc-macro features. The existing iOS fix is retained, and the old macro feature remains an inert compatibility alias.
- Pin https://github.com/cooperlees/monitord/pull/198, which explicitly requests async-only private proxies when another crate enables zbus blocking support. Default dependency features and generated async method bodies are unchanged.

The generated Monarch Cargo updates propagate the same public dependency pins to its zbus/zvariant users. The pins are temporary upstream contributions. Both public PRs await maintainer workflow approval and review; no upstream approval is claimed. The source fixes have before/after compiler regression evidence and independent review. No private cgroups source overlay, dependency omission or custom cfg remains.

Two existing async-only client proxies now explicitly disable blocking proxy generation, preserving their previous API set when another dependency enables zbus blocking support.

Differential Revision: D119713850

fbshipit-source-id: f1a8f2731b5a00f0f8b2974458bcbece98e0fd69
